### PR TITLE
feat(public): add Card, Tooltip, and Toast widgets

### DIFF
--- a/src/bootstack/widgets/public/__init__.py
+++ b/src/bootstack/widgets/public/__init__.py
@@ -8,6 +8,7 @@ from bootstack.widgets.public.grid import Grid
 from bootstack.widgets.public.app import App
 from bootstack.widgets.public.primitives.boolean_controls import Checkbox, Switch, ToggleButton
 from bootstack.widgets.public.primitives.button import Button
+from bootstack.widgets.public.primitives.card import Card
 from bootstack.widgets.public.primitives.expander import Accordion, Expander
 from bootstack.widgets.public.primitives.gauge import Gauge
 from bootstack.widgets.public.primitives.label import Badge, Label
@@ -22,7 +23,9 @@ from bootstack.widgets.public.primitives.spinbox import Spinbox
 from bootstack.widgets.public.primitives.tabs import TabChangeEventData, TabRef, Tabs
 from bootstack.widgets.public.primitives.textarea import TextArea
 from bootstack.widgets.public.primitives.textfield import TextField
+from bootstack.widgets.public.primitives.toast import Toast, toast
 from bootstack.widgets.public.primitives.togglegroup import ToggleGroup
+from bootstack.widgets.public.primitives.tooltip import Tooltip
 
 __all__ = [
     "Accordion",
@@ -30,6 +33,7 @@ __all__ = [
     "Badge",
     "BootstackV2Error",
     "Button",
+    "Card",
     "Checkbox",
     "Event",
     "Expander",
@@ -56,8 +60,11 @@ __all__ = [
     "Tabs",
     "TextArea",
     "TextField",
+    "Toast",
+    "toast",
     "ToggleButton",
     "ToggleGroup",
+    "Tooltip",
     "UnknownEventError",
     "VStack",
 ]

--- a/src/bootstack/widgets/public/primitives/__init__.py
+++ b/src/bootstack/widgets/public/primitives/__init__.py
@@ -1,5 +1,6 @@
 from bootstack.widgets.public.primitives.boolean_controls import Checkbox, Switch, ToggleButton
 from bootstack.widgets.public.primitives.button import Button
+from bootstack.widgets.public.primitives.card import Card
 from bootstack.widgets.public.primitives.expander import Accordion, Expander
 from bootstack.widgets.public.primitives.gauge import Gauge
 from bootstack.widgets.public.primitives.label import Badge, Label
@@ -14,11 +15,14 @@ from bootstack.widgets.public.primitives.spinbox import Spinbox
 from bootstack.widgets.public.primitives.tabs import TabChangeEventData, TabRef, Tabs
 from bootstack.widgets.public.primitives.textarea import TextArea
 from bootstack.widgets.public.primitives.textfield import TextField
+from bootstack.widgets.public.primitives.toast import Toast, toast
 from bootstack.widgets.public.primitives.togglegroup import ToggleGroup
+from bootstack.widgets.public.primitives.tooltip import Tooltip
 
 __all__ = [
-    "Accordion", "Badge", "Button", "Checkbox", "Expander", "Gauge", "Label",
-    "NumericEntry", "PasswordEntry", "ProgressBar", "RadioGroup", "RangeSlider",
-    "Select", "Separator", "Slider", "Spinbox", "Switch", "TabChangeEventData",
-    "TabRef", "Tabs", "TextArea", "TextField", "ToggleButton", "ToggleGroup",
+    "Accordion", "Badge", "Button", "Card", "Checkbox", "Expander", "Gauge",
+    "Label", "NumericEntry", "PasswordEntry", "ProgressBar", "RadioGroup",
+    "RangeSlider", "Select", "Separator", "Slider", "Spinbox", "Switch",
+    "TabChangeEventData", "TabRef", "Tabs", "TextArea", "TextField", "Toast",
+    "toast", "ToggleButton", "ToggleGroup", "Tooltip",
 ]

--- a/src/bootstack/widgets/public/primitives/card.py
+++ b/src/bootstack/widgets/public/primitives/card.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from typing import Any
+
+from bootstack.widgets.primitives.card import Card as _InternalCard
+from bootstack.widgets.public.container import PublicContainer, PACK_KEYS, normalize_fill
+
+
+class Card(PublicContainer):
+    """A styled container with a border and padding — the standard surface for grouping content.
+
+    Children placed inside the context block are packed vertically by default.
+
+    Args:
+        padding: Space inside the card between its border and content. Default `16`.
+        show_border: Draw a border around the card. Default `True`.
+        accent: Accent token. Default `'card'`.
+        surface: Surface token for the background.
+        width: Requested width in pixels.
+        height: Requested height in pixels.
+        fill: Self-placement — fill direction in parent (`'x'`, `'y'`, `'both'`).
+        expand: Self-placement — expand to fill available space in parent.
+        parent: Override the context-stack parent.
+    """
+
+    def __init__(
+        self,
+        *,
+        padding: Any = 16,
+        show_border: bool = True,
+        accent: str | None = None,
+        surface: str | None = None,
+        width: int | None = None,
+        height: int | None = None,
+        # Self-placement
+        fill: str | None = None,
+        expand: bool | None = None,
+        anchor: str | None = None,
+        parent: Any = None,
+        **extra_kw: Any,
+    ) -> None:
+        self._parent = self._resolve_parent(parent)
+
+        layout_kw: dict[str, Any] = {}
+        if fill is not None:
+            layout_kw["fill"] = normalize_fill(fill)
+        if expand is not None:
+            layout_kw["expand"] = expand
+        if anchor is not None:
+            layout_kw["anchor"] = anchor
+        layout_kw.update(self._split_layout_kwargs(extra_kw))
+
+        card_kwargs: dict[str, Any] = {
+            "padding": padding,
+            "show_border": show_border,
+        }
+        if accent is not None:
+            card_kwargs["accent"] = accent
+        if surface is not None:
+            card_kwargs["surface"] = surface
+        if width is not None:
+            card_kwargs["width"] = width
+        if height is not None:
+            card_kwargs["height"] = height
+        card_kwargs.update(extra_kw)
+
+        tk_master = self._parent._child_master() if self._parent else None
+        self._internal = _InternalCard(tk_master, **card_kwargs)
+        self._attach_to_parent(layout_kw)
+
+    def _default_layout_method(self) -> str:
+        return "pack"
+
+    def _merge_layout_options(self, child: Any, layout_kw: dict) -> tuple[str, dict]:
+        options = {k: v for k, v in layout_kw.items() if k in PACK_KEYS}
+        return ("pack", options)

--- a/src/bootstack/widgets/public/primitives/toast.py
+++ b/src/bootstack/widgets/public/primitives/toast.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from typing import Any, Callable, Sequence
+
+from bootstack.widgets.composites.toast import Toast as _InternalToast
+
+
+class Toast:
+    """A temporary notification that appears in a corner of the screen.
+
+    Create a toast, then call `.show()` to display it. Auto-dismisses after
+    `duration` milliseconds if set; otherwise stays until closed by the user.
+
+    Usage::
+
+        t = bs.Toast(message="File saved.", accent="success", duration=3000)
+        t.show()
+
+    Args:
+        title: Header text. Shown larger when there is no message.
+        message: Main body text. Shown below the title when both are provided.
+        memo: Small muted metadata string (e.g. `"just now"`).
+        icon: Icon name string, or an `IconSpec` dict with `name`, `size`, `color`.
+        duration: Auto-dismiss delay in milliseconds. `None` = no auto-dismiss.
+        accent: Accent token for the container (e.g. `'success'`, `'danger'`).
+        show_close_button: Show the × close button. Default `True`.
+        buttons: Sequence of button kwargs dicts. Each dict is passed to an
+            internal Button. Clicking a button dismisses the toast and passes
+            the button's dict to `on_dismissed`.
+        position: Tkinter geometry offset string (e.g. `'-25-75'`). `None` uses
+            platform defaults (bottom-right on Windows/macOS, top-right on Linux).
+        alert: Play a system bell when shown.
+        on_dismissed: Callback invoked on dismiss. Receives the button dict when
+            dismissed via a button, or `None` otherwise.
+    """
+
+    def __init__(
+        self,
+        *,
+        title: str | None = None,
+        message: str | None = None,
+        memo: str | None = None,
+        icon: str | dict | None = None,
+        duration: int | None = None,
+        accent: str | None = None,
+        show_close_button: bool = True,
+        buttons: Sequence[dict[str, Any]] | None = None,
+        position: str | None = None,
+        alert: bool = False,
+        on_dismissed: Callable[[Any], None] | None = None,
+    ) -> None:
+        self._internal = _InternalToast(
+            title=title,
+            message=message,
+            memo=memo,
+            icon=icon,
+            duration=duration,
+            accent=accent,
+            show_close_button=show_close_button,
+            buttons=buttons,
+            position=position,
+            alert=alert,
+            on_dismissed=on_dismissed,
+        )
+
+    def show(self) -> None:
+        """Display the toast."""
+        self._internal.show()
+
+    def hide(self) -> None:
+        """Dismiss the toast immediately."""
+        self._internal.hide()
+
+    def destroy(self) -> None:
+        """Destroy the toast window and free resources."""
+        self._internal.destroy()
+
+
+def toast(
+    message: str,
+    *,
+    title: str | None = None,
+    duration: int = 3000,
+    accent: str | None = None,
+    icon: str | dict | None = None,
+    on_dismissed: Callable[[Any], None] | None = None,
+) -> None:
+    """Show a simple notification toast and return immediately.
+
+    Args:
+        message: Body text of the notification.
+        title: Optional header text.
+        duration: Auto-dismiss delay in milliseconds. Default `3000`.
+        accent: Accent token (e.g. `'success'`, `'danger'`).
+        icon: Icon name or `IconSpec` dict.
+        on_dismissed: Called when the toast is dismissed.
+    """
+    t = Toast(
+        message=message,
+        title=title,
+        duration=duration,
+        accent=accent,
+        icon=icon,
+        on_dismissed=on_dismissed,
+    )
+    t.show()

--- a/src/bootstack/widgets/public/primitives/tooltip.py
+++ b/src/bootstack/widgets/public/primitives/tooltip.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from bootstack.widgets.composites.tooltip import ToolTip as _InternalToolTip
+from bootstack.widgets.public.base import PublicWidgetBase
+
+
+class Tooltip:
+    """A hover tooltip attached to a target widget.
+
+    The tooltip appears after `delay` milliseconds when the mouse enters the target
+    and disappears on mouse leave or click. Positioning follows the mouse by default;
+    pass `anchor_point` and `window_point` to anchor it to the widget instead.
+
+    Args:
+        target: The widget to attach the tooltip to.
+        text: Tooltip text content.
+        delay: Milliseconds before the tooltip appears. Default `250`.
+        accent: Accent token for tooltip styling.
+        wraplength: Maximum line width in pixels before text wraps. Default `None` (no wrap).
+        justify: Text alignment — `'left'` (default), `'center'`, or `'right'`.
+        anchor_point: Widget anchor for tooltip positioning (e.g. `'n'`, `'se'`).
+        window_point: Tooltip anchor matched to `anchor_point`.
+        auto_flip: Flip the tooltip to stay on screen. Default `True`.
+    """
+
+    def __init__(
+        self,
+        target: PublicWidgetBase | Any,
+        text: str = "",
+        *,
+        delay: int = 250,
+        accent: str | None = None,
+        wraplength: int | None = None,
+        justify: Literal["left", "center", "right"] = "left",
+        anchor_point: str | None = None,
+        window_point: str | None = None,
+        auto_flip: bool | Literal["vertical", "horizontal"] = True,
+    ) -> None:
+        tk_widget = target.tk if isinstance(target, PublicWidgetBase) else target
+
+        internal_kwargs: dict[str, Any] = {
+            "text": text,
+            "delay": delay,
+            "justify": justify,
+            "auto_flip": auto_flip,
+        }
+        if accent is not None:
+            internal_kwargs["accent"] = accent
+        if wraplength is not None:
+            internal_kwargs["wraplength"] = wraplength
+        if anchor_point is not None:
+            internal_kwargs["anchor_point"] = anchor_point
+        if window_point is not None:
+            internal_kwargs["window_point"] = window_point
+
+        self._internal = _InternalToolTip(tk_widget, **internal_kwargs)
+
+    def destroy(self) -> None:
+        """Remove the tooltip and unbind all event handlers."""
+        self._internal.destroy()

--- a/tests/features/toast_tooltip_card.py
+++ b/tests/features/toast_tooltip_card.py
@@ -1,0 +1,100 @@
+"""Visual test for public Toast, Tooltip, and Card widgets."""
+from bootstack.widgets.public import (
+    App, VStack, HStack, Card, Label, Button, Separator,
+    TextField, Badge, Toast, toast, Tooltip,
+)
+
+
+def main():
+    with App(title="Toast + Tooltip + Card", minsize=(560, 480), padding=24, gap=16) as app:
+
+        # --- Card ---
+        Label("Card — default styling")
+        with Card(fill="x"):
+            Label("Inside a Card", font="body[bold]")
+            Label("Cards group related content with a border and padding.")
+            with HStack(gap=8):
+                Button("Primary action", accent="primary")
+                Button("Secondary", variant="outline")
+
+        with Card(fill="x", accent="primary", show_border=False):
+            Label("Card with accent='primary', no border", font="body[bold]")
+            Label("Useful for highlighted content sections.")
+
+        Separator(fill="x")
+
+        # --- Tooltip ---
+        Label("Tooltip — hover over the buttons")
+        with HStack(gap=12):
+            b1 = Button("Hover me")
+            Tooltip(b1, "This button does something helpful.", delay=200)
+
+            b2 = Button("Anchored tip", accent="primary", variant="outline")
+            Tooltip(b2, "Anchored below the button.", anchor_point="s", window_point="n", delay=200)
+
+            b3 = Button("Long tip", variant="ghost")
+            Tooltip(b3, "This is a longer tooltip that will wrap when it exceeds the wraplength.", wraplength=180, delay=200)
+
+        Separator(fill="x")
+
+        # --- Toast ---
+        Label("Toast — click to trigger notifications")
+        with HStack(gap=8):
+            Button(
+                "Default toast",
+                on_click=lambda: toast("File saved successfully.", duration=3000),
+            )
+            Button(
+                "Success",
+                accent="success",
+                on_click=lambda: toast(
+                    "Operation completed.",
+                    title="Success",
+                    accent="success",
+                    icon="check-circle",
+                    duration=3000,
+                ),
+            )
+            Button(
+                "Danger",
+                accent="danger",
+                on_click=lambda: toast(
+                    "Something went wrong.",
+                    title="Error",
+                    accent="danger",
+                    icon="exclamation-triangle",
+                    duration=4000,
+                ),
+            )
+
+        with HStack(gap=8):
+            Button(
+                "With buttons",
+                variant="outline",
+                on_click=lambda: Toast(
+                    title="Delete item?",
+                    message="This action cannot be undone.",
+                    accent="warning",
+                    buttons=[
+                        {"text": "Cancel", "variant": "ghost"},
+                        {"text": "Delete", "accent": "danger"},
+                    ],
+                    on_dismissed=lambda btn: print(f"Dismissed via: {btn}"),
+                ).show(),
+            )
+            Button(
+                "No auto-dismiss",
+                variant="outline",
+                on_click=lambda: Toast(
+                    title="Persistent toast",
+                    message="Close me manually.",
+                    memo="no timeout",
+                    duration=None,
+                ).show(),
+            )
+
+    app.run()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- **`Card`** — `PublicContainer` wrapping the internal `Card`; `padding=16` and `show_border=True` by default; supports self-placement kwargs (`fill`, `expand`, `anchor`) and passes children through `pack`
- **`Tooltip`** — standalone class that attaches to any `PublicWidgetBase` target via `.tk`; forwards `delay`, `wraplength`, `justify`, `anchor_point`, `window_point`, `auto_flip`
- **`Toast`** — class-based notification with `show()` / `hide()`; module-level `bs.toast()` convenience function for simple one-shot calls

## Test plan

- [ ] Run `python tests/features/toast_tooltip_card.py` — cards render correctly, tooltips appear on hover, all toast variants trigger and auto-dismiss
- [ ] `pytest tests/widgets/public/test_base_layer.py -m "not gui"` — 11 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)