### PR TITLE
feat(public): Slider and RangeSlider

### DIFF
--- a/src/bootstack/widgets/public/__init__.py
+++ b/src/bootstack/widgets/public/__init__.py
@@ -12,6 +12,7 @@ from bootstack.widgets.public.primitives.label import Badge, Label
 from bootstack.widgets.public.primitives.numericentry import NumericEntry
 from bootstack.widgets.public.primitives.radiogroup import RadioGroup
 from bootstack.widgets.public.primitives.select import Select
+from bootstack.widgets.public.primitives.slider import RangeSlider, Slider
 from bootstack.widgets.public.primitives.textfield import TextField
 
 __all__ = [
@@ -29,7 +30,9 @@ __all__ = [
     "PublicContainer",
     "PublicWidgetBase",
     "RadioGroup",
+    "RangeSlider",
     "Select",
+    "Slider",
     "Subscription",
     "Switch",
     "TextField",

--- a/src/bootstack/widgets/public/primitives/__init__.py
+++ b/src/bootstack/widgets/public/primitives/__init__.py
@@ -4,9 +4,10 @@ from bootstack.widgets.public.primitives.label import Badge, Label
 from bootstack.widgets.public.primitives.numericentry import NumericEntry
 from bootstack.widgets.public.primitives.radiogroup import RadioGroup
 from bootstack.widgets.public.primitives.select import Select
+from bootstack.widgets.public.primitives.slider import RangeSlider, Slider
 from bootstack.widgets.public.primitives.textfield import TextField
 
 __all__ = [
     "Badge", "Button", "Checkbox", "Label", "NumericEntry",
-    "RadioGroup", "Select", "Switch", "TextField", "ToggleButton",
+    "RadioGroup", "RangeSlider", "Select", "Slider", "Switch", "TextField", "ToggleButton",
 ]

--- a/src/bootstack/widgets/public/primitives/slider.py
+++ b/src/bootstack/widgets/public/primitives/slider.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import tkinter
+from typing import Any, Callable
+
+from bootstack.widgets.composites.slider.slider import Slider as _InternalSlider
+from bootstack.widgets.composites.slider.rangeslider import RangeSlider as _InternalRangeSlider
+from bootstack.widgets.public.base import PublicWidgetBase
+from bootstack.widgets.public.events import register_widget_events
+from bootstack.widgets.public.subscription import Subscription
+
+_SLIDER_EVENTS: dict[str, str] = {
+    "change": "<<Change>>",
+    "commit": "<<Commit>>",
+}
+
+
+class Slider(PublicWidgetBase):
+    """A single-handle slider for selecting a value within a range.
+
+    Args:
+        value: Initial value.
+        min_value: Minimum of the range. Default `0`.
+        max_value: Maximum of the range. Default `100`.
+        signal: Reactive `Signal[float]` linked to the value.
+        orient: `'horizontal'` (default) or `'vertical'`.
+        show_value: Show a floating badge displaying the current value.
+        show_minmax: Show min/max labels at the track ends.
+        tick_interval: Spacing between major tick marks. `None` disables ticks.
+        minor_ticks: Number of minor ticks between each major tick.
+        tick_labels: Show numeric labels at major tick positions.
+        tick_format: Format string for tick and badge labels, e.g. `'{:.1f}°C'`.
+        parent: Override the context-stack parent.
+    """
+
+    def __init__(
+        self,
+        value: float = 0,
+        *,
+        min_value: float = 0,
+        max_value: float = 100,
+        signal: Any = None,
+        orient: str = "horizontal",
+        show_value: bool = False,
+        show_minmax: bool = False,
+        tick_interval: float | None = None,
+        minor_ticks: int = 0,
+        tick_labels: bool = True,
+        tick_format: str = "{:.0f}",
+        parent: Any = None,
+        **kwargs: Any,
+    ) -> None:
+        self._parent = self._resolve_parent(parent)
+        layout_kw = self._split_layout_kwargs(kwargs)
+
+        tk_master = self._parent._child_master() if self._parent else None
+
+        internal_kwargs: dict[str, Any] = {
+            "value": value,
+            "minvalue": min_value,
+            "maxvalue": max_value,
+            "orient": orient,
+            "show_value": show_value,
+            "show_minmax": show_minmax,
+            "tick_interval": tick_interval,
+            "minor_ticks": minor_ticks,
+            "tick_labels": tick_labels,
+            "tick_format": tick_format,
+        }
+        if signal is not None:
+            internal_kwargs["signal"] = signal
+        internal_kwargs.update(kwargs)
+
+        self._internal = _InternalSlider(tk_master, **internal_kwargs)
+        self._attach_to_parent(layout_kw)
+
+    # ----- Properties -----
+
+    @property
+    def value(self) -> float:
+        return self._internal.value
+
+    @value.setter
+    def value(self, v: float) -> None:
+        self._internal._signal.set(float(v))
+
+    # ----- Event shorthands -----
+
+    def on_change(self, handler: Callable[[tkinter.Event], Any]) -> Subscription:
+        """Register a callback fired continuously as the handle moves.
+
+        The current value is available via `slider.value` inside the handler.
+
+        Returns:
+            Subscription — call `.cancel()` to unsubscribe.
+        """
+        return self.on("change", handler)
+
+    def on_commit(self, handler: Callable[[tkinter.Event], Any]) -> Subscription:
+        """Register a callback fired when the handle is released.
+
+        Returns:
+            Subscription — call `.cancel()` to unsubscribe.
+        """
+        return self.on("commit", handler)
+
+
+register_widget_events(Slider, _SLIDER_EVENTS)
+
+
+class RangeSlider(PublicWidgetBase):
+    """A two-handle slider for selecting a low/high value range.
+
+    Args:
+        lo_value: Initial low-handle value. Default `0`.
+        hi_value: Initial high-handle value. Default `100`.
+        min_value: Minimum of the range. Default `0`.
+        max_value: Maximum of the range. Default `100`.
+        lo_signal: Reactive `Signal[float]` linked to the low handle.
+        hi_signal: Reactive `Signal[float]` linked to the high handle.
+        orient: `'horizontal'` (default) or `'vertical'`.
+        show_value: Show floating badges on both handles.
+        tick_interval: Spacing between major tick marks.
+        minor_ticks: Number of minor ticks between each major tick.
+        tick_labels: Show numeric labels at major tick positions.
+        tick_format: Format string for tick and badge labels.
+        parent: Override the context-stack parent.
+    """
+
+    def __init__(
+        self,
+        lo_value: float = 0,
+        hi_value: float = 100,
+        *,
+        min_value: float = 0,
+        max_value: float = 100,
+        lo_signal: Any = None,
+        hi_signal: Any = None,
+        orient: str = "horizontal",
+        show_value: bool = False,
+        tick_interval: float | None = None,
+        minor_ticks: int = 0,
+        tick_labels: bool = True,
+        tick_format: str = "{:.0f}",
+        parent: Any = None,
+        **kwargs: Any,
+    ) -> None:
+        self._parent = self._resolve_parent(parent)
+        layout_kw = self._split_layout_kwargs(kwargs)
+
+        tk_master = self._parent._child_master() if self._parent else None
+
+        internal_kwargs: dict[str, Any] = {
+            "lovalue": lo_value,
+            "hivalue": hi_value,
+            "minvalue": min_value,
+            "maxvalue": max_value,
+            "orient": orient,
+            "show_value": show_value,
+            "tick_interval": tick_interval,
+            "minor_ticks": minor_ticks,
+            "tick_labels": tick_labels,
+            "tick_format": tick_format,
+        }
+        if lo_signal is not None:
+            internal_kwargs["lo_signal"] = lo_signal
+        if hi_signal is not None:
+            internal_kwargs["hi_signal"] = hi_signal
+        internal_kwargs.update(kwargs)
+
+        self._internal = _InternalRangeSlider(tk_master, **internal_kwargs)
+        self._attach_to_parent(layout_kw)
+
+    # ----- Properties -----
+
+    @property
+    def lo(self) -> float:
+        return self._internal.lovalue
+
+    @lo.setter
+    def lo(self, v: float) -> None:
+        self._internal._lo_signal.set(float(v))
+
+    @property
+    def hi(self) -> float:
+        return self._internal.hivalue
+
+    @hi.setter
+    def hi(self, v: float) -> None:
+        self._internal._hi_signal.set(float(v))
+
+    @property
+    def value(self) -> tuple[float, float]:
+        """Current `(lo, hi)` values as a tuple."""
+        return (self._internal.lovalue, self._internal.hivalue)
+
+    # ----- Event shorthands -----
+
+    def on_change(self, handler: Callable[[tkinter.Event], Any]) -> Subscription:
+        """Register a callback fired continuously as either handle moves.
+
+        Returns:
+            Subscription — call `.cancel()` to unsubscribe.
+        """
+        return self.on("change", handler)
+
+    def on_commit(self, handler: Callable[[tkinter.Event], Any]) -> Subscription:
+        """Register a callback fired when a handle is released.
+
+        Returns:
+            Subscription — call `.cancel()` to unsubscribe.
+        """
+        return self.on("commit", handler)
+
+
+register_widget_events(RangeSlider, _SLIDER_EVENTS)

--- a/tests/features/slider.py
+++ b/tests/features/slider.py
@@ -1,0 +1,64 @@
+"""Visual test for public Slider and RangeSlider widgets."""
+from bootstack.widgets.public import App, VStack, HStack, Label, Slider, RangeSlider, Button
+from bootstack.signals import Signal
+
+
+def main():
+    with App(title="Slider + RangeSlider — visual test", minsize=(520, 100), padding=24, gap=16) as app:
+
+        readout = Signal("(move a handle)")
+
+        # Basic horizontal slider
+        Label("Slider — basic")
+        s1 = Slider(50, min_value=0, max_value=100, fill="x", expand=True)
+        s1.on_change(lambda e: readout.set(f"slider: {s1.value:.0f}"))
+
+        # With value badge and ticks
+        Label("Slider — show_value + ticks")
+        Slider(
+            25, min_value=0, max_value=100,
+            show_value=True,
+            tick_interval=25,
+            fill="x", expand=True,
+        )
+
+        # With min/max labels
+        Label("Slider — show_minmax")
+        Slider(
+            60, min_value=0, max_value=200,
+            show_minmax=True,
+            tick_format="{:.0f}°",
+            fill="x", expand=True,
+        )
+
+        # Signal-driven
+        Label("Slider — signal-driven")
+        sig = Signal(40.0)
+        with HStack(gap=12, anchor_items="center", fill="x", expand=True):
+            Slider(signal=sig, fill="x", expand=True)
+            Button("→ 80", on_click=lambda: sig.set(80.0), variant="outline")
+
+        # RangeSlider
+        Label("RangeSlider — basic")
+        r1 = RangeSlider(20, 75, min_value=0, max_value=100, fill="x", expand=True)
+        r1.on_change(lambda e: readout.set(f"range: {r1.lo:.0f} – {r1.hi:.0f}"))
+
+        # RangeSlider with value badges and ticks
+        Label("RangeSlider — show_value + ticks")
+        RangeSlider(
+            10, 90, min_value=0, max_value=100,
+            show_value=True,
+            tick_interval=10,
+            fill="x", expand=True,
+        )
+
+        # Readout
+        with HStack(gap=8, anchor_items="center"):
+            Label("Last change:")
+            Label(text_signal=readout, color="#0d6efd")
+
+    app.run()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds `Slider` and `RangeSlider` in `widgets/public/primitives/slider.py`
- Both wrap the canvas-based composites — events fire directly on the widget so no inner-entry routing is needed
- API renames: `min_value=`/`max_value=` (were `minvalue=`/`maxvalue=`), `lo_value=`/`hi_value=` (were `lovalue=`/`hivalue=`)
- Value setters coerce to `float` to satisfy the typed `Signal`
- `RangeSlider.value` returns `(lo, hi)` tuple; `.lo`/`.hi` properties for individual access
- `on_change()` / `on_commit()` return `Subscription` on both

## Test plan

- [ ] `python tests/features/slider.py` — all variants render; dragging updates readout; signal-driven slider responds to → 80 button
- [ ] `pytest tests/widgets/public/ -m "not gui"` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)