### PR TITLE
perf: fix progressive theme-change and page-load slowdown

### DIFF
--- a/src/bootstack/style/bootstyle.py
+++ b/src/bootstack/style/bootstyle.py
@@ -483,15 +483,10 @@ class Bootstyle:
             # ==== Update widget style & register for theme changes =====
 
             from bootstack.style.style import get_style
-            from bootstack.style.bootstyle_builder_tk import BootstyleBuilderBuilderTk
             style = get_style()
-            builder_tk = BootstyleBuilderBuilderTk(
-                theme_provider=style.theme_provider if style else None,
-                style_instance=style
-            )
             surface = getattr(self, '_surface', 'content')
-            builder_tk.call_builder(self, surface=surface)
-
+            style._get_tk_builder().call_builder(self, surface=surface)
+            self._bs_theme_version = style._theme_version
             style.register_tk_widget(self)
 
         return __init__wrapper

--- a/src/bootstack/style/style.py
+++ b/src/bootstack/style/style.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import tkinter
 import weakref
 from tkinter.ttk import Style as ttkStyle
 from typing import Dict, Optional, Set
@@ -77,6 +78,12 @@ class Style(ttkStyle):
 
         # Track legacy Tk widgets for theme-change restyling
         self._tk_widgets = weakref.WeakSet()
+
+        # Incremented on every theme change so widgets can detect a missed restyle
+        self._theme_version: int = 0
+
+        # Cached Tk builder — lazily initialized, reused across all widget creations
+        self._cached_tk_builder = None
 
         self.theme_use(theme)
         self._initialized = True
@@ -177,9 +184,13 @@ class Style(ttkStyle):
             accent: Optional accent token (e.g., "success", "blue[100]")
             options: Optional custom style options
         """
-        # Check if already exists in this theme
+        # Fast path: Python-side set lookup before crossing into Tcl
+        if ttk_style in self._style_registry:
+            return
+        # Fallback for styles known to Tcl but not our registry (e.g. external theme changes)
         if self.style_exists(ttk_style):
-            return  # Already created for this theme
+            self.register_style(ttk_style, options)
+            return
 
         # Call builder with widget class, variant, and parsed accent
         self._style_builder.call_builder(
@@ -229,6 +240,9 @@ class Style(ttkStyle):
 
         self._rebuild_all_styles()
 
+        # Bump version so hidden widgets know they missed this theme change
+        self._theme_version += 1
+
         # Re-apply Tk widget styling (legacy widgets)
         self._rebuild_all_tk_widgets()
 
@@ -275,21 +289,60 @@ class Style(ttkStyle):
                 **options
             )
 
+    def _get_tk_builder(self):
+        """Return the cached Tk builder, creating it on first call."""
+        if self._cached_tk_builder is None:
+            from bootstack.style.bootstyle_builder_tk import BootstyleBuilderBuilderTk
+            self._cached_tk_builder = BootstyleBuilderBuilderTk(
+                theme_provider=self._theme_provider,
+                style_instance=self,
+            )
+        return self._cached_tk_builder
+
+    def _restyle_single_tk_widget(self, widget) -> None:
+        """Restyle one Tk widget and stamp it with the current theme version."""
+        try:
+            surface = getattr(widget, '_surface', 'content')
+            self._get_tk_builder().call_builder(widget, surface=surface)
+            widget._bs_theme_version = self._theme_version
+        except Exception:
+            pass
+
     def register_tk_widget(self, widget) -> None:
         """Register a Tk widget to be restyled on theme changes."""
         self._tk_widgets.add(widget)
 
-    def _rebuild_all_tk_widgets(self) -> None:
-        """Restyle all registered Tk widgets on theme change."""
-        from bootstack.style.bootstyle_builder_tk import BootstyleBuilderBuilderTk
-        builder_tk = BootstyleBuilderBuilderTk(theme_provider=self._theme_provider, style_instance=self)
+        # Lazily restyle if a theme change happened while the widget was hidden.
+        # <Map> fires when a widget transitions from unmapped to mapped (e.g. when
+        # its page is shown after pack_forget), so this is the right hook point.
+        style = self
 
+        def _on_map(event):
+            w = event.widget
+            if getattr(w, '_bs_theme_version', -1) != style._theme_version:
+                style._restyle_single_tk_widget(w)
+
+        # Use BaseWidget.bind to bypass any bind() override on subclasses
+        # (e.g. _MultilineCore forwards bind() to self.text, which doesn't exist
+        # yet when this is called from inside __init__).
+        tkinter.BaseWidget.bind(widget, '<Map>', _on_map, add='+')
+
+    def _rebuild_all_tk_widgets(self) -> None:
+        """Restyle all currently visible Tk widgets on theme change.
+
+        Widgets that are hidden (winfo_viewable() == 0, e.g. on a background page)
+        are skipped here — their <Map> handler will restyle them the next time
+        their page is shown.
+        """
+        version = self._theme_version
         for widget in list(self._tk_widgets):
             try:
-                surface = getattr(widget, '_surface', 'background')
-                builder_tk.call_builder(widget, surface=surface)
+                if not widget.winfo_viewable():
+                    continue  # deferred to <Map> handler
+                surface = getattr(widget, '_surface', 'content')
+                self._get_tk_builder().call_builder(widget, surface=surface)
+                widget._bs_theme_version = version
             except Exception:
-                # ignore incompatible or unmapped widgets
                 pass
 
     @staticmethod

--- a/src/bootstack/widgets/composites/floodgauge.py
+++ b/src/bootstack/widgets/composites/floodgauge.py
@@ -98,9 +98,10 @@ class FloodGauge(ConfigureDelegationMixin, Canvas):
 
         self.bind("<Configure>", self._on_resize)
 
-        # Bind to root to receive theme change events
         root = self.nametowidget('.')
-        root.bind('<<ThemeChanged>>', lambda e: self._update_theme_colors(), add='+')
+        _tid = root.bind('<<ThemeChanged>>', lambda e: self._update_theme_colors(), add='+')
+        self.bind("<Destroy>", lambda e, r=root, b=_tid: r.unbind("<<ThemeChanged>>", b), add="+")
+        self.bind("<Map>", lambda e: self._on_map(), add="+")
 
         self._draw()
 
@@ -251,6 +252,10 @@ class FloodGauge(ConfigureDelegationMixin, Canvas):
         self._text = self._textvariable.get()
         self._draw()
 
+    def _on_map(self) -> None:
+        if getattr(self, '_theme_update_pending', False):
+            self._update_theme_colors()
+
     def _update_theme_colors(self) -> None:
         """Update widget colors based on current theme and accent."""
         from bootstack.style.style import get_style
@@ -260,6 +265,10 @@ class FloodGauge(ConfigureDelegationMixin, Canvas):
         self._bar_color = b.color(self._accent)
         self._trough_color = b.border(b.subtle(self._accent, surface))
         self._text_color = b.on_color(self._bar_color)
+        if not self.winfo_viewable():
+            self._theme_update_pending = True
+            return
+        self._theme_update_pending = False
         self._draw()
 
     def _on_resize(self, event: Event) -> None:

--- a/src/bootstack/widgets/composites/slider/rangeslider.py
+++ b/src/bootstack/widgets/composites/slider/rangeslider.py
@@ -269,7 +269,9 @@ class RangeSlider(ConfigureDelegationMixin, tk.Frame):
         self._lo_var.trace_add("write", self._on_lo_write)
         self._hi_var.trace_add("write", self._on_hi_write)
         root = self.nametowidget(".")
-        root.bind("<<ThemeChanged>>", lambda e: self._on_theme_changed(), add="+")
+        _tid = root.bind("<<ThemeChanged>>", lambda e: self._on_theme_changed(), add="+")
+        self.bind("<Destroy>", lambda e, r=root, b=_tid: r.unbind("<<ThemeChanged>>", b), add="+")
+        self.bind("<Map>", lambda e: self._on_map(), add="+")
 
     # ------------------------------------------------------------------
     # Layout helpers
@@ -622,7 +624,15 @@ class RangeSlider(ConfigureDelegationMixin, tk.Frame):
         self._prev_lovalue = lo
         self._prev_hivalue = hi
 
+    def _on_map(self) -> None:
+        if getattr(self, '_theme_update_pending', False):
+            self._on_theme_changed()
+
     def _on_theme_changed(self) -> None:
+        if not self.winfo_viewable():
+            self._theme_update_pending = True
+            return
+        self._theme_update_pending = False
         self._colors = resolve_colors(self._accent, self._surface, get_widget_bg(self.master))
         colors = self._colors
         self.configure(

--- a/src/bootstack/widgets/composites/slider/slider.py
+++ b/src/bootstack/widgets/composites/slider/slider.py
@@ -268,7 +268,9 @@ class Slider(ConfigureDelegationMixin, tk.Frame):
 
         self._var.trace_add("write", self._on_var_write)
         root = self.nametowidget(".")
-        root.bind("<<ThemeChanged>>", lambda e: self._on_theme_changed(), add="+")
+        _tid = root.bind("<<ThemeChanged>>", lambda e: self._on_theme_changed(), add="+")
+        self.bind("<Destroy>", lambda e, r=root, b=_tid: r.unbind("<<ThemeChanged>>", b), add="+")
+        self.bind("<Map>", lambda e: self._on_map(), add="+")
 
     # ------------------------------------------------------------------
     # Layout helpers
@@ -551,7 +553,15 @@ class Slider(ConfigureDelegationMixin, tk.Frame):
         self._var.set(new)
         self.event_generate("<<Commit>>", data={"value": new})
 
+    def _on_map(self) -> None:
+        if getattr(self, '_theme_update_pending', False):
+            self._on_theme_changed()
+
     def _on_theme_changed(self) -> None:
+        if not self.winfo_viewable():
+            self._theme_update_pending = True
+            return
+        self._theme_update_pending = False
         self._colors = resolve_colors(self._accent, self._surface, get_widget_bg(self.master))
         colors = self._colors
         self.configure(

--- a/src/bootstack/widgets/primitives/frame.py
+++ b/src/bootstack/widgets/primitives/frame.py
@@ -10,7 +10,6 @@ from bootstack._core.mixins.widget import WidgetCapabilitiesMixin
 from bootstack.widgets._internal.wrapper_base import TTKWrapperBase
 from bootstack.widgets.types import Master, StyledKwargs
 from bootstack.style.style import get_style
-from bootstack.style.bootstyle_builder_tk import BootstyleBuilderBuilderTk
 from ..mixins import configure_delegate
 
 
@@ -92,10 +91,7 @@ class Frame(TTKWrapperBase, WidgetCapabilitiesMixin, TtkStateMixin, ttk.Frame):
             return
 
         style = get_style()
-        builder_tk = BootstyleBuilderBuilderTk(
-            theme_provider=style.theme_provider if style else None,
-            style_instance=style,
-        )
+        builder_tk = style._get_tk_builder()
 
         for child in self._iter_descendants():
             try:
@@ -136,10 +132,7 @@ class Frame(TTKWrapperBase, WidgetCapabilitiesMixin, TtkStateMixin, ttk.Frame):
             return
 
         style = get_style()
-        builder_tk = BootstyleBuilderBuilderTk(
-            theme_provider=style.theme_provider if style else None,
-            style_instance=style,
-        )
+        builder_tk = style._get_tk_builder()
 
         for child in self._iter_descendants():
             try:


### PR DESCRIPTION
## Summary

- **Root cause**: `Slider`, `RangeSlider`, and `FloodGauge` called `root.bind("<<ThemeChanged>>", handler, add="+")` in their constructors. Because gallery pages are hidden with `pack_forget()` (never destroyed), these bindings accumulated on the root window forever — visiting N pages meant N×(widgets/page) callbacks all firing synchronously on every theme change.
- **Secondary cause**: `create_style()` made a Tcl round-trip (`self.configure(style_name)`) to check if a TTK style existed, even for styles already in the Python-side registry — once per widget creation.
- **Tertiary cause**: `BootstyleBuilderBuilderTk` was instantiated fresh on every `tk.Frame`/`Canvas` creation instead of being cached.

## Changes

**`slider.py` / `rangeslider.py` / `floodgauge.py`**
- Track `root.bind` ID and unbind on `<Destroy>`
- Add `winfo_viewable()` guard in theme-change handler — skip canvas work when widget is on a hidden page, set `_theme_update_pending = True`
- Add `<Map>` binding to apply deferred update when the page is shown again

**`style.py`**
- `create_style()`: check `_style_registry` (Python set) before calling into Tcl
- `_rebuild_all_tk_widgets()`: skip hidden widgets (`winfo_viewable() == 0`), defer restyle to `<Map>` handler via `_theme_version` counter
- Cache `BootstyleBuilderBuilderTk` as singleton on `Style` (`_get_tk_builder()`)
- `register_tk_widget()`: use `tkinter.BaseWidget.bind` to bypass subclass `bind()` overrides (fixes `_MultilineCore` crash)

**`frame.py`**
- Use `style._get_tk_builder()` in surface/input-background refresh helpers instead of creating a new instance

## Test plan

- [ ] Open gallery demo, visit all pages — no errors, no progressive slowdown on page load
- [ ] Toggle theme repeatedly after visiting many pages — theme change should feel instant regardless of how many pages have been visited
- [ ] Navigate away from a page, change theme, navigate back — widget colors should be correct (deferred restyle via `<Map>`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)