### PR TITLE
feat(public): add dialog functions and FormDialog

### DIFF
--- a/src/bootstack/dialogs/formdialog.py
+++ b/src/bootstack/dialogs/formdialog.py
@@ -269,27 +269,32 @@ class FormDialog:
 
         # Calculate dialog size: content + padding (10x2) + dialog chrome (~40)
         dialog_width = measured_width + 60
-        dialog_height = 500  # Default height, will adjust after geometry update
 
-        # Apply user minsize if provided
+        _MIN_HEIGHT = 150
+        _MAX_HEIGHT = 800
+
+        min_height = _MIN_HEIGHT
         if self._user_minsize:
             user_width, user_height = self._user_minsize
             dialog_width = max(user_width, dialog_width)
-            dialog_height = max(user_height, dialog_height)
+            min_height = max(user_height, _MIN_HEIGHT)
 
-        if self._height:
-            dialog_height = self._height + 100
-
-        dialog_height = min(dialog_height, 800)
         # Store the intended content width for pre-show sizing of the scrollview
         self._desired_canvas_width = measured_width
 
-        # Set minsize and geometry BEFORE forcing layout
         if self._dialog.toplevel:
-            self._dialog.toplevel.minsize(dialog_width, dialog_height)
-            self._dialog.toplevel.geometry(f"{dialog_width}x{dialog_height}")
+            # Seed width and minimum height, then measure natural content height
+            self._dialog.toplevel.minsize(dialog_width, min_height)
+            self._dialog.toplevel.geometry(f"{dialog_width}x{min_height}")
+            self._dialog.toplevel.update_idletasks()
 
-            # Force complete geometry calculation while window is still withdrawn
+            if self._height:
+                dialog_height = min(self._height + 100, _MAX_HEIGHT)
+            else:
+                natural = self._dialog.toplevel.winfo_reqheight()
+                dialog_height = min(max(natural, min_height), _MAX_HEIGHT)
+
+            self._dialog.toplevel.geometry(f"{dialog_width}x{dialog_height}")
             self._dialog.toplevel.update_idletasks()
 
     def _schedule_initial_layout(self):

--- a/src/bootstack/widgets/public/__init__.py
+++ b/src/bootstack/widgets/public/__init__.py
@@ -1,3 +1,8 @@
+from bootstack.widgets.public.dialogs import (
+    alert, confirm,
+    ask_string, ask_integer, ask_float, ask_date, ask_item,
+    FormDialog, Dialog, DialogButton,
+)
 from bootstack.widgets.public.events import Event
 from bootstack.widgets.public.exceptions import BootstackV2Error, UnknownEventError, ParentResolutionError
 from bootstack.widgets.public.subscription import Subscription
@@ -39,16 +44,26 @@ from bootstack.widgets.public.primitives.tooltip import Tooltip
 
 __all__ = [
     "Accordion",
+    "alert",
     "App",
+    "ask_date",
+    "ask_float",
+    "ask_integer",
+    "ask_item",
+    "ask_string",
     "Badge",
     "BootstackV2Error",
     "Button",
     "Card",
     "Checkbox",
     "CodeEditor",
+    "confirm",
     "DateField",
+    "Dialog",
+    "DialogButton",
     "EditFilter",
     "Event",
+    "FormDialog",
     "Expander",
     "Gauge",
     "Grid",

--- a/src/bootstack/widgets/public/dialogs.py
+++ b/src/bootstack/widgets/public/dialogs.py
@@ -1,0 +1,283 @@
+from __future__ import annotations
+
+from datetime import date
+from typing import Any, Callable, Iterable, Literal, Mapping, Sequence
+
+from bootstack.dialogs.dialog import Dialog, DialogButton, ButtonSpec
+from bootstack.dialogs.message import MessageBox as _MessageBox
+from bootstack.dialogs.query import QueryBox as _QueryBox
+from bootstack.dialogs.formdialog import FormDialog as _InternalFormDialog
+
+
+# ---------------------------------------------------------------------------
+# Module-level convenience functions
+# ---------------------------------------------------------------------------
+
+def alert(
+    message: str,
+    *,
+    title: str = "",
+    parent: Any = None,
+) -> None:
+    """Show a message dialog with an OK button.
+
+    Args:
+        message: The message text to display.
+        title: Dialog window title.
+        parent: Parent widget. Defaults to the active root window.
+    """
+    _MessageBox.ok(message, title=title or " ", master=parent)
+
+
+def confirm(
+    message: str,
+    *,
+    title: str = "",
+    parent: Any = None,
+) -> bool:
+    """Show a Yes/No confirmation dialog.
+
+    Args:
+        message: The question text to display.
+        title: Dialog window title.
+        parent: Parent widget. Defaults to the active root window.
+
+    Returns:
+        `True` if the user clicked Yes, `False` otherwise.
+    """
+    result = _MessageBox.yesno(message, title=title or " ", master=parent)
+    return result == "Yes"
+
+
+def ask_string(
+    prompt: str,
+    *,
+    title: str = "",
+    value: str | None = None,
+    parent: Any = None,
+) -> str | None:
+    """Show a text-input dialog.
+
+    Args:
+        prompt: Prompt text displayed above the input field.
+        title: Dialog window title.
+        value: Pre-filled initial value.
+        parent: Parent widget. Defaults to the active root window.
+
+    Returns:
+        The entered string, or `None` if cancelled.
+    """
+    return _QueryBox.get_string(
+        prompt,
+        title=title or " ",
+        value=value,
+        master=parent,
+    )
+
+
+def ask_integer(
+    prompt: str,
+    *,
+    title: str = "",
+    value: int | None = None,
+    min_value: int | None = None,
+    max_value: int | None = None,
+    step: int | None = None,
+    parent: Any = None,
+) -> int | None:
+    """Show an integer-input dialog with optional range validation.
+
+    Args:
+        prompt: Prompt text displayed above the input field.
+        title: Dialog window title.
+        value: Pre-filled initial value.
+        min_value: Minimum accepted value.
+        max_value: Maximum accepted value.
+        step: Increment/decrement step size.
+        parent: Parent widget. Defaults to the active root window.
+
+    Returns:
+        The entered integer, or `None` if cancelled.
+    """
+    return _QueryBox.get_integer(
+        prompt,
+        title=title or " ",
+        value=value,
+        minvalue=min_value,
+        maxvalue=max_value,
+        increment=step,
+        master=parent,
+    )
+
+
+def ask_float(
+    prompt: str,
+    *,
+    title: str = "",
+    value: float | None = None,
+    min_value: float | None = None,
+    max_value: float | None = None,
+    step: float | None = None,
+    parent: Any = None,
+) -> float | None:
+    """Show a float-input dialog with optional range validation.
+
+    Args:
+        prompt: Prompt text displayed above the input field.
+        title: Dialog window title.
+        value: Pre-filled initial value.
+        min_value: Minimum accepted value.
+        max_value: Maximum accepted value.
+        step: Increment/decrement step size.
+        parent: Parent widget. Defaults to the active root window.
+
+    Returns:
+        The entered float, or `None` if cancelled.
+    """
+    return _QueryBox.get_float(
+        prompt,
+        title=title or " ",
+        value=value,
+        minvalue=min_value,
+        maxvalue=max_value,
+        increment=step,
+        master=parent,
+    )
+
+
+def ask_date(
+    prompt: str = "",
+    *,
+    title: str = "",
+    value: date | None = None,
+    parent: Any = None,
+) -> date | None:
+    """Show a calendar date-picker dialog.
+
+    Args:
+        prompt: Prompt text (used as the dialog title when `title` is not set).
+        title: Dialog window title. Falls back to `prompt` when omitted.
+        value: Pre-selected initial date.
+        parent: Parent widget. Defaults to the active root window.
+
+    Returns:
+        The selected `date`, or `None` if cancelled.
+    """
+    return _QueryBox.get_date(
+        master=parent,
+        title=title or prompt or " ",
+        value=value,
+    )
+
+
+def ask_item(
+    prompt: str,
+    options: list[str],
+    *,
+    title: str = "",
+    value: str | None = None,
+    parent: Any = None,
+) -> str | None:
+    """Show a dropdown-selection dialog.
+
+    Args:
+        prompt: Prompt text displayed above the dropdown.
+        options: List of selectable items.
+        title: Dialog window title.
+        value: Pre-selected initial item.
+        parent: Parent widget. Defaults to the active root window.
+
+    Returns:
+        The selected item string, or `None` if cancelled.
+    """
+    return _QueryBox.get_item(
+        prompt,
+        title=title or " ",
+        value=value,
+        items=options,
+        master=parent,
+    )
+
+
+# ---------------------------------------------------------------------------
+# FormDialog — public wrapper
+# ---------------------------------------------------------------------------
+
+class FormDialog:
+    """A dialog window that embeds a Form for structured data entry.
+
+    Args:
+        title: Dialog window title.
+        data: Initial data backing the form. Keys become field names.
+        items: Explicit form layout — `FormItem` / `GroupItem` / `TabsItem`
+            instances or equivalent dicts. If omitted, fields are inferred
+            from `data`.
+        col_count: Number of form columns. Default `1`.
+        min_col_width: Minimum column width in pixels.
+        on_data_changed: Callback invoked on every field change, receiving
+            the current data dict.
+        width: Explicit form width in pixels.
+        height: Explicit form height in pixels.
+        buttons: Footer button specs. Defaults to Cancel + OK.
+        min_size: Minimum dialog window size `(width, height)`.
+        max_size: Maximum dialog window size `(width, height)`.
+        resizable: Allow window resizing. Default `False`.
+        parent: Parent widget. Defaults to the active root window.
+    """
+
+    def __init__(
+        self,
+        *,
+        title: str = "Form",
+        data: dict[str, Any] | None = None,
+        items: Sequence[Any] | None = None,
+        col_count: int = 1,
+        min_col_width: int | None = None,
+        on_data_changed: Callable[[dict[str, Any]], Any] | None = None,
+        width: int | None = None,
+        height: int | None = None,
+        buttons: Iterable[ButtonSpec | str] | None = None,
+        min_size: tuple[int, int] | None = None,
+        max_size: tuple[int, int] | None = None,
+        resizable: tuple[bool, bool] | bool = False,
+        parent: Any = None,
+    ) -> None:
+        internal_kwargs: dict[str, Any] = {
+            "title": title,
+            "col_count": col_count,
+            "resizable": resizable,
+        }
+        if data is not None:
+            internal_kwargs["data"] = data
+        if items is not None:
+            internal_kwargs["items"] = items
+        if min_col_width is not None:
+            internal_kwargs["min_col_width"] = min_col_width
+        if on_data_changed is not None:
+            internal_kwargs["on_data_changed"] = on_data_changed
+        if width is not None:
+            internal_kwargs["width"] = width
+        if height is not None:
+            internal_kwargs["height"] = height
+        if buttons is not None:
+            internal_kwargs["buttons"] = buttons
+        if min_size is not None:
+            internal_kwargs["minsize"] = min_size
+        if max_size is not None:
+            internal_kwargs["maxsize"] = max_size
+
+        self._internal = _InternalFormDialog(master=parent, **internal_kwargs)
+
+    def show(self) -> None:
+        """Display the dialog and block until it is closed."""
+        self._internal.show()
+
+    @property
+    def result(self) -> dict[str, Any] | None:
+        """Form data dict after closing, or `None` if cancelled."""
+        return self._internal.result
+
+    @property
+    def form(self) -> Any:
+        """The embedded `Form` widget — for advanced programmatic access."""
+        return self._internal.form

--- a/tests/features/dialogs_public.py
+++ b/tests/features/dialogs_public.py
@@ -1,0 +1,81 @@
+"""Visual test for public dialog functions and FormDialog."""
+from bootstack.widgets.public import (
+    App, VStack, HStack, Label, Button, Separator,
+    alert, confirm, ask_string, ask_integer, ask_float, ask_date, ask_item,
+    FormDialog,
+)
+
+
+def main():
+    with App(title="Public Dialogs", minsize=(540, 560), padding=20, gap=14) as app:
+
+        result_lbl = Label("(click a button to see its result)")
+
+        def show(v):
+            result_lbl.value = f"result: {v!r}"
+
+        # --- Module-level functions ---
+        Label("Module-level functions", font="heading-lg")
+
+        with HStack(gap=8, fill="x"):
+            Button("alert()", on_click=lambda: (
+                alert("This is an alert message.", title="Alert"),
+                show(None),
+            ))
+            Button("confirm()", on_click=lambda: show(
+                confirm("Do you want to proceed?", title="Confirm")
+            ))
+
+        with HStack(gap=8, fill="x"):
+            Button("ask_string()", on_click=lambda: show(
+                ask_string("Enter your name:", title="Ask String", value="Ada")
+            ))
+            Button("ask_integer()", on_click=lambda: show(
+                ask_integer("Enter an age:", title="Ask Integer",
+                            value=25, min_value=0, max_value=120)
+            ))
+            Button("ask_float()", on_click=lambda: show(
+                ask_float("Enter a ratio:", title="Ask Float",
+                          value=1.5, min_value=0.0, max_value=10.0, step=0.1)
+            ))
+
+        with HStack(gap=8, fill="x"):
+            Button("ask_date()", on_click=lambda: show(
+                ask_date("Select a date", title="Ask Date")
+            ))
+            Button("ask_item()", on_click=lambda: show(
+                ask_item("Choose a language:", ["Python", "Rust", "Go", "TypeScript"],
+                         title="Ask Item", value="Python")
+            ))
+
+        Separator(fill="x")
+
+        # --- FormDialog ---
+        Label("FormDialog", font="heading-lg")
+
+        form_result_lbl = Label("(no result yet)")
+
+        def _show_form():
+            dlg = FormDialog(
+                title="User Profile",
+                data={
+                    "name": "Ada Lovelace",
+                    "email": "",
+                    "age": 28,
+                    "active": True,
+                },
+                col_count=1,
+            )
+            dlg.show()
+            if dlg.result:
+                form_result_lbl.value = f"result: {dlg.result}"
+            else:
+                form_result_lbl.value = "cancelled"
+
+        Button("Open FormDialog", on_click=_show_form)
+
+    app.run()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Module-level functions: `alert()`, `confirm()`, `ask_string()`, `ask_integer()`, `ask_float()`, `ask_date()`, `ask_item()` — thin wrappers over `MessageBox`/`QueryBox` with clean public kwargs (`min_value`/`max_value`/`step` instead of `minvalue`/`maxvalue`/`increment`, `parent` instead of `master`)
- `confirm()` returns `bool` (True = Yes)
- `FormDialog` public wrapper with `parent=`, `min_size=`/`max_size=` renames
- `Dialog` and `DialogButton` re-exported at `bs.*`
- Fixes `FormDialog` height: replaces fixed 500px default with content-driven `winfo_reqheight()` measurement, clamped between 150px min and 800px max
- Visual test: `tests/features/dialogs_public.py`

## Test plan

- [ ] Run `python tests/features/dialogs_public.py`
- [ ] Verify each function button opens the correct dialog and result is displayed
- [ ] Verify `confirm()` returns `True`/`False`
- [ ] Verify FormDialog sizes to content (not a fixed 500px)
- [ ] Run `pytest tests/widgets/public/test_base_layer.py -m "not gui"` — 11 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)