### PR TITLE
feat(public): ProgressBar and Gauge; fix Progressbar setter recursion

### DIFF
--- a/src/bootstack/widgets/primitives/progressbar.py
+++ b/src/bootstack/widgets/primitives/progressbar.py
@@ -60,11 +60,11 @@ class Progressbar(SignalMixin, TTKWrapperBase, WidgetCapabilitiesMixin, TtkState
 
     def get(self) -> float:
         """Return the current progress value."""
-        return self.cget('value')
+        return float(ttk.Progressbar.cget(self, 'value'))
 
     def set(self, value: float) -> None:
         """Set the progress value."""
-        self.configure(value=value)
+        ttk.Progressbar.configure(self, value=value)
 
     @property
     def value(self) -> float:

--- a/src/bootstack/widgets/public/__init__.py
+++ b/src/bootstack/widgets/public/__init__.py
@@ -8,8 +8,10 @@ from bootstack.widgets.public.grid import Grid
 from bootstack.widgets.public.app import App
 from bootstack.widgets.public.primitives.boolean_controls import Checkbox, Switch, ToggleButton
 from bootstack.widgets.public.primitives.button import Button
+from bootstack.widgets.public.primitives.gauge import Gauge
 from bootstack.widgets.public.primitives.label import Badge, Label
 from bootstack.widgets.public.primitives.numericentry import NumericEntry
+from bootstack.widgets.public.primitives.progressbar import ProgressBar
 from bootstack.widgets.public.primitives.radiogroup import RadioGroup
 from bootstack.widgets.public.primitives.select import Select
 from bootstack.widgets.public.primitives.slider import RangeSlider, Slider
@@ -22,11 +24,13 @@ __all__ = [
     "Button",
     "Checkbox",
     "Event",
+    "Gauge",
     "Grid",
     "HStack",
     "Label",
     "NumericEntry",
     "ParentResolutionError",
+    "ProgressBar",
     "PublicContainer",
     "PublicWidgetBase",
     "RadioGroup",

--- a/src/bootstack/widgets/public/primitives/__init__.py
+++ b/src/bootstack/widgets/public/primitives/__init__.py
@@ -1,13 +1,16 @@
 from bootstack.widgets.public.primitives.boolean_controls import Checkbox, Switch, ToggleButton
 from bootstack.widgets.public.primitives.button import Button
+from bootstack.widgets.public.primitives.gauge import Gauge
 from bootstack.widgets.public.primitives.label import Badge, Label
 from bootstack.widgets.public.primitives.numericentry import NumericEntry
+from bootstack.widgets.public.primitives.progressbar import ProgressBar
 from bootstack.widgets.public.primitives.radiogroup import RadioGroup
 from bootstack.widgets.public.primitives.select import Select
 from bootstack.widgets.public.primitives.slider import RangeSlider, Slider
 from bootstack.widgets.public.primitives.textfield import TextField
 
 __all__ = [
-    "Badge", "Button", "Checkbox", "Label", "NumericEntry",
-    "RadioGroup", "RangeSlider", "Select", "Slider", "Switch", "TextField", "ToggleButton",
+    "Badge", "Button", "Checkbox", "Gauge", "Label", "NumericEntry",
+    "ProgressBar", "RadioGroup", "RangeSlider", "Select", "Slider",
+    "Switch", "TextField", "ToggleButton",
 ]

--- a/src/bootstack/widgets/public/primitives/gauge.py
+++ b/src/bootstack/widgets/public/primitives/gauge.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from typing import Any
+
+from bootstack.widgets.composites.meter import Meter as _InternalMeter
+from bootstack.widgets.public.base import PublicWidgetBase
+from bootstack.widgets.public.events import register_widget_events
+
+
+class Gauge(PublicWidgetBase):
+    """A circular gauge for displaying a value within a range.
+
+    Args:
+        value: Initial value.
+        min_value: Minimum of the range. Default `0`.
+        max_value: Maximum of the range. Default `100`.
+        subtitle: Text displayed below the value.
+        value_prefix: Text prepended to the value display (e.g. `'$'`).
+        value_suffix: Text appended to the value display (e.g. `'%'`).
+        value_format: Format string for the value (e.g. `'{:.1f}'`).
+        size: Diameter in pixels. Default `200`.
+        thickness: Arc width in pixels. Default `10`.
+        style: `'full'` (default) for a full circle or `'semi'` for a semicircle.
+        segment_width: Segment width for a dashed/segmented arc. `0` means solid.
+        interactive: If True, the user can click/drag to change the value.
+        step_size: Increment used in interactive mode.
+        show_text: If False, hides the value text.
+        accent: Accent token for the arc colour.
+        parent: Override the context-stack parent.
+    """
+
+    def __init__(
+        self,
+        value: int | float = 0,
+        *,
+        min_value: int | float = 0,
+        max_value: int | float = 100,
+        subtitle: str | None = None,
+        value_prefix: str | None = None,
+        value_suffix: str | None = None,
+        value_format: str = "{:.0f}",
+        size: int = 200,
+        thickness: int = 10,
+        style: str = "full",
+        segment_width: int = 0,
+        interactive: bool = False,
+        step_size: int | float = 1,
+        show_text: bool = True,
+        accent: str | None = None,
+        parent: Any = None,
+        **kwargs: Any,
+    ) -> None:
+        self._parent = self._resolve_parent(parent)
+        layout_kw = self._split_layout_kwargs(kwargs)
+
+        tk_master = self._parent._child_master() if self._parent else None
+
+        internal_kwargs: dict[str, Any] = {
+            "value": value,
+            "minvalue": min_value,
+            "maxvalue": max_value,
+            "value_format": value_format,
+            "size": size,
+            "thickness": thickness,
+            "meter_type": style,
+            "segment_width": segment_width,
+            "interactive": interactive,
+            "step_size": step_size,
+            "show_text": show_text,
+        }
+        if subtitle is not None:
+            internal_kwargs["subtitle"] = subtitle
+        if value_prefix is not None:
+            internal_kwargs["value_prefix"] = value_prefix
+        if value_suffix is not None:
+            internal_kwargs["value_suffix"] = value_suffix
+        if accent is not None:
+            internal_kwargs["accent"] = accent
+        internal_kwargs.update(kwargs)
+
+        self._internal = _InternalMeter(tk_master, **internal_kwargs)
+        self._attach_to_parent(layout_kw)
+
+    # ----- Properties -----
+
+    @property
+    def value(self) -> int | float:
+        return self._internal.value
+
+    @value.setter
+    def value(self, v: int | float) -> None:
+        self._internal.value = v
+
+    @property
+    def subtitle(self) -> str:
+        return self._internal.subtitle
+
+    @subtitle.setter
+    def subtitle(self, v: str) -> None:
+        self._internal.subtitle = v
+
+
+register_widget_events(Gauge, {})

--- a/src/bootstack/widgets/public/primitives/progressbar.py
+++ b/src/bootstack/widgets/public/primitives/progressbar.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from typing import Any
+
+from bootstack.widgets.primitives.progressbar import Progressbar as _InternalProgressbar
+from bootstack.widgets.public.base import PublicWidgetBase
+from bootstack.widgets.public.events import register_widget_events
+
+
+class ProgressBar(PublicWidgetBase):
+    """A progress indicator bar.
+
+    Args:
+        value: Initial progress value.
+        maximum: Value that represents 100% progress. Default `100`.
+        mode: `'determinate'` (default) shows a fixed percentage;
+            `'indeterminate'` animates continuously.
+        orient: `'horizontal'` (default) or `'vertical'`.
+        signal: Reactive `Signal` linked to the value.
+        accent: Accent token, e.g. `'primary'`, `'success'`.
+        variant: Style variant, e.g. `'thin'`.
+        parent: Override the context-stack parent.
+    """
+
+    def __init__(
+        self,
+        value: float = 0,
+        *,
+        maximum: float = 100,
+        mode: str = "determinate",
+        orient: str = "horizontal",
+        signal: Any = None,
+        accent: str | None = None,
+        variant: str | None = None,
+        parent: Any = None,
+        **kwargs: Any,
+    ) -> None:
+        self._parent = self._resolve_parent(parent)
+        layout_kw = self._split_layout_kwargs(kwargs)
+
+        tk_master = self._parent._child_master() if self._parent else None
+
+        internal_kwargs: dict[str, Any] = {
+            "value": value,
+            "maximum": maximum,
+            "mode": mode,
+            "orient": orient,
+        }
+        if signal is not None:
+            internal_kwargs["signal"] = signal
+        if accent is not None:
+            internal_kwargs["accent"] = accent
+        if variant is not None:
+            internal_kwargs["variant"] = variant
+        internal_kwargs.update(kwargs)
+
+        self._internal = _InternalProgressbar(tk_master, **internal_kwargs)
+        self._attach_to_parent(layout_kw)
+
+    # ----- Properties -----
+
+    @property
+    def value(self) -> float:
+        return self._internal.get()
+
+    @value.setter
+    def value(self, v: float) -> None:
+        self._internal.set(v)
+
+    # ----- Methods -----
+
+    def start(self, interval: int = 50) -> None:
+        """Start indeterminate animation. `interval` is the step delay in ms."""
+        self._internal.start(interval)
+
+    def stop(self) -> None:
+        """Stop indeterminate animation."""
+        self._internal.stop()
+
+    def step(self, amount: float = 1.0) -> None:
+        """Advance the value by `amount`."""
+        self._internal.step(amount)
+
+
+register_widget_events(ProgressBar, {})

--- a/tests/features/progressbar_gauge.py
+++ b/tests/features/progressbar_gauge.py
@@ -1,0 +1,50 @@
+"""Visual test for public ProgressBar and Gauge widgets."""
+from bootstack.widgets.public import (
+    App, VStack, HStack, Grid, Label, ProgressBar, Gauge, Button
+)
+
+
+def main():
+    with App(title="ProgressBar + Gauge — visual test", minsize=(560, 100), padding=24, gap=16) as app:
+
+        pb = ProgressBar(0, maximum=100, accent="primary", fill="x", expand=True)
+
+        # ProgressBar variants
+        Label("ProgressBar — accents")
+        for accent in ("primary", "success", "warning", "danger"):
+            ProgressBar(40, accent=accent, fill="x", expand=True)
+
+        Label("ProgressBar — thin variant")
+        ProgressBar(60, accent="primary", variant="thin", fill="x", expand=True)
+
+        Label("ProgressBar — controlled")
+        with HStack(gap=8, anchor_items="center"):
+            pb
+            Button("+10", on_click=lambda: pb.step(10), variant="outline")
+            Button("Reset", on_click=lambda: setattr(pb, "value", 0), variant="outline")
+
+        Label("ProgressBar — indeterminate")
+        pb_ind = ProgressBar(mode="indeterminate", accent="success", fill="x", expand=True)
+        with HStack(gap=8):
+            Button("Start", on_click=lambda: pb_ind.start(), variant="outline")
+            Button("Stop", on_click=lambda: pb_ind.stop(), variant="outline")
+
+        # Gauge variants
+        Label("Gauge")
+        with HStack(gap=24):
+            Gauge(72, subtitle="CPU", value_suffix="%", accent="primary", size=150)
+            Gauge(45, subtitle="Memory", value_suffix="%", accent="warning", size=150)
+            Gauge(18, subtitle="Disk", value_suffix="%", accent="success", size=150)
+
+        Label("Gauge — semi-circle")
+        with HStack(gap=24):
+            Gauge(60, style="semi", value_suffix="°C", subtitle="Temp",
+                  accent="danger", size=150, thickness=14)
+            Gauge(33, style="semi", value_suffix="%", subtitle="Load",
+                  size=150, thickness=14)
+
+    app.run()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- **Bug fix:** `Progressbar.get()`/`set()` now call `ttk.Progressbar.cget/configure` directly, breaking the infinite recursion through the bootstack delegate loop (gap #11)
- Adds `ProgressBar` wrapping the fixed internal: `value=`, `maximum=`, `mode=`, `orient=`, `start()`/`stop()`/`step()`
- Adds `Gauge` wrapping `Meter`: `min_value=`/`max_value=` (replace `minvalue=`/`maxvalue=`), `style=` (replaces `meter_type=`), `subtitle=`, `value_prefix=`/`value_suffix=`

## Test plan

- [ ] `python tests/features/progressbar_gauge.py` — bars and gauges render; +10/Reset drive the controlled bar; Start/Stop animate the indeterminate bar; semi-circle gauges display correctly
- [ ] `pytest tests/widgets/public/ -m "not gui"` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)