### PR TITLE
feat(public): add Radio and RadioToggleButton

### DIFF
--- a/src/bootstack/widgets/public/__init__.py
+++ b/src/bootstack/widgets/public/__init__.py
@@ -19,6 +19,7 @@ from bootstack.widgets.public.primitives.pagestack import PageStack
 from bootstack.widgets.public.primitives.pathfield import PathField
 from bootstack.widgets.public.primitives.passwordentry import PasswordEntry
 from bootstack.widgets.public.primitives.progressbar import ProgressBar
+from bootstack.widgets.public.primitives.radio_variants import Radio, RadioToggleButton
 from bootstack.widgets.public.primitives.radiogroup import RadioGroup
 from bootstack.widgets.public.primitives.scrollbar import Scrollbar
 from bootstack.widgets.public.primitives.select import Select
@@ -58,7 +59,9 @@ __all__ = [
     "ProgressBar",
     "PublicContainer",
     "PublicWidgetBase",
+    "Radio",
     "RadioGroup",
+    "RadioToggleButton",
     "RangeSlider",
     "Scrollbar",
     "Select",

--- a/src/bootstack/widgets/public/primitives/__init__.py
+++ b/src/bootstack/widgets/public/primitives/__init__.py
@@ -11,6 +11,7 @@ from bootstack.widgets.public.primitives.pagestack import PageStack
 from bootstack.widgets.public.primitives.passwordentry import PasswordEntry
 from bootstack.widgets.public.primitives.pathfield import PathField
 from bootstack.widgets.public.primitives.progressbar import ProgressBar
+from bootstack.widgets.public.primitives.radio_variants import Radio, RadioToggleButton
 from bootstack.widgets.public.primitives.radiogroup import RadioGroup
 from bootstack.widgets.public.primitives.scrollbar import Scrollbar
 from bootstack.widgets.public.primitives.select import Select
@@ -28,7 +29,8 @@ from bootstack.widgets.public.primitives.tooltip import Tooltip
 
 __all__ = [
     "Accordion", "Badge", "Button", "Card", "Checkbox", "Expander", "Gauge",
-    "Label", "NumericEntry", "PasswordEntry", "ProgressBar", "RadioGroup",
+    "Label", "NumericEntry", "PasswordEntry", "ProgressBar",
+    "Radio", "RadioGroup", "RadioToggleButton",
     "RangeSlider", "Select", "Separator", "Slider", "Spinbox", "Switch",
     "DateField", "GroupBox", "PageStack", "PathField", "SplitView",
     "TabChangeEventData", "TabRef", "Tabs", "TextArea", "TextField", "Toast",

--- a/src/bootstack/widgets/public/primitives/radio_variants.py
+++ b/src/bootstack/widgets/public/primitives/radio_variants.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import tkinter
+from typing import Any, Callable
+
+from bootstack.widgets.primitives.radiobutton import RadioButton as _InternalRadioButton
+from bootstack.widgets.primitives.radiotoggle import RadioToggle as _InternalRadioToggle
+from bootstack.widgets.public.base import PublicWidgetBase
+from bootstack.widgets.public.events import register_widget_events
+from bootstack.widgets.public.subscription import Subscription
+
+_RADIO_EVENTS: dict[str, str] = {
+    "change": "<<Change>>",
+    "select": "<<Select>>",
+}
+
+
+class _RadioBase(PublicWidgetBase):
+    """Shared base for Radio and RadioToggleButton."""
+
+    _internal_class: type
+
+    def __init__(
+        self,
+        label: str = "",
+        value: Any = None,
+        *,
+        signal: Any = None,
+        text_signal: Any = None,
+        on_change: Callable[[], Any] | None = None,
+        icon: str | None = None,
+        selected_icon: str | None = None,
+        unselected_icon: str | None = None,
+        icon_only: bool = False,
+        show_indicator: bool = True,
+        compound: str | None = None,
+        disabled: bool = False,
+        accent: str | None = None,
+        density: str | None = None,
+        parent: Any = None,
+        **kwargs: Any,
+    ) -> None:
+        self._parent = self._resolve_parent(parent)
+        layout_kw = self._split_layout_kwargs(kwargs)
+
+        tk_master = self._parent._child_master() if self._parent else None
+
+        _ctor_callback = on_change
+
+        internal_kwargs: dict[str, Any] = {}
+        if label:
+            internal_kwargs["text"] = label
+        if value is not None:
+            internal_kwargs["value"] = value
+        if signal is not None:
+            internal_kwargs["signal"] = signal
+        if text_signal is not None:
+            internal_kwargs["textsignal"] = text_signal
+        if icon is not None:
+            internal_kwargs["icon"] = icon
+        if selected_icon is not None:
+            internal_kwargs["on_icon"] = selected_icon
+        if unselected_icon is not None:
+            internal_kwargs["off_icon"] = unselected_icon
+        if icon_only:
+            internal_kwargs["icon_only"] = True
+        if not show_indicator:
+            internal_kwargs["show_indicator"] = False
+        if compound is not None:
+            internal_kwargs["compound"] = compound
+        if disabled:
+            internal_kwargs["state"] = "disabled"
+        if accent is not None:
+            internal_kwargs["accent"] = accent
+        if density is not None:
+            internal_kwargs["density"] = density
+        internal_kwargs.update(kwargs)
+
+        self._internal = self._internal_class(tk_master, **internal_kwargs)
+
+        def _command():
+            self._internal.event_generate("<<Change>>")
+            self._internal.event_generate("<<Select>>")
+            if _ctor_callback is not None:
+                _ctor_callback()
+
+        self._internal.configure(command=_command)
+        self._attach_to_parent(layout_kw)
+
+    # ----- Properties -----
+
+    @property
+    def selected(self) -> bool:
+        """True if this radio is the currently selected option in its group."""
+        return self._internal.get() == self._internal.cget("value")
+
+    @property
+    def disabled(self) -> bool:
+        return str(self._internal.cget("state")) == "disabled"
+
+    @disabled.setter
+    def disabled(self, v: bool) -> None:
+        self._internal.configure(state="disabled" if v else "normal")
+
+    # ----- Methods -----
+
+    def select(self) -> None:
+        """Programmatically select this radio button."""
+        self._internal.invoke()
+
+    # ----- Event shorthands -----
+
+    def on_change(self, handler: Callable[[tkinter.Event], Any]) -> Subscription:
+        """Register a callback fired when this radio is selected.
+
+        Returns:
+            Subscription — call `.cancel()` to unsubscribe.
+        """
+        return self.on("change", handler)
+
+    def on_select(self, handler: Callable[[tkinter.Event], Any]) -> Subscription:
+        """Register a callback fired when this radio is selected.
+
+        Returns:
+            Subscription — call `.cancel()` to unsubscribe.
+        """
+        return self.on("select", handler)
+
+
+class Radio(_RadioBase):
+    """A single radio button — one selectable option in a mutually-exclusive group.
+
+    Radio buttons in a group share a `signal`; clicking one sets the signal
+    to the radio's `value`.
+
+    Usage::
+
+        sig = bs.Signal("a")
+        bs.Radio("Option A", "a", signal=sig)
+        bs.Radio("Option B", "b", signal=sig)
+
+    Args:
+        label: Text displayed beside the radio indicator.
+        value: The value written to `signal` when this radio is selected.
+        signal: Shared `Signal` that holds the group's current value.
+        text_signal: Reactive `Signal` linked to the label text.
+        on_change: Callback fired when this radio is selected.
+        icon: Icon shown for all states.
+        selected_icon: Icon shown when this radio is selected.
+        unselected_icon: Icon shown when this radio is not selected.
+        icon_only: If True, removes extra padding reserved for the label.
+        show_indicator: If False, hides the circular indicator.
+        compound: Image placement relative to text.
+        disabled: If True, widget is non-interactive.
+        accent: Accent token, e.g. `'primary'`, `'success'`.
+        density: Widget density — `'default'` or `'compact'`.
+        parent: Override the context-stack parent.
+    """
+    _internal_class = _InternalRadioButton
+
+
+class RadioToggleButton(_RadioBase):
+    """A radio button that renders as a toggle button — toolbar/segmented-control style.
+
+    Behaves identically to `Radio` but renders as a depressed button when
+    selected rather than showing the circular indicator.
+
+    Args:
+        label: Text displayed on the button.
+        value: The value written to `signal` when this button is selected.
+        signal: Shared `Signal` that holds the group's current value.
+        text_signal: Reactive `Signal` linked to the label text.
+        on_change: Callback fired when this button is selected.
+        icon: Icon shown for all states.
+        selected_icon: Icon shown when selected.
+        unselected_icon: Icon shown when not selected.
+        icon_only: If True, removes extra label padding.
+        disabled: If True, widget is non-interactive.
+        accent: Accent token, e.g. `'primary'`, `'success'`.
+        density: Widget density — `'default'` or `'compact'`.
+        parent: Override the context-stack parent.
+    """
+    _internal_class = _InternalRadioToggle
+
+
+register_widget_events(Radio, _RADIO_EVENTS)
+register_widget_events(RadioToggleButton, _RADIO_EVENTS)

--- a/tests/features/radio_variants.py
+++ b/tests/features/radio_variants.py
@@ -1,0 +1,86 @@
+"""Visual test for public Radio and RadioToggleButton widgets."""
+from bootstack.widgets.public import (
+    App, VStack, HStack, Label, Separator,
+    Radio, RadioToggleButton,
+)
+from bootstack.signals import Signal
+
+
+def main():
+    with App(title="Radio + RadioToggleButton", minsize=(520, 540), padding=20, gap=16) as app:
+
+        # --- Radio ---
+        Label("Radio — shared Signal group", font="heading-lg")
+
+        with HStack(gap=12, fill="x"):
+            with VStack(gap=6, fill="x", expand=True):
+                Label("Default (pre-selected B)")
+                sig_a = Signal("b")
+                Radio("Option A", "a", signal=sig_a)
+                Radio("Option B", "b", signal=sig_a)
+                Radio("Option C", "c", signal=sig_a)
+
+            with VStack(gap=6, fill="x", expand=True):
+                Label("Success accent")
+                sig_b = Signal("x")
+                Radio("Choice X", "x", signal=sig_b, accent="success")
+                Radio("Choice Y", "y", signal=sig_b, accent="success")
+                Radio("Choice Z", "z", signal=sig_b, accent="success")
+
+        with HStack(gap=12, fill="x"):
+            with VStack(gap=6, fill="x", expand=True):
+                Label("on_change callback")
+                sig_c = Signal("one")
+                cb_lbl = Label("selected: one")
+
+                def _update(e):
+                    cb_lbl.value = f"selected: {sig_c.get()}"
+
+                r1 = Radio("One", "one", signal=sig_c)
+                r2 = Radio("Two", "two", signal=sig_c)
+                r3 = Radio("Three", "three", signal=sig_c)
+                r1.on_change(_update)
+                r2.on_change(_update)
+                r3.on_change(_update)
+
+            with VStack(gap=6, fill="x", expand=True):
+                Label("Disabled option")
+                sig_d = Signal("yes")
+                Radio("Yes", "yes", signal=sig_d)
+                Radio("No", "no", signal=sig_d)
+                Radio("Unavailable", "na", signal=sig_d, disabled=True)
+
+        Separator(fill="x")
+
+        # --- RadioToggleButton ---
+        Label("RadioToggleButton — toggle-button style", font="heading-lg")
+
+        with VStack(gap=10, fill="x"):
+            Label("Horizontal segmented control")
+            sig_e = Signal("day")
+            with HStack(gap=4):
+                RadioToggleButton("Day", "day", signal=sig_e)
+                RadioToggleButton("Week", "week", signal=sig_e)
+                RadioToggleButton("Month", "month", signal=sig_e)
+                RadioToggleButton("Year", "year", signal=sig_e)
+
+            Label("Primary accent")
+            sig_f = Signal("s")
+            with HStack(gap=4):
+                RadioToggleButton("S", "s", signal=sig_f, accent="primary")
+                RadioToggleButton("M", "m", signal=sig_f, accent="primary")
+                RadioToggleButton("L", "l", signal=sig_f, accent="primary")
+                RadioToggleButton("XL", "xl", signal=sig_f, accent="primary")
+
+            Label("Compact density")
+            sig_g = Signal("left")
+            with HStack(gap=4):
+                RadioToggleButton("Left", "left", signal=sig_g, density="compact")
+                RadioToggleButton("Center", "center", signal=sig_g, density="compact")
+                RadioToggleButton("Right", "right", signal=sig_g, density="compact")
+
+    app.run()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- `Radio` wraps `RadioButton`; single selectable option in a mutually-exclusive group via a shared `Signal`
- `RadioToggleButton` wraps `RadioToggle`; same behavior rendered as a depressed toggle button (segmented-control / toolbar style)
- Both share `_RadioBase`: `label`/`value` positional args, `signal=`, `on_change=`, icon args (`icon`, `selected_icon`, `unselected_icon`), `disabled`, `accent`, `density`
- `selected` property returns True when this specific radio is the active choice
- `select()` method programmatically activates a radio
- `on_change()` / `on_select()` event shorthands
- Visual test: `tests/features/radio_variants.py`

## Test plan

- [ ] Run `python tests/features/radio_variants.py` — verify Radio groups render and selection is mutually exclusive
- [ ] Verify `on_change` callback label updates correctly
- [ ] Verify disabled radio is non-interactive
- [ ] Verify RadioToggleButton groups (segmented, accent, compact) render and toggle correctly
- [ ] Run `pytest tests/widgets/public/test_base_layer.py -m "not gui"` — 11 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)