### PR TITLE
feat(public): add CodeEditor

### DIFF
--- a/src/bootstack/widgets/composites/textarea/search_overlay.py
+++ b/src/bootstack/widgets/composites/textarea/search_overlay.py
@@ -66,7 +66,7 @@ class SearchOverlay(PackFrame):
         self._close_btn.pack()
 
         self._find_entry = TextEntry(_fr, density="compact")
-        self._find_entry.insert_addon(Label, position="before", icon="search")
+        self._find_entry.insert_addon(Label, position="before", icon="search", icon_only=True)
         self._find_entry.on_changed(self._on_query_changed)
         self._find_entry.pack(fill="x", expand=True)
 
@@ -112,14 +112,14 @@ class SearchOverlay(PackFrame):
         self._replace_entry.pack(fill="x", expand=True)
 
         self._replace_btn = Button(
-            self._replace_row, text="Replace",
+            self._replace_row, icon="pencil", icon_only=True,
             variant="ghost", density="compact",
             command=self._replace_current,
         )
         self._replace_btn.pack(padx=(8, 0))
 
         self._replace_all_btn = Button(
-            self._replace_row, text="Replace All",
+            self._replace_row, icon="pencil-fill", icon_only=True,
             variant="ghost", density="compact",
             command=self._replace_all,
         )

--- a/src/bootstack/widgets/public/__init__.py
+++ b/src/bootstack/widgets/public/__init__.py
@@ -8,6 +8,8 @@ from bootstack.widgets.public.grid import Grid
 from bootstack.widgets.public.app import App
 from bootstack.widgets.public.primitives.boolean_controls import Checkbox, Switch, ToggleButton
 from bootstack.widgets.public.primitives.button import Button
+from bootstack.widgets.public.primitives.codeeditor import CodeEditor
+from bootstack.widgets.composites.textarea.filter import EditFilter
 from bootstack.widgets.public.primitives.card import Card
 from bootstack.widgets.public.primitives.datefield import DateField
 from bootstack.widgets.public.primitives.expander import Accordion, Expander
@@ -43,7 +45,9 @@ __all__ = [
     "Button",
     "Card",
     "Checkbox",
+    "CodeEditor",
     "DateField",
+    "EditFilter",
     "Event",
     "Expander",
     "Gauge",

--- a/src/bootstack/widgets/public/primitives/__init__.py
+++ b/src/bootstack/widgets/public/primitives/__init__.py
@@ -1,5 +1,6 @@
 from bootstack.widgets.public.primitives.boolean_controls import Checkbox, Switch, ToggleButton
 from bootstack.widgets.public.primitives.button import Button
+from bootstack.widgets.public.primitives.codeeditor import CodeEditor
 from bootstack.widgets.public.primitives.card import Card
 from bootstack.widgets.public.primitives.datefield import DateField
 from bootstack.widgets.public.primitives.expander import Accordion, Expander
@@ -28,7 +29,7 @@ from bootstack.widgets.public.primitives.togglegroup import ToggleGroup
 from bootstack.widgets.public.primitives.tooltip import Tooltip
 
 __all__ = [
-    "Accordion", "Badge", "Button", "Card", "Checkbox", "Expander", "Gauge",
+    "Accordion", "Badge", "Button", "Card", "Checkbox", "CodeEditor", "Expander", "Gauge",
     "Label", "NumericEntry", "PasswordEntry", "ProgressBar",
     "Radio", "RadioGroup", "RadioToggleButton",
     "RangeSlider", "Select", "Separator", "Slider", "Spinbox", "Switch",

--- a/src/bootstack/widgets/public/primitives/codeeditor.py
+++ b/src/bootstack/widgets/public/primitives/codeeditor.py
@@ -1,0 +1,319 @@
+from __future__ import annotations
+
+import tkinter
+from contextlib import contextmanager
+from typing import Any, Callable, Iterator
+
+from bootstack.widgets.composites.textarea.codeeditor import CodeEditor as _InternalCodeEditor
+from bootstack.widgets.composites.textarea.filter import EditFilter
+from bootstack.widgets.public.base import PublicWidgetBase
+from bootstack.widgets.public.events import register_widget_events
+from bootstack.widgets.public.subscription import Subscription
+
+_CODEEDITOR_EVENTS: dict[str, str] = {
+    "change":      "<<Change>>",
+    "input":       "<KeyRelease>",
+    "modified":    "<<TextModified>>",
+    "undo":        "<<TextUndo>>",
+    "redo":        "<<TextRedo>>",
+    "cursor_move": "<<CursorMove>>",
+    "focus":       "<FocusIn>",
+    "blur":        "<FocusOut>",
+}
+
+_INNER_SEQUENCES = frozenset({
+    "<<Change>>", "<<TextModified>>", "<<TextUndo>>", "<<TextRedo>>",
+    "<<CursorMove>>", "<KeyRelease>", "<FocusIn>", "<FocusOut>",
+})
+
+
+class CodeEditor(PublicWidgetBase):
+    """A full-featured code editor with line numbers, bracket matching, and syntax highlighting.
+
+    Not Field-wrapped — use `TextArea` for labeled form inputs.
+
+    Args:
+        value: Initial text content.
+        text_signal: Reactive `Signal[str]` bound to the editor content.
+        language: Pygments lexer name for syntax highlighting (e.g. `'python'`,
+            `'sql'`). `None` disables highlighting.
+        pygments_style: Pygments color scheme (e.g. `'default'`, `'monokai'`).
+        read_only: If True, content is visible but not editable.
+        wrap: If True, long lines wrap. Default `False` (horizontal scroll).
+        tab_width: Number of spaces per tab stop. Default `4`.
+        insert_spaces: If True, Tab inserts spaces instead of a tab character.
+        auto_indent: If True, Return replicates the current line's indentation.
+        show_line_numbers: If True (default), shows a line-number gutter.
+        show_indent_guides: If True, draws subtle vertical guide marks at
+            each indent stop.
+        scrollbars: Scrollbar visibility — `'both'` (default), `'auto'`,
+            `'vertical'`, or `'none'`.
+        font: Font for the editor. Default `'TkFixedFont'`.
+        extensions: Additional `EditFilter` instances to install on top of
+            the built-in set.
+        parent: Override the context-stack parent.
+    """
+
+    def __init__(
+        self,
+        value: str = "",
+        *,
+        text_signal: Any = None,
+        language: str | None = None,
+        pygments_style: str = "default",
+        read_only: bool = False,
+        wrap: bool = False,
+        tab_width: int = 4,
+        insert_spaces: bool = True,
+        auto_indent: bool = True,
+        show_line_numbers: bool = True,
+        show_indent_guides: bool = False,
+        scrollbars: str = "both",
+        font: str = "TkFixedFont",
+        extensions: list[EditFilter] | None = None,
+        parent: Any = None,
+        **kwargs: Any,
+    ) -> None:
+        self._parent = self._resolve_parent(parent)
+        layout_kw = self._split_layout_kwargs(kwargs)
+
+        tk_master = self._parent._child_master() if self._parent else None
+
+        internal_kwargs: dict[str, Any] = {
+            "value": value,
+            "language": language,
+            "pygments_style": pygments_style,
+            "read_only": read_only,
+            "wrap": wrap,
+            "tab_width": tab_width,
+            "insert_spaces": insert_spaces,
+            "auto_indent": auto_indent,
+            "show_line_numbers": show_line_numbers,
+            "show_indent_guides": show_indent_guides,
+            "scrollbars": scrollbars,
+            "font": font,
+        }
+        if text_signal is not None:
+            internal_kwargs["textsignal"] = text_signal
+        if extensions is not None:
+            internal_kwargs["extensions"] = extensions
+
+        self._internal = _InternalCodeEditor(tk_master, **internal_kwargs)
+
+        # Generate <<CursorMove>> so on_cursor_move() subscribers always work.
+        t = self._internal._core.text
+        t.bind("<KeyRelease>",      lambda e: t.event_generate("<<CursorMove>>"), add="+")
+        t.bind("<ButtonRelease-1>", lambda e: t.event_generate("<<CursorMove>>"), add="+")
+
+        self._attach_to_parent(layout_kw)
+
+    # ----- Event routing -----
+
+    def _text_widget(self) -> tkinter.Misc:
+        return self._internal._core.text
+
+    def on(self, event: str, handler: Callable[[tkinter.Event], Any]) -> Subscription:
+        from bootstack.widgets.public.events import resolve_event
+        sequence = resolve_event(self, str(event))
+        widget = self._text_widget() if sequence in _INNER_SEQUENCES else self._internal
+        bind_id = widget.bind(sequence, handler, add="+")
+        return Subscription(widget, sequence, bind_id)
+
+    # ----- Properties -----
+
+    @property
+    def value(self) -> str:
+        """Full text content (trailing newline stripped)."""
+        return self._internal.value
+
+    @value.setter
+    def value(self, v: str) -> None:
+        self._internal.value = v
+
+    @property
+    def is_dirty(self) -> bool:
+        """True if content has changed since the last `mark_saved()` call."""
+        return self._internal.is_dirty
+
+    @property
+    def language(self) -> str | None:
+        """Active syntax highlighting language, or `None` if disabled."""
+        return self._internal._language
+
+    @language.setter
+    def language(self, v: str | None) -> None:
+        self._internal.set_language(v)
+
+    @property
+    def read_only(self) -> bool:
+        return self._internal._core._read_only
+
+    @read_only.setter
+    def read_only(self, v: bool) -> None:
+        self._internal._core._read_only = v
+        self._internal._core.text.configure(
+            state=tkinter.DISABLED if v else tkinter.NORMAL
+        )
+
+    @property
+    def disabled(self) -> bool:
+        return self.read_only
+
+    @disabled.setter
+    def disabled(self, v: bool) -> None:
+        self.read_only = v
+
+    # ----- Methods -----
+
+    def clear(self) -> None:
+        """Clear all text content."""
+        self._internal.value = ""
+
+    def insert(self, index: str, text: str) -> None:
+        """Insert `text` at `index` (Tk text index, e.g. `'end'` or `'1.0'`)."""
+        self._internal._core.text.insert(index, text)
+
+    def select_all(self) -> None:
+        """Select all text content."""
+        tw = self._internal._core.text
+        tw.focus_set()
+        tw.tag_add("sel", "1.0", "end-1c")
+        tw.mark_set("insert", "end-1c")
+
+    def focus(self) -> None:
+        """Move keyboard focus to the editor."""
+        self._internal.focus_set()
+
+    def goto_line(self, n: int) -> None:
+        """Move the cursor to the start of line `n` and scroll it into view.
+
+        Args:
+            n: 1-indexed line number.
+        """
+        self._internal.focus_set()
+        self._internal.goto_line(n)
+
+    def undo(self) -> None:
+        """Undo the last edit."""
+        self._internal.undo()
+
+    def redo(self) -> None:
+        """Redo the last undone edit."""
+        self._internal.redo()
+
+    @contextmanager
+    def undo_block(self) -> Iterator[None]:
+        """Context manager that groups edits into a single undo step.
+
+        Usage::
+
+            with editor.undo_block():
+                editor.insert("1.0", "# header\\n")
+                editor.value = new_content
+        """
+        self._internal.undo_block_start()
+        try:
+            yield
+        finally:
+            self._internal.undo_block_stop()
+
+    def mark_saved(self) -> None:
+        """Mark the current state as the saved baseline (clears `is_dirty`)."""
+        self._internal.mark_saved()
+
+    def install(self, f: EditFilter) -> None:
+        """Install a custom filter extension.
+
+        Args:
+            f: The `EditFilter` to add.
+        """
+        self._internal.install(f)
+
+    def uninstall(self, f: EditFilter) -> None:
+        """Remove a previously installed filter extension.
+
+        Args:
+            f: The `EditFilter` to remove.
+        """
+        self._internal.uninstall(f)
+
+    def show_search(self) -> None:
+        """Show the find bar and focus the search input."""
+        self._internal.show_search()
+
+    def show_replace(self) -> None:
+        """Show the find/replace bar with the replace row visible."""
+        self._internal.show_replace()
+
+    def hide_search(self) -> None:
+        """Hide the find/replace bar."""
+        self._internal.hide_search()
+
+    # ----- Event shorthands -----
+
+    def on_change(self, handler: Callable[[tkinter.Event], Any]) -> Subscription:
+        """Register a callback fired on every edit.
+
+        Returns:
+            Subscription — call `.cancel()` to unsubscribe.
+        """
+        return self.on("change", handler)
+
+    def on_input(self, handler: Callable[[tkinter.Event], Any]) -> Subscription:
+        """Register a callback fired on every keystroke.
+
+        Returns:
+            Subscription — call `.cancel()` to unsubscribe.
+        """
+        return self.on("input", handler)
+
+    def on_modified(self, handler: Callable[[tkinter.Event], Any]) -> Subscription:
+        """Register a callback fired when `is_dirty` changes.
+
+        Returns:
+            Subscription — call `.cancel()` to unsubscribe.
+        """
+        return self.on("modified", handler)
+
+    def on_undo(self, handler: Callable[[tkinter.Event], Any]) -> Subscription:
+        """Register a callback fired after an undo operation.
+
+        Returns:
+            Subscription — call `.cancel()` to unsubscribe.
+        """
+        return self.on("undo", handler)
+
+    def on_redo(self, handler: Callable[[tkinter.Event], Any]) -> Subscription:
+        """Register a callback fired after a redo operation.
+
+        Returns:
+            Subscription — call `.cancel()` to unsubscribe.
+        """
+        return self.on("redo", handler)
+
+    def on_cursor_move(self, handler: Callable[[tkinter.Event], Any]) -> Subscription:
+        """Register a callback fired when the cursor position changes.
+
+        Returns:
+            Subscription — call `.cancel()` to unsubscribe.
+        """
+        return self.on("cursor_move", handler)
+
+    def on_focus(self, handler: Callable[[tkinter.Event], Any]) -> Subscription:
+        """Register a callback fired when the editor gains focus.
+
+        Returns:
+            Subscription — call `.cancel()` to unsubscribe.
+        """
+        return self.on("focus", handler)
+
+    def on_blur(self, handler: Callable[[tkinter.Event], Any]) -> Subscription:
+        """Register a callback fired when the editor loses focus.
+
+        Returns:
+            Subscription — call `.cancel()` to unsubscribe.
+        """
+        return self.on("blur", handler)
+
+
+register_widget_events(CodeEditor, _CODEEDITOR_EVENTS)

--- a/tests/features/code_editor_public.py
+++ b/tests/features/code_editor_public.py
@@ -1,0 +1,101 @@
+"""Visual test for the public CodeEditor widget."""
+from bootstack.widgets.public import (
+    App, VStack, HStack, Label, Button, Separator, CodeEditor,
+)
+
+_PYTHON_SAMPLE = '''\
+def greet(name: str) -> str:
+    """Return a greeting string."""
+    return f"Hello, {name}!"
+
+
+class Counter:
+    def __init__(self, start: int = 0) -> None:
+        self.value = start
+
+    def increment(self) -> None:
+        self.value += 1
+
+    def reset(self) -> None:
+        self.value = 0
+'''
+
+_SQL_SAMPLE = '''\
+SELECT
+    u.id,
+    u.name,
+    COUNT(o.id) AS order_count
+FROM users u
+LEFT JOIN orders o ON o.user_id = u.id
+WHERE u.active = 1
+GROUP BY u.id, u.name
+ORDER BY order_count DESC
+LIMIT 20;
+'''
+
+
+def main():
+    with App(title="CodeEditor — public layer", minsize=(780, 640), padding=16, gap=12) as app:
+
+        Label("CodeEditor", font="heading-lg")
+
+        with HStack(gap=12, fill="both", expand=True):
+
+            with VStack(gap=6, fill="both", expand=True):
+                Label("Python — line numbers, syntax highlight")
+                py_editor = CodeEditor(
+                    _PYTHON_SAMPLE,
+                    language="python",
+                    pygments_style="default",
+                    show_line_numbers=True,
+                    fill="both",
+                    expand=True,
+                )
+
+            with VStack(gap=6, fill="both", expand=True):
+                Label("SQL — no line numbers")
+                sql_editor = CodeEditor(
+                    _SQL_SAMPLE,
+                    language="sql",
+                    show_line_numbers=False,
+                    fill="both",
+                    expand=True,
+                )
+
+        Separator(fill="x")
+
+        Label("Controls", font="heading-sm")
+        status_lbl = Label("is_dirty: False")
+
+        def _refresh_dirty(e=None):
+            status_lbl.value = f"is_dirty: {py_editor.is_dirty}"
+
+        py_editor.on_change(_refresh_dirty)
+
+        with HStack(gap=8):
+            Button("Mark saved", variant="outline",
+                   on_click=lambda: (py_editor.mark_saved(), _refresh_dirty()))
+            Button("Goto line 5", variant="outline",
+                   on_click=lambda: py_editor.goto_line(5))
+            Button("Select all", variant="outline",
+                   on_click=lambda: py_editor.select_all())
+            Button("Clear", variant="outline",
+                   on_click=lambda: (py_editor.clear(), _refresh_dirty()))
+            Button("Find (Ctrl+F)", variant="outline",
+                   on_click=lambda: py_editor.show_search())
+            Button("Replace", variant="outline",
+                   on_click=lambda: py_editor.show_replace())
+
+        with HStack(gap=8):
+            Button("Toggle read-only", variant="outline",
+                   on_click=lambda: setattr(py_editor, "read_only", not py_editor.read_only))
+            Button("Python", on_click=lambda: setattr(py_editor, "language", "python"))
+            Button("JSON", on_click=lambda: setattr(py_editor, "language", "json"))
+            Button("None", variant="outline",
+                   on_click=lambda: setattr(py_editor, "language", None))
+
+    app.run()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- `CodeEditor` public wrapper over the internal `CodeEditor` composite
- `value` (positional), `language`, `pygments_style`, `read_only`, `wrap`, `tab_width`, `insert_spaces`, `auto_indent`, `show_line_numbers`, `show_indent_guides`, `scrollbars`, `font`, `extensions`, `text_signal` constructor args
- Properties: `value`, `is_dirty`, `language` (RW via `set_language()`), `read_only` / `disabled` (aliased)
- Methods: `clear()`, `insert()`, `select_all()`, `focus()`, `goto_line()`, `undo()`, `redo()`, `undo_block()` (context manager), `mark_saved()`, `install()` / `uninstall()`, `show_search()` / `show_replace()` / `hide_search()`
- Events: `change`, `input`, `modified`, `undo`, `redo`, `cursor_move`, `focus`, `blur` — all routed to inner `_core.text`
- `EditFilter` re-exported at `bs.EditFilter` so users never import from `composites.*`
- `goto_line()` calls `focus_set()` first so the scroll is visible
- Fixes `SearchOverlay` Replace / Replace All buttons to icon-only (`pencil` / `pencil-fill`)
- Visual test: `tests/features/code_editor_public.py`

## Test plan

- [ ] Run `python tests/features/code_editor_public.py` — two editors render with syntax highlighting
- [ ] Verify Goto line 5 scrolls and focuses the Python editor
- [ ] Verify Select All, Clear, Mark Saved, read-only toggle work
- [ ] Open Find bar (button or Ctrl+F) — verify icon-only replace buttons in replace row
- [ ] Verify language switcher (Python → JSON → None) updates highlighting live
- [ ] Run `pytest tests/widgets/public/test_base_layer.py -m "not gui"` — 11 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)