### PR TITLE
feat(public): Spinbox and Separator

### DIFF
--- a/src/bootstack/widgets/public/__init__.py
+++ b/src/bootstack/widgets/public/__init__.py
@@ -14,7 +14,9 @@ from bootstack.widgets.public.primitives.numericentry import NumericEntry
 from bootstack.widgets.public.primitives.progressbar import ProgressBar
 from bootstack.widgets.public.primitives.radiogroup import RadioGroup
 from bootstack.widgets.public.primitives.select import Select
+from bootstack.widgets.public.primitives.separator import Separator
 from bootstack.widgets.public.primitives.slider import RangeSlider, Slider
+from bootstack.widgets.public.primitives.spinbox import Spinbox
 from bootstack.widgets.public.primitives.textfield import TextField
 
 __all__ = [
@@ -36,7 +38,9 @@ __all__ = [
     "RadioGroup",
     "RangeSlider",
     "Select",
+    "Separator",
     "Slider",
+    "Spinbox",
     "Subscription",
     "Switch",
     "TextField",

--- a/src/bootstack/widgets/public/app.py
+++ b/src/bootstack/widgets/public/app.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from bootstack._runtime.app import App as _InternalApp
 from bootstack.widgets.primitives.packframe import PackFrame
-from bootstack.widgets.public.container import PublicContainer, PACK_KEYS
+from bootstack.widgets.public.container import PublicContainer, PACK_KEYS, normalize_fill
 
 
 class App(PublicContainer):
@@ -52,7 +52,7 @@ class App(PublicContainer):
         frame_kwargs: dict[str, Any] = {
             "direction": "vertical",
             "gap": gap,
-            "fill_items": fill_items,
+            "fill_items": normalize_fill(fill_items),
             "expand_items": expand_items,
             "anchor_items": anchor_items,
         }

--- a/src/bootstack/widgets/public/container.py
+++ b/src/bootstack/widgets/public/container.py
@@ -24,6 +24,21 @@ PLACE_KEYS = frozenset({
 # Presence of any of these signals "use place() instead of pack()/grid()"
 PLACE_TRIGGER_KEYS = frozenset({"x", "y", "relx", "rely", "relwidth", "relheight"})
 
+# Human-readable aliases for Tk's single-character fill values.
+# Accepted everywhere fill= or fill_items= appears in the public API.
+_FILL_ALIASES: dict[str, str] = {
+    "horizontal": "x",
+    "vertical":   "y",
+    "all":        "both",
+}
+
+
+def normalize_fill(value: str | None) -> str | None:
+    """Resolve a fill alias to its Tk value, passing through unknowns unchanged."""
+    if value is None:
+        return None
+    return _FILL_ALIASES.get(value, value)
+
 
 # ---  PublicContainer  -------------------------------------------------------
 # Imported here (after constants) to avoid circular imports in base.py.
@@ -53,6 +68,8 @@ class PublicContainer(PublicWidgetBase):
 
     def guide_layout(self, child: PublicWidgetBase, **layout_kw: Any) -> None:
         """Place `child._internal` under this container."""
+        if "fill" in layout_kw:
+            layout_kw["fill"] = normalize_fill(layout_kw["fill"])
         place_mode = any(k in layout_kw for k in PLACE_TRIGGER_KEYS)
         tk_widget = child._internal
 

--- a/src/bootstack/widgets/public/primitives/__init__.py
+++ b/src/bootstack/widgets/public/primitives/__init__.py
@@ -6,11 +6,13 @@ from bootstack.widgets.public.primitives.numericentry import NumericEntry
 from bootstack.widgets.public.primitives.progressbar import ProgressBar
 from bootstack.widgets.public.primitives.radiogroup import RadioGroup
 from bootstack.widgets.public.primitives.select import Select
+from bootstack.widgets.public.primitives.separator import Separator
 from bootstack.widgets.public.primitives.slider import RangeSlider, Slider
+from bootstack.widgets.public.primitives.spinbox import Spinbox
 from bootstack.widgets.public.primitives.textfield import TextField
 
 __all__ = [
     "Badge", "Button", "Checkbox", "Gauge", "Label", "NumericEntry",
-    "ProgressBar", "RadioGroup", "RangeSlider", "Select", "Slider",
-    "Switch", "TextField", "ToggleButton",
+    "ProgressBar", "RadioGroup", "RangeSlider", "Select", "Separator",
+    "Slider", "Spinbox", "Switch", "TextField", "ToggleButton",
 ]

--- a/src/bootstack/widgets/public/primitives/separator.py
+++ b/src/bootstack/widgets/public/primitives/separator.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import Any
+
+from bootstack.widgets.primitives.separator import Separator as _InternalSeparator
+from bootstack.widgets.public.base import PublicWidgetBase
+from bootstack.widgets.public.events import register_widget_events
+
+
+class Separator(PublicWidgetBase):
+    """A horizontal or vertical dividing line.
+
+    Args:
+        orient: `'horizontal'` (default) or `'vertical'`.
+        accent: Accent token for the line colour.
+        thickness: Line thickness in pixels.
+        length: Fixed length in pixels. If not set, stretches to fill.
+        parent: Override the context-stack parent.
+    """
+
+    def __init__(
+        self,
+        orient: str = "horizontal",
+        *,
+        accent: str | None = None,
+        thickness: int | None = None,
+        length: int | None = None,
+        parent: Any = None,
+        **kwargs: Any,
+    ) -> None:
+        self._parent = self._resolve_parent(parent)
+        layout_kw = self._split_layout_kwargs(kwargs)
+
+        tk_master = self._parent._child_master() if self._parent else None
+
+        internal_kwargs: dict[str, Any] = {"orient": orient}
+        if accent is not None:
+            internal_kwargs["accent"] = accent
+        if thickness is not None:
+            internal_kwargs["thickness"] = thickness
+        if length is not None:
+            internal_kwargs["length"] = length
+        internal_kwargs.update(kwargs)
+
+        self._internal = _InternalSeparator(tk_master, **internal_kwargs)
+        self._attach_to_parent(layout_kw)
+
+
+register_widget_events(Separator, {})

--- a/src/bootstack/widgets/public/primitives/spinbox.py
+++ b/src/bootstack/widgets/public/primitives/spinbox.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import tkinter
+from typing import Any, Callable
+
+from bootstack.widgets.primitives.spinbox import Spinbox as _InternalSpinbox
+from bootstack.widgets.public.base import PublicWidgetBase
+from bootstack.widgets.public.events import register_widget_events
+from bootstack.widgets.public.subscription import Subscription
+
+_SPINBOX_EVENTS: dict[str, str] = {
+    "change": "<KeyRelease>",
+    "submit": "<Return>",
+}
+
+
+class Spinbox(PublicWidgetBase):
+    """A spin-box that cycles through a fixed list or numeric range.
+
+    Pass either `options=` for a discrete list, or `min_value=`/`max_value=`
+    for a numeric range. `options=` takes precedence if both are provided.
+
+    Args:
+        value: Initial display value.
+        options: Fixed list of values to cycle through.
+        min_value: Minimum numeric value (used when `options=` is not set).
+        max_value: Maximum numeric value.
+        step: Increment between values. Default `1`.
+        wrap: If True, wraps from max back to min and vice versa.
+        text_signal: Reactive `Signal` linked to the displayed text.
+        width: Width in character cells.
+        disabled: If True, widget is non-interactive.
+        density: `'default'` or `'compact'`.
+        accent: Accent token.
+        parent: Override the context-stack parent.
+    """
+
+    def __init__(
+        self,
+        value: Any = "",
+        *,
+        options: list[Any] | None = None,
+        min_value: float | None = None,
+        max_value: float | None = None,
+        step: float = 1,
+        wrap: bool = False,
+        text_signal: Any = None,
+        width: int | None = None,
+        disabled: bool = False,
+        density: str | None = None,
+        accent: str | None = None,
+        parent: Any = None,
+        **kwargs: Any,
+    ) -> None:
+        self._parent = self._resolve_parent(parent)
+        layout_kw = self._split_layout_kwargs(kwargs)
+
+        tk_master = self._parent._child_master() if self._parent else None
+
+        internal_kwargs: dict[str, Any] = {"wrap": wrap}
+        if options is not None:
+            internal_kwargs["values"] = [str(o) for o in options]
+        elif min_value is not None or max_value is not None:
+            if min_value is not None:
+                internal_kwargs["from_"] = min_value
+            if max_value is not None:
+                internal_kwargs["to"] = max_value
+            internal_kwargs["increment"] = step
+        if text_signal is not None:
+            internal_kwargs["textsignal"] = text_signal
+        if width is not None:
+            internal_kwargs["width"] = width
+        if disabled:
+            internal_kwargs["state"] = "disabled"
+        if density is not None:
+            internal_kwargs["density"] = density
+        if accent is not None:
+            internal_kwargs["accent"] = accent
+        # Clean up any None values accidentally set
+        internal_kwargs = {k: v for k, v in internal_kwargs.items() if v is not None}
+        internal_kwargs.update(kwargs)
+
+        self._internal = _InternalSpinbox(tk_master, **internal_kwargs)
+
+        # Seed the display value after construction in all cases.
+        if value != "":
+            self._internal.set(str(value))
+
+        self._attach_to_parent(layout_kw)
+
+    # ----- Properties -----
+
+    @property
+    def value(self) -> str:
+        return self._internal.get()
+
+    @value.setter
+    def value(self, v: Any) -> None:
+        self._internal.set(str(v))
+
+    @property
+    def disabled(self) -> bool:
+        return str(self._internal.cget("state")) == "disabled"
+
+    @disabled.setter
+    def disabled(self, v: bool) -> None:
+        self._internal.configure(state="disabled" if v else "normal")
+
+    # ----- Event shorthands -----
+
+    def on_change(self, handler: Callable[[tkinter.Event], Any]) -> Subscription:
+        """Register a callback fired on each keystroke or spin-button click.
+
+        Returns:
+            Subscription — call `.cancel()` to unsubscribe.
+        """
+        return self.on("change", handler)
+
+
+register_widget_events(Spinbox, _SPINBOX_EVENTS)

--- a/src/bootstack/widgets/public/stacks.py
+++ b/src/bootstack/widgets/public/stacks.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 from bootstack.widgets.primitives.packframe import PackFrame
-from bootstack.widgets.public.container import PublicContainer, PACK_KEYS
+from bootstack.widgets.public.container import PublicContainer, PACK_KEYS, normalize_fill
 
 
 class _StackBase(PublicContainer):
@@ -36,7 +36,7 @@ class _StackBase(PublicContainer):
 
         layout_kw: dict[str, Any] = {}
         if fill is not None:
-            layout_kw["fill"] = fill
+            layout_kw["fill"] = normalize_fill(fill)
         if expand is not None:
             layout_kw["expand"] = expand
         if anchor is not None:
@@ -47,7 +47,7 @@ class _StackBase(PublicContainer):
         frame_kwargs: dict[str, Any] = {
             "direction": self._direction,
             "gap": gap,
-            "fill_items": fill_items,
+            "fill_items": normalize_fill(fill_items),
             "expand_items": expand_items,
             "anchor_items": anchor_items,
         }

--- a/tests/features/spinbox_separator.py
+++ b/tests/features/spinbox_separator.py
@@ -1,0 +1,54 @@
+"""Visual test for public Spinbox and Separator widgets."""
+from bootstack.widgets.public import App, VStack, HStack, Label, Spinbox, Separator
+
+
+def main():
+    with App(title="Spinbox + Separator — visual test", minsize=(400, 100), padding=24, gap=12) as app:
+
+        # List-based
+        Label("Spinbox — fixed options")
+        Spinbox("Medium", options=["Small", "Medium", "Large", "X-Large"])
+
+        Label("Spinbox — text list, wrap=True")
+        Spinbox("Mon", options=["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"], wrap=True)
+
+        Separator(fill="x")
+
+        # Numeric range
+        Label("Spinbox — numeric range")
+        Spinbox(5, min_value=0, max_value=20, step=1)
+
+        Label("Spinbox — float range, step=0.5")
+        Spinbox(1.5, min_value=0.0, max_value=5.0, step=0.5)
+
+        Separator(fill="x")
+
+        # States
+        Label("Spinbox — disabled")
+        Spinbox("Medium", options=["Small", "Medium", "Large"], disabled=True)
+
+        Label("Spinbox — compact density")
+        Spinbox(3, min_value=1, max_value=10, density="compact")
+
+        Separator(fill="x")
+
+        # Separator orientations
+        Label("Separator — horizontal (default)")
+        Separator(fill="x")
+
+        Label("Separator — accented")
+        Separator(accent="primary", fill="x")
+
+        Label("Separators — vertical, inside HStack")
+        with HStack(gap=12, fill_items="y"):
+            Label("Left")
+            Separator("vertical")
+            Label("Middle")
+            Separator("vertical")
+            Label("Right")
+
+    app.run()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds `Spinbox`: `options=` for a fixed list (replaces `values=`), `min_value=`/`max_value=`/`step=` for numeric range (replace `from_=`/`to=`/`increment=`). Value seeded after construction in all modes.
- Adds `Separator`: positional `orient=`, `accent=`, `thickness=`, `length=`.

## Test plan

- [ ] `python tests/features/spinbox_separator.py` — list and numeric spinboxes render; separators horizontal and vertical display correctly
- [ ] `pytest tests/widgets/public/ -m "not gui"` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)