### PR TITLE
Release 0.1.0a1

### DIFF
--- a/docs/changelog/index.md
+++ b/docs/changelog/index.md
@@ -1,8 +1,10 @@
 # Changelog
 
-## 0.1.0 — initial release
+## 0.1.0a1 — first alpha
 
-**Breaking changes:**
+First publicly tagged alpha of bootstack. Install with `pip install --pre bootstack`. APIs are not yet stable.
+
+**Differences from ttkbootstrap:**
 
 - Package renamed from `ttkbootstrap` to `bootstack`. Update all imports:
   ```python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bootstack"
-version = "0.1.0"
+version = "0.1.0a1"
 description = "A full UI framework for Python desktop apps built on tkinter — rich widgets, theming, and application structure out of the box."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/bootstack/__init__.py
+++ b/src/bootstack/__init__.py
@@ -13,7 +13,10 @@ Examples:
     ```
 """
 import importlib as _importlib
+from importlib.metadata import version as _pkg_version
 from typing import TYPE_CHECKING
+
+__version__ = _pkg_version("bootstack")
 
 from tkinter import (
     BooleanVar,


### PR DESCRIPTION
## Summary

First publicly tagged alpha of bootstack.

- Bump version `0.1.0` → `0.1.0a1` in `pyproject.toml`
- Update `docs/changelog/index.md` header to "0.1.0a1 — first alpha" with note about installation via `pip install --pre bootstack`
- Define `bootstack.__version__` in `src/bootstack/__init__.py` via `importlib.metadata.version("bootstack")` so the value stays in sync with `pyproject.toml` automatically (fixes the latent `AttributeError` from `cli/__init__.py:122`)

Build verified locally:
- `python -m build` produces `bootstack-0.1.0a1-py3-none-any.whl` and `bootstack-0.1.0a1.tar.gz`
- `twine check dist/*` → PASSED on both
- `python -c "import bootstack; print(bootstack.__version__)"` → `0.1.0a1`

## Release plan after merge

1. Tag the merge commit: `git tag v0.1.0a1 && git push origin v0.1.0a1`
2. (Optional) Upload to TestPyPI first to verify install: `twine upload --repository testpypi dist/*`
3. Upload to PyPI: `twine upload dist/*`
4. Verify: `pip install --pre bootstack==0.1.0a1` in a clean venv
5. Create a GitHub Release pointing at the tag with the changelog entry

## Test plan

- [x] Merge to main
- [ ] Tag `v0.1.0a1` on the merge commit and push tag
- [ ] Upload to PyPI (or TestPyPI first)
- [ ] `pip install --pre bootstack==0.1.0a1` in a fresh venv and verify `bootstack --version` and a basic `import bootstack as bs; bs.App().mainloop()` smoke test

🤖 Generated with [Claude Code](https://claude.com/claude-code)