### PR TITLE
feat(public): Select and NumericEntry

### DIFF
--- a/src/bootstack/widgets/public/__init__.py
+++ b/src/bootstack/widgets/public/__init__.py
@@ -9,7 +9,9 @@ from bootstack.widgets.public.app import App
 from bootstack.widgets.public.primitives.boolean_controls import Checkbox, Switch, ToggleButton
 from bootstack.widgets.public.primitives.button import Button
 from bootstack.widgets.public.primitives.label import Badge, Label
+from bootstack.widgets.public.primitives.numericentry import NumericEntry
 from bootstack.widgets.public.primitives.radiogroup import RadioGroup
+from bootstack.widgets.public.primitives.select import Select
 from bootstack.widgets.public.primitives.textfield import TextField
 
 __all__ = [
@@ -22,10 +24,12 @@ __all__ = [
     "Grid",
     "HStack",
     "Label",
+    "NumericEntry",
     "ParentResolutionError",
     "PublicContainer",
     "PublicWidgetBase",
     "RadioGroup",
+    "Select",
     "Subscription",
     "Switch",
     "TextField",

--- a/src/bootstack/widgets/public/primitives/__init__.py
+++ b/src/bootstack/widgets/public/primitives/__init__.py
@@ -1,7 +1,12 @@
 from bootstack.widgets.public.primitives.boolean_controls import Checkbox, Switch, ToggleButton
 from bootstack.widgets.public.primitives.button import Button
 from bootstack.widgets.public.primitives.label import Badge, Label
+from bootstack.widgets.public.primitives.numericentry import NumericEntry
 from bootstack.widgets.public.primitives.radiogroup import RadioGroup
+from bootstack.widgets.public.primitives.select import Select
 from bootstack.widgets.public.primitives.textfield import TextField
 
-__all__ = ["Badge", "Button", "Checkbox", "Label", "RadioGroup", "Switch", "TextField", "ToggleButton"]
+__all__ = [
+    "Badge", "Button", "Checkbox", "Label", "NumericEntry",
+    "RadioGroup", "Select", "Switch", "TextField", "ToggleButton",
+]

--- a/src/bootstack/widgets/public/primitives/numericentry.py
+++ b/src/bootstack/widgets/public/primitives/numericentry.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import tkinter
+from typing import Any, Callable
+
+from bootstack.widgets.composites.numericentry import NumericEntry as _InternalNumericEntry
+from bootstack.widgets.public.base import PublicWidgetBase
+from bootstack.widgets.public.events import register_widget_events
+from bootstack.widgets.public.subscription import Subscription
+from bootstack.widgets.public.primitives.textfield import _INNER_ENTRY_SEQUENCES
+
+_NUMERIC_ENTRY_EVENTS: dict[str, str] = {
+    "change": "<<Change>>",
+    "submit": "<Return>",
+}
+
+
+class NumericEntry(PublicWidgetBase):
+    """A numeric input field with optional spin buttons.
+
+    Args:
+        value: Initial numeric value.
+        label: Label displayed above the field.
+        message: Hint text displayed below the field.
+        min_value: Minimum allowed value (inclusive).
+        max_value: Maximum allowed value (inclusive).
+        step: Increment/decrement step size.
+        show_spin_buttons: If False, hides the +/− buttons.
+        required: If True, field cannot be left empty.
+        disabled: If True, field is non-interactive.
+        read_only: If True, value is visible but not editable.
+        width: Width in character cells.
+        accent: Accent token for the focus ring.
+        density: Widget density — `'default'` or `'compact'`.
+        parent: Override the context-stack parent.
+    """
+
+    def __init__(
+        self,
+        value: int | float = 0,
+        *,
+        label: str | None = None,
+        message: str | None = None,
+        min_value: int | float | None = None,
+        max_value: int | float | None = None,
+        step: int | float = 1,
+        show_spin_buttons: bool = True,
+        required: bool = False,
+        disabled: bool = False,
+        read_only: bool = False,
+        width: int | None = None,
+        accent: str | None = None,
+        density: str | None = None,
+        parent: Any = None,
+        **kwargs: Any,
+    ) -> None:
+        self._parent = self._resolve_parent(parent)
+        layout_kw = self._split_layout_kwargs(kwargs)
+
+        tk_master = self._parent._child_master() if self._parent else None
+
+        internal_kwargs: dict[str, Any] = {
+            "value": value,
+            "increment": step,
+            "show_spin_buttons": show_spin_buttons,
+        }
+        if label is not None:
+            internal_kwargs["label"] = label
+        if message is not None:
+            internal_kwargs["message"] = message
+        if min_value is not None:
+            internal_kwargs["minvalue"] = min_value
+        if max_value is not None:
+            internal_kwargs["maxvalue"] = max_value
+        if required:
+            internal_kwargs["required"] = True
+        if disabled:
+            internal_kwargs["state"] = "disabled"
+        elif read_only:
+            internal_kwargs["state"] = "readonly"
+        if width is not None:
+            internal_kwargs["width"] = width
+        if accent is not None:
+            internal_kwargs["accent"] = accent
+        if density is not None:
+            internal_kwargs["density"] = density
+        internal_kwargs.update(kwargs)
+
+        self._internal = _InternalNumericEntry(tk_master, **internal_kwargs)
+        self._attach_to_parent(layout_kw)
+
+    # ----- Event routing -----
+
+    def _entry_widget(self) -> tkinter.Misc:
+        return self._internal._entry
+
+    def on(self, event: str, handler: Callable[[tkinter.Event], Any]) -> Subscription:
+        from bootstack.widgets.public.events import resolve_event
+        sequence = resolve_event(self, str(event))
+        widget = self._entry_widget() if sequence in _INNER_ENTRY_SEQUENCES else self._internal
+        bind_id = widget.bind(sequence, handler, add="+")
+        return Subscription(widget, sequence, bind_id)
+
+    # ----- Properties -----
+
+    @property
+    def value(self) -> int | float | None:
+        return self._internal.value
+
+    @value.setter
+    def value(self, v: int | float) -> None:
+        self._internal.value = v
+
+    @property
+    def disabled(self) -> bool:
+        return str(self._internal._entry.cget("state")) == "disabled"
+
+    @disabled.setter
+    def disabled(self, v: bool) -> None:
+        self._internal.configure(state="disabled" if v else "normal")
+
+    # ----- Methods -----
+
+    def increment(self, steps: int = 1) -> None:
+        """Increment the value by `steps` × step size."""
+        self._internal.step(steps)
+
+    def decrement(self, steps: int = 1) -> None:
+        """Decrement the value by `steps` × step size."""
+        self._internal.step(-steps)
+
+    # ----- Event shorthands -----
+
+    def on_change(self, handler: Callable[[tkinter.Event], Any]) -> Subscription:
+        """Register a callback fired when the value is committed.
+
+        Returns:
+            Subscription — call `.cancel()` to unsubscribe.
+        """
+        return self.on("change", handler)
+
+    def on_submit(self, handler: Callable[[tkinter.Event], Any]) -> Subscription:
+        """Register a callback fired on Enter key.
+
+        Returns:
+            Subscription — call `.cancel()` to unsubscribe.
+        """
+        return self.on("submit", handler)
+
+
+register_widget_events(NumericEntry, _NUMERIC_ENTRY_EVENTS)

--- a/src/bootstack/widgets/public/primitives/select.py
+++ b/src/bootstack/widgets/public/primitives/select.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import tkinter
+from typing import Any, Callable
+
+from bootstack.widgets.composites.selectbox import SelectBox as _InternalSelectBox
+from bootstack.widgets.public.base import PublicWidgetBase
+from bootstack.widgets.public.events import register_widget_events
+from bootstack.widgets.public.subscription import Subscription
+from bootstack.widgets.public.primitives.textfield import _INNER_ENTRY_SEQUENCES
+
+_SELECT_EVENTS: dict[str, str] = {
+    "change": "<<Change>>",
+}
+
+
+class Select(PublicWidgetBase):
+    """A single-selection dropdown field.
+
+    Args:
+        options: List of string choices presented in the popup.
+        value: Initially selected value.
+        text_signal: Reactive `Signal` linked to the selected text.
+        label: Label displayed above the field.
+        message: Hint text displayed below the field.
+        required: If True, field cannot be left empty.
+        searchable: If True, typing filters the option list.
+        allow_custom: If True, users may type values not in `options`.
+        disabled: If True, field is non-interactive.
+        read_only: If True, value is visible but the popup cannot be opened.
+        width: Width in character cells.
+        accent: Accent token for the focus ring.
+        density: Widget density — `'default'` or `'compact'`.
+        parent: Override the context-stack parent.
+    """
+
+    def __init__(
+        self,
+        options: list[str] | None = None,
+        *,
+        value: str | None = None,
+        text_signal: Any = None,
+        label: str | None = None,
+        message: str | None = None,
+        required: bool = False,
+        searchable: bool = False,
+        allow_custom: bool = False,
+        disabled: bool = False,
+        read_only: bool = False,
+        width: int | None = None,
+        accent: str | None = None,
+        density: str | None = None,
+        parent: Any = None,
+        **kwargs: Any,
+    ) -> None:
+        self._parent = self._resolve_parent(parent)
+        layout_kw = self._split_layout_kwargs(kwargs)
+
+        tk_master = self._parent._child_master() if self._parent else None
+
+        internal_kwargs: dict[str, Any] = {
+            "items": options or [],
+            "enable_search": searchable,
+            "allow_custom_values": allow_custom,
+        }
+        if value is not None:
+            internal_kwargs["value"] = value
+        if text_signal is not None:
+            internal_kwargs["textsignal"] = text_signal
+        if label is not None:
+            internal_kwargs["label"] = label
+        if message is not None:
+            internal_kwargs["message"] = message
+        if required:
+            internal_kwargs["required"] = True
+        if disabled:
+            internal_kwargs["state"] = "disabled"
+        elif read_only:
+            internal_kwargs["state"] = "readonly"
+        if width is not None:
+            internal_kwargs["width"] = width
+        if accent is not None:
+            internal_kwargs["accent"] = accent
+        if density is not None:
+            internal_kwargs["density"] = density
+        internal_kwargs.update(kwargs)
+
+        self._internal = _InternalSelectBox(tk_master, **internal_kwargs)
+        self._attach_to_parent(layout_kw)
+
+    # ----- Event routing -----
+
+    def _entry_widget(self) -> tkinter.Misc:
+        return self._internal._entry
+
+    def on(self, event: str, handler: Callable[[tkinter.Event], Any]) -> Subscription:
+        from bootstack.widgets.public.events import resolve_event
+        sequence = resolve_event(self, str(event))
+        widget = self._entry_widget() if sequence in _INNER_ENTRY_SEQUENCES else self._internal
+        bind_id = widget.bind(sequence, handler, add="+")
+        return Subscription(widget, sequence, bind_id)
+
+    # ----- Properties -----
+
+    @property
+    def value(self) -> str:
+        return self._internal.value
+
+    @value.setter
+    def value(self, v: str) -> None:
+        self._internal.value = v
+
+    @property
+    def options(self) -> list[str]:
+        return list(self._internal._items)
+
+    @options.setter
+    def options(self, items: list[str]) -> None:
+        self._internal._items = list(items)
+
+    @property
+    def disabled(self) -> bool:
+        return str(self._internal._entry.cget("state")) == "disabled"
+
+    @disabled.setter
+    def disabled(self, v: bool) -> None:
+        self._internal.configure(state="disabled" if v else "normal")
+
+    # ----- Event shorthands -----
+
+    def on_change(self, handler: Callable[[tkinter.Event], Any]) -> Subscription:
+        """Register a callback fired when the selection changes.
+
+        Returns:
+            Subscription — call `.cancel()` to unsubscribe.
+        """
+        return self.on("change", handler)
+
+
+register_widget_events(Select, _SELECT_EVENTS)

--- a/tests/features/select_numeric.py
+++ b/tests/features/select_numeric.py
@@ -1,0 +1,62 @@
+"""Visual test for public Select and NumericEntry widgets."""
+from bootstack.widgets.public import (
+    App, VStack, HStack, Label, Select, NumericEntry, Button
+)
+from bootstack.signals import Signal
+
+
+def main():
+    with App(title="Select + NumericEntry — visual test", minsize=(480, 100), padding=24, gap=14) as app:
+
+        readout = Signal("(nothing committed yet)")
+
+        # Basic select
+        Label("Select — basic")
+        sel = Select(["Apple", "Banana", "Cherry", "Date"], value="Banana", label="Fruit")
+        sel.on_change(lambda e: readout.set(f"fruit: {sel.value}"))
+
+        # Searchable
+        Label("Select — searchable")
+        Select(
+            ["Python", "JavaScript", "Rust", "Go", "TypeScript", "C++"],
+            label="Language",
+            value="Python",
+            searchable=True,
+        )
+
+        # Allow custom
+        Label("Select — allow custom values")
+        Select(["Option A", "Option B"], label="Custom allowed", allow_custom=True)
+
+        # Disabled
+        Label("Select — disabled")
+        Select(["One", "Two", "Three"], value="Two", disabled=True)
+
+        # NumericEntry — basic
+        Label("NumericEntry — basic")
+        num = NumericEntry(10, label="Quantity", min_value=0, max_value=100, step=5)
+        num.on_change(lambda e: readout.set(f"qty: {num.value}"))
+
+        # NumericEntry — no spin buttons
+        Label("NumericEntry — no spin buttons")
+        NumericEntry(3.14, label="Float value", step=0.1, show_spin_buttons=False)
+
+        # NumericEntry — disabled
+        Label("NumericEntry — disabled")
+        NumericEntry(99, label="Disabled", disabled=True)
+
+        # Inline controls
+        with HStack(gap=8, anchor_items="center"):
+            Button("−5", on_click=lambda: num.decrement(), variant="outline")
+            Button("+5", on_click=lambda: num.increment(), variant="outline")
+
+        # Readout
+        with HStack(gap=8, anchor_items="center"):
+            Label("Last committed:")
+            Label(text_signal=readout, color="#0d6efd")
+
+    app.run()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds `Select` wrapping `composites/SelectBox`: positional `options=`, `searchable=` (was `enable_search=`), `allow_custom=` (was `allow_custom_values=`)
- Adds `NumericEntry` wrapping `composites/NumericEntry`: `min_value=`/`max_value=`/`step=` replace `minvalue=`/`maxvalue=`/`increment=`; `increment()`/`decrement()` methods
- Both share the same inner-entry event routing pattern established in `TextField`
- Both expose `on_change()` returning `Subscription`

## Test plan

- [ ] `python tests/features/select_numeric.py` — all variants render; change readout updates; +5/−5 buttons drive NumericEntry
- [ ] `pytest tests/widgets/public/ -m "not gui"` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)