### PR TITLE
Add release workflow (tag-triggered PyPI publish + GitHub Release)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,60 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build tooling
+        run: pip install build
+
+      - name: Build sdist + wheel
+        run: python -m build
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - uses: pypa/gh-action-pypi-publish@release/v1
+
+  release:
+    name: Create GitHub Release
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          prerelease: ${{ contains(github.ref_name, 'a') || contains(github.ref_name, 'b') || contains(github.ref_name, 'rc') }}
+          files: dist/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,3 +80,27 @@ where = ["src"]
     # ship compiled gettext catalogs within the package
     "assets/locales/**/LC_MESSAGES/*.mo",
 ]
+
+[tool.bumpversion]
+current_version = "0.1.0a1"
+parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)((?P<pre>a|b|rc)(?P<pre_n>\\d+))?"
+serialize = [
+    "{major}.{minor}.{patch}{pre}{pre_n}",
+    "{major}.{minor}.{patch}",
+]
+search = "version = \"{current_version}\""
+replace = "version = \"{new_version}\""
+commit = true
+tag = true
+tag_name = "v{new_version}"
+tag_message = "Release {new_version}"
+message = "Release {new_version}"
+allow_dirty = false
+
+[tool.bumpversion.parts.pre]
+optional_value = ""
+first_value = ""
+values = ["", "a", "b", "rc"]
+
+[tool.bumpversion.parts.pre_n]
+first_value = "1"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,6 +15,7 @@ Babel>=2.12
 # Build & Publishing
 build>=1.0
 twine>=5.0
+bump-my-version>=1.0
 
 # Code Quality
 ruff>=0.8


### PR DESCRIPTION
## Summary

Automates the release pipeline so future releases are a single `git push origin vX.Y.Z`.

Workflow triggers on tag push matching `v*` and runs three jobs:

1. **build** — checks out the tagged commit and runs `python -m build`
2. **publish** — uploads the sdist + wheel to PyPI via [OIDC Trusted Publishing](https://docs.pypi.org/trusted-publishers/) (no API token required, no secrets to manage)
3. **release** — creates a GitHub Release with auto-generated notes; automatically flagged as a pre-release for tags containing `a`, `b`, or `rc` (so `v0.1.0a2` is correctly marked alpha)

## Prereqs

PyPI Trusted Publisher already configured for `israel-dryer/bootstack` with workflow `release.yml`. No GitHub Actions secrets needed.

## Future release flow

```bash
# 1. Bump version in pyproject.toml + add changelog entry
# 2. PR + merge

git checkout main && git pull
git tag v0.1.0a2
git push origin v0.1.0a2
# Workflow handles: build → PyPI → GitHub Release
```

## Test plan

- [ ] Merge to `main`
- [ ] Next release: tag v0.1.0a2, push, verify all three jobs succeed in the Actions tab
- [ ] Confirm package appears on PyPI
- [ ] Confirm GitHub Release is created (and marked as pre-release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)