### PR TITLE
feat(public): PasswordEntry and TextArea

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -521,6 +521,7 @@ See memory `project_api_gaps.md` for full list. Key items:
 - `TabView(variant='pill')` crashes — no pill style builder for `TabItem.TFrame`
 - `on_changed`/`on_input` callback shape inconsistency vs `on_valid`/`on_invalid`
 - `Field` message label (`_message_lbl`) shows gray background when `required=True` auto-enables `show_message` and validation first fires — background doesn't match surface
+- `TextArea` uses the raw Tk Text widget border instead of the Field-style themed border — should adopt the same focus-ring/border approach as other Field composites
 - `Style._tk_widgets` grows forever — destroyed widgets never removed; causes theme-change slowdown *(partially resolved in Session 26 — WeakSet + visibility guard; remaining issue is pages are never destroyed)*
 
 ---

--- a/src/bootstack/widgets/public/__init__.py
+++ b/src/bootstack/widgets/public/__init__.py
@@ -13,10 +13,12 @@ from bootstack.widgets.public.primitives.label import Badge, Label
 from bootstack.widgets.public.primitives.numericentry import NumericEntry
 from bootstack.widgets.public.primitives.progressbar import ProgressBar
 from bootstack.widgets.public.primitives.radiogroup import RadioGroup
+from bootstack.widgets.public.primitives.passwordentry import PasswordEntry
 from bootstack.widgets.public.primitives.select import Select
 from bootstack.widgets.public.primitives.separator import Separator
 from bootstack.widgets.public.primitives.slider import RangeSlider, Slider
 from bootstack.widgets.public.primitives.spinbox import Spinbox
+from bootstack.widgets.public.primitives.textarea import TextArea
 from bootstack.widgets.public.primitives.textfield import TextField
 
 __all__ = [
@@ -32,6 +34,7 @@ __all__ = [
     "Label",
     "NumericEntry",
     "ParentResolutionError",
+    "PasswordEntry",
     "ProgressBar",
     "PublicContainer",
     "PublicWidgetBase",
@@ -43,6 +46,7 @@ __all__ = [
     "Spinbox",
     "Subscription",
     "Switch",
+    "TextArea",
     "TextField",
     "ToggleButton",
     "UnknownEventError",

--- a/src/bootstack/widgets/public/primitives/__init__.py
+++ b/src/bootstack/widgets/public/primitives/__init__.py
@@ -6,13 +6,15 @@ from bootstack.widgets.public.primitives.numericentry import NumericEntry
 from bootstack.widgets.public.primitives.progressbar import ProgressBar
 from bootstack.widgets.public.primitives.radiogroup import RadioGroup
 from bootstack.widgets.public.primitives.select import Select
+from bootstack.widgets.public.primitives.passwordentry import PasswordEntry
 from bootstack.widgets.public.primitives.separator import Separator
 from bootstack.widgets.public.primitives.slider import RangeSlider, Slider
 from bootstack.widgets.public.primitives.spinbox import Spinbox
+from bootstack.widgets.public.primitives.textarea import TextArea
 from bootstack.widgets.public.primitives.textfield import TextField
 
 __all__ = [
     "Badge", "Button", "Checkbox", "Gauge", "Label", "NumericEntry",
-    "ProgressBar", "RadioGroup", "RangeSlider", "Select", "Separator",
-    "Slider", "Spinbox", "Switch", "TextField", "ToggleButton",
+    "PasswordEntry", "ProgressBar", "RadioGroup", "RangeSlider", "Select",
+    "Separator", "Slider", "Spinbox", "Switch", "TextArea", "TextField", "ToggleButton",
 ]

--- a/src/bootstack/widgets/public/primitives/passwordentry.py
+++ b/src/bootstack/widgets/public/primitives/passwordentry.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import tkinter
+from typing import Any, Callable
+
+from bootstack.widgets.composites.passwordentry import PasswordEntry as _InternalPasswordEntry
+from bootstack.widgets.public.base import PublicWidgetBase
+from bootstack.widgets.public.events import register_widget_events
+from bootstack.widgets.public.subscription import Subscription
+from bootstack.widgets.public.primitives.textfield import _INNER_ENTRY_SEQUENCES
+
+_PASSWORD_EVENTS: dict[str, str] = {
+    "change": "<<Change>>",
+    "submit": "<Return>",
+}
+
+
+class PasswordEntry(PublicWidgetBase):
+    """A masked text field for password input with an optional visibility toggle.
+
+    Args:
+        value: Initial password value (displayed masked).
+        label: Label displayed above the field.
+        message: Hint text displayed below the field.
+        required: If True, field cannot be left empty.
+        mask_char: Character used to mask input. Default `'•'`.
+        show_toggle: If True (default), shows the eye-icon visibility button.
+        disabled: If True, field is non-interactive.
+        read_only: If True, value is visible but not editable.
+        width: Width in character cells.
+        accent: Accent token for the focus ring.
+        density: Widget density — `'default'` or `'compact'`.
+        parent: Override the context-stack parent.
+    """
+
+    def __init__(
+        self,
+        value: str = "",
+        *,
+        label: str | None = None,
+        message: str | None = None,
+        required: bool = False,
+        mask_char: str = "•",
+        show_toggle: bool = True,
+        disabled: bool = False,
+        read_only: bool = False,
+        width: int | None = None,
+        accent: str | None = None,
+        density: str | None = None,
+        parent: Any = None,
+        **kwargs: Any,
+    ) -> None:
+        self._parent = self._resolve_parent(parent)
+        layout_kw = self._split_layout_kwargs(kwargs)
+
+        tk_master = self._parent._child_master() if self._parent else None
+
+        internal_kwargs: dict[str, Any] = {
+            "show": mask_char,
+            "show_visibility_toggle": show_toggle,
+        }
+        if value:
+            internal_kwargs["value"] = value
+        if label is not None:
+            internal_kwargs["label"] = label
+        if message is not None:
+            internal_kwargs["message"] = message
+        if required:
+            internal_kwargs["required"] = True
+        if disabled:
+            internal_kwargs["state"] = "disabled"
+        elif read_only:
+            internal_kwargs["state"] = "readonly"
+        if width is not None:
+            internal_kwargs["width"] = width
+        if accent is not None:
+            internal_kwargs["accent"] = accent
+        if density is not None:
+            internal_kwargs["density"] = density
+        internal_kwargs.update(kwargs)
+
+        self._internal = _InternalPasswordEntry(tk_master, **internal_kwargs)
+        self._attach_to_parent(layout_kw)
+
+    # ----- Event routing -----
+
+    def _entry_widget(self) -> tkinter.Misc:
+        return self._internal._entry
+
+    def on(self, event: str, handler: Callable[[tkinter.Event], Any]) -> Subscription:
+        from bootstack.widgets.public.events import resolve_event
+        sequence = resolve_event(self, str(event))
+        widget = self._entry_widget() if sequence in _INNER_ENTRY_SEQUENCES else self._internal
+        bind_id = widget.bind(sequence, handler, add="+")
+        return Subscription(widget, sequence, bind_id)
+
+    # ----- Properties -----
+
+    @property
+    def value(self) -> str:
+        return self._internal.value
+
+    @value.setter
+    def value(self, v: str) -> None:
+        self._internal.value = v
+
+    @property
+    def disabled(self) -> bool:
+        return str(self._internal._entry.cget("state")) == "disabled"
+
+    @disabled.setter
+    def disabled(self, v: bool) -> None:
+        self._internal.configure(state="disabled" if v else "normal")
+
+    # ----- Methods -----
+
+    def reveal(self) -> None:
+        """Remove character masking to show the password in plain text."""
+        self._internal.reveal()
+
+    def hide(self) -> None:
+        """Restore character masking."""
+        self._internal.hide()
+
+    # ----- Event shorthands -----
+
+    def on_change(self, handler: Callable[[tkinter.Event], Any]) -> Subscription:
+        """Register a callback fired when the value is committed.
+
+        Returns:
+            Subscription — call `.cancel()` to unsubscribe.
+        """
+        return self.on("change", handler)
+
+
+register_widget_events(PasswordEntry, _PASSWORD_EVENTS)

--- a/src/bootstack/widgets/public/primitives/textarea.py
+++ b/src/bootstack/widgets/public/primitives/textarea.py
@@ -122,7 +122,10 @@ class TextArea(PublicWidgetBase):
 
     def select_all(self) -> None:
         """Select all text content."""
-        self._internal._core.text.tag_add("sel", "1.0", "end")
+        tw = self._internal._core.text
+        tw.focus_set()
+        tw.tag_add("sel", "1.0", "end-1c")
+        tw.mark_set("insert", "end-1c")
 
     # ----- Event shorthands -----
 

--- a/src/bootstack/widgets/public/primitives/textarea.py
+++ b/src/bootstack/widgets/public/primitives/textarea.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import tkinter
+from typing import Any, Callable
+
+from bootstack.widgets.composites.textarea.textarea import TextArea as _InternalTextArea
+from bootstack.widgets.public.base import PublicWidgetBase
+from bootstack.widgets.public.events import register_widget_events
+from bootstack.widgets.public.subscription import Subscription
+
+_TEXTAREA_EVENTS: dict[str, str] = {
+    "change": "<<Change>>",
+    "input":  "<KeyRelease>",
+}
+
+
+class TextArea(PublicWidgetBase):
+    """A multi-line text input with optional label, placeholder, and scrollbars.
+
+    Args:
+        value: Initial text content.
+        text_signal: Reactive `Signal[str]` linked to the text content.
+        label: Label displayed above the field.
+        message: Hint text displayed below the field.
+        required: If True, field cannot be left empty.
+        placeholder: Placeholder text shown when the field is empty.
+        max_length: Maximum number of characters allowed.
+        read_only: If True, text is visible but not editable.
+        wrap: If True (default), long lines wrap at the widget boundary.
+        height: Visible row count. Default `4`.
+        scrollbars: Scrollbar visibility — `'auto'` (default), `'vertical'`,
+            `'both'`, or `'none'`.
+        font: Font token. Default `'body'`.
+        accent: Accent token for the focus border.
+        parent: Override the context-stack parent.
+    """
+
+    def __init__(
+        self,
+        value: str = "",
+        *,
+        text_signal: Any = None,
+        label: str | None = None,
+        message: str | None = None,
+        required: bool = False,
+        placeholder: str | None = None,
+        max_length: int | None = None,
+        read_only: bool = False,
+        wrap: bool = True,
+        height: int = 4,
+        scrollbars: str = "auto",
+        font: Any = "body",
+        accent: str = "primary",
+        parent: Any = None,
+        **kwargs: Any,
+    ) -> None:
+        self._parent = self._resolve_parent(parent)
+        layout_kw = self._split_layout_kwargs(kwargs)
+
+        tk_master = self._parent._child_master() if self._parent else None
+
+        internal_kwargs: dict[str, Any] = {
+            "value": value,
+            "read_only": read_only,
+            "wrap": wrap,
+            "height": height,
+            "scrollbars": scrollbars,
+            "font": font,
+            "accent": accent,
+        }
+        if text_signal is not None:
+            internal_kwargs["textsignal"] = text_signal
+        if label is not None:
+            internal_kwargs["label"] = label
+        if message is not None:
+            internal_kwargs["message"] = message
+        if required:
+            internal_kwargs["required"] = True
+        if placeholder is not None:
+            internal_kwargs["placeholder"] = placeholder
+        if max_length is not None:
+            internal_kwargs["max_length"] = max_length
+        internal_kwargs.update(kwargs)
+
+        self._internal = _InternalTextArea(tk_master, **internal_kwargs)
+        self._attach_to_parent(layout_kw)
+
+    # ----- Event routing -----
+
+    def _text_widget(self) -> tkinter.Misc:
+        """The underlying Tk Text widget where input events fire."""
+        return self._internal._core.text
+
+    def on(self, event: str, handler: Callable[[tkinter.Event], Any]) -> Subscription:
+        from bootstack.widgets.public.events import resolve_event
+        sequence = resolve_event(self, str(event))
+        # Change and keystroke events fire on the inner text widget
+        inner_sequences = {"<<Change>>", "<KeyRelease>", "<FocusIn>", "<FocusOut>"}
+        widget = self._text_widget() if sequence in inner_sequences else self._internal
+        bind_id = widget.bind(sequence, handler, add="+")
+        return Subscription(widget, sequence, bind_id)
+
+    # ----- Properties -----
+
+    @property
+    def value(self) -> str:
+        return self._internal.value
+
+    @value.setter
+    def value(self, v: str) -> None:
+        self._internal.value = v
+
+    # ----- Methods -----
+
+    def clear(self) -> None:
+        """Clear all text content."""
+        self._internal.value = ""
+
+    def insert(self, index: str, text: str) -> None:
+        """Insert `text` at `index` (Tk text index, e.g. `'end'` or `'1.0'`)."""
+        self._internal._core.text.insert(index, text)
+
+    def select_all(self) -> None:
+        """Select all text content."""
+        self._internal._core.text.tag_add("sel", "1.0", "end")
+
+    # ----- Event shorthands -----
+
+    def on_change(self, handler: Callable[[tkinter.Event], Any]) -> Subscription:
+        """Register a callback fired when the value is committed (blur).
+
+        Returns:
+            Subscription — call `.cancel()` to unsubscribe.
+        """
+        return self.on("change", handler)
+
+    def on_input(self, handler: Callable[[tkinter.Event], Any]) -> Subscription:
+        """Register a callback fired on every keystroke.
+
+        Returns:
+            Subscription — call `.cancel()` to unsubscribe.
+        """
+        return self.on("input", handler)
+
+
+register_widget_events(TextArea, _TEXTAREA_EVENTS)

--- a/tests/features/password_textarea.py
+++ b/tests/features/password_textarea.py
@@ -1,0 +1,51 @@
+"""Visual test for public PasswordEntry and TextArea widgets."""
+from bootstack.widgets.public import App, VStack, HStack, Label, PasswordEntry, TextArea, Button
+
+
+def main():
+    with App(title="PasswordEntry + TextArea — visual test", minsize=(480, 100), padding=24, gap=14) as app:
+
+        # PasswordEntry variants
+        Label("PasswordEntry — basic (with visibility toggle)")
+        PasswordEntry(label="Password")
+
+        Label("PasswordEntry — custom mask character")
+        PasswordEntry("secret", label="API key", mask_char="*")
+
+        Label("PasswordEntry — no visibility toggle")
+        PasswordEntry(label="PIN", show_toggle=False)
+
+        Label("PasswordEntry — required")
+        PasswordEntry(label="Required password", required=True)
+
+        Label("PasswordEntry — disabled")
+        PasswordEntry("hidden", label="Disabled", disabled=True)
+
+        # TextArea variants
+        Label("TextArea — basic")
+        ta = TextArea("Initial content here.", label="Notes", height=3)
+
+        Label("TextArea — with placeholder")
+        TextArea(label="Description", placeholder="Type something...", height=3)
+
+        Label("TextArea — read-only")
+        TextArea(
+            "This text cannot be edited.",
+            label="Read-only",
+            read_only=True,
+            height=2,
+        )
+
+        Label("TextArea — max length (50 chars)")
+        TextArea(label="Limited", max_length=50, height=2)
+
+        # Controls
+        with HStack(gap=8):
+            Button("Clear notes", on_click=lambda: ta.clear(), variant="outline")
+            Button("Select all", on_click=lambda: ta.select_all(), variant="outline")
+
+    app.run()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds `PasswordEntry`: `mask_char=` (replaces `show=`, defaults to `'•'`), `show_toggle=` (replaces `show_visibility_toggle=`), `reveal()`/`hide()` methods
- Adds `TextArea`: `text_signal=`, `placeholder=`, `max_length=`, `wrap=`, `height=`, `scrollbars=`. Routes `<<Change>>` and `<KeyRelease>` to `_core.text` where they actually fire. `clear()`/`insert()`/`select_all()` methods.
- Known issue logged in CLAUDE.md: TextArea uses raw Tk Text border instead of Field-style themed border

## Test plan

- [ ] `python tests/features/password_textarea.py` — all variants render; visibility toggle works; Clear/Select-all buttons function
- [ ] `pytest tests/widgets/public/ -m "not gui"` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)