### PR TITLE
feat(public): add SizeGrip and Scrollbar widgets

### DIFF
--- a/src/bootstack/widgets/public/__init__.py
+++ b/src/bootstack/widgets/public/__init__.py
@@ -16,8 +16,10 @@ from bootstack.widgets.public.primitives.numericentry import NumericEntry
 from bootstack.widgets.public.primitives.passwordentry import PasswordEntry
 from bootstack.widgets.public.primitives.progressbar import ProgressBar
 from bootstack.widgets.public.primitives.radiogroup import RadioGroup
+from bootstack.widgets.public.primitives.scrollbar import Scrollbar
 from bootstack.widgets.public.primitives.select import Select
 from bootstack.widgets.public.primitives.separator import Separator
+from bootstack.widgets.public.primitives.sizegrip import SizeGrip
 from bootstack.widgets.public.primitives.slider import RangeSlider, Slider
 from bootstack.widgets.public.primitives.spinbox import Spinbox
 from bootstack.widgets.public.primitives.tabs import TabChangeEventData, TabRef, Tabs
@@ -49,8 +51,10 @@ __all__ = [
     "PublicWidgetBase",
     "RadioGroup",
     "RangeSlider",
+    "Scrollbar",
     "Select",
     "Separator",
+    "SizeGrip",
     "Slider",
     "Spinbox",
     "Subscription",

--- a/src/bootstack/widgets/public/primitives/__init__.py
+++ b/src/bootstack/widgets/public/primitives/__init__.py
@@ -8,8 +8,10 @@ from bootstack.widgets.public.primitives.numericentry import NumericEntry
 from bootstack.widgets.public.primitives.passwordentry import PasswordEntry
 from bootstack.widgets.public.primitives.progressbar import ProgressBar
 from bootstack.widgets.public.primitives.radiogroup import RadioGroup
+from bootstack.widgets.public.primitives.scrollbar import Scrollbar
 from bootstack.widgets.public.primitives.select import Select
 from bootstack.widgets.public.primitives.separator import Separator
+from bootstack.widgets.public.primitives.sizegrip import SizeGrip
 from bootstack.widgets.public.primitives.slider import RangeSlider, Slider
 from bootstack.widgets.public.primitives.spinbox import Spinbox
 from bootstack.widgets.public.primitives.tabs import TabChangeEventData, TabRef, Tabs
@@ -24,5 +26,5 @@ __all__ = [
     "Label", "NumericEntry", "PasswordEntry", "ProgressBar", "RadioGroup",
     "RangeSlider", "Select", "Separator", "Slider", "Spinbox", "Switch",
     "TabChangeEventData", "TabRef", "Tabs", "TextArea", "TextField", "Toast",
-    "toast", "ToggleButton", "ToggleGroup", "Tooltip",
+    "toast", "ToggleButton", "ToggleGroup", "Tooltip", "Scrollbar", "SizeGrip",
 ]

--- a/src/bootstack/widgets/public/primitives/scrollbar.py
+++ b/src/bootstack/widgets/public/primitives/scrollbar.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from bootstack.widgets.primitives.scrollbar import Scrollbar as _InternalScrollbar
+from bootstack.widgets.public.base import PublicWidgetBase
+
+
+class Scrollbar(PublicWidgetBase):
+    """A themed scrollbar — horizontal or vertical.
+
+    Most users will never instantiate `Scrollbar` directly; scrollable
+    containers wire scrollbars automatically. Use this when you need an
+    explicit, manually managed scrollbar.
+
+    Args:
+        orient: `'vertical'` (default) or `'horizontal'`.
+        on_scroll: Callback invoked on scroll actions. Receives the standard
+            Tk scroll arguments `(fraction,)` or `(first, last)`.
+        accent: Accent token for styling.
+        parent: Override the context-stack parent.
+    """
+
+    def __init__(
+        self,
+        orient: str = "vertical",
+        *,
+        on_scroll: Callable | None = None,
+        accent: str | None = None,
+        parent: Any = None,
+        **kwargs: Any,
+    ) -> None:
+        self._parent = self._resolve_parent(parent)
+        layout_kw = self._split_layout_kwargs(kwargs)
+
+        tk_master = self._parent._child_master() if self._parent else None
+
+        internal_kwargs: dict[str, Any] = {"orient": orient}
+        if on_scroll is not None:
+            internal_kwargs["command"] = on_scroll
+        if accent is not None:
+            internal_kwargs["accent"] = accent
+        internal_kwargs.update(kwargs)
+
+        self._internal = _InternalScrollbar(tk_master, **internal_kwargs)
+        self._attach_to_parent(layout_kw)
+
+    @property
+    def position(self) -> tuple[float, float]:
+        """Current scroll position as a `(first, last)` fraction pair."""
+        return self._internal.get()
+
+    @position.setter
+    def position(self, value: tuple[float, float]) -> None:
+        self._internal.set(*value)

--- a/src/bootstack/widgets/public/primitives/sizegrip.py
+++ b/src/bootstack/widgets/public/primitives/sizegrip.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import Any
+
+from bootstack.widgets.primitives.sizegrip import SizeGrip as _InternalSizeGrip
+from bootstack.widgets.public.base import PublicWidgetBase
+
+
+class SizeGrip(PublicWidgetBase):
+    """A resize handle placed in the corner of a window or panel.
+
+    Typically anchored to the bottom-right corner so users can drag to resize
+    the parent window.
+
+    Args:
+        accent: Accent token for styling.
+        parent: Override the context-stack parent.
+    """
+
+    def __init__(
+        self,
+        *,
+        accent: str | None = None,
+        parent: Any = None,
+        **kwargs: Any,
+    ) -> None:
+        self._parent = self._resolve_parent(parent)
+        layout_kw = self._split_layout_kwargs(kwargs)
+
+        tk_master = self._parent._child_master() if self._parent else None
+
+        internal_kwargs: dict[str, Any] = {}
+        if accent is not None:
+            internal_kwargs["accent"] = accent
+        internal_kwargs.update(kwargs)
+
+        self._internal = _InternalSizeGrip(tk_master, **internal_kwargs)
+        self._attach_to_parent(layout_kw)

--- a/tests/features/sizegrip_scrollbar.py
+++ b/tests/features/sizegrip_scrollbar.py
@@ -1,0 +1,47 @@
+"""Visual test for public SizeGrip and Scrollbar widgets."""
+from bootstack.widgets.public import (
+    App, VStack, HStack, Label, TextArea, Separator, SizeGrip, Scrollbar,
+)
+
+
+def main():
+    with App(title="SizeGrip + Scrollbar", minsize=(480, 400), padding=20, gap=16) as app:
+
+        # Scrollbar — shown standalone (vertical and horizontal)
+        Label("Scrollbar — standalone (unsized, fills parent)", font="body[bold]")
+        with HStack(gap=12, fill="x"):
+            with VStack(gap=4, fill="x", expand=True):
+                Label("vertical")
+                Scrollbar(orient="vertical", fill="y")
+            with VStack(gap=4, fill="x", expand=True):
+                Label("horizontal")
+                Scrollbar(orient="horizontal", fill="x")
+            with VStack(gap=4, fill="x", expand=True):
+                Label("accent='primary'")
+                Scrollbar(orient="vertical", accent="primary", fill="y")
+
+        Separator(fill="x")
+
+        # TextArea has a built-in scrollbar — demonstrates the real use case
+        Label("TextArea (built-in scrollbar for reference)", font="body[bold]")
+        TextArea(
+            "\n".join(f"Line {i}: The quick brown fox jumps over the lazy dog." for i in range(1, 30)),
+            height=120,
+            fill="x",
+        )
+
+        Separator(fill="x")
+
+        Label("SizeGrip — drag bottom-right corner to resize", font="body[bold]")
+        with HStack(fill="x"):
+            Label("Resize this window by dragging the handle in the bottom-right corner.")
+
+    # SizeGrip placed at the bottom-right of the window via place()
+    sg = SizeGrip()
+    sg._internal.place(relx=1.0, rely=1.0, anchor="se")
+
+    app.run()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- **`SizeGrip`** — thin wrapper over the internal `SizeGrip`; forwards `accent`; positioned via `.tk.place()` for corner anchoring
- **`Scrollbar`** — wraps `orient` and `on_scroll` (maps to internal `command=`); exposes `position` property as a `(first, last)` fraction tuple

## Test plan

- [ ] Run `python tests/features/sizegrip_scrollbar.py` — scrollbars render in all orientations/accents, SizeGrip handle visible in bottom-right corner and resizes the window on drag
- [ ] `pytest tests/widgets/public/test_base_layer.py -m "not gui"` — 11 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)