### PR TITLE
feat(public): Checkbox, Switch, and ToggleButton

### DIFF
--- a/src/bootstack/widgets/public/__init__.py
+++ b/src/bootstack/widgets/public/__init__.py
@@ -6,6 +6,7 @@ from bootstack.widgets.public.base import PublicWidgetBase
 from bootstack.widgets.public.stacks import HStack, VStack
 from bootstack.widgets.public.grid import Grid
 from bootstack.widgets.public.app import App
+from bootstack.widgets.public.primitives.boolean_controls import Checkbox, Switch, ToggleButton
 from bootstack.widgets.public.primitives.button import Button
 from bootstack.widgets.public.primitives.label import Badge, Label
 from bootstack.widgets.public.primitives.textfield import TextField
@@ -15,6 +16,7 @@ __all__ = [
     "Badge",
     "BootstackV2Error",
     "Button",
+    "Checkbox",
     "Event",
     "Grid",
     "HStack",
@@ -23,7 +25,9 @@ __all__ = [
     "PublicContainer",
     "PublicWidgetBase",
     "Subscription",
+    "Switch",
     "TextField",
+    "ToggleButton",
     "UnknownEventError",
     "VStack",
 ]

--- a/src/bootstack/widgets/public/primitives/__init__.py
+++ b/src/bootstack/widgets/public/primitives/__init__.py
@@ -1,5 +1,6 @@
+from bootstack.widgets.public.primitives.boolean_controls import Checkbox, Switch, ToggleButton
 from bootstack.widgets.public.primitives.button import Button
 from bootstack.widgets.public.primitives.label import Badge, Label
 from bootstack.widgets.public.primitives.textfield import TextField
 
-__all__ = ["Badge", "Button", "Label", "TextField"]
+__all__ = ["Badge", "Button", "Checkbox", "Label", "Switch", "TextField", "ToggleButton"]

--- a/src/bootstack/widgets/public/primitives/boolean_controls.py
+++ b/src/bootstack/widgets/public/primitives/boolean_controls.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import tkinter
+from typing import Any, Callable
+
+from bootstack.widgets.primitives.checkbutton import CheckButton as _InternalCheckButton
+from bootstack.widgets.primitives.switch import Switch as _InternalSwitch
+from bootstack.widgets.primitives.checktoggle import CheckToggle as _InternalCheckToggle
+from bootstack.widgets.public.base import PublicWidgetBase
+from bootstack.widgets.public.events import register_widget_events
+from bootstack.widgets.public.subscription import Subscription
+
+_BOOLEAN_EVENTS: dict[str, str] = {
+    "change":   "<<Change>>",
+    "check":    "<<ToggleOn>>",
+    "uncheck":  "<<ToggleOff>>",
+}
+
+
+class _BooleanControlBase(PublicWidgetBase):
+    """Shared base for Checkbox, Switch, and ToggleButton."""
+
+    _internal_class: type  # set by subclass
+
+    def __init__(
+        self,
+        label: str = "",
+        *,
+        signal: Any = None,
+        value: Any = None,
+        checked_value: Any = True,
+        unchecked_value: Any = False,
+        on_change: Callable[[], Any] | None = None,
+        icon: str | None = None,
+        icon_only: bool = False,
+        show_indicator: bool = True,
+        disabled: bool = False,
+        accent: str | None = None,
+        variant: str | None = None,
+        density: str | None = None,
+        parent: Any = None,
+        **kwargs: Any,
+    ) -> None:
+        self._parent = self._resolve_parent(parent)
+        layout_kw = self._split_layout_kwargs(kwargs)
+        self._checked_value = checked_value
+
+        tk_master = self._parent._child_master() if self._parent else None
+
+        # Ctor on_change callback — stored so the command wrapper can call it.
+        _ctor_callback = on_change
+
+        internal_kwargs: dict[str, Any] = {}
+        if label:
+            internal_kwargs["text"] = label
+        if signal is not None:
+            internal_kwargs["signal"] = signal
+        if checked_value is not True:
+            internal_kwargs["onvalue"] = checked_value
+        if unchecked_value is not False:
+            internal_kwargs["offvalue"] = unchecked_value
+        if icon is not None:
+            internal_kwargs["icon"] = icon
+        if icon_only:
+            internal_kwargs["icon_only"] = True
+        if not show_indicator:
+            internal_kwargs["show_indicator"] = False
+        if disabled:
+            internal_kwargs["state"] = "disabled"
+        if accent is not None:
+            internal_kwargs["accent"] = accent
+        if variant is not None:
+            internal_kwargs["variant"] = variant
+        if density is not None:
+            internal_kwargs["density"] = density
+        internal_kwargs.update(kwargs)
+
+        self._internal = self._internal_class(tk_master, **internal_kwargs)
+
+        # Seed initial value only when no signal was passed (mirrors internal behaviour).
+        if value is not None and signal is None:
+            self._internal.set(value)
+
+        # Wire command → virtual events so on_change() / on_check() subscriptions work.
+        def _command():
+            v = self._internal.get()
+            self._internal.event_generate("<<Change>>")
+            if v == self._checked_value:
+                self._internal.event_generate("<<ToggleOn>>")
+            else:
+                self._internal.event_generate("<<ToggleOff>>")
+            if _ctor_callback is not None:
+                _ctor_callback()
+
+        self._internal.configure(command=_command)
+        self._attach_to_parent(layout_kw)
+
+    # ----- Properties -----
+
+    @property
+    def value(self) -> Any:
+        return self._internal.get()
+
+    @value.setter
+    def value(self, v: Any) -> None:
+        self._internal.set(v)
+
+    @property
+    def checked(self) -> bool:
+        return self._internal.get() == self._checked_value
+
+    @checked.setter
+    def checked(self, v: bool) -> None:
+        self._internal.set(self._checked_value if v else self._internal.cget("offvalue"))
+
+    @property
+    def disabled(self) -> bool:
+        return str(self._internal.cget("state")) == "disabled"
+
+    @disabled.setter
+    def disabled(self, v: bool) -> None:
+        self._internal.configure(state="disabled" if v else "normal")
+
+    # ----- Methods -----
+
+    def toggle(self) -> None:
+        """Toggle the control's state programmatically."""
+        self._internal.invoke()
+
+    # ----- Event shorthands -----
+
+    def on_change(self, handler: Callable[[tkinter.Event], Any]) -> Subscription:
+        """Register a callback fired whenever the value changes.
+
+        Returns:
+            Subscription — call `.cancel()` to unsubscribe.
+        """
+        return self.on("change", handler)
+
+    def on_check(self, handler: Callable[[tkinter.Event], Any]) -> Subscription:
+        """Register a callback fired when the control is checked/selected.
+
+        Returns:
+            Subscription — call `.cancel()` to unsubscribe.
+        """
+        return self.on("check", handler)
+
+    def on_uncheck(self, handler: Callable[[tkinter.Event], Any]) -> Subscription:
+        """Register a callback fired when the control is unchecked/deselected.
+
+        Returns:
+            Subscription — call `.cancel()` to unsubscribe.
+        """
+        return self.on("uncheck", handler)
+
+
+class Checkbox(_BooleanControlBase):
+    """A labelled checkbox — checked or unchecked.
+
+    Args:
+        label: Label text displayed beside the checkbox.
+        signal: Reactive `Signal` controlling the checked state.
+        value: Initial value (ignored when `signal=` is passed).
+        checked_value: Value that represents the checked state. Default `True`.
+        unchecked_value: Value that represents the unchecked state. Default `False`.
+        on_change: Callback fired on every toggle.
+        show_indicator: If False, hides the box indicator (use with `icon=`).
+        disabled: If True, widget is non-interactive.
+        accent: Accent token, e.g. `'primary'`, `'success'`.
+        variant: Style variant, e.g. `'round'`, `'square'`.
+        parent: Override the context-stack parent.
+    """
+    _internal_class = _InternalCheckButton
+
+
+class Switch(_BooleanControlBase):
+    """A toggle switch — on or off.
+
+    Same kwargs as `Checkbox`. Visual difference only: renders as a
+    sliding track-and-thumb instead of a box.
+    """
+    _internal_class = _InternalSwitch
+
+
+class ToggleButton(_BooleanControlBase):
+    """A button that stays pressed when active — toolbar-style toggle.
+
+    Same kwargs as `Checkbox`. Visual difference only: renders as a
+    depressed button rather than a checkbox or switch.
+    """
+    _internal_class = _InternalCheckToggle
+
+
+register_widget_events(Checkbox, _BOOLEAN_EVENTS)
+register_widget_events(Switch, _BOOLEAN_EVENTS)
+register_widget_events(ToggleButton, _BOOLEAN_EVENTS)

--- a/tests/features/boolean_controls.py
+++ b/tests/features/boolean_controls.py
@@ -1,0 +1,63 @@
+"""Visual test for public Checkbox, Switch, and ToggleButton widgets."""
+from bootstack.widgets.public import (
+    App, VStack, HStack, Label, Checkbox, Switch, ToggleButton, Button
+)
+from bootstack.signals import Signal
+
+
+def main():
+    with App(title="Boolean controls — visual test", minsize=(480, 100), padding=24, gap=16) as app:
+
+        status = Signal("(none changed yet)")
+
+        def report(name):
+            return lambda: status.set(f"{name} toggled")
+
+        # Checkboxes
+        Label("Checkbox")
+        with HStack(gap=16):
+            Checkbox("Default", on_change=report("Checkbox default"))
+            Checkbox("Checked", value=True, on_change=report("Checkbox checked"))
+            Checkbox("Primary", accent="primary", value=True)
+            Checkbox("Disabled", disabled=True)
+            Checkbox("Disabled on", value=True, disabled=True)
+
+        # Switches
+        Label("Switch")
+        with HStack(gap=16):
+            Switch("Default", on_change=report("Switch default"))
+            Switch("On", value=True, on_change=report("Switch on"))
+            Switch("Primary", accent="primary", value=True)
+            Switch("Disabled", disabled=True)
+            Switch("Disabled on", value=True, disabled=True)
+
+        # Toggle buttons
+        Label("ToggleButton")
+        with HStack(gap=8):
+            ToggleButton("Bold", accent="primary", on_change=report("Bold"))
+            ToggleButton("Italic", on_change=report("Italic"))
+            ToggleButton("Underline", value=True, on_change=report("Underline"))
+            ToggleButton("Disabled", disabled=True)
+
+        # Signal-driven checkbox
+        Label("Signal-driven")
+        sig = Signal(False)
+        state_label_sig = Signal("off")
+        def _flip():
+            sig.set(not sig.get())
+            state_label_sig.set("ON" if sig.get() else "off")
+        with HStack(gap=12, anchor_items="center"):
+            Checkbox("Controlled", signal=sig)
+            Button("Flip", on_click=_flip, variant="outline")
+            Label(text_signal=state_label_sig)
+
+        # Last changed readout
+        with HStack(gap=8, anchor_items="center"):
+            Label("Last change:")
+            Label(text_signal=status, color="#0d6efd")
+
+    app.run()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds `widgets/public/primitives/boolean_controls.py` with `Checkbox`, `Switch`, `ToggleButton`
- Shared `_BooleanControlBase` holds the constructor — subclasses set `_internal_class` only
- `command=` wired internally to generate `<<Change>>`, `<<ToggleOn>>`, `<<ToggleOff>>` virtual events, enabling `on_change()` / `on_check()` / `on_uncheck()` to return proper `Subscription` objects
- Public API: positional `label`, `signal=`, `value=`, `checked_value=`, `unchecked_value=`, `checked: bool` property, `toggle()` method, `disabled: bool` property

## Test plan

- [ ] `python tests/features/boolean_controls.py` — all variants render; toggles fire; Flip button drives signal-controlled checkbox
- [ ] `pytest tests/widgets/public/ -m "not gui"` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)