### PR TITLE
fix(timeentry): move __future__ import to top of file

### DIFF
--- a/src/bootstack/widgets/composites/timeentry.py
+++ b/src/bootstack/widgets/composites/timeentry.py
@@ -4,8 +4,9 @@ Provides a specialized entry field for time input with a searchable dropdown
 list of time values at specified intervals.
 """
 
-import datetime
 from __future__ import annotations
+
+import datetime
 from bootstack.core.localization.intl_format import DateFormatSpec
 
 from typing_extensions import Unpack


### PR DESCRIPTION
from __future__ imports must be the first statement in a module (after the docstring). timeentry.py had `import datetime` before it, which raised a SyntaxError at import time.