### PR TITLE
feat(public): add Tabs widget

### DIFF
--- a/src/bootstack/widgets/public/__init__.py
+++ b/src/bootstack/widgets/public/__init__.py
@@ -19,6 +19,7 @@ from bootstack.widgets.public.primitives.select import Select
 from bootstack.widgets.public.primitives.separator import Separator
 from bootstack.widgets.public.primitives.slider import RangeSlider, Slider
 from bootstack.widgets.public.primitives.spinbox import Spinbox
+from bootstack.widgets.public.primitives.tabs import TabChangeEventData, TabRef, Tabs
 from bootstack.widgets.public.primitives.textarea import TextArea
 from bootstack.widgets.public.primitives.textfield import TextField
 from bootstack.widgets.public.primitives.togglegroup import ToggleGroup
@@ -50,6 +51,9 @@ __all__ = [
     "Spinbox",
     "Subscription",
     "Switch",
+    "TabChangeEventData",
+    "TabRef",
+    "Tabs",
     "TextArea",
     "TextField",
     "ToggleButton",

--- a/src/bootstack/widgets/public/primitives/__init__.py
+++ b/src/bootstack/widgets/public/primitives/__init__.py
@@ -11,6 +11,7 @@ from bootstack.widgets.public.primitives.select import Select
 from bootstack.widgets.public.primitives.separator import Separator
 from bootstack.widgets.public.primitives.slider import RangeSlider, Slider
 from bootstack.widgets.public.primitives.spinbox import Spinbox
+from bootstack.widgets.public.primitives.tabs import TabChangeEventData, TabRef, Tabs
 from bootstack.widgets.public.primitives.textarea import TextArea
 from bootstack.widgets.public.primitives.textfield import TextField
 from bootstack.widgets.public.primitives.togglegroup import ToggleGroup
@@ -18,6 +19,6 @@ from bootstack.widgets.public.primitives.togglegroup import ToggleGroup
 __all__ = [
     "Accordion", "Badge", "Button", "Checkbox", "Expander", "Gauge", "Label",
     "NumericEntry", "PasswordEntry", "ProgressBar", "RadioGroup", "RangeSlider",
-    "Select", "Separator", "Slider", "Spinbox", "Switch", "TextArea", "TextField",
-    "ToggleButton", "ToggleGroup",
+    "Select", "Separator", "Slider", "Spinbox", "Switch", "TabChangeEventData",
+    "TabRef", "Tabs", "TextArea", "TextField", "ToggleButton", "ToggleGroup",
 ]

--- a/src/bootstack/widgets/public/primitives/tabs.py
+++ b/src/bootstack/widgets/public/primitives/tabs.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import tkinter
+from typing import Any, Callable, Literal
+
+from bootstack.widgets.composites.tabs.tabview import TabView as _InternalTabView
+from bootstack.widgets.composites.tabs.events import TabChangeEventData, TabRef
+from bootstack.widgets.public.base import PublicWidgetBase
+from bootstack.widgets.public.container import PACK_KEYS
+from bootstack.widgets.public.context import push_container, pop_container
+from bootstack.widgets.public.events import register_widget_events, resolve_event
+from bootstack.widgets.public.subscription import Subscription
+
+_TABS_EVENTS: dict[str, str] = {
+    "change":    "<<TabChanged>>",
+    "tab_close": "<<TabClose>>",
+    "tab_add":   "<<TabAdd>>",
+}
+
+
+class _TabPage:
+    """Context-manager for placing children inside a tab's page frame."""
+
+    def __init__(self, page_widget: tkinter.Widget) -> None:
+        self._page = page_widget
+
+    def _child_master(self) -> tkinter.Widget:
+        return self._page
+
+    def guide_layout(self, child: PublicWidgetBase, **layout_kw: Any) -> None:
+        options = {k: v for k, v in layout_kw.items() if k in PACK_KEYS}
+        child._internal.pack(in_=self._page, **options)
+
+    def __enter__(self) -> "_TabPage":
+        push_container(self)
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        pop_container(self)
+
+
+class Tabs(PublicWidgetBase):
+    """A tabbed container. Add pages with `.add()` and place children inside them.
+
+    Usage::
+
+        tabs = bs.Tabs()
+        with tabs.add("home", text="Home"):
+            bs.Label("Welcome")
+        with tabs.add("settings", text="Settings"):
+            bs.Label("Settings here")
+
+    Args:
+        orient: `'horizontal'` (default, tabs above content) or `'vertical'` (tabs left).
+        show_divider: Show a divider line between the tab bar and the page area.
+        tab_width: Fixed tab width in pixels, `'stretch'` to fill available space, or
+            `None` (default, size to content).
+        enable_closing: Show close buttons on tabs. `True` = always, `False` = never,
+            `'hover'` = on hover. Default `False`.
+        enable_adding: Show an add-tab button that fires the `tab_add` event.
+        accent: Accent token for the tab bar.
+        parent: Override the context-stack parent.
+    """
+
+    def __init__(
+        self,
+        *,
+        orient: Literal["horizontal", "vertical"] = "horizontal",
+        show_divider: bool | None = None,
+        tab_width: int | Literal["stretch"] | None = None,
+        enable_closing: bool | Literal["hover"] = False,
+        enable_adding: bool = False,
+        accent: str | None = None,
+        parent: Any = None,
+        **kwargs: Any,
+    ) -> None:
+        self._parent = self._resolve_parent(parent)
+        layout_kw = self._split_layout_kwargs(kwargs)
+
+        tk_master = self._parent._child_master() if self._parent else None
+
+        internal_kwargs: dict[str, Any] = {
+            "orient": orient,
+            "enable_closing": enable_closing,
+            "enable_adding": enable_adding,
+        }
+        if show_divider is not None:
+            internal_kwargs["show_divider"] = show_divider
+        if tab_width is not None:
+            internal_kwargs["tab_width"] = tab_width
+        if accent is not None:
+            internal_kwargs["accent"] = accent
+        internal_kwargs.update(kwargs)
+
+        self._internal = _InternalTabView(tk_master, **internal_kwargs)
+        self._attach_to_parent(layout_kw)
+
+    # ----- Event routing -----
+
+    def on(self, event: str, handler: Callable[[tkinter.Event], Any]) -> Subscription:
+        """Bind `handler` to `event` and return a `Subscription`."""
+        sequence = resolve_event(self, str(event))
+        # <<TabAdd>> and <<TabClose>> are generated on the internal Tabs bar widget,
+        # not on the TabView frame itself.
+        if sequence in ("<<TabAdd>>", "<<TabClose>>"):
+            target = self._internal._tabs
+        else:
+            target = self._internal
+        bind_id = target.bind(sequence, handler, add="+")
+        return Subscription(target, sequence, bind_id)
+
+    # ----- Tab management -----
+
+    def add(
+        self,
+        key: str,
+        *,
+        text: str = "",
+        icon: str | None = None,
+        closable: bool | Literal["hover"] | None = None,
+        close_command: Callable | None = None,
+    ) -> _TabPage:
+        """Add a tab and return a context manager for placing its children.
+
+        Usage::
+
+            with tabs.add("home", text="Home"):
+                bs.Label("Content goes here")
+
+        Args:
+            key: Unique identifier for the tab/page.
+            text: Label displayed on the tab.
+            icon: Icon name displayed on the tab.
+            closable: Close-button visibility for this tab. Overrides `enable_closing`.
+            close_command: Called when the close button is clicked. Defaults to
+                removing the tab via `forget_tab()`.
+
+        Returns:
+            `_TabPage` — use as a context manager to place children.
+        """
+        add_kwargs: dict[str, Any] = {}
+        if icon is not None:
+            add_kwargs["icon"] = icon
+        if closable is not None:
+            add_kwargs["closable"] = closable
+        if close_command is not None:
+            add_kwargs["close_command"] = close_command
+
+        page_widget = self._internal.add(key, text=text, **add_kwargs)
+        return _TabPage(page_widget)
+
+    def select(self, key: str) -> None:
+        """Select the tab identified by `key`."""
+        self._internal.select(key)
+
+    def hide_tab(self, key: str) -> None:
+        """Hide a tab without removing it. Restore with `show_tab()`."""
+        self._internal.hide_tab(key)
+
+    def show_tab(self, key: str) -> None:
+        """Restore a previously hidden tab."""
+        self._internal.show_tab(key)
+
+    def forget_tab(self, key: str) -> None:
+        """Remove a tab and its page entirely."""
+        self._internal.forget_tab(key)
+
+    # ----- Properties / introspection -----
+
+    @property
+    def current(self) -> str | None:
+        """Key of the currently selected tab, or `None` if no tab is selected."""
+        return self._internal.current
+
+    def tab_keys(self) -> tuple[str, ...]:
+        """All tab keys in insertion order."""
+        return self._internal.tab_keys()
+
+    def page_keys(self) -> tuple[str, ...]:
+        """All page keys in insertion order."""
+        return self._internal.page_keys()
+
+    # ----- Event shorthands -----
+
+    def on_change(self, handler: Callable[[tkinter.Event], Any]) -> Subscription:
+        """Register a callback fired when the selected tab changes.
+
+        Returns:
+            Subscription — call `.cancel()` to unsubscribe.
+        """
+        return self.on("change", handler)
+
+    def on_tab_close(self, handler: Callable[[tkinter.Event], Any]) -> Subscription:
+        """Register a callback fired when a tab's close button is clicked.
+
+        Returns:
+            Subscription — call `.cancel()` to unsubscribe.
+        """
+        return self.on("tab_close", handler)
+
+    def on_tab_add(self, handler: Callable[[tkinter.Event], Any]) -> Subscription:
+        """Register a callback fired when the add-tab button is clicked.
+
+        Returns:
+            Subscription — call `.cancel()` to unsubscribe.
+        """
+        return self.on("tab_add", handler)
+
+
+register_widget_events(Tabs, _TABS_EVENTS)
+
+__all__ = ["Tabs", "TabChangeEventData", "TabRef"]

--- a/tests/features/tabs.py
+++ b/tests/features/tabs.py
@@ -1,0 +1,74 @@
+"""Visual test for public Tabs widget."""
+from bootstack.widgets.public import (
+    App, VStack, HStack, Label, Button, Separator, TextField, Tabs,
+)
+from bootstack.signals import Signal
+
+
+def main():
+    with App(title="Tabs", minsize=(600, 400), padding=0, gap=0) as app:
+        status = Signal("(no change yet)")
+
+        # Horizontal tabs (default) — fills the window
+        tabs = Tabs(fill="both", expand=True)
+
+        with tabs.add("home", text="Home"):
+            with VStack(padding=24, gap=12, fill="both", expand=True):
+                Label("Welcome to the Home tab", font="heading-lg")
+                Label("Select another tab to switch pages.")
+                Separator(fill="x")
+                with HStack(gap=8):
+                    Button("Go to Settings", accent="primary",
+                           on_click=lambda: tabs.select("settings"))
+                    Button("Go to About", variant="outline",
+                           on_click=lambda: tabs.select("about"))
+
+        with tabs.add("settings", text="Settings"):
+            with VStack(padding=24, gap=12, fill="both", expand=True):
+                Label("Settings", font="heading-lg")
+                TextField(label="Username")
+                TextField(label="Email")
+                Separator(fill="x")
+                with HStack(gap=8):
+                    Button("Save", accent="success")
+                    Button("Reset", variant="ghost")
+
+        with tabs.add("about", text="About"):
+            with VStack(padding=24, gap=12, fill="both", expand=True):
+                Label("About", font="heading-lg")
+                Label("bootstack — batteries-included Python desktop UI framework.")
+                Label("Public API — Tabs widget demo.")
+
+        tabs.on_change(lambda e: status.set(f"active tab: {tabs.current}"))
+
+        # Status bar at the bottom
+        Separator(fill="x")
+        with HStack(padding=(8, 12), gap=8, fill="x"):
+            Label("Status:", font="body[bold]")
+            Label(textsignal=status)
+
+
+    # --- Vertical tabs demo ---
+    with App(title="Tabs — vertical", minsize=(600, 350), padding=0, gap=0) as app2:
+        tabs2 = Tabs(orient="vertical", fill="both", expand=True)
+
+        with tabs2.add("dashboard", text="Dashboard"):
+            with VStack(padding=24, gap=8, fill="both", expand=True):
+                Label("Dashboard", font="heading-lg")
+                Label("Vertical tab layout demo.")
+
+        with tabs2.add("reports", text="Reports"):
+            with VStack(padding=24, gap=8, fill="both", expand=True):
+                Label("Reports", font="heading-lg")
+                Label("Charts and summaries would go here.")
+
+        with tabs2.add("users", text="Users"):
+            with VStack(padding=24, gap=8, fill="both", expand=True):
+                Label("Users", font="heading-lg")
+                Label("User management would go here.")
+
+    app.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/widgets/public/test_base_layer.py
+++ b/tests/widgets/public/test_base_layer.py
@@ -1,4 +1,4 @@
-"""Smoke tests for the v2 public API base layer."""
+"""Smoke tests for the public API base layer."""
 from __future__ import annotations
 
 import threading


### PR DESCRIPTION
## Summary

- Adds `bs.Tabs` public widget wrapping the internal `TabView` composite
- `tabs.add(key, text=...)` returns a `_TabPage` context manager for placing children inside a tab's page
- Exposes `select()`, `hide_tab()`, `show_tab()`, `forget_tab()`, `current`, `tab_keys()`, `page_keys()`
- `on_change()`, `on_tab_close()`, `on_tab_add()` event shorthands; `<<TabAdd>>`/`<<TabClose>>` route to the internal tab bar widget via `on()` override
- Re-exports `TabChangeEventData` and `TabRef` from `bs.*`

## Test plan

- [ ] Run `python tests/features/tabs.py` — two windows open (horizontal + vertical tabs), tab switching works, status bar updates on change
- [ ] `pytest tests/widgets/public/test_base_layer.py -m "not gui"` — 11 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)