### PR TITLE
feat(public): Expander, Accordion, and ToggleGroup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -522,6 +522,7 @@ See memory `project_api_gaps.md` for full list. Key items:
 - `on_changed`/`on_input` callback shape inconsistency vs `on_valid`/`on_invalid`
 - `Field` message label (`_message_lbl`) shows gray background when `required=True` auto-enables `show_message` and validation first fires — background doesn't match surface
 - `TextArea` uses the raw Tk Text widget border instead of the Field-style themed border — should adopt the same focus-ring/border approach as other Field composites
+- `ToggleGroup` solid (default) variant has poor contrast — selected button text is hard to read against the filled background; needs a style-builder fix
 - `Style._tk_widgets` grows forever — destroyed widgets never removed; causes theme-change slowdown *(partially resolved in Session 26 — WeakSet + visibility guard; remaining issue is pages are never destroyed)*
 
 ---

--- a/src/bootstack/widgets/public/__init__.py
+++ b/src/bootstack/widgets/public/__init__.py
@@ -8,26 +8,30 @@ from bootstack.widgets.public.grid import Grid
 from bootstack.widgets.public.app import App
 from bootstack.widgets.public.primitives.boolean_controls import Checkbox, Switch, ToggleButton
 from bootstack.widgets.public.primitives.button import Button
+from bootstack.widgets.public.primitives.expander import Accordion, Expander
 from bootstack.widgets.public.primitives.gauge import Gauge
 from bootstack.widgets.public.primitives.label import Badge, Label
 from bootstack.widgets.public.primitives.numericentry import NumericEntry
+from bootstack.widgets.public.primitives.passwordentry import PasswordEntry
 from bootstack.widgets.public.primitives.progressbar import ProgressBar
 from bootstack.widgets.public.primitives.radiogroup import RadioGroup
-from bootstack.widgets.public.primitives.passwordentry import PasswordEntry
 from bootstack.widgets.public.primitives.select import Select
 from bootstack.widgets.public.primitives.separator import Separator
 from bootstack.widgets.public.primitives.slider import RangeSlider, Slider
 from bootstack.widgets.public.primitives.spinbox import Spinbox
 from bootstack.widgets.public.primitives.textarea import TextArea
 from bootstack.widgets.public.primitives.textfield import TextField
+from bootstack.widgets.public.primitives.togglegroup import ToggleGroup
 
 __all__ = [
+    "Accordion",
     "App",
     "Badge",
     "BootstackV2Error",
     "Button",
     "Checkbox",
     "Event",
+    "Expander",
     "Gauge",
     "Grid",
     "HStack",
@@ -49,6 +53,7 @@ __all__ = [
     "TextArea",
     "TextField",
     "ToggleButton",
+    "ToggleGroup",
     "UnknownEventError",
     "VStack",
 ]

--- a/src/bootstack/widgets/public/primitives/__init__.py
+++ b/src/bootstack/widgets/public/primitives/__init__.py
@@ -1,20 +1,23 @@
 from bootstack.widgets.public.primitives.boolean_controls import Checkbox, Switch, ToggleButton
 from bootstack.widgets.public.primitives.button import Button
+from bootstack.widgets.public.primitives.expander import Accordion, Expander
 from bootstack.widgets.public.primitives.gauge import Gauge
 from bootstack.widgets.public.primitives.label import Badge, Label
 from bootstack.widgets.public.primitives.numericentry import NumericEntry
+from bootstack.widgets.public.primitives.passwordentry import PasswordEntry
 from bootstack.widgets.public.primitives.progressbar import ProgressBar
 from bootstack.widgets.public.primitives.radiogroup import RadioGroup
 from bootstack.widgets.public.primitives.select import Select
-from bootstack.widgets.public.primitives.passwordentry import PasswordEntry
 from bootstack.widgets.public.primitives.separator import Separator
 from bootstack.widgets.public.primitives.slider import RangeSlider, Slider
 from bootstack.widgets.public.primitives.spinbox import Spinbox
 from bootstack.widgets.public.primitives.textarea import TextArea
 from bootstack.widgets.public.primitives.textfield import TextField
+from bootstack.widgets.public.primitives.togglegroup import ToggleGroup
 
 __all__ = [
-    "Badge", "Button", "Checkbox", "Gauge", "Label", "NumericEntry",
-    "PasswordEntry", "ProgressBar", "RadioGroup", "RangeSlider", "Select",
-    "Separator", "Slider", "Spinbox", "Switch", "TextArea", "TextField", "ToggleButton",
+    "Accordion", "Badge", "Button", "Checkbox", "Expander", "Gauge", "Label",
+    "NumericEntry", "PasswordEntry", "ProgressBar", "RadioGroup", "RangeSlider",
+    "Select", "Separator", "Slider", "Spinbox", "Switch", "TextArea", "TextField",
+    "ToggleButton", "ToggleGroup",
 ]

--- a/src/bootstack/widgets/public/primitives/expander.py
+++ b/src/bootstack/widgets/public/primitives/expander.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import tkinter
+from typing import Any, Callable
+
+from bootstack.widgets.composites.expander import Expander as _InternalExpander
+from bootstack.widgets.composites.accordion import Accordion as _InternalAccordion
+from bootstack.widgets.public.container import PublicContainer, PACK_KEYS
+from bootstack.widgets.public.base import PublicWidgetBase
+from bootstack.widgets.public.context import push_container, pop_container
+from bootstack.widgets.public.events import register_widget_events
+from bootstack.widgets.public.subscription import Subscription
+
+_EXPANDER_EVENTS: dict[str, str] = {
+    "expand":   "<<Toggle>>",
+    "collapse":  "<<Toggle>>",
+    "toggle":    "<<Toggle>>",
+}
+
+
+class Expander(PublicContainer):
+    """A collapsible container with a clickable header.
+
+    Children placed inside the context block go into the expandable body.
+
+    Args:
+        title: Header text.
+        expanded: If True (default), body is visible on creation.
+        collapsible: If False, the header cannot be clicked to collapse.
+        icon: Icon displayed in the header (left of title).
+        accent: Accent token for header styling.
+        parent: Override the context-stack parent.
+    """
+
+    def __init__(
+        self,
+        title: str = "",
+        *,
+        expanded: bool = True,
+        collapsible: bool = True,
+        icon: str | None = None,
+        accent: str | None = None,
+        parent: Any = None,
+        **kwargs: Any,
+    ) -> None:
+        self._parent = self._resolve_parent(parent)
+        layout_kw = self._split_layout_kwargs(kwargs)
+
+        tk_master = self._parent._child_master() if self._parent else None
+
+        internal_kwargs: dict[str, Any] = {
+            "title": title,
+            "expanded": expanded,
+            "collapsible": collapsible,
+        }
+        if icon is not None:
+            internal_kwargs["icon"] = icon
+        if accent is not None:
+            internal_kwargs["accent"] = accent
+        internal_kwargs.update(kwargs)
+
+        self._internal = _InternalExpander(tk_master, **internal_kwargs)
+        self._attach_to_parent(layout_kw)
+
+    def _child_master(self) -> tkinter.Misc:
+        return self._internal._content_frame
+
+    def _default_layout_method(self) -> str:
+        return "pack"
+
+    def _merge_layout_options(self, child: Any, layout_kw: dict) -> tuple[str, dict]:
+        return ("pack", {k: v for k, v in layout_kw.items() if k in PACK_KEYS})
+
+    # ----- Properties -----
+
+    @property
+    def expanded(self) -> bool:
+        return self._internal._expanded
+
+    # ----- Methods -----
+
+    def expand(self) -> None:
+        """Expand the body."""
+        self._internal.expand()
+
+    def collapse(self) -> None:
+        """Collapse the body."""
+        self._internal.collapse()
+
+    def toggle(self) -> None:
+        """Toggle between expanded and collapsed."""
+        self._internal.toggle()
+
+    # ----- Event shorthands -----
+
+    def on_toggle(self, handler: Callable[[tkinter.Event], Any]) -> Subscription:
+        """Register a callback fired when the expander is expanded or collapsed.
+
+        Returns:
+            Subscription — call `.cancel()` to unsubscribe.
+        """
+        return self.on("toggle", handler)
+
+
+register_widget_events(Expander, _EXPANDER_EVENTS)
+
+
+# ---------------------------------------------------------------------------
+# _AccordionSection — lightweight context-manager wrapper returned by
+# Accordion.add(). Not part of the public API directly.
+# ---------------------------------------------------------------------------
+
+class _AccordionSection:
+    """Context-manager wrapper around an Accordion section body."""
+
+    def __init__(self, internal_expander: _InternalExpander) -> None:
+        self._expander = internal_expander
+
+    def _child_master(self) -> tkinter.Misc:
+        return self._expander._content_frame
+
+    def guide_layout(self, child: PublicWidgetBase, **layout_kw: Any) -> None:
+        options = {k: v for k, v in layout_kw.items() if k in PACK_KEYS}
+        child._internal.pack(in_=self._child_master(), **options)
+
+    def __enter__(self) -> "_AccordionSection":
+        push_container(self)
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        pop_container(self)
+
+
+class Accordion(PublicWidgetBase):
+    """A list of collapsible sections, optionally limited to one open at a time.
+
+    Args:
+        allow_multiple: If True, multiple sections can be expanded simultaneously.
+            Default `False` (only one section open at a time).
+        allow_collapse_all: If True, all sections can be collapsed. Default `True`.
+        accent: Accent token for section headers.
+        parent: Override the context-stack parent.
+    """
+
+    def __init__(
+        self,
+        *,
+        allow_multiple: bool = False,
+        allow_collapse_all: bool = True,
+        accent: str | None = None,
+        parent: Any = None,
+        **kwargs: Any,
+    ) -> None:
+        self._parent = self._resolve_parent(parent)
+        layout_kw = self._split_layout_kwargs(kwargs)
+
+        tk_master = self._parent._child_master() if self._parent else None
+
+        internal_kwargs: dict[str, Any] = {
+            "allow_multiple": allow_multiple,
+            "allow_collapse_all": allow_collapse_all,
+        }
+        if accent is not None:
+            internal_kwargs["accent"] = accent
+        internal_kwargs.update(kwargs)
+
+        self._internal = _InternalAccordion(tk_master, **internal_kwargs)
+        self._attach_to_parent(layout_kw)
+
+    def add(
+        self,
+        title: str,
+        *,
+        expanded: bool | None = None,
+        icon: str | None = None,
+    ) -> _AccordionSection:
+        """Add a section and return a context manager for placing its children.
+
+        Usage::
+
+            with acc.add("Section title") as section:
+                Label("Content goes here")
+
+        Returns:
+            `_AccordionSection` — use as a context manager to place children.
+        """
+        kwargs: dict[str, Any] = {}
+        if expanded is not None:
+            kwargs["expanded"] = expanded
+        if icon is not None:
+            kwargs["icon"] = icon
+        internal_exp = self._internal.add(title=title, **kwargs)
+        return _AccordionSection(internal_exp)

--- a/src/bootstack/widgets/public/primitives/togglegroup.py
+++ b/src/bootstack/widgets/public/primitives/togglegroup.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import tkinter
+from typing import Any, Callable
+
+from bootstack.widgets.composites.togglegroup import ToggleGroup as _InternalToggleGroup
+from bootstack.widgets.public.base import PublicWidgetBase
+from bootstack.widgets.public.events import register_widget_events
+from bootstack.widgets.public.subscription import Subscription
+
+_TOGGLEGROUP_EVENTS: dict[str, str] = {
+    "change": "<<Change>>",
+}
+
+
+class ToggleGroup(PublicWidgetBase):
+    """A group of toggle buttons — single-select or multi-select.
+
+    Options are passed at construction via `options=`. Each option is either
+    a plain string (label and value are the same) or a `(label, value)` tuple.
+
+    Args:
+        options: Choices, e.g. `["Grid", "List"]` or `[("Label", "val"), ...]`.
+        mode: `'single'` (default, radio behaviour) or `'multi'` (checkbox behaviour).
+        signal: Reactive `Signal` holding the selected value(s).
+        value: Initially selected value (string for `'single'`, set for `'multi'`).
+        orient: `'horizontal'` (default) or `'vertical'`.
+        accent: Accent token applied to all buttons.
+        variant: Style variant, e.g. `'outline'`, `'ghost'`.
+        disabled: If True, all buttons are non-interactive.
+        parent: Override the context-stack parent.
+    """
+
+    def __init__(
+        self,
+        options: list[str | tuple[str, Any]] | None = None,
+        *,
+        mode: str = "single",
+        signal: Any = None,
+        value: Any = None,
+        orient: str = "horizontal",
+        accent: str | None = None,
+        variant: str | None = None,
+        disabled: bool = False,
+        parent: Any = None,
+        **kwargs: Any,
+    ) -> None:
+        self._parent = self._resolve_parent(parent)
+        layout_kw = self._split_layout_kwargs(kwargs)
+
+        tk_master = self._parent._child_master() if self._parent else None
+
+        internal_kwargs: dict[str, Any] = {
+            "mode": mode,
+            "orient": orient,
+        }
+        if signal is not None:
+            internal_kwargs["signal"] = signal
+        if value is not None:
+            internal_kwargs["value"] = value
+        if accent is not None:
+            internal_kwargs["accent"] = accent
+        if variant is not None:
+            internal_kwargs["variant"] = variant
+        if disabled:
+            internal_kwargs["state"] = "disabled"
+        internal_kwargs.update(kwargs)
+
+        self._internal = _InternalToggleGroup(tk_master, **internal_kwargs)
+
+        # Populate options passed at construction.
+        if options:
+            for opt in options:
+                if isinstance(opt, str):
+                    self._internal.add(text=opt, value=opt)
+                else:
+                    lbl, val = opt
+                    self._internal.add(text=lbl, value=val)
+
+        # Trace signal → <<Change>> for consistent Subscription-based on_change().
+        def _on_value_change(_new_value: Any) -> None:
+            try:
+                self._internal.event_generate("<<Change>>")
+            except tkinter.TclError:
+                pass
+
+        self._trace_id = self._internal.signal.subscribe(_on_value_change)
+        self._attach_to_parent(layout_kw)
+
+    # ----- Properties -----
+
+    @property
+    def value(self) -> Any:
+        return self._internal.get()
+
+    @value.setter
+    def value(self, v: Any) -> None:
+        self._internal.set(v)
+
+    @property
+    def disabled(self) -> bool:
+        return self._internal._state == "disabled"
+
+    @disabled.setter
+    def disabled(self, v: bool) -> None:
+        self._internal.configure(state="disabled" if v else "normal")
+
+    # ----- Methods -----
+
+    def add(self, label: str, value: Any | None = None, **kwargs: Any) -> None:
+        """Add a toggle button at runtime.
+
+        Args:
+            label: Display text.
+            value: Value this button represents. Defaults to `label`.
+        """
+        self._internal.add(text=label, value=value if value is not None else label, **kwargs)
+
+    # ----- Event shorthands -----
+
+    def on_change(self, handler: Callable[[tkinter.Event], Any]) -> Subscription:
+        """Register a callback fired whenever the selection changes.
+
+        Returns:
+            Subscription — call `.cancel()` to unsubscribe.
+        """
+        return self.on("change", handler)
+
+
+register_widget_events(ToggleGroup, _TOGGLEGROUP_EVENTS)

--- a/tests/features/expander_accordion_togglegroup.py
+++ b/tests/features/expander_accordion_togglegroup.py
@@ -1,0 +1,71 @@
+"""Visual test for public Expander, Accordion, and ToggleGroup widgets."""
+from bootstack.widgets.public import (
+    App, VStack, HStack, Label, Button, Separator,
+    Expander, Accordion, ToggleGroup, TextField,
+)
+from bootstack.signals import Signal
+
+
+def main():
+    with App(title="Expander + Accordion + ToggleGroup", minsize=(500, 100), padding=24, gap=16) as app:
+
+        readout = Signal("(no change yet)")
+
+        # Expander
+        Label("Expander")
+        with Expander("Settings", fill="x", expand=True):
+            TextField(label="API key", mask_char="*")
+            with HStack(gap=8):
+                Button("Save", accent="primary", variant="outline")
+                Button("Cancel", variant="outline")
+
+        with Expander("Collapsed by default", expanded=False, fill="x", expand=True):
+            Label("Hidden until expanded")
+
+        Separator(fill="x")
+
+        # Accordion
+        Label("Accordion — single open at a time")
+        acc = Accordion(fill="x", expand=True)
+        with acc.add("Personal info"):
+            TextField(label="Name")
+            TextField(label="Email")
+        with acc.add("Preferences", expanded=False):
+            ToggleGroup(["Light", "Dark", "System"], value="System")
+        with acc.add("Advanced", expanded=False):
+            Label("Advanced settings go here")
+
+        Separator(fill="x")
+
+        # ToggleGroup — single
+        Label("ToggleGroup — single select")
+        tg = ToggleGroup(
+            ["Day", "Week", "Month", "Year"],
+            value="Week",
+            accent="primary",
+        )
+        tg.on_change(lambda e: readout.set(f"view: {tg.value}"))
+
+        # ToggleGroup — multi
+        Label("ToggleGroup — multi select")
+        tg2 = ToggleGroup(
+            [("Bold", "bold"), ("Italic", "italic"), ("Underline", "underline")],
+            mode="multi",
+            value={"bold"},
+        )
+        tg2.on_change(lambda e: readout.set(f"format: {tg2.value}"))
+
+        # ToggleGroup — vertical
+        Label("ToggleGroup — vertical")
+        ToggleGroup(["Option A", "Option B", "Option C"], orient="vertical", value="Option A")
+
+        # Readout
+        with HStack(gap=8, anchor_items="center"):
+            Label("Last change:")
+            Label(text_signal=readout, color="#0d6efd")
+
+    app.run()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- `Expander` — `PublicContainer`; context-manager places children into `_content_frame`; `expand()`/`collapse()`/`toggle()` methods; `on_toggle()` → `Subscription`
- `Accordion` — `PublicWidgetBase`; `add(title)` returns `_AccordionSection` (lightweight context manager routing children to the section body); fixes known `options=` gap for accordion-style layouts
- `ToggleGroup` — same pattern as `RadioGroup`; `options=` constructor (fixes known gap); `mode='single'|'multi'`; signal trace → `<<Change>>`; `on_change()` → `Subscription`

## Test plan

- [ ] `python tests/features/expander_accordion_togglegroup.py` — expanders toggle; accordion sections open/close; ToggleGroup single and multi selections update readout
- [ ] `pytest tests/widgets/public/ -m "not gui"` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)