### PR TITLE
feat(public): add DateField and PathField

### DIFF
--- a/src/bootstack/widgets/public/__init__.py
+++ b/src/bootstack/widgets/public/__init__.py
@@ -9,12 +9,14 @@ from bootstack.widgets.public.app import App
 from bootstack.widgets.public.primitives.boolean_controls import Checkbox, Switch, ToggleButton
 from bootstack.widgets.public.primitives.button import Button
 from bootstack.widgets.public.primitives.card import Card
+from bootstack.widgets.public.primitives.datefield import DateField
 from bootstack.widgets.public.primitives.expander import Accordion, Expander
 from bootstack.widgets.public.primitives.gauge import Gauge
 from bootstack.widgets.public.primitives.groupbox import GroupBox
 from bootstack.widgets.public.primitives.label import Badge, Label
 from bootstack.widgets.public.primitives.numericentry import NumericEntry
 from bootstack.widgets.public.primitives.pagestack import PageStack
+from bootstack.widgets.public.primitives.pathfield import PathField
 from bootstack.widgets.public.primitives.passwordentry import PasswordEntry
 from bootstack.widgets.public.primitives.progressbar import ProgressBar
 from bootstack.widgets.public.primitives.radiogroup import RadioGroup
@@ -40,6 +42,7 @@ __all__ = [
     "Button",
     "Card",
     "Checkbox",
+    "DateField",
     "Event",
     "Expander",
     "Gauge",
@@ -50,6 +53,7 @@ __all__ = [
     "NumericEntry",
     "PageStack",
     "ParentResolutionError",
+    "PathField",
     "PasswordEntry",
     "ProgressBar",
     "PublicContainer",

--- a/src/bootstack/widgets/public/primitives/__init__.py
+++ b/src/bootstack/widgets/public/primitives/__init__.py
@@ -1,6 +1,7 @@
 from bootstack.widgets.public.primitives.boolean_controls import Checkbox, Switch, ToggleButton
 from bootstack.widgets.public.primitives.button import Button
 from bootstack.widgets.public.primitives.card import Card
+from bootstack.widgets.public.primitives.datefield import DateField
 from bootstack.widgets.public.primitives.expander import Accordion, Expander
 from bootstack.widgets.public.primitives.gauge import Gauge
 from bootstack.widgets.public.primitives.groupbox import GroupBox
@@ -8,6 +9,7 @@ from bootstack.widgets.public.primitives.label import Badge, Label
 from bootstack.widgets.public.primitives.numericentry import NumericEntry
 from bootstack.widgets.public.primitives.pagestack import PageStack
 from bootstack.widgets.public.primitives.passwordentry import PasswordEntry
+from bootstack.widgets.public.primitives.pathfield import PathField
 from bootstack.widgets.public.primitives.progressbar import ProgressBar
 from bootstack.widgets.public.primitives.radiogroup import RadioGroup
 from bootstack.widgets.public.primitives.scrollbar import Scrollbar
@@ -28,7 +30,7 @@ __all__ = [
     "Accordion", "Badge", "Button", "Card", "Checkbox", "Expander", "Gauge",
     "Label", "NumericEntry", "PasswordEntry", "ProgressBar", "RadioGroup",
     "RangeSlider", "Select", "Separator", "Slider", "Spinbox", "Switch",
-    "GroupBox", "PageStack", "SplitView",
+    "DateField", "GroupBox", "PageStack", "PathField", "SplitView",
     "TabChangeEventData", "TabRef", "Tabs", "TextArea", "TextField", "Toast",
     "toast", "ToggleButton", "ToggleGroup", "Tooltip", "Scrollbar", "SizeGrip",
 ]

--- a/src/bootstack/widgets/public/primitives/datefield.py
+++ b/src/bootstack/widgets/public/primitives/datefield.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import tkinter
+from datetime import date
+from typing import Any, Callable, Iterable
+
+from bootstack.widgets.composites.dateentry import DateEntry as _InternalDateEntry
+from bootstack.widgets.public.base import PublicWidgetBase
+from bootstack.widgets.public.events import resolve_event, register_widget_events
+from bootstack.widgets.public.subscription import Subscription
+from bootstack.widgets.public.primitives.textfield import _INNER_ENTRY_SEQUENCES
+
+_DATEFIELD_EVENTS: dict[str, str] = {
+    "change":   "<<Change>>",
+    "validate": "<<Validate>>",
+    "valid":    "<<Valid>>",
+    "invalid":  "<<Invalid>>",
+    "submit":   "<Return>",
+}
+
+
+class DateField(PublicWidgetBase):
+    """A date input field with an optional calendar picker button.
+
+    In `'single'` mode `value` returns a `date`; in `'range'` mode it returns
+    a `(start, end)` tuple of dates.
+
+    Args:
+        value: Initial date value — a `date` object or an ISO string
+            (`'YYYY-MM-DD'`). `None` for an empty field.
+        value_format: Display format token. Default `'longDate'`.
+        label: Label displayed above the field.
+        message: Hint text displayed below the field.
+        show_picker_button: Show the calendar icon button. Default `True`.
+        picker_title: Title of the picker dialog.
+        picker_first_weekday: First day of week in the picker (0=Mon … 6=Sun).
+            Default `6` (Sunday).
+        selection_mode: `'single'` (default) or `'range'`.
+        range_start: Pre-selected range start date (range mode only).
+        range_end: Pre-selected range end date (range mode only).
+        min_date: Earliest selectable date.
+        max_date: Latest selectable date.
+        disabled_dates: Dates that cannot be selected.
+        required: Mark field as required; blocks empty submission.
+        disabled: If True, field is non-interactive.
+        read_only: If True, value is visible but not editable.
+        accent: Accent token for the focus ring.
+        density: Widget density — `'default'` or `'compact'`.
+        parent: Override the context-stack parent.
+    """
+
+    def __init__(
+        self,
+        value: str | date | None = None,
+        *,
+        value_format: str = "longDate",
+        label: str | None = None,
+        message: str | None = None,
+        show_picker_button: bool = True,
+        picker_title: str | None = None,
+        picker_first_weekday: int = 6,
+        selection_mode: str = "single",
+        range_start: date | str | None = None,
+        range_end: date | str | None = None,
+        min_date: date | str | None = None,
+        max_date: date | str | None = None,
+        disabled_dates: Iterable[date | str] | None = None,
+        required: bool = False,
+        disabled: bool = False,
+        read_only: bool = False,
+        accent: str | None = None,
+        density: str | None = None,
+        parent: Any = None,
+        **kwargs: Any,
+    ) -> None:
+        self._parent = self._resolve_parent(parent)
+        layout_kw = self._split_layout_kwargs(kwargs)
+
+        tk_master = self._parent._child_master() if self._parent else None
+
+        internal_kwargs: dict[str, Any] = {
+            "value_format": value_format,
+            "show_picker_button": show_picker_button,
+            "picker_first_weekday": picker_first_weekday,
+            "selection_mode": selection_mode,
+        }
+        if value is not None:
+            internal_kwargs["value"] = value
+        if label is not None:
+            internal_kwargs["label"] = label
+        if message is not None:
+            internal_kwargs["message"] = message
+        if picker_title is not None:
+            internal_kwargs["picker_title"] = picker_title
+        if range_start is not None:
+            internal_kwargs["start_date"] = range_start
+        if range_end is not None:
+            internal_kwargs["end_date"] = range_end
+        if min_date is not None:
+            internal_kwargs["min_date"] = min_date
+        if max_date is not None:
+            internal_kwargs["max_date"] = max_date
+        if disabled_dates is not None:
+            internal_kwargs["disabled_dates"] = disabled_dates
+        if required:
+            internal_kwargs["required"] = True
+        if disabled:
+            internal_kwargs["state"] = "disabled"
+        elif read_only:
+            internal_kwargs["state"] = "readonly"
+        if accent is not None:
+            internal_kwargs["accent"] = accent
+        if density is not None:
+            internal_kwargs["density"] = density
+        internal_kwargs.update(kwargs)
+
+        self._internal = _InternalDateEntry(tk_master, **internal_kwargs)
+        self._attach_to_parent(layout_kw)
+
+    # ----- Event routing -----
+
+    def _entry_widget(self) -> tkinter.Misc:
+        return self._internal._entry
+
+    def on(self, event: str, handler: Callable[[tkinter.Event], Any]) -> Subscription:
+        sequence = resolve_event(self, str(event))
+        widget = self._entry_widget() if sequence in _INNER_ENTRY_SEQUENCES else self._internal
+        bind_id = widget.bind(sequence, handler, add="+")
+        return Subscription(widget, sequence, bind_id)
+
+    # ----- Properties -----
+
+    @property
+    def value(self) -> "date | tuple[date, date] | None":
+        """Selected date, or `(start, end)` tuple in range mode."""
+        return self._internal.value
+
+    @value.setter
+    def value(self, v: "date | str | None") -> None:
+        self._internal.value = v
+
+    @property
+    def disabled(self) -> bool:
+        return str(self._entry_widget().cget("state")) == "disabled"
+
+    @disabled.setter
+    def disabled(self, v: bool) -> None:
+        self._internal.configure(state="disabled" if v else "normal")
+
+    @property
+    def read_only(self) -> bool:
+        return str(self._entry_widget().cget("state")) == "readonly"
+
+    @read_only.setter
+    def read_only(self, v: bool) -> None:
+        self._internal.configure(state="readonly" if v else "normal")
+
+    # ----- Event shorthands -----
+
+    def on_change(self, handler: Callable[[tkinter.Event], Any]) -> Subscription:
+        """Register a callback fired when the selected date changes.
+
+        Returns:
+            Subscription — call `.cancel()` to unsubscribe.
+        """
+        return self.on("change", handler)
+
+
+register_widget_events(DateField, _DATEFIELD_EVENTS)

--- a/src/bootstack/widgets/public/primitives/pathfield.py
+++ b/src/bootstack/widgets/public/primitives/pathfield.py
@@ -25,7 +25,7 @@ class PathField(PublicWidgetBase):
     Args:
         value: Initial path string.
         dialog: Dialog type — `'openfilename'` (default), `'saveasfilename'`,
-            `'askdirectory'`, or `'askopenfilenames'` (multiple files).
+            `'directory'`, or `'openfilenames'` (multiple files).
         dialog_options: Extra kwargs forwarded to the native dialog
             (e.g. `{'filetypes': [('Images', '*.png')]}`).
         button_label: Browse button label. Default `'Browse'`.

--- a/src/bootstack/widgets/public/primitives/pathfield.py
+++ b/src/bootstack/widgets/public/primitives/pathfield.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import tkinter
+from typing import Any, Callable
+
+from bootstack.widgets.composites.pathentry import PathEntry as _InternalPathEntry
+from bootstack.widgets.public.base import PublicWidgetBase
+from bootstack.widgets.public.events import resolve_event, register_widget_events
+from bootstack.widgets.public.subscription import Subscription
+from bootstack.widgets.public.primitives.textfield import _INNER_ENTRY_SEQUENCES
+
+_PATHFIELD_EVENTS: dict[str, str] = {
+    "change": "<<Change>>",
+    "submit": "<Return>",
+}
+
+
+class PathField(PublicWidgetBase):
+    """A text field with a browse button that opens a native file/directory dialog.
+
+    After the user picks a path, the field text is updated and a `change` event
+    fires. `dialog_result` holds the raw result from the dialog (a string for
+    single-file dialogs, a tuple of strings for multi-file dialogs).
+
+    Args:
+        value: Initial path string.
+        dialog: Dialog type — `'openfilename'` (default), `'saveasfilename'`,
+            `'askdirectory'`, or `'askopenfilenames'` (multiple files).
+        dialog_options: Extra kwargs forwarded to the native dialog
+            (e.g. `{'filetypes': [('Images', '*.png')]}`).
+        button_label: Browse button label. Default `'Browse'`.
+        button_accent: Accent token for the browse button.
+        label: Label displayed above the field.
+        message: Hint text displayed below the field.
+        required: Mark field as required.
+        disabled: If True, field is non-interactive.
+        read_only: If True, value is visible but not editable.
+        accent: Accent token for the focus ring.
+        density: Widget density — `'default'` or `'compact'`.
+        parent: Override the context-stack parent.
+    """
+
+    def __init__(
+        self,
+        value: str = "",
+        *,
+        dialog: str = "openfilename",
+        dialog_options: dict[str, Any] | None = None,
+        button_label: str = "Browse",
+        button_accent: str | None = None,
+        label: str | None = None,
+        message: str | None = None,
+        required: bool = False,
+        disabled: bool = False,
+        read_only: bool = False,
+        accent: str | None = None,
+        density: str | None = None,
+        parent: Any = None,
+        **kwargs: Any,
+    ) -> None:
+        self._parent = self._resolve_parent(parent)
+        layout_kw = self._split_layout_kwargs(kwargs)
+
+        tk_master = self._parent._child_master() if self._parent else None
+
+        internal_kwargs: dict[str, Any] = {
+            "dialog": dialog,
+            "button_text": button_label,
+        }
+        if value:
+            internal_kwargs["value"] = value
+        if dialog_options is not None:
+            internal_kwargs["dialog_options"] = dialog_options
+        if button_accent is not None:
+            internal_kwargs["button_accent"] = button_accent
+        if label is not None:
+            internal_kwargs["label"] = label
+        if message is not None:
+            internal_kwargs["message"] = message
+        if required:
+            internal_kwargs["required"] = True
+        if disabled:
+            internal_kwargs["state"] = "disabled"
+        elif read_only:
+            internal_kwargs["state"] = "readonly"
+        if accent is not None:
+            internal_kwargs["accent"] = accent
+        if density is not None:
+            internal_kwargs["density"] = density
+        internal_kwargs.update(kwargs)
+
+        self._internal = _InternalPathEntry(tk_master, **internal_kwargs)
+        self._attach_to_parent(layout_kw)
+
+    # ----- Event routing -----
+
+    def _entry_widget(self) -> tkinter.Misc:
+        return self._internal._entry
+
+    def on(self, event: str, handler: Callable[[tkinter.Event], Any]) -> Subscription:
+        sequence = resolve_event(self, str(event))
+        widget = self._entry_widget() if sequence in _INNER_ENTRY_SEQUENCES else self._internal
+        bind_id = widget.bind(sequence, handler, add="+")
+        return Subscription(widget, sequence, bind_id)
+
+    # ----- Properties -----
+
+    @property
+    def value(self) -> str:
+        """The current path string shown in the field."""
+        return self._internal.value
+
+    @value.setter
+    def value(self, v: str) -> None:
+        self._internal.value = v
+
+    @property
+    def dialog_result(self) -> "str | tuple[str, ...] | None":
+        """Raw result from the most recent dialog (string or tuple of strings)."""
+        return self._internal.dialog_result
+
+    @property
+    def disabled(self) -> bool:
+        return str(self._entry_widget().cget("state")) == "disabled"
+
+    @disabled.setter
+    def disabled(self, v: bool) -> None:
+        self._internal.configure(state="disabled" if v else "normal")
+
+    @property
+    def read_only(self) -> bool:
+        return str(self._entry_widget().cget("state")) == "readonly"
+
+    @read_only.setter
+    def read_only(self, v: bool) -> None:
+        self._internal.configure(state="readonly" if v else "normal")
+
+    # ----- Event shorthands -----
+
+    def on_change(self, handler: Callable[[tkinter.Event], Any]) -> Subscription:
+        """Register a callback fired when the path value changes.
+
+        Returns:
+            Subscription — call `.cancel()` to unsubscribe.
+        """
+        return self.on("change", handler)
+
+
+register_widget_events(PathField, _PATHFIELD_EVENTS)

--- a/tests/features/input_fields.py
+++ b/tests/features/input_fields.py
@@ -1,0 +1,96 @@
+"""Visual test for public DateField and PathField widgets."""
+from datetime import date
+
+import bootstack as bs
+from bootstack.widgets.public import App, VStack, HStack, Label, Separator, DateField, PathField
+
+
+def main():
+    with App(title="DateField + PathField", minsize=(520, 560), padding=20, gap=16) as app:
+
+        Label("DateField", font="heading-lg")
+
+        with HStack(gap=12, fill="x"):
+            with VStack(gap=8, fill="x", expand=True):
+                Label("Single date (default)")
+                df_single = DateField(label="Start date", density="default")
+
+            with VStack(gap=8, fill="x", expand=True):
+                Label("With initial value")
+                df_value = DateField(
+                    value=date.today(),
+                    label="Today",
+                    message="Pre-filled with today's date",
+                )
+
+        with HStack(gap=12, fill="x"):
+            with VStack(gap=8, fill="x", expand=True):
+                Label("Range mode")
+                df_range = DateField(
+                    selection_mode="range",
+                    label="Date range",
+                    message="Pick a start and end date",
+                )
+
+            with VStack(gap=8, fill="x", expand=True):
+                Label("Disabled")
+                df_disabled = DateField(
+                    value=date(2025, 1, 1),
+                    label="Locked date",
+                    disabled=True,
+                )
+
+        status_lbl = Label("(pick a date to see value)")
+
+        def on_date_change(e):
+            status_lbl.value = f"single value: {df_single.value}"
+
+        df_single.on_change(on_date_change)
+
+        Separator(fill="x")
+
+        Label("PathField", font="heading-lg")
+
+        with HStack(gap=12, fill="x"):
+            with VStack(gap=8, fill="x", expand=True):
+                Label("Open file (default)")
+                pf_open = PathField(label="Select file")
+
+            with VStack(gap=8, fill="x", expand=True):
+                Label("Select directory")
+                pf_dir = PathField(
+                    dialog="askdirectory",
+                    button_label="Browse…",
+                    label="Directory",
+                    message="Pick a folder",
+                )
+
+        with HStack(gap=12, fill="x"):
+            with VStack(gap=8, fill="x", expand=True):
+                Label("Save as")
+                pf_save = PathField(
+                    dialog="saveasfilename",
+                    label="Output file",
+                    dialog_options={"defaultextension": ".txt"},
+                )
+
+            with VStack(gap=8, fill="x", expand=True):
+                Label("Read-only")
+                pf_readonly = PathField(
+                    value="/some/preset/path.txt",
+                    label="Fixed path",
+                    read_only=True,
+                )
+
+        path_lbl = Label("(browse to see path value)")
+
+        def on_path_change(e):
+            path_lbl.value = f"path: {pf_open.value}"
+
+        pf_open.on_change(on_path_change)
+
+    app.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/features/input_fields.py
+++ b/tests/features/input_fields.py
@@ -59,7 +59,7 @@ def main():
             with VStack(gap=8, fill="x", expand=True):
                 Label("Select directory")
                 pf_dir = PathField(
-                    dialog="askdirectory",
+                    dialog="directory",
                     button_label="Browse…",
                     label="Directory",
                     message="Pick a folder",


### PR DESCRIPTION
## Summary

- `DateField` wraps `DateEntry` composite; supports single and range selection modes, min/max/disabled dates, calendar picker button, and all field options (label, message, required, disabled, read_only, accent, density)
- `PathField` wraps `PathEntry` composite; supports all native dialog types (`openfilename`, `saveasfilename`, `askdirectory`, `askopenfilenames`), configurable `button_label`/`button_accent`, and standard field options
- Both route input events to `self._internal._entry` via `_INNER_ENTRY_SEQUENCES`; expose `value`, `disabled`, `read_only` properties and `on_change()` shorthand
- Visual test: `tests/features/input_fields.py`

## Test plan

- [ ] Run `python tests/features/input_fields.py` and verify all four DateField variants render correctly
- [ ] Verify single-date picker opens and updates `value`
- [ ] Verify range mode shows start/end selection in picker
- [ ] Verify disabled DateField is non-interactive
- [ ] Run `python tests/features/input_fields.py` and verify all four PathField variants render
- [ ] Verify browse button opens native dialog and updates field text
- [ ] Run `pytest tests/widgets/public/test_base_layer.py -m "not gui"` — 11 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)