### PR TITLE
feat(public): add ButtonGroup, ContextMenu, MenuButton, Toolbar

### DIFF
--- a/src/bootstack/widgets/public/__init__.py
+++ b/src/bootstack/widgets/public/__init__.py
@@ -13,6 +13,8 @@ from bootstack.widgets.public.grid import Grid
 from bootstack.widgets.public.app import App
 from bootstack.widgets.public.primitives.boolean_controls import Checkbox, Switch, ToggleButton
 from bootstack.widgets.public.primitives.button import Button
+from bootstack.widgets.public.primitives.buttongroup import ButtonGroup
+from bootstack.widgets.public.primitives.contextmenu import ContextMenu
 from bootstack.widgets.public.primitives.codeeditor import CodeEditor
 from bootstack.widgets.composites.textarea.filter import EditFilter
 from bootstack.widgets.public.primitives.card import Card
@@ -21,6 +23,7 @@ from bootstack.widgets.public.primitives.expander import Accordion, Expander
 from bootstack.widgets.public.primitives.gauge import Gauge
 from bootstack.widgets.public.primitives.groupbox import GroupBox
 from bootstack.widgets.public.primitives.label import Badge, Label
+from bootstack.widgets.public.primitives.menubutton import MenuButton
 from bootstack.widgets.public.primitives.numericentry import NumericEntry
 from bootstack.widgets.public.primitives.pagestack import PageStack
 from bootstack.widgets.public.primitives.pathfield import PathField
@@ -40,6 +43,7 @@ from bootstack.widgets.public.primitives.textarea import TextArea
 from bootstack.widgets.public.primitives.textfield import TextField
 from bootstack.widgets.public.primitives.toast import Toast, toast
 from bootstack.widgets.public.primitives.togglegroup import ToggleGroup
+from bootstack.widgets.public.primitives.toolbar import Toolbar
 from bootstack.widgets.public.primitives.tooltip import Tooltip
 
 __all__ = [
@@ -54,10 +58,12 @@ __all__ = [
     "Badge",
     "BootstackV2Error",
     "Button",
+    "ButtonGroup",
     "Card",
     "Checkbox",
     "CodeEditor",
     "confirm",
+    "ContextMenu",
     "DateField",
     "Dialog",
     "DialogButton",
@@ -70,6 +76,7 @@ __all__ = [
     "GroupBox",
     "HStack",
     "Label",
+    "MenuButton",
     "NumericEntry",
     "PageStack",
     "ParentResolutionError",
@@ -100,6 +107,7 @@ __all__ = [
     "toast",
     "ToggleButton",
     "ToggleGroup",
+    "Toolbar",
     "Tooltip",
     "UnknownEventError",
     "VStack",

--- a/src/bootstack/widgets/public/dialogs.py
+++ b/src/bootstack/widgets/public/dialogs.py
@@ -268,9 +268,14 @@ class FormDialog:
 
         self._internal = _InternalFormDialog(master=parent, **internal_kwargs)
 
-    def show(self) -> None:
-        """Display the dialog and block until it is closed."""
+    def show(self) -> "FormDialog":
+        """Display the dialog and block until it is closed.
+
+        Returns:
+            `self` — allows chaining: `dlg = FormDialog(...).show(); dlg.result`.
+        """
         self._internal.show()
+        return self
 
     @property
     def result(self) -> dict[str, Any] | None:

--- a/src/bootstack/widgets/public/primitives/__init__.py
+++ b/src/bootstack/widgets/public/primitives/__init__.py
@@ -1,12 +1,15 @@
 from bootstack.widgets.public.primitives.boolean_controls import Checkbox, Switch, ToggleButton
 from bootstack.widgets.public.primitives.button import Button
+from bootstack.widgets.public.primitives.buttongroup import ButtonGroup
 from bootstack.widgets.public.primitives.codeeditor import CodeEditor
+from bootstack.widgets.public.primitives.contextmenu import ContextMenu
 from bootstack.widgets.public.primitives.card import Card
 from bootstack.widgets.public.primitives.datefield import DateField
 from bootstack.widgets.public.primitives.expander import Accordion, Expander
 from bootstack.widgets.public.primitives.gauge import Gauge
 from bootstack.widgets.public.primitives.groupbox import GroupBox
 from bootstack.widgets.public.primitives.label import Badge, Label
+from bootstack.widgets.public.primitives.menubutton import MenuButton
 from bootstack.widgets.public.primitives.numericentry import NumericEntry
 from bootstack.widgets.public.primitives.pagestack import PageStack
 from bootstack.widgets.public.primitives.passwordentry import PasswordEntry
@@ -26,14 +29,16 @@ from bootstack.widgets.public.primitives.textarea import TextArea
 from bootstack.widgets.public.primitives.textfield import TextField
 from bootstack.widgets.public.primitives.toast import Toast, toast
 from bootstack.widgets.public.primitives.togglegroup import ToggleGroup
+from bootstack.widgets.public.primitives.toolbar import Toolbar
 from bootstack.widgets.public.primitives.tooltip import Tooltip
 
 __all__ = [
-    "Accordion", "Badge", "Button", "Card", "Checkbox", "CodeEditor", "Expander", "Gauge",
+    "Accordion", "Badge", "Button", "ButtonGroup", "Card", "Checkbox", "CodeEditor",
+    "ContextMenu", "Expander", "Gauge",
     "Label", "NumericEntry", "PasswordEntry", "ProgressBar",
     "Radio", "RadioGroup", "RadioToggleButton",
     "RangeSlider", "Select", "Separator", "Slider", "Spinbox", "Switch",
-    "DateField", "GroupBox", "PageStack", "PathField", "SplitView",
+    "DateField", "GroupBox", "MenuButton", "PageStack", "PathField", "SplitView",
     "TabChangeEventData", "TabRef", "Tabs", "TextArea", "TextField", "Toast",
-    "toast", "ToggleButton", "ToggleGroup", "Tooltip", "Scrollbar", "SizeGrip",
+    "toast", "ToggleButton", "ToggleGroup", "Toolbar", "Tooltip", "Scrollbar", "SizeGrip",
 ]

--- a/src/bootstack/widgets/public/primitives/buttongroup.py
+++ b/src/bootstack/widgets/public/primitives/buttongroup.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from bootstack.widgets.composites.buttongroup import ButtonGroup as _InternalButtonGroup
+from bootstack.widgets.public.base import PublicWidgetBase
+
+
+class ButtonGroup(PublicWidgetBase):
+    """A row (or column) of visually-connected buttons sharing accent and variant.
+
+    Buttons are added via `add()`. The group propagates `accent`, `variant`,
+    and `density` to every member automatically.
+
+    Args:
+        orient: `'horizontal'` (default) or `'vertical'`.
+        accent: Accent token applied to all buttons.
+        variant: Style variant — `'solid'` (default), `'outline'`, `'ghost'`.
+        density: Widget density — `'default'` or `'compact'`.
+        disabled: If True, all buttons are non-interactive.
+        parent: Override the context-stack parent.
+    """
+
+    def __init__(
+        self,
+        orient: str = "horizontal",
+        *,
+        accent: str | None = None,
+        variant: str = "solid",
+        density: str = "default",
+        disabled: bool = False,
+        parent: Any = None,
+        **kwargs: Any,
+    ) -> None:
+        self._parent = self._resolve_parent(parent)
+        layout_kw = self._split_layout_kwargs(kwargs)
+        tk_master = self._parent._child_master() if self._parent else None
+
+        internal_kwargs: dict[str, Any] = {
+            "orient": orient,
+            "variant": variant,
+            "density": density,
+        }
+        if accent is not None:
+            internal_kwargs["accent"] = accent
+        if disabled:
+            internal_kwargs["state"] = "disabled"
+        internal_kwargs.update(kwargs)
+
+        self._internal = _InternalButtonGroup(tk_master, **internal_kwargs)
+        self._attach_to_parent(layout_kw)
+
+    # ----- Item management -----
+
+    def add(
+        self,
+        label: str = "",
+        *,
+        key: str | None = None,
+        on_click: Callable[[], Any] | None = None,
+        icon: str | None = None,
+        disabled: bool = False,
+        **kwargs: Any,
+    ) -> str:
+        """Add a button to the group.
+
+        Args:
+            label: Button label text.
+            key: Unique string key. Auto-generated if omitted.
+            on_click: Callback fired when the button is clicked.
+            icon: Icon name shown on the button.
+            disabled: If True, this button starts disabled.
+
+        Returns:
+            The key assigned to this button.
+        """
+        if key is None:
+            key = f"widget_{self._internal._counter}"
+
+        btn_kwargs: dict[str, Any] = {}
+        if icon is not None:
+            btn_kwargs["icon"] = icon
+        if disabled:
+            btn_kwargs["state"] = "disabled"
+        btn_kwargs.update(kwargs)
+
+        self._internal.add(label or None, key=key, command=on_click, **btn_kwargs)
+        return key
+
+    def remove(self, key: str) -> None:
+        """Remove the button identified by `key`.
+
+        Args:
+            key: Key returned by `add()`.
+        """
+        self._internal.remove(key)
+
+    def update_item(self, key: str, **kwargs: Any) -> None:
+        """Reconfigure a button after creation.
+
+        Args:
+            key: Key returned by `add()`.
+            **kwargs: Options forwarded to the button's `configure()`.
+        """
+        self._internal.configure_item(key, **kwargs)
+
+    # ----- Properties -----
+
+    @property
+    def keys(self) -> tuple[str, ...]:
+        """Keys of all buttons in insertion order."""
+        return self._internal.keys()
+
+    @property
+    def disabled(self) -> bool:
+        return str(self._internal.cget("state")) == "disabled"
+
+    @disabled.setter
+    def disabled(self, v: bool) -> None:
+        self._internal.configure(state="disabled" if v else "normal")
+
+    @property
+    def accent(self) -> str | None:
+        return self._internal._accent
+
+    @accent.setter
+    def accent(self, v: str | None) -> None:
+        self._internal.configure(accent=v)
+
+    @property
+    def variant(self) -> str:
+        return self._internal._variant
+
+    @variant.setter
+    def variant(self, v: str) -> None:
+        self._internal.configure(variant=v)

--- a/src/bootstack/widgets/public/primitives/contextmenu.py
+++ b/src/bootstack/widgets/public/primitives/contextmenu.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from bootstack.widgets.composites.contextmenu import ContextMenu as _InternalContextMenu
+
+_TRIGGER_MAP: dict[str | None, str | None] = {
+    "right_click": "right-click",
+    "left_click": "left-click",
+    "double_click": "double-click",
+    None: None,
+    "manual": None,
+}
+
+
+def _resolve_tk(widget: Any) -> Any:
+    """Return the underlying Tk widget from a public wrapper or pass through."""
+    return getattr(widget, "_internal", widget)
+
+
+class ContextMenu:
+    """A popup menu that attaches to a target widget.
+
+    Items fire an `on_select` callback receiving a dict with `type`, `text`,
+    and `value` keys.
+
+    Args:
+        target: Widget the menu attaches to. Accepts public widgets or raw Tk
+            widgets. Defaults to the root window.
+        min_width: Minimum menu width in pixels. Default `150`.
+        trigger: Gesture that opens the menu — `'right_click'` (default),
+            `'left_click'`, `'double_click'`, or `None` (manual only).
+        on_select: Callback fired when any item is activated.
+        items: Initial list of `ContextMenuItem` dicts to add at construction.
+        density: Item density — `'default'` or `'compact'`.
+        parent: Parent widget for Tk hierarchy. Defaults to `target`.
+    """
+
+    def __init__(
+        self,
+        target: Any = None,
+        *,
+        min_width: int = 150,
+        trigger: str | None = "right_click",
+        on_select: Callable[[dict[str, Any]], Any] | None = None,
+        items: list[Any] | None = None,
+        density: str = "default",
+        parent: Any = None,
+    ) -> None:
+        tk_target = _resolve_tk(target) if target is not None else None
+        tk_master = _resolve_tk(parent) if parent is not None else tk_target
+
+        internal_kwargs: dict[str, Any] = {
+            "minwidth": min_width,
+            "trigger": _TRIGGER_MAP.get(trigger, trigger),
+            "density": density,
+        }
+        if on_select is not None:
+            internal_kwargs["command"] = on_select
+        if items is not None:
+            internal_kwargs["items"] = items
+        if tk_target is not None:
+            internal_kwargs["target"] = tk_target
+
+        self._internal = _InternalContextMenu(tk_master, **internal_kwargs)
+
+    # ----- Item management -----
+
+    def add_item(
+        self,
+        label: str,
+        *,
+        on_click: Callable[[], Any] | None = None,
+        icon: str | None = None,
+        shortcut: str | None = None,
+        disabled: bool = False,
+        key: str | None = None,
+    ) -> str:
+        """Add a command item.
+
+        Args:
+            label: Item label text.
+            on_click: Callback fired when the item is clicked.
+            icon: Icon name shown beside the label.
+            shortcut: Keyboard shortcut hint displayed on the right.
+            disabled: If True, item is shown but non-interactive.
+            key: Unique string key. Auto-generated if omitted.
+
+        Returns:
+            The key assigned to this item.
+        """
+        kw: dict[str, Any] = {"text": label, "disabled": disabled}
+        if on_click is not None:
+            kw["command"] = on_click
+        if icon is not None:
+            kw["icon"] = icon
+        if shortcut is not None:
+            kw["shortcut"] = shortcut
+        if key is not None:
+            kw["key"] = key
+        result = self._internal.add_command(**kw)
+        return result.key if hasattr(result, "key") else key or label
+
+    def add_check_item(
+        self,
+        label: str,
+        *,
+        value: bool = False,
+        on_click: Callable[[], Any] | None = None,
+        key: str | None = None,
+    ) -> str:
+        """Add a checkbutton item.
+
+        Args:
+            label: Item label text.
+            value: Initial checked state.
+            on_click: Callback fired on toggle.
+            key: Unique string key. Auto-generated if omitted.
+
+        Returns:
+            The key assigned to this item.
+        """
+        kw: dict[str, Any] = {"text": label, "value": value}
+        if on_click is not None:
+            kw["command"] = on_click
+        if key is not None:
+            kw["key"] = key
+        result = self._internal.add_checkbutton(**kw)
+        return result.key if hasattr(result, "key") else key or label
+
+    def add_radio_item(
+        self,
+        label: str,
+        *,
+        value: Any = None,
+        variable: Any = None,
+        on_click: Callable[[], Any] | None = None,
+        key: str | None = None,
+    ) -> str:
+        """Add a radiobutton item.
+
+        Args:
+            label: Item label text.
+            value: Value assigned when this item is selected.
+            variable: Shared Tk variable for the radio group.
+            on_click: Callback fired when selected.
+            key: Unique string key. Auto-generated if omitted.
+
+        Returns:
+            The key assigned to this item.
+        """
+        kw: dict[str, Any] = {"text": label}
+        if value is not None:
+            kw["value"] = value
+        if variable is not None:
+            kw["variable"] = variable
+        if on_click is not None:
+            kw["command"] = on_click
+        if key is not None:
+            kw["key"] = key
+        result = self._internal.add_radiobutton(**kw)
+        return result.key if hasattr(result, "key") else key or label
+
+    def add_separator(self, *, key: str | None = None) -> None:
+        """Add a horizontal separator.
+
+        Args:
+            key: Unique string key. Auto-generated if omitted.
+        """
+        kw: dict[str, Any] = {}
+        if key is not None:
+            kw["key"] = key
+        self._internal.add_separator(**kw)
+
+    def update_item(self, key: str, **kwargs: Any) -> None:
+        """Reconfigure an item after creation.
+
+        Args:
+            key: Key returned by `add_item()` / `add_check_item()` etc.
+            **kwargs: Options forwarded to the item's configure method.
+        """
+        self._internal.configure_item(key, **kwargs)
+
+    def remove_item(self, key: str) -> None:
+        """Remove an item by key.
+
+        Args:
+            key: Key returned by an `add_*` method.
+        """
+        self._internal.remove_item(key)
+
+    # ----- Properties -----
+
+    @property
+    def keys(self) -> tuple[str, ...]:
+        """Keys of all items in insertion order."""
+        return self._internal.keys()
+
+    # ----- Display -----
+
+    def show(self, position: tuple[int, int] | None = None) -> "ContextMenu":
+        """Show the menu, optionally at a screen `(x, y)` position.
+
+        Returns:
+            `self` — allows chaining: `ContextMenu(target).add_item(...).show()`.
+        """
+        self._internal.show(position)
+        return self
+
+    def hide(self) -> None:
+        """Hide the menu."""
+        self._internal.hide()

--- a/src/bootstack/widgets/public/primitives/menubutton.py
+++ b/src/bootstack/widgets/public/primitives/menubutton.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from bootstack.widgets.composites.dropdownbutton import DropdownButton as _InternalDropdownButton
+from bootstack.widgets.public.base import PublicWidgetBase
+
+
+class MenuButton(PublicWidgetBase):
+    """A button that opens a dropdown menu when clicked.
+
+    Items are added at construction via `items=` or dynamically with
+    `add_item()`. The `on_select` callback fires for every item click,
+    receiving a dict with `type`, `text`, and `value` keys.
+
+    Args:
+        label: Button label text.
+        items: Initial list of `ContextMenuItem` dicts.
+        on_select: Callback fired when any menu item is activated.
+        icon: Icon shown on the button.
+        icon_only: If True, hides the label (icon only).
+        show_arrow: If True (default), shows the dropdown chevron.
+        disabled: If True, button is non-interactive.
+        accent: Accent token, e.g. `'primary'`, `'danger'`.
+        variant: Style variant, e.g. `'outline'`, `'ghost'`.
+        density: Widget density — `'default'` or `'compact'`.
+        parent: Override the context-stack parent.
+    """
+
+    def __init__(
+        self,
+        label: str = "",
+        *,
+        items: list[Any] | None = None,
+        on_select: Callable[[dict[str, Any]], Any] | None = None,
+        icon: str | None = None,
+        icon_only: bool = False,
+        show_arrow: bool = True,
+        disabled: bool = False,
+        accent: str | None = None,
+        variant: str | None = None,
+        density: str | None = None,
+        parent: Any = None,
+        **kwargs: Any,
+    ) -> None:
+        self._parent = self._resolve_parent(parent)
+        layout_kw = self._split_layout_kwargs(kwargs)
+        tk_master = self._parent._child_master() if self._parent else None
+
+        internal_kwargs: dict[str, Any] = {
+            "show_dropdown_button": show_arrow,
+        }
+        if label:
+            internal_kwargs["text"] = label
+        if items is not None:
+            internal_kwargs["items"] = items
+        if on_select is not None:
+            internal_kwargs["command"] = on_select
+        if icon is not None:
+            internal_kwargs["icon"] = icon
+        if icon_only:
+            internal_kwargs["icon_only"] = True
+        if disabled:
+            internal_kwargs["state"] = "disabled"
+        if accent is not None:
+            internal_kwargs["accent"] = accent
+        if variant is not None:
+            internal_kwargs["variant"] = variant
+        if density is not None:
+            internal_kwargs["density"] = density
+        internal_kwargs.update(kwargs)
+
+        self._internal = _InternalDropdownButton(tk_master, **internal_kwargs)
+        self._attach_to_parent(layout_kw)
+
+    # ----- Item management -----
+
+    def add_item(
+        self,
+        label: str,
+        *,
+        on_click: Callable[[], Any] | None = None,
+        icon: str | None = None,
+        shortcut: str | None = None,
+        disabled: bool = False,
+        key: str | None = None,
+    ) -> str:
+        """Add a command item to the dropdown.
+
+        Args:
+            label: Item label text.
+            on_click: Callback fired when the item is clicked.
+            icon: Icon name shown beside the label.
+            shortcut: Keyboard shortcut hint displayed on the right.
+            disabled: If True, item is shown but non-interactive.
+            key: Unique string key. Auto-generated if omitted.
+
+        Returns:
+            The key assigned to this item.
+        """
+        kw: dict[str, Any] = {"text": label, "disabled": disabled}
+        if on_click is not None:
+            kw["command"] = on_click
+        if icon is not None:
+            kw["icon"] = icon
+        if shortcut is not None:
+            kw["shortcut"] = shortcut
+        if key is not None:
+            kw["key"] = key
+        result = self._internal.add_command(**kw)
+        return result.key if hasattr(result, "key") else key or label
+
+    def add_check_item(
+        self,
+        label: str,
+        *,
+        value: bool = False,
+        on_click: Callable[[], Any] | None = None,
+        key: str | None = None,
+    ) -> str:
+        """Add a checkbutton item to the dropdown.
+
+        Args:
+            label: Item label text.
+            value: Initial checked state.
+            on_click: Callback fired on toggle.
+            key: Unique string key. Auto-generated if omitted.
+
+        Returns:
+            The key assigned to this item.
+        """
+        kw: dict[str, Any] = {"text": label, "value": value}
+        if on_click is not None:
+            kw["command"] = on_click
+        if key is not None:
+            kw["key"] = key
+        result = self._internal.add_checkbutton(**kw)
+        return result.key if hasattr(result, "key") else key or label
+
+    def add_separator(self, *, key: str | None = None) -> None:
+        """Add a horizontal separator to the dropdown."""
+        kw: dict[str, Any] = {}
+        if key is not None:
+            kw["key"] = key
+        self._internal.add_separator(**kw)
+
+    def update_item(self, key: str, **kwargs: Any) -> None:
+        """Reconfigure a dropdown item after creation.
+
+        Args:
+            key: Key returned by an `add_*` method.
+            **kwargs: Options forwarded to the item's configure method.
+        """
+        self._internal.configure_item(key, **kwargs)
+
+    def remove_item(self, key: str) -> None:
+        """Remove a dropdown item by key.
+
+        Args:
+            key: Key returned by an `add_*` method.
+        """
+        self._internal.remove_item(key)
+
+    def show_menu(self) -> None:
+        """Open the dropdown menu programmatically."""
+        self._internal.show_menu()
+
+    # ----- Properties -----
+
+    @property
+    def keys(self) -> tuple[str, ...]:
+        """Keys of all menu items in insertion order."""
+        return self._internal.keys()
+
+    @property
+    def menu(self) -> Any:
+        """The underlying `ContextMenu` — for advanced programmatic access."""
+        return self._internal.context_menu
+
+    @property
+    def disabled(self) -> bool:
+        return str(self._internal.cget("state")) == "disabled"
+
+    @disabled.setter
+    def disabled(self, v: bool) -> None:
+        self._internal.configure(state="disabled" if v else "normal")

--- a/src/bootstack/widgets/public/primitives/toolbar.py
+++ b/src/bootstack/widgets/public/primitives/toolbar.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from bootstack.widgets.composites.toolbar import Toolbar as _InternalToolbar
+from bootstack.widgets.public.base import PublicWidgetBase
+
+
+class Toolbar(PublicWidgetBase):
+    """A horizontal strip of buttons and other widgets.
+
+    Items are added left-to-right via `add_button()`, `add_label()`,
+    `add_separator()`, and `add_spacer()`. Call `add_spacer()` to push
+    subsequent items to the right side.
+
+    Args:
+        button_variant: Default variant for toolbar buttons. Default `'ghost'`.
+        density: Button density — `'default'` or `'compact'`.
+        show_window_controls: If True, adds minimize/maximize/close buttons
+            on the right side.
+        draggable: If True, clicking and dragging the toolbar moves the window.
+        parent: Override the context-stack parent.
+    """
+
+    def __init__(
+        self,
+        *,
+        button_variant: str = "ghost",
+        density: str = "default",
+        show_window_controls: bool = False,
+        draggable: bool = False,
+        parent: Any = None,
+        **kwargs: Any,
+    ) -> None:
+        self._parent = self._resolve_parent(parent)
+        layout_kw = self._split_layout_kwargs(kwargs)
+        tk_master = self._parent._child_master() if self._parent else None
+
+        internal_kwargs: dict[str, Any] = {
+            "button_variant": button_variant,
+            "density": density,
+            "show_window_controls": show_window_controls,
+            "draggable": draggable,
+        }
+        internal_kwargs.update(kwargs)
+
+        self._internal = _InternalToolbar(tk_master, **internal_kwargs)
+        self._attach_to_parent(layout_kw)
+
+    # ----- Content -----
+
+    def add_button(
+        self,
+        label: str | None = None,
+        *,
+        icon: str | None = None,
+        on_click: Callable[[], Any] | None = None,
+        accent: str | None = None,
+        variant: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Add a button to the toolbar.
+
+        Args:
+            label: Button label text.
+            icon: Icon name.
+            on_click: Callback fired when clicked.
+            accent: Accent token override.
+            variant: Variant override.
+        """
+        kw: dict[str, Any] = {}
+        if label is not None:
+            kw["text"] = label
+        if icon is not None:
+            kw["icon"] = icon
+        if on_click is not None:
+            kw["command"] = on_click
+        if accent is not None:
+            kw["accent"] = accent
+        if variant is not None:
+            kw["variant"] = variant
+        kw.update(kwargs)
+        self._internal.add_button(**kw)
+
+    def add_label(
+        self,
+        text: str | None = None,
+        *,
+        icon: str | None = None,
+        font: Any = None,
+        **kwargs: Any,
+    ) -> None:
+        """Add a label to the toolbar.
+
+        Args:
+            text: Label text.
+            icon: Icon name.
+            font: Font token.
+        """
+        kw: dict[str, Any] = {}
+        if text is not None:
+            kw["text"] = text
+        if icon is not None:
+            kw["icon"] = icon
+        if font is not None:
+            kw["font"] = font
+        kw.update(kwargs)
+        self._internal.add_label(**kw)
+
+    def add_separator(self, length: int = 16) -> None:
+        """Add a vertical separator.
+
+        Args:
+            length: Separator height in pixels.
+        """
+        self._internal.add_separator(length=length)
+
+    def add_spacer(self) -> None:
+        """Add a flexible spacer that pushes subsequent items to the right."""
+        self._internal.add_spacer()
+
+    def add_widget(self, widget: Any, **pack_kwargs: Any) -> None:
+        """Add an arbitrary widget to the toolbar.
+
+        Args:
+            widget: A public widget or raw Tk widget.
+            **pack_kwargs: Pack options forwarded to the widget's placement.
+        """
+        tk_widget = getattr(widget, "_internal", widget)
+        self._internal.add_widget(tk_widget, **pack_kwargs)

--- a/tests/features/action_toolbar.py
+++ b/tests/features/action_toolbar.py
@@ -1,0 +1,80 @@
+"""Visual test for ButtonGroup, ContextMenu, MenuButton, and Toolbar."""
+from bootstack.widgets.public import (
+    App, VStack, HStack, Label, Button, Separator,
+    ButtonGroup, ContextMenu, MenuButton, Toolbar,
+)
+
+
+def on_select(data):
+    print("selected:", data)
+
+
+def main():
+    with App(title="Action / Toolbar", minsize=(700, 500), padding=16, gap=12) as app:
+
+        # --- Toolbar ---
+        tb = Toolbar(draggable=False)
+        tb.add_button(icon="house", on_click=lambda: print("home"))
+        tb.add_button(icon="folder2-open", on_click=lambda: print("open"))
+        tb.add_button(icon="floppy", on_click=lambda: print("save"))
+        tb.add_separator()
+        tb.add_button(icon="scissors", on_click=lambda: print("cut"))
+        tb.add_button(icon="copy", on_click=lambda: print("copy"))
+        tb.add_button(icon="clipboard", on_click=lambda: print("paste"))
+        tb.add_spacer()
+        tb.add_button(icon="question-circle", on_click=lambda: print("help"))
+
+        Separator()
+
+        # --- ButtonGroup ---
+        Label("ButtonGroup (horizontal):")
+        with HStack(gap=4):
+            bg = ButtonGroup(accent="primary")
+            bg.add("Day", key="day", on_click=lambda: print("day"))
+            bg.add("Week", key="week", on_click=lambda: print("week"))
+            bg.add("Month", key="month", on_click=lambda: print("month"))
+
+        Label("ButtonGroup (vertical):")
+        with HStack(gap=4):
+            bg2 = ButtonGroup(orient="vertical", variant="outline", accent="primary")
+            bg2.add("Option A", key="a")
+            bg2.add("Option B", key="b")
+            bg2.add("Option C", key="c")
+
+        Separator()
+
+        # --- MenuButton ---
+        Label("MenuButton:")
+        with HStack(gap=8):
+            mb = MenuButton("File", on_select=on_select)
+            mb.add_item("New", icon="file-earmark", shortcut="Ctrl+N", key="new",
+                        on_click=lambda: print("new"))
+            mb.add_item("Open...", icon="folder2-open", shortcut="Ctrl+O", key="open",
+                        on_click=lambda: print("open"))
+            mb.add_separator()
+            mb.add_item("Save", icon="floppy", shortcut="Ctrl+S", key="save",
+                        on_click=lambda: print("save"))
+            mb.add_item("Exit", key="exit", on_click=lambda: print("exit"))
+
+            mb2 = MenuButton("View", variant="outline")
+            mb2.add_check_item("Status Bar", value=True, key="statusbar")
+            mb2.add_check_item("Line Numbers", value=False, key="linenums")
+            mb2.add_separator()
+            mb2.add_item("Zoom In", shortcut="Ctrl++")
+            mb2.add_item("Zoom Out", shortcut="Ctrl+-")
+
+        Separator()
+
+        # --- ContextMenu ---
+        lbl = Label("Right-click me for a context menu", accent="primary")
+        cm = ContextMenu(target=lbl, on_select=on_select)
+        cm.add_item("Copy", icon="copy", shortcut="Ctrl+C", key="copy")
+        cm.add_item("Paste", icon="clipboard", shortcut="Ctrl+V", key="paste")
+        cm.add_separator()
+        cm.add_item("Select All", shortcut="Ctrl+A", key="select_all")
+
+    app.run()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- **`ButtonGroup`** — wraps internal `ButtonGroup`; `add()` returns the item key; `orient`, `accent`, `variant`, `density` kwargs
- **`ContextMenu`** — plain class (not `PublicWidgetBase`); accepts public widgets as `target` via `._internal` unwrapping; `trigger` uses snake_case (`right_click`, `left_click`, etc.); `show()` returns `self` for chaining
- **`MenuButton`** — wraps `DropdownButton`; renamed `show_arrow=` from `show_dropdown_button=`; `on_select=` replaces `command=`; `show_menu()` for programmatic open
- **`Toolbar`** — wraps internal `Toolbar`; `add_button/label/separator/spacer/widget`; `add_widget()` unwraps public widget `._internal` automatically
- **`FormDialog.show()`** — now returns `self` to allow chaining: `dlg = FormDialog(...).show(); dlg.result`
- Visual test: `tests/features/action_toolbar.py`

## Test plan

- [ ] Run `tests/features/action_toolbar.py` — toolbar, button groups, menu buttons, and context menu all render and respond to clicks
- [ ] Right-click labeled widget to confirm context menu appears at correct position
- [ ] `pytest tests/widgets/public/test_base_layer.py -m "not gui"` — 12 non-GUI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)