### PR TITLE
feat(public): add GroupBox, SplitView, and PageStack widgets

### DIFF
--- a/src/bootstack/widgets/public/__init__.py
+++ b/src/bootstack/widgets/public/__init__.py
@@ -11,8 +11,10 @@ from bootstack.widgets.public.primitives.button import Button
 from bootstack.widgets.public.primitives.card import Card
 from bootstack.widgets.public.primitives.expander import Accordion, Expander
 from bootstack.widgets.public.primitives.gauge import Gauge
+from bootstack.widgets.public.primitives.groupbox import GroupBox
 from bootstack.widgets.public.primitives.label import Badge, Label
 from bootstack.widgets.public.primitives.numericentry import NumericEntry
+from bootstack.widgets.public.primitives.pagestack import PageStack
 from bootstack.widgets.public.primitives.passwordentry import PasswordEntry
 from bootstack.widgets.public.primitives.progressbar import ProgressBar
 from bootstack.widgets.public.primitives.radiogroup import RadioGroup
@@ -20,6 +22,7 @@ from bootstack.widgets.public.primitives.scrollbar import Scrollbar
 from bootstack.widgets.public.primitives.select import Select
 from bootstack.widgets.public.primitives.separator import Separator
 from bootstack.widgets.public.primitives.sizegrip import SizeGrip
+from bootstack.widgets.public.primitives.splitview import SplitView
 from bootstack.widgets.public.primitives.slider import RangeSlider, Slider
 from bootstack.widgets.public.primitives.spinbox import Spinbox
 from bootstack.widgets.public.primitives.tabs import TabChangeEventData, TabRef, Tabs
@@ -41,9 +44,11 @@ __all__ = [
     "Expander",
     "Gauge",
     "Grid",
+    "GroupBox",
     "HStack",
     "Label",
     "NumericEntry",
+    "PageStack",
     "ParentResolutionError",
     "PasswordEntry",
     "ProgressBar",
@@ -55,6 +60,7 @@ __all__ = [
     "Select",
     "Separator",
     "SizeGrip",
+    "SplitView",
     "Slider",
     "Spinbox",
     "Subscription",

--- a/src/bootstack/widgets/public/primitives/__init__.py
+++ b/src/bootstack/widgets/public/primitives/__init__.py
@@ -3,8 +3,10 @@ from bootstack.widgets.public.primitives.button import Button
 from bootstack.widgets.public.primitives.card import Card
 from bootstack.widgets.public.primitives.expander import Accordion, Expander
 from bootstack.widgets.public.primitives.gauge import Gauge
+from bootstack.widgets.public.primitives.groupbox import GroupBox
 from bootstack.widgets.public.primitives.label import Badge, Label
 from bootstack.widgets.public.primitives.numericentry import NumericEntry
+from bootstack.widgets.public.primitives.pagestack import PageStack
 from bootstack.widgets.public.primitives.passwordentry import PasswordEntry
 from bootstack.widgets.public.primitives.progressbar import ProgressBar
 from bootstack.widgets.public.primitives.radiogroup import RadioGroup
@@ -12,6 +14,7 @@ from bootstack.widgets.public.primitives.scrollbar import Scrollbar
 from bootstack.widgets.public.primitives.select import Select
 from bootstack.widgets.public.primitives.separator import Separator
 from bootstack.widgets.public.primitives.sizegrip import SizeGrip
+from bootstack.widgets.public.primitives.splitview import SplitView
 from bootstack.widgets.public.primitives.slider import RangeSlider, Slider
 from bootstack.widgets.public.primitives.spinbox import Spinbox
 from bootstack.widgets.public.primitives.tabs import TabChangeEventData, TabRef, Tabs
@@ -25,6 +28,7 @@ __all__ = [
     "Accordion", "Badge", "Button", "Card", "Checkbox", "Expander", "Gauge",
     "Label", "NumericEntry", "PasswordEntry", "ProgressBar", "RadioGroup",
     "RangeSlider", "Select", "Separator", "Slider", "Spinbox", "Switch",
+    "GroupBox", "PageStack", "SplitView",
     "TabChangeEventData", "TabRef", "Tabs", "TextArea", "TextField", "Toast",
     "toast", "ToggleButton", "ToggleGroup", "Tooltip", "Scrollbar", "SizeGrip",
 ]

--- a/src/bootstack/widgets/public/primitives/groupbox.py
+++ b/src/bootstack/widgets/public/primitives/groupbox.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from typing import Any
+
+from bootstack.widgets.primitives.labelframe import LabelFrame as _InternalLabelFrame
+from bootstack.widgets.public.container import PublicContainer, PACK_KEYS, normalize_fill
+
+
+class GroupBox(PublicContainer):
+    """A labelled container that groups related content inside a bordered frame.
+
+    Args:
+        title: Text displayed in the border label.
+        title_anchor: Where the label sits on the border edge —
+            `'nw'` (default), `'n'`, `'ne'`, `'w'`, `'e'`, `'sw'`, `'s'`, `'se'`.
+        padding: Space between the border and the content area.
+        accent: Accent token for border styling.
+        relief: Border style (e.g. `'groove'`, `'ridge'`, `'flat'`).
+        border_width: Border thickness in pixels.
+        width: Requested width in pixels.
+        height: Requested height in pixels.
+        fill: Self-placement fill direction in parent (`'x'`, `'y'`, `'both'`).
+        expand: Self-placement expand flag.
+        parent: Override the context-stack parent.
+    """
+
+    def __init__(
+        self,
+        title: str = "",
+        *,
+        title_anchor: str | None = None,
+        padding: Any = None,
+        accent: str | None = None,
+        relief: str | None = None,
+        border_width: int | None = None,
+        width: int | None = None,
+        height: int | None = None,
+        # Self-placement
+        fill: str | None = None,
+        expand: bool | None = None,
+        anchor: str | None = None,
+        parent: Any = None,
+        **extra_kw: Any,
+    ) -> None:
+        self._parent = self._resolve_parent(parent)
+
+        layout_kw: dict[str, Any] = {}
+        if fill is not None:
+            layout_kw["fill"] = normalize_fill(fill)
+        if expand is not None:
+            layout_kw["expand"] = expand
+        if anchor is not None:
+            layout_kw["anchor"] = anchor
+        layout_kw.update(self._split_layout_kwargs(extra_kw))
+
+        frame_kwargs: dict[str, Any] = {"text": title}
+        if title_anchor is not None:
+            frame_kwargs["labelanchor"] = title_anchor
+        if padding is not None:
+            frame_kwargs["padding"] = padding
+        if accent is not None:
+            frame_kwargs["accent"] = accent
+        if relief is not None:
+            frame_kwargs["relief"] = relief
+        if border_width is not None:
+            frame_kwargs["borderwidth"] = border_width
+        if width is not None:
+            frame_kwargs["width"] = width
+        if height is not None:
+            frame_kwargs["height"] = height
+        frame_kwargs.update(extra_kw)
+
+        tk_master = self._parent._child_master() if self._parent else None
+        self._internal = _InternalLabelFrame(tk_master, **frame_kwargs)
+        self._attach_to_parent(layout_kw)
+
+    def _default_layout_method(self) -> str:
+        return "pack"
+
+    def _merge_layout_options(self, child: Any, layout_kw: dict) -> tuple[str, dict]:
+        options = {k: v for k, v in layout_kw.items() if k in PACK_KEYS}
+        return ("pack", options)
+
+    # ----- Properties -----
+
+    @property
+    def title(self) -> str:
+        """The border label text."""
+        return self._internal.cget("text")
+
+    @title.setter
+    def title(self, value: str) -> None:
+        self._internal.configure(text=value)

--- a/src/bootstack/widgets/public/primitives/pagestack.py
+++ b/src/bootstack/widgets/public/primitives/pagestack.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import tkinter
+from typing import Any, Callable
+
+from bootstack.widgets.composites.pagestack import PageStack as _InternalPageStack
+from bootstack.widgets.public.base import PublicWidgetBase
+from bootstack.widgets.public.container import PACK_KEYS, normalize_fill
+from bootstack.widgets.public.context import push_container, pop_container
+from bootstack.widgets.public.events import register_widget_events
+from bootstack.widgets.public.subscription import Subscription
+
+_PAGESTACK_EVENTS: dict[str, str] = {
+    "page_change": "<<PageChange>>",
+    "page_mount":  "<<PageMount>>",
+}
+
+
+class _StackPage:
+    """Context-manager for placing children inside a PageStack page."""
+
+    def __init__(self, page_widget: tkinter.Widget) -> None:
+        self._page = page_widget
+
+    def _child_master(self) -> tkinter.Widget:
+        return self._page
+
+    def guide_layout(self, child: PublicWidgetBase, **layout_kw: Any) -> None:
+        options = {k: v for k, v in layout_kw.items() if k in PACK_KEYS}
+        child._internal.pack(in_=self._page, **options)
+
+    def __enter__(self) -> "_StackPage":
+        push_container(self)
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        pop_container(self)
+
+
+class PageStack(PublicWidgetBase):
+    """A browser-style navigation container showing one page at a time.
+
+    Add pages with `.add()` and place children inside each page using the
+    returned context manager. Navigate between pages with `navigate()`,
+    `back()`, and `forward()`.
+
+    Usage::
+
+        ps = bs.PageStack(fill="both", expand=True)
+        with ps.add("home"):
+            bs.Label("Home page")
+        with ps.add("settings"):
+            bs.Label("Settings page")
+        ps.navigate("home")
+
+    Args:
+        padding: Space around the page area.
+        width: Requested width in pixels.
+        height: Requested height in pixels.
+        fill: Self-placement fill direction in parent.
+        expand: Self-placement expand flag.
+        parent: Override the context-stack parent.
+    """
+
+    def __init__(
+        self,
+        *,
+        padding: Any = None,
+        width: int | None = None,
+        height: int | None = None,
+        # Self-placement
+        fill: str | None = None,
+        expand: bool | None = None,
+        anchor: str | None = None,
+        parent: Any = None,
+        **extra_kw: Any,
+    ) -> None:
+        self._parent = self._resolve_parent(parent)
+
+        layout_kw: dict[str, Any] = {}
+        if fill is not None:
+            layout_kw["fill"] = normalize_fill(fill)
+        if expand is not None:
+            layout_kw["expand"] = expand
+        if anchor is not None:
+            layout_kw["anchor"] = anchor
+        layout_kw.update(self._split_layout_kwargs(extra_kw))
+
+        ps_kwargs: dict[str, Any] = {}
+        if padding is not None:
+            ps_kwargs["padding"] = padding
+        if width is not None:
+            ps_kwargs["width"] = width
+        if height is not None:
+            ps_kwargs["height"] = height
+        ps_kwargs.update(extra_kw)
+
+        tk_master = self._parent._child_master() if self._parent else None
+        self._internal = _InternalPageStack(tk_master, **ps_kwargs)
+        self._attach_to_parent(layout_kw)
+
+    # ----- Page management -----
+
+    def add(self, key: str) -> _StackPage:
+        """Add a page and return a context manager for placing its children.
+
+        Usage::
+
+            with ps.add("home"):
+                bs.Label("Welcome")
+
+        Args:
+            key: Unique identifier for this page.
+
+        Returns:
+            `_StackPage` — use as a context manager to place children.
+        """
+        page_widget = self._internal.add(key)
+        return _StackPage(page_widget)
+
+    def remove(self, key: str) -> None:
+        """Remove a page and destroy its widget."""
+        self._internal.remove(key)
+
+    # ----- Navigation -----
+
+    def navigate(self, key: str, data: dict | None = None) -> None:
+        """Navigate to the page identified by `key`.
+
+        Args:
+            key: Page identifier to navigate to.
+            data: Optional data dict passed to the page's mount event.
+        """
+        self._internal.navigate(key, data=data)
+
+    def back(self) -> None:
+        """Navigate to the previous page in history."""
+        self._internal.back()
+
+    def forward(self) -> None:
+        """Navigate to the next page in history."""
+        self._internal.forward()
+
+    # ----- Properties / introspection -----
+
+    @property
+    def can_back(self) -> bool:
+        """True if backward navigation is possible."""
+        return self._internal.can_back()
+
+    @property
+    def can_forward(self) -> bool:
+        """True if forward navigation is possible."""
+        return self._internal.can_forward()
+
+    @property
+    def current(self) -> str | None:
+        """Key of the currently displayed page, or `None`."""
+        result = self._internal.current()
+        return result[0] if result else None
+
+    def page_keys(self) -> tuple[str, ...]:
+        """All registered page keys in insertion order."""
+        return self._internal.keys()
+
+    # ----- Event shorthands -----
+
+    def on_page_change(self, handler: Callable[[tkinter.Event], Any]) -> Subscription:
+        """Register a callback fired after every navigation.
+
+        Returns:
+            Subscription — call `.cancel()` to unsubscribe.
+        """
+        return self.on("page_change", handler)
+
+    def on_page_mount(self, handler: Callable[[tkinter.Event], Any]) -> Subscription:
+        """Register a callback fired when a page is mounted.
+
+        Returns:
+            Subscription — call `.cancel()` to unsubscribe.
+        """
+        return self.on("page_mount", handler)
+
+
+register_widget_events(PageStack, _PAGESTACK_EVENTS)

--- a/src/bootstack/widgets/public/primitives/splitview.py
+++ b/src/bootstack/widgets/public/primitives/splitview.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import tkinter
+from typing import Any
+
+from bootstack.widgets.primitives.panedwindow import PanedWindow as _InternalPanedWindow
+from bootstack.widgets.primitives.frame import Frame as _InternalFrame
+from bootstack.widgets.public.base import PublicWidgetBase
+from bootstack.widgets.public.container import PACK_KEYS, normalize_fill
+from bootstack.widgets.public.context import push_container, pop_container
+
+
+class _SplitPane:
+    """Context-manager for placing children inside a SplitView pane."""
+
+    def __init__(self, frame: tkinter.Widget) -> None:
+        self._frame = frame
+
+    def _child_master(self) -> tkinter.Widget:
+        return self._frame
+
+    def guide_layout(self, child: PublicWidgetBase, **layout_kw: Any) -> None:
+        options = {k: v for k, v in layout_kw.items() if k in PACK_KEYS}
+        child._internal.pack(in_=self._frame, **options)
+
+    def __enter__(self) -> "_SplitPane":
+        push_container(self)
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        pop_container(self)
+
+
+class SplitView(PublicWidgetBase):
+    """A resizable split container with one or more panes separated by draggable sashes.
+
+    Add panes with `.add()` and place children inside each pane using the
+    returned context manager.
+
+    Usage::
+
+        sv = bs.SplitView(fill="both", expand=True)
+        with sv.add(weight=1):
+            bs.Label("Left pane")
+        with sv.add(weight=2):
+            bs.Label("Right pane")
+
+    Args:
+        orient: `'horizontal'` (default, panes side-by-side) or `'vertical'` (stacked).
+        padding: Space around the pane area.
+        accent: Accent token for styling.
+        width: Requested width in pixels.
+        height: Requested height in pixels.
+        fill: Self-placement fill direction in parent.
+        expand: Self-placement expand flag.
+        parent: Override the context-stack parent.
+    """
+
+    def __init__(
+        self,
+        orient: str = "horizontal",
+        *,
+        padding: Any = None,
+        accent: str | None = None,
+        width: int | None = None,
+        height: int | None = None,
+        # Self-placement
+        fill: str | None = None,
+        expand: bool | None = None,
+        anchor: str | None = None,
+        parent: Any = None,
+        **extra_kw: Any,
+    ) -> None:
+        self._parent = self._resolve_parent(parent)
+
+        layout_kw: dict[str, Any] = {}
+        if fill is not None:
+            layout_kw["fill"] = normalize_fill(fill)
+        if expand is not None:
+            layout_kw["expand"] = expand
+        if anchor is not None:
+            layout_kw["anchor"] = anchor
+        layout_kw.update(self._split_layout_kwargs(extra_kw))
+
+        pw_kwargs: dict[str, Any] = {"orient": orient}
+        if padding is not None:
+            pw_kwargs["padding"] = padding
+        if accent is not None:
+            pw_kwargs["accent"] = accent
+        if width is not None:
+            pw_kwargs["width"] = width
+        if height is not None:
+            pw_kwargs["height"] = height
+        pw_kwargs.update(extra_kw)
+
+        tk_master = self._parent._child_master() if self._parent else None
+        self._internal = _InternalPanedWindow(tk_master, **pw_kwargs)
+        self._attach_to_parent(layout_kw)
+
+    # ----- Pane management -----
+
+    def add(self, *, weight: int = 1) -> _SplitPane:
+        """Add a pane and return a context manager for placing its children.
+
+        Usage::
+
+            with sv.add(weight=1):
+                bs.Label("Content")
+
+        Args:
+            weight: Relative size weight when the container is resized.
+                Higher values take proportionally more space.
+
+        Returns:
+            `_SplitPane` — use as a context manager to place children.
+        """
+        frame = _InternalFrame(self._internal)
+        self._internal.add(frame, weight=weight)
+        return _SplitPane(frame)
+
+    # ----- Sash control -----
+
+    def sash_position(self, index: int, position: int | None = None) -> int | None:
+        """Get or set the position of a sash.
+
+        Args:
+            index: Zero-based sash index.
+            position: New position in pixels. If `None`, returns the current position.
+
+        Returns:
+            Current sash position in pixels when `position` is `None`.
+        """
+        if position is None:
+            return self._internal.sashpos(index)
+        self._internal.sashpos(index, position)
+        return None

--- a/tests/features/structural_containers.py
+++ b/tests/features/structural_containers.py
@@ -1,0 +1,78 @@
+"""Visual test for public GroupBox, SplitView, and PageStack widgets."""
+from bootstack.widgets.public import (
+    App, VStack, HStack, Label, Button, Separator,
+    GroupBox, SplitView, PageStack, TextField, RadioGroup,
+)
+from bootstack.signals import Signal
+
+
+def main():
+    with App(title="GroupBox + SplitView + PageStack", minsize=(620, 560), padding=20, gap=16) as app:
+
+        # --- GroupBox ---
+        Label("GroupBox", font="heading-lg")
+        with HStack(gap=12, fill="x"):
+            with GroupBox("Personal Info", fill="x", expand=True):
+                TextField(label="Name")
+                TextField(label="Email")
+
+            with GroupBox("Preferences", fill="x", expand=True):
+                RadioGroup(
+                    options=[("Light", "light"), ("Dark", "dark"), ("System", "system")],
+                    value="system",
+                )
+
+        Separator(fill="x")
+
+        # --- SplitView ---
+        Label("SplitView — drag the sash to resize panes", font="heading-lg")
+        sv = SplitView(orient="horizontal", fill="x")
+        with sv.add(weight=1):
+            with VStack(padding=8, gap=4, fill="both", expand=True):
+                Label("Left pane", font="body[bold]")
+                Label("weight=1")
+        with sv.add(weight=2):
+            with VStack(padding=8, gap=4, fill="both", expand=True):
+                Label("Right pane", font="body[bold]")
+                Label("weight=2 — starts wider")
+
+        Separator(fill="x")
+
+        # --- PageStack ---
+        Label("PageStack — browser-style navigation", font="heading-lg")
+
+        ps = PageStack(fill="x", expand=False)
+        with ps.add("home"):
+            with VStack(padding=12, gap=8, fill="x"):
+                Label("Home Page", font="heading-lg")
+                Label("Navigate using the buttons below.")
+
+        with ps.add("profile"):
+            with VStack(padding=12, gap=8, fill="x"):
+                Label("Profile Page", font="heading-lg")
+                TextField(label="Display name")
+
+        with ps.add("settings"):
+            with VStack(padding=12, gap=8, fill="x"):
+                Label("Settings Page", font="heading-lg")
+                RadioGroup(
+                    options=[("Light", "light"), ("Dark", "dark")],
+                    value="light",
+                )
+
+        ps.navigate("home")
+
+        with HStack(gap=8, fill="x"):
+            Button("← Back", variant="outline",
+                   on_click=lambda: ps.back() if ps.can_back else None)
+            Button("Home", on_click=lambda: ps.navigate("home"))
+            Button("Profile", on_click=lambda: ps.navigate("profile"))
+            Button("Settings", on_click=lambda: ps.navigate("settings"))
+            Button("Forward →", variant="outline",
+                   on_click=lambda: ps.forward() if ps.can_forward else None)
+
+    app.run()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- **`GroupBox`** — `PublicContainer` wrapping `LabelFrame`; `title=` positional arg, `title_anchor=` maps to internal `labelanchor=`; `title` property for runtime updates
- **`SplitView`** — wraps `PanedWindow`; `add(weight=)` returns a `_SplitPane` context manager backed by an internal `Frame`; `sash_position()` for programmatic sash control
- **`PageStack`** — wraps internal `PageStack`; `add(key)` returns a `_StackPage` context manager; `navigate`/`back`/`forward`/`can_back`/`can_forward`/`current`; `on_page_change` and `on_page_mount` event shorthands

## Test plan

- [ ] Run `python tests/features/structural_containers.py` — GroupBox borders render with titles, SplitView sash is draggable, PageStack navigates between three pages with back/forward working
- [ ] `pytest tests/widgets/public/test_base_layer.py -m "not gui"` — 11 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)