### PR TITLE
Add landing page hero, pre-release banner, and PyPI image fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![bootstack](assets/banner-readme.png)
+![bootstack](https://raw.githubusercontent.com/israel-dryer/bootstack/main/assets/banner-readme.png)
 
 ![](https://img.shields.io/github/release/israel-dryer/bootstack.svg)
 [![Downloads](https://pepy.tech/badge/bootstack)](https://pepy.tech/project/bootstack)
@@ -21,8 +21,10 @@ The aim is to take you from `pip install` to a working, themed application witho
 
 Requires Python 3.12+.
 
+bootstack is currently in **active alpha**, so the `--pre` flag is required to opt in to pre-release versions:
+
 ```bash
-pip install bootstack
+pip install --pre bootstack
 ```
 
 ## Quick Start

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -28,15 +28,20 @@ It runs anywhere Tk runs — Windows, macOS, and Linux — and installs like any
 
 ## Install with pip
 
+bootstack is currently in **active alpha**, so pip won't install it by default — you need the `--pre` flag to opt in to pre-release versions:
+
 ```bash
-python -m pip install bootstack
+python -m pip install --pre bootstack
 ```
 
 If you’re upgrading:
 
 ```bash
-python -m pip install --upgrade bootstack
+python -m pip install --upgrade --pre bootstack
 ```
+
+!!! note "Pinning to a specific alpha"
+    Once stable releases ship, the `--pre` flag will no longer be required. To stay on the alpha line in the meantime, you can pin a specific version, e.g. `pip install bootstack==0.1.0a2`.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,81 +1,23 @@
 ---
-title: Home
+title: bootstack
+hide:
+  - navigation
+  - toc
+  - footer
 ---
 
-# bootstack
-
-**bootstack** is a batteries-included desktop application framework for Python, built on Tk. It grew out of [ttkbootstrap](https://github.com/israel-dryer/ttkbootstrap) — which brought Bootstrap-style theming to ttk widgets — and bundles the layers you'd expect from a modern framework around it: app scaffolding, layout containers, semantic styling, reactive signals, forms and validation, i18n, a data layer, and a CLI for scaffolding and packaging.
-
-The aim is to take you from `pip install` to a working, themed application without wiring those pieces together yourself or dropping down to raw Tk geometry calls.
-
----
-
-## What bootstack provides
-
-- a structured application root (`App`, `AppShell`)
-- container-first layout (`PackFrame`, `GridFrame`, `ScrollView`)
-- a design system with semantic colors, variants, and typography
-- optional reactivity via signals
-- forms and validation, localization, icons, and theming as first-class concerns
-- a CLI for scaffolding new projects and packaging applications
-
-These pieces are designed to work together. You can adopt them incrementally, but most of the leverage comes from following the framework's conventions for layout, styling, and state.
-
----
-
-## How the documentation is organized
-
-The documentation is structured by intent, not by inheritance or module layout.
-
-### Getting Started
-
-Create your first bootstack application and learn the core mental model.
-
-→ [Start here if you're new](getting-started/index.md)
-
-### Guides
-
-Workflow-oriented documentation that shows how to build real applications:
-layout patterns, reactivity, styling, localization, and structure.
-
-### Widgets
-
-Practical documentation for each widget: when to use it, how it behaves, and how it fits into the framework.
-
-### Design System
-
-Semantic colors, variants, typography, icons, and theming.
-
-### Platform
-
-How Tk and ttk work under the hood — behavior, constraints, and mechanics rather than usage patterns.
-
-### Capabilities
-
-Reference pages for framework features such as signals, localization, layout properties, and state handling — what each capability is and how it's defined.
-
-### Tooling
-
-The CLI, project structure, and packaging — everything you need to scaffold, run, and distribute a bootstack application.
-
-### API Reference
-
-Auto-generated reference for classes, methods, and functions.
-
-### Showcase
-
-Example applications and a gallery of what's been built with bootstack.
-
----
-
-## Where to start
-
-If you're new to bootstack:
-
-1. Begin with **Getting Started**
-2. Read the **Guides** relevant to your task
-3. Refer to **Widgets** for specifics
-4. Reach for **Capabilities** and **Platform** when you need deeper understanding
-5. See **Tooling** when you're ready to ship
-
-If you're coming from Tkinter, the layout, styling, and state conventions are where bootstack diverges most — those are worth reading before reaching for the API reference.
+<div class="bs-hero">
+  <div class="bs-hero__content">
+    <h1 class="bs-hero__title">Modern desktop apps in pure Python.</h1>
+    <p class="bs-hero__lede">bootstack is a batteries-included Tk framework — themed widgets, reactive state, layout containers, and a CLI that takes you from scaffold to ship.</p>
+    <p class="bs-hero__byline">bootstack is the successor to <a href="https://github.com/israel-dryer/ttkbootstrap">ttkbootstrap</a>.</p>
+    <div class="bs-hero__cta">
+      <a href="getting-started/installation/" class="bs-hero__btn bs-hero__btn--primary">Get started</a>
+      <a href="guides/" class="bs-hero__btn bs-hero__btn--ghost">Read the docs</a>
+    </div>
+  </div>
+  <div class="bs-hero__visual" aria-hidden="true">
+    <span class="bs-hero__glow"></span>
+    <img src="assets/bootstack-icon.png" alt="">
+  </div>
+</div>

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -3,3 +3,170 @@
 
 [data-md-color-scheme="slate"] .only-dark { display: block; }
 [data-md-color-scheme="slate"] .only-light { display: none; }
+
+/* =============================================================
+   Homepage hero
+   ============================================================= */
+
+.bs-hero {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr);
+  gap: 3rem;
+  align-items: center;
+  padding: 4rem 3rem;
+  margin: 0 0 3rem;
+  border-radius: 1rem;
+  background:
+    radial-gradient(ellipse at 80% 30%, rgba(13, 110, 253, 0.30), transparent 60%),
+    radial-gradient(ellipse at 30% 90%, rgba(102, 16, 242, 0.28), transparent 60%),
+    #0b0d12;
+  color: #fff;
+  overflow: hidden;
+}
+
+.bs-hero::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, transparent 0%, rgba(0, 0, 0, 0.2) 100%);
+  pointer-events: none;
+}
+
+@media (max-width: 900px) {
+  .bs-hero {
+    grid-template-columns: 1fr;
+    text-align: center;
+    padding: 3rem 1.5rem;
+    gap: 2rem;
+  }
+}
+
+.bs-hero__content {
+  position: relative;
+  z-index: 1;
+}
+
+.bs-hero__title {
+  font-size: clamp(2.25rem, 5vw, 3.75rem);
+  font-weight: 800;
+  line-height: 1.05;
+  letter-spacing: -0.02em;
+  margin: 0 0 1.25rem;
+  color: #fff;
+  background: linear-gradient(135deg, #ffffff 0%, #b3c7ff 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.bs-hero__lede {
+  font-size: 1.125rem;
+  line-height: 1.6;
+  color: rgba(255, 255, 255, 0.78);
+  margin: 0 0 0.75rem;
+  max-width: 42ch;
+}
+
+@media (max-width: 900px) {
+  .bs-hero__lede { margin-left: auto; margin-right: auto; }
+}
+
+.bs-hero__byline {
+  font-style: italic;
+  font-size: 0.95rem;
+  color: rgba(255, 255, 255, 0.6);
+  margin: 0 0 2rem;
+}
+
+.bs-hero__byline a {
+  color: rgba(255, 255, 255, 0.85);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.bs-hero__cta {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+@media (max-width: 900px) {
+  .bs-hero__cta { justify-content: center; }
+}
+
+.md-typeset .bs-hero__btn,
+.bs-hero__btn {
+  display: inline-block;
+  padding: 0.75rem 1.5rem;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.95rem;
+  text-decoration: none;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+}
+
+.md-typeset .bs-hero__btn:hover,
+.bs-hero__btn:hover {
+  text-decoration: none;
+}
+
+.md-typeset .bs-hero__btn--primary,
+.bs-hero__btn--primary {
+  background: linear-gradient(135deg, #0d6efd 0%, #6610f2 100%);
+  color: #fff;
+  box-shadow: 0 4px 16px rgba(13, 110, 253, 0.35);
+}
+
+.md-typeset .bs-hero__btn--primary:hover,
+.bs-hero__btn--primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 22px rgba(13, 110, 253, 0.5);
+  color: #fff;
+}
+
+.md-typeset .bs-hero__btn--ghost,
+.bs-hero__btn--ghost {
+  background: rgba(255, 255, 255, 0.08);
+  color: #fff;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+}
+
+.md-typeset .bs-hero__btn--ghost:hover,
+.bs-hero__btn--ghost:hover {
+  background: rgba(255, 255, 255, 0.14);
+  color: #fff;
+}
+
+.bs-hero__visual {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 320px;
+  z-index: 1;
+}
+
+.bs-hero__glow {
+  position: absolute;
+  inset: 10%;
+  background:
+    radial-gradient(circle at 50% 50%, rgba(13, 110, 253, 0.55), transparent 60%),
+    radial-gradient(circle at 30% 70%, rgba(102, 16, 242, 0.45), transparent 65%);
+  filter: blur(50px);
+  border-radius: 50%;
+  z-index: 0;
+}
+
+.bs-hero__visual img {
+  position: relative;
+  z-index: 1;
+  width: min(60%, 260px);
+  height: auto;
+  filter: drop-shadow(0 0 30px rgba(102, 16, 242, 0.55));
+}
+
+@media (max-width: 900px) {
+  .bs-hero__visual { min-height: 220px; }
+}
+

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+
+{% block announce %}
+  <strong>bootstack is in active alpha.</strong> APIs may change before the first stable release.
+  Install with <code>pip install --pre bootstack</code>.
+  &nbsp;·&nbsp;
+  <a href="https://github.com/israel-dryer/bootstack/issues">Report an issue</a>
+{% endblock %}

--- a/zensical.toml
+++ b/zensical.toml
@@ -5,13 +5,16 @@ site_author = "Israel Dryer"
 site_url = "https://www.bootstack.com"
 copyright = "Copyright &copy; 2021 - 2026 Israel Dryer"
 
+repo_url = "https://github.com/israel-dryer/bootstack"
+repo_name = "israel-dryer/bootstack"
+
 docs_dir = "docs"
 
 extra_css = ["stylesheets/extra.css"]
 
 nav = [
     { "Getting Started" = [
-        { "Overview" = "index.md" },
+        { "Overview" = "getting-started/index.md" },
         { "Installation" = "getting-started/installation.md" },
         { "Quick Start" = "getting-started/quick-start.md" },
     ] },
@@ -357,6 +360,7 @@ nav = [
 language = "en"
 favicon = "assets/favicon.ico"
 logo = "assets/bootstack-icon.png"
+custom_dir = "overrides"
 
 features = [
     "navigation.tabs",
@@ -367,6 +371,7 @@ features = [
     "navigation.top",
     "content.code.copy",
     "search.highlight",
+    "announce.dismiss",
 ]
 
 [[project.theme.palette]]


### PR DESCRIPTION
## Summary

- Replace the docs homepage with a hero-style landing page: dark gradient background, blue→indigo gradient CTA, ghost outline secondary, glow + `bootstack-icon.png` visual, italic byline linking to ttkbootstrap. Page hides nav/toc/footer for a true landing-page feel.
- Add a dismissible **pre-release announcement banner** via Zensical's `announce.dismiss` feature, served from a new `overrides/main.html` template (`custom_dir = "overrides"`).
- Show the **GitHub repo link** in the site header (`repo_url` / `repo_name`).
- Update install instructions in README and `docs/getting-started/installation.md` to use `pip install --pre bootstack` while in alpha, with a note about pinning to a specific version.
- Fix the README banner image to use an absolute `raw.githubusercontent.com` URL so it renders correctly on the PyPI project page (relative paths break there). Takes effect on the next release.
- Nav restructure: "Getting Started → Overview" now points to `getting-started/index.md` (its own dedicated overview) instead of the site root, since the site root is now the landing page.

## Test plan

- [ ] `zensical serve` and visit `/`
  - [ ] Pre-release banner shows at top with dismissible X
  - [ ] Header shows "bootstack" next to logo and `israel-dryer/bootstack` link top-right
  - [ ] Hero renders dark with gradient headline, italic byline, two CTAs (white button text)
  - [ ] Logo (top-left) navigates back to `/`
- [ ] Resize to ~900px — hero stacks vertically and centers
- [ ] Visit `/getting-started/` — Overview page renders, sidebar nav intact
- [ ] Other docs pages unaffected (header shows site name, sidebar nav present)
- [ ] Install docs show `pip install --pre bootstack` and the pin-to-version note
- [ ] README renders on GitHub with banner image
- [ ] After next PyPI release, README banner displays on the PyPI project page

🤖 Generated with [Claude Code](https://claude.com/claude-code)