### PR TITLE
feat(public): Label and Badge

### DIFF
--- a/src/bootstack/widgets/public/__init__.py
+++ b/src/bootstack/widgets/public/__init__.py
@@ -7,14 +7,17 @@ from bootstack.widgets.public.stacks import HStack, VStack
 from bootstack.widgets.public.grid import Grid
 from bootstack.widgets.public.app import App
 from bootstack.widgets.public.primitives.button import Button
+from bootstack.widgets.public.primitives.label import Badge, Label
 
 __all__ = [
     "App",
-    "Button",
+    "Badge",
     "BootstackV2Error",
+    "Button",
     "Event",
     "Grid",
     "HStack",
+    "Label",
     "ParentResolutionError",
     "PublicContainer",
     "PublicWidgetBase",

--- a/src/bootstack/widgets/public/primitives/__init__.py
+++ b/src/bootstack/widgets/public/primitives/__init__.py
@@ -1,3 +1,4 @@
 from bootstack.widgets.public.primitives.button import Button
+from bootstack.widgets.public.primitives.label import Badge, Label
 
-__all__ = ["Button"]
+__all__ = ["Badge", "Button", "Label"]

--- a/src/bootstack/widgets/public/primitives/label.py
+++ b/src/bootstack/widgets/public/primitives/label.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from bootstack.widgets.primitives.label import Label as _InternalLabel
+from bootstack.widgets.primitives.badge import Badge as _InternalBadge
+from bootstack.widgets.public.base import PublicWidgetBase
+from bootstack.widgets.public.events import register_widget_events
+
+
+class Label(PublicWidgetBase):
+    """Static text or formatted value display.
+
+    Args:
+        text: Text to display.
+        text_signal: Reactive `Signal` linked to the label text.
+        icon: Bootstrap Icons name.
+        icon_only: If True, show only the icon.
+        anchor: Content alignment within the label area.
+        justify: Multi-line text justification.
+        padding: Inner spacing.
+        width: Width in character cells.
+        wrap_width: Maximum pixel width before text wraps.
+        font: Font token string.
+        color: Text color.
+        background_color: Background color.
+        relief: Border style.
+        disabled: If True, widget is non-interactive.
+        localize: Localization mode.
+        value_format: Format spec applied to the signal value.
+        accent: Accent token, e.g. `'primary'`.
+        variant: Style variant.
+        surface: Surface token.
+        parent: Override the context-stack parent.
+    """
+
+    _internal_class = _InternalLabel
+
+    def __init__(
+        self,
+        text: str = "",
+        *,
+        text_signal: Any = None,
+        icon: str | None = None,
+        icon_only: bool = False,
+        anchor: str | None = None,
+        justify: str | None = None,
+        padding: Any = None,
+        width: int | None = None,
+        wrap_width: int | None = None,
+        font: Any = None,
+        color: str | None = None,
+        background_color: str | None = None,
+        relief: str | None = None,
+        disabled: bool = False,
+        localize: Any = None,
+        value_format: Any = None,
+        accent: str | None = None,
+        variant: str | None = None,
+        surface: str | None = None,
+        parent: Any = None,
+        **kwargs: Any,
+    ) -> None:
+        self._parent = self._resolve_parent(parent)
+        layout_kw = self._split_layout_kwargs(kwargs)
+
+        tk_master = self._parent._child_master() if self._parent else None
+
+        internal_kwargs: dict[str, Any] = {}
+        if text:
+            internal_kwargs["text"] = text
+        if text_signal is not None:
+            internal_kwargs["textsignal"] = text_signal
+        if icon is not None:
+            internal_kwargs["icon"] = icon
+        if icon_only:
+            internal_kwargs["icon_only"] = True
+        if anchor is not None:
+            internal_kwargs["anchor"] = anchor
+        if justify is not None:
+            internal_kwargs["justify"] = justify
+        if padding is not None:
+            internal_kwargs["padding"] = padding
+        if width is not None:
+            internal_kwargs["width"] = width
+        if wrap_width is not None:
+            internal_kwargs["wraplength"] = wrap_width
+        if font is not None:
+            internal_kwargs["font"] = font
+        if color is not None:
+            internal_kwargs["foreground"] = color
+        if background_color is not None:
+            internal_kwargs["background"] = background_color
+        if relief is not None:
+            internal_kwargs["relief"] = relief
+        if disabled:
+            internal_kwargs["state"] = "disabled"
+        if localize is not None:
+            internal_kwargs["localize"] = localize
+        if value_format is not None:
+            internal_kwargs["value_format"] = value_format
+        if accent is not None:
+            internal_kwargs["accent"] = accent
+        if variant is not None:
+            internal_kwargs["variant"] = variant
+        if surface is not None:
+            internal_kwargs["surface"] = surface
+        internal_kwargs.update(kwargs)
+
+        self._internal = self._internal_class(tk_master, **internal_kwargs)
+        self._attach_to_parent(layout_kw)
+
+    # ----- Properties -----
+
+    @property
+    def text(self) -> str:
+        return str(self._internal.cget("text"))
+
+    @text.setter
+    def text(self, value: str) -> None:
+        self._internal.configure(text=value)
+
+    @property
+    def color(self) -> str:
+        return str(self._internal.cget("foreground"))
+
+    @color.setter
+    def color(self, value: str) -> None:
+        self._internal.configure(foreground=value)
+
+    @property
+    def disabled(self) -> bool:
+        return str(self._internal.cget("state")) == "disabled"
+
+    @disabled.setter
+    def disabled(self, value: bool) -> None:
+        self._internal.configure(state="disabled" if value else "normal")
+
+    # ----- Event shorthands -----
+
+    def on_click(self, handler: Callable[[], Any]):
+        """Register a click handler.
+
+        Returns:
+            Subscription — call `.cancel()` to unsubscribe.
+        """
+        return self.on("click", lambda e: handler())
+
+
+register_widget_events(Label, {})
+
+
+class Badge(Label):
+    """Compact styled pill or square for status, counts, and tags.
+
+    Inherits all `Label` kwargs. Icon and image kwargs are accepted but
+    ignored at render time — the badge style layout omits the image element.
+
+    Args:
+        text: Text to display.
+        accent: Accent token, e.g. `'primary'`, `'success'`, `'danger'`.
+        variant: `'square'` (default) or `'pill'`.
+        parent: Override the context-stack parent.
+    """
+
+    _internal_class = _InternalBadge
+
+    def __init__(
+        self,
+        text: str = "",
+        *,
+        accent: str = "primary",
+        variant: str = "square",
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(text, accent=accent, variant=variant, **kwargs)
+
+
+register_widget_events(Badge, {})

--- a/tests/features/label_badge.py
+++ b/tests/features/label_badge.py
@@ -1,0 +1,63 @@
+"""Visual test for public Label and Badge widgets."""
+from bootstack.widgets.public import App, VStack, HStack, Label, Badge, Button
+from bootstack.signals import Signal
+
+
+def main():
+    with App(title="Label + Badge — visual test", minsize=(480, 200), padding=24, gap=16) as app:
+
+        counter = Signal(0)
+        status = Signal("idle")
+        counter_label_signal = Signal("0")
+
+        def increment():
+            counter.set(counter.get() + 1)
+            counter_label_signal.set(str(counter.get()))
+
+        def toggle_status():
+            status.set("running" if status.get() == "idle" else "idle")
+
+        # Plain text labels
+        with VStack(gap=6):
+            Label("Plain label — default style")
+            Label("Colored label", color="#e63946")
+            Label("Muted label", color="#6c757d")
+            Label(
+                "Wrapped label — lorem ipsum dolor sit amet consectetur adipiscing elit",
+                wrap_width=300,
+            )
+
+        # Reactive label
+        with HStack(gap=8, anchor_items="center"):
+            Label("Counter:")
+            Label(text_signal=counter_label_signal)
+            Button("Increment", on_click=increment, accent="primary", variant="outline")
+
+        # Status toggle
+        with HStack(gap=8, anchor_items="center"):
+            Label("Status:")
+            Label(text_signal=status)
+            Button("Toggle", on_click=toggle_status, variant="outline")
+
+        # Badges — square
+        Label("Badges — square (default)")
+        with HStack(gap=6):
+            for accent in ("primary", "success", "warning", "danger"):
+                Badge(accent, accent=accent)
+
+        # Badges — pill
+        Label("Badges — pill variant")
+        with HStack(gap=6):
+            for accent in ("primary", "success", "warning", "danger"):
+                Badge(accent, accent=accent, variant="pill")
+
+        # Count indicator
+        with HStack(gap=8, anchor_items="center"):
+            Label("Messages")
+            Badge("99+", accent="danger", variant="pill")
+
+    app.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/widgets/public/test_label_badge.py
+++ b/tests/widgets/public/test_label_badge.py
@@ -1,0 +1,108 @@
+"""Tests for public Label and Badge widgets."""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def app_ctx():
+    from bootstack.widgets.public import App, VStack
+    with App() as app:
+        with VStack() as stack:
+            yield stack
+    app._tk_root.destroy()
+
+
+@pytest.mark.gui
+def test_label_text_positional(app_ctx):
+    from bootstack.widgets.public import Label
+    lbl = Label("Hello")
+    assert lbl.text == "Hello"
+
+
+@pytest.mark.gui
+def test_label_text_property_rw(app_ctx):
+    from bootstack.widgets.public import Label
+    lbl = Label("initial")
+    lbl.text = "updated"
+    assert lbl.text == "updated"
+
+
+@pytest.mark.gui
+def test_label_color_kwarg(app_ctx):
+    from bootstack.widgets.public import Label
+    lbl = Label("Hi", color="#ff0000")
+    assert lbl.color == "#ff0000"
+
+
+@pytest.mark.gui
+def test_label_color_property_rw(app_ctx):
+    from bootstack.widgets.public import Label
+    lbl = Label("Hi")
+    lbl.color = "#00ff00"
+    assert lbl.color == "#00ff00"
+
+
+@pytest.mark.gui
+def test_label_disabled_kwarg(app_ctx):
+    from bootstack.widgets.public import Label
+    lbl = Label("Hi", disabled=True)
+    assert lbl.disabled is True
+
+
+@pytest.mark.gui
+def test_label_disabled_property_rw(app_ctx):
+    from bootstack.widgets.public import Label
+    lbl = Label("Hi")
+    assert lbl.disabled is False
+    lbl.disabled = True
+    assert lbl.disabled is True
+    lbl.disabled = False
+    assert lbl.disabled is False
+
+
+@pytest.mark.gui
+def test_label_wrap_width_maps_to_wraplength(app_ctx):
+    from bootstack.widgets.public import Label
+    lbl = Label("Long text", wrap_width=200)
+    assert int(lbl.tk.cget("wraplength")) == 200
+
+
+@pytest.mark.gui
+def test_label_tk_is_internal_label(app_ctx):
+    from bootstack.widgets.public import Label
+    from bootstack.widgets.primitives.label import Label as _InternalLabel
+    lbl = Label("Hi")
+    assert isinstance(lbl.tk, _InternalLabel)
+
+
+@pytest.mark.gui
+def test_badge_defaults(app_ctx):
+    from bootstack.widgets.public import Badge
+    b = Badge("99+")
+    assert b.text == "99+"
+
+
+@pytest.mark.gui
+def test_badge_is_label_subclass():
+    from bootstack.widgets.public import Badge, Label
+    assert issubclass(Badge, Label)
+
+
+@pytest.mark.gui
+def test_badge_tk_is_internal_badge(app_ctx):
+    from bootstack.widgets.public import Badge
+    from bootstack.widgets.primitives.badge import Badge as _InternalBadge
+    b = Badge("new")
+    assert isinstance(b.tk, _InternalBadge)
+
+
+@pytest.mark.gui
+def test_label_text_signal(app_ctx):
+    from bootstack.widgets.public import Label
+    from bootstack.signals import Signal
+    sig = Signal("initial")
+    lbl = Label(text_signal=sig)
+    assert lbl.text == "initial"
+    sig.set("updated")
+    assert lbl.text == "updated"


### PR DESCRIPTION
## Summary

- Adds `widgets/public/primitives/label.py` with `Label` and `Badge`
- Public API renames: `color=` (was `foreground=`), `background_color=`, `wrap_width=` (was `wraplength=`), `text_signal=` (was `textsignal=`), `disabled: bool` property
- `Badge` inherits `Label` via `_internal_class` class variable — shared constructor, different internal widget
- 13 GUI-gated tests covering text, color, disabled, wrap_width mapping, tk escape hatch, text_signal reactivity, Badge isinstance checks

## Test plan

- [ ] `pytest tests/widgets/public/ -m "not gui"` — 11 base-layer tests pass
- [ ] GUI tests pass with a display (`-m gui`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)