### PR TITLE
Fix toast positioned off-screen on Windows with multiple monitors

### DIFF
--- a/src/bootstack/runtime/window_utilities.py
+++ b/src/bootstack/runtime/window_utilities.py
@@ -224,11 +224,18 @@ import bootstack.runtime.toplevel            >>> parent = tkinter.Tk()
         w_width = window.winfo_reqwidth()
         w_height = window.winfo_reqheight()
 
-        # Use virtual root for multi-monitor support
-        screen_x0 = window.winfo_vrootx()
-        screen_y0 = window.winfo_vrooty()
-        screen_width = window.winfo_vrootwidth()
-        screen_height = window.winfo_vrootheight()
+        # Use the monitor containing the proposed position when screeninfo is
+        # available — on Windows, winfo_vroot* only covers the primary monitor,
+        # so clamping with it moves windows that legitimately belong on a
+        # secondary monitor back onto the primary.
+        monitor = WindowPositioning._get_monitor_at_point(x, y)
+        if monitor:
+            screen_x0, screen_y0, screen_width, screen_height = monitor
+        else:
+            screen_x0 = window.winfo_vrootx()
+            screen_y0 = window.winfo_vrooty()
+            screen_width = window.winfo_vrootwidth()
+            screen_height = window.winfo_vrootheight()
 
         # Calculate screen boundaries
         screen_x1 = screen_x0 + screen_width

--- a/src/bootstack/widgets/composites/toast.py
+++ b/src/bootstack/widgets/composites/toast.py
@@ -311,7 +311,14 @@ class Toast:
 
         # ------ Positioning -------
 
-        # Update layout to get final window size
+        # Deiconify off-screen first so the geometry manager runs a full
+        # layout pass on a mapped window. winfo_height() returns 1 on a
+        # withdrawn window, causing the toast to be placed with ~0 height
+        # and therefore positioned flush against the screen edge.
+        top.deiconify()
+        top.geometry(
+            f"+{top.winfo_screenwidth() * 2}+{top.winfo_screenheight() * 2}"
+        )
         top.update_idletasks()
 
         # Apply positioning using WindowPositioning utilities


### PR DESCRIPTION
Two issues combined to push the toast below the visible screen area:

1. window_utilities.ensure_on_screen used winfo_vrootwidth/height, which on Windows only covers the primary monitor. A toast legitimately on a secondary monitor was clamped back to primary-monitor bounds, producing a mismatched position.

2. Toast height was measured on a withdrawn (never-mapped) window, where winfo_height() returns 1. The near-zero height caused the SE-anchor offset to place the top edge of the toast flush with the screen bottom, so the full window body extended off-screen.

Fix (1): ensure_on_screen now resolves the monitor containing the proposed position via screeninfo and clamps to that monitor's bounds.

Fix (2): _build_toast deiconifies the window off-screen before calling update_idletasks(), so the geometry manager runs a full layout pass on a mapped window and winfo_height() returns the actual rendered height.