### PR TITLE
feat(public): add AppShell and Window

### DIFF
--- a/src/bootstack/widgets/public/__init__.py
+++ b/src/bootstack/widgets/public/__init__.py
@@ -11,6 +11,8 @@ from bootstack.widgets.public.base import PublicWidgetBase
 from bootstack.widgets.public.stacks import HStack, VStack
 from bootstack.widgets.public.grid import Grid
 from bootstack.widgets.public.app import App
+from bootstack.widgets.public.appshell import AppShell
+from bootstack.widgets.public.window import Window
 from bootstack.widgets.public.primitives.boolean_controls import Checkbox, Switch, ToggleButton
 from bootstack.widgets.public.primitives.button import Button
 from bootstack.widgets.public.primitives.buttongroup import ButtonGroup
@@ -50,6 +52,7 @@ __all__ = [
     "Accordion",
     "alert",
     "App",
+    "AppShell",
     "ask_date",
     "ask_float",
     "ask_integer",
@@ -111,4 +114,5 @@ __all__ = [
     "Tooltip",
     "UnknownEventError",
     "VStack",
+    "Window",
 ]

--- a/src/bootstack/widgets/public/appshell.py
+++ b/src/bootstack/widgets/public/appshell.py
@@ -1,0 +1,288 @@
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from bootstack.widgets.composites.appshell import AppShell as _InternalAppShell
+from bootstack.widgets.public.container import PACK_KEYS, normalize_fill
+from bootstack.widgets.public.context import push_container, pop_container
+
+
+class _PageFrame:
+    """Context-manager proxy returned by `AppShell.add_page()`.
+
+    Push onto the context stack so widgets created inside
+    ``with shell.add_page(...):`` are automatically parented to the page.
+    """
+
+    def __init__(self, tk_frame: Any) -> None:
+        self._internal = tk_frame
+
+    def _child_master(self) -> Any:
+        return self._internal
+
+    def guide_layout(self, child: Any, **layout_kw: Any) -> None:
+        if "fill" in layout_kw:
+            layout_kw["fill"] = normalize_fill(layout_kw["fill"])
+        options = {k: v for k, v in layout_kw.items() if k in PACK_KEYS}
+        child._internal.pack(in_=self._internal, **options)
+
+    def __enter__(self) -> "_PageFrame":
+        push_container(self)
+        return self
+
+    def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+        pop_container(self)
+
+
+class AppShell:
+    """Application window with built-in toolbar, sidebar navigation, and page stack.
+
+    Wraps the internal AppShell to provide the standard desktop app scaffold:
+    toolbar across the top, collapsible sidebar on the left, and a page
+    content area on the right.
+
+    Use `add_page()` to register nav items and their page frames together.
+    Pages support context-manager syntax so widgets inside the ``with`` block
+    are automatically parented to that page.
+
+    Args:
+        title: Window title and (in undecorated mode) toolbar label.
+        size: Initial window size as `(width, height)`.
+        position: Initial window position as `(x, y)`.
+        min_size: Minimum window size as `(width, height)`.
+        max_size: Maximum window size as `(width, height)`.
+        resizable: Whether the window can be resized as `(x, y)`.
+        undecorated: Remove OS window decorations and use a custom chrome.
+            Automatically enables `show_window_controls` and `draggable`.
+            Ignored on macOS.
+        show_toolbar: Show the toolbar at the top. Default `True`.
+        show_window_controls: Add minimize/maximize/close buttons to the toolbar.
+        draggable: Allow window dragging via the toolbar.
+        toolbar_density: Toolbar button density — `'default'` or `'compact'`.
+        show_nav: Show the sidebar navigation. Default `True`.
+        nav_display_mode: Initial sidebar mode — `'expanded'`, `'compact'`,
+            or `'minimal'`.
+        nav_accent: Accent color for the active nav item. Default `'primary'`.
+        settings: `AppSettings` dict or instance for theme, locale, etc.
+    """
+
+    def __init__(
+        self,
+        *,
+        title: str = "",
+        size: tuple[int, int] | None = None,
+        position: tuple[int, int] | None = None,
+        min_size: tuple[int, int] | None = None,
+        max_size: tuple[int, int] | None = None,
+        resizable: tuple[bool, bool] | None = None,
+        undecorated: bool = False,
+        show_toolbar: bool = True,
+        show_window_controls: bool = False,
+        draggable: bool = False,
+        toolbar_density: str = "default",
+        show_nav: bool = True,
+        nav_display_mode: str = "expanded",
+        nav_accent: str = "primary",
+        settings: Any = None,
+        **kwargs: Any,
+    ) -> None:
+        init_kwargs: dict[str, Any] = {
+            "title": title,
+            "show_toolbar": show_toolbar,
+            "show_window_controls": show_window_controls,
+            "draggable": draggable,
+            "toolbar_density": toolbar_density,
+            "show_nav": show_nav,
+            "nav_display_mode": nav_display_mode,
+            "nav_accent": nav_accent,
+            "undecorated": undecorated,
+        }
+        if size is not None:
+            init_kwargs["size"] = size
+        if position is not None:
+            init_kwargs["position"] = position
+        if min_size is not None:
+            init_kwargs["minsize"] = min_size
+        if max_size is not None:
+            init_kwargs["maxsize"] = max_size
+        if resizable is not None:
+            init_kwargs["resizable"] = resizable
+        if settings is not None:
+            init_kwargs["settings"] = settings
+        init_kwargs.update(kwargs)
+
+        self._internal = _InternalAppShell(**init_kwargs)
+
+    def __enter__(self) -> "AppShell":
+        return self
+
+    def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+        try:
+            self._internal.update_idletasks()
+        except Exception:
+            pass
+
+    # ----- Content -----
+
+    def add_page(
+        self,
+        key: str,
+        *,
+        text: str = "",
+        icon: str | dict | None = None,
+        group: str | None = None,
+        is_footer: bool = False,
+        scrollable: bool = False,
+        **nav_kwargs: Any,
+    ) -> _PageFrame:
+        """Add a nav item and its page, returning a context-manager page proxy.
+
+        Args:
+            key: Unique identifier for the nav item and page.
+            text: Display label in the sidebar.
+            icon: Icon name or icon configuration dict.
+            group: Key of the nav group to add this item to.
+            is_footer: If `True`, add the item to the footer section.
+            scrollable: If `True`, wrap the page in a vertical `ScrollView`.
+            **nav_kwargs: Extra kwargs forwarded to the internal nav item.
+
+        Returns:
+            A `_PageFrame` context manager. Use with ``with`` to parent
+            child widgets into the page automatically.
+        """
+        kw: dict[str, Any] = {"text": text, "scrollable": scrollable}
+        if icon is not None:
+            kw["icon"] = icon
+        if group is not None:
+            kw["group"] = group
+        if is_footer:
+            kw["is_footer"] = True
+        kw.update(nav_kwargs)
+        tk_frame = self._internal.add_page(key, **kw)
+        return _PageFrame(tk_frame)
+
+    def add_group(
+        self,
+        key: str,
+        *,
+        text: str = "",
+        icon: str | dict | None = None,
+        expanded: bool = False,
+        **kwargs: Any,
+    ) -> Any:
+        """Add a collapsible nav group.
+
+        Args:
+            key: Unique identifier for the group.
+            text: Display label.
+            icon: Icon name or configuration.
+            expanded: Initial expansion state.
+
+        Returns:
+            The internal `SideNavGroup`.
+        """
+        kw: dict[str, Any] = {"text": text, "is_expanded": expanded}
+        if icon is not None:
+            kw["icon"] = icon
+        kw.update(kwargs)
+        return self._internal.add_group(key, **kw)
+
+    def add_header(self, text: str, **kwargs: Any) -> Any:
+        """Add a section header to the nav sidebar.
+
+        Args:
+            text: Header text.
+
+        Returns:
+            The internal `SideNavHeader`.
+        """
+        return self._internal.add_header(text, **kwargs)
+
+    def add_nav_separator(self, **kwargs: Any) -> Any:
+        """Add a separator to the nav sidebar.
+
+        Returns:
+            The internal `SideNavSeparator`.
+        """
+        return self._internal.add_separator(**kwargs)
+
+    # ----- Navigation -----
+
+    def navigate(self, key: str, data: dict | None = None) -> None:
+        """Navigate programmatically, updating the nav selection and page stack.
+
+        Args:
+            key: Page key to navigate to.
+            data: Optional data dict passed to the page.
+        """
+        self._internal.navigate(key, data=data)
+
+    def select(self, key: str, data: dict | None = None) -> None:
+        """Alias for `navigate()`.
+
+        Args:
+            key: Page key to navigate to.
+            data: Optional data dict passed to the page.
+        """
+        self._internal.navigate(key, data=data)
+
+    # ----- Events -----
+
+    def on_page_changed(self, callback: Callable) -> str:
+        """Register a callback for `<<PageChanged>>` events.
+
+        Args:
+            callback: Called when the active page changes.
+
+        Returns:
+            Bind ID — pass to `off_page_changed()` to unsubscribe.
+        """
+        return self._internal.on_page_changed(callback)
+
+    def off_page_changed(self, bind_id: str | None = None) -> None:
+        """Unsubscribe from `<<PageChanged>>`.
+
+        Args:
+            bind_id: ID returned by `on_page_changed()`. If `None`, removes all.
+        """
+        self._internal.off_page_changed(bind_id)
+
+    # ----- Lifecycle -----
+
+    def run(self) -> None:
+        """Show the window and start the event loop."""
+        self._internal.deiconify()
+        self._internal.mainloop()
+
+    mainloop = run
+
+    # ----- Properties -----
+
+    @property
+    def tk(self) -> Any:
+        """Underlying `tk.Tk` root window. UNSUPPORTED — escape-hatch use only."""
+        return self._internal
+
+    @property
+    def toolbar(self) -> Any:
+        """The internal `Toolbar`, or `None` if `show_toolbar=False`.
+
+        Note: This is the internal composite — use `command=` (not `on_click=`)
+        when calling `add_button()` on it.
+        """
+        return self._internal.toolbar
+
+    @property
+    def nav(self) -> Any:
+        """The internal `SideNav`, or `None` if `show_nav=False`."""
+        return self._internal.nav
+
+    @property
+    def pages(self) -> Any:
+        """The internal `PageStack`."""
+        return self._internal.pages
+
+    @property
+    def current_page(self) -> str | None:
+        """Key of the currently displayed page, or `None`."""
+        return self._internal.current_page

--- a/src/bootstack/widgets/public/window.py
+++ b/src/bootstack/widgets/public/window.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+from typing import Any, Callable, Literal
+
+from bootstack.widgets.primitives.packframe import PackFrame
+from bootstack.widgets.public.container import PublicContainer, PACK_KEYS, normalize_fill
+
+
+class Window(PublicContainer):
+    """A secondary top-level window.
+
+    Behaves as an implicit `VStack` from the user's perspective: children
+    created inside a ``with`` block are automatically packed into its content
+    frame top-to-bottom.  Call `show()` to display the window after building
+    its content, or `block_until_closed()` to show it and wait for the user
+    to close it.
+
+    Args:
+        title: Window title bar text.
+        size: Initial size as `(width, height)`.
+        position: Initial position as `(x, y)`.
+        min_size: Minimum window size as `(width, height)`.
+        max_size: Maximum window size as `(width, height)`.
+        resizable: Whether the window can be resized as `(width, height)`.
+        modal: Modality level. `False` — non-modal (default). `True` or
+            `'window'` — grabs input from the parent only. `'app'` — grabs
+            input from all windows.
+        center_on_parent: Center over the parent/transient window.
+        center_on_screen: Center on the screen.
+        topmost: Keep the window above other windows.
+        undecorated: Remove OS window decorations (`overrideredirect`).
+        on_close: Callback invoked when the user clicks the close button.
+            Return `False` to veto; return `None` or `True` to allow.
+        padding: Inner padding for the content frame.
+        gap: Spacing between children.
+        fill_items: Default `fill` value for children.
+        expand_items: Default `expand` value for children.
+    """
+
+    _auto_place = False  # top-level window — no parent manages its position
+
+    def __init__(
+        self,
+        *,
+        title: str = "",
+        size: tuple[int, int] | None = None,
+        position: tuple[int, int] | None = None,
+        min_size: tuple[int, int] | None = None,
+        max_size: tuple[int, int] | None = None,
+        resizable: tuple[bool, bool] | None = None,
+        modal: Literal[False, True, "window", "app"] = False,
+        center_on_parent: bool = False,
+        center_on_screen: bool = False,
+        topmost: bool = False,
+        undecorated: bool = False,
+        on_close: Callable[[], bool | None] | None = None,
+        # Content frame layout
+        padding: Any = None,
+        gap: int = 0,
+        fill_items: str | None = None,
+        expand_items: bool | None = None,
+        anchor_items: str | None = None,
+        surface: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        from bootstack._runtime.toplevel import Toplevel as _InternalToplevel
+
+        self._parent = None
+
+        init_kwargs: dict[str, Any] = {
+            "title": title,
+            "modal": modal,
+            "center_on_parent": center_on_parent,
+            "center_on_screen": center_on_screen,
+            "topmost": topmost,
+            "overrideredirect": undecorated,
+        }
+        if size is not None:
+            init_kwargs["size"] = size
+        if position is not None:
+            init_kwargs["position"] = position
+        if min_size is not None:
+            init_kwargs["minsize"] = min_size
+        if max_size is not None:
+            init_kwargs["maxsize"] = max_size
+        if resizable is not None:
+            init_kwargs["resizable"] = resizable
+        if on_close is not None:
+            init_kwargs["on_close"] = on_close
+        init_kwargs.update(kwargs)
+
+        self._tk_toplevel = _InternalToplevel(**init_kwargs)
+
+        frame_kwargs: dict[str, Any] = {
+            "direction": "vertical",
+            "gap": gap,
+            "fill_items": normalize_fill(fill_items),
+            "expand_items": expand_items,
+            "anchor_items": anchor_items,
+        }
+        if padding is not None:
+            frame_kwargs["padding"] = padding
+        if surface is not None:
+            frame_kwargs["surface"] = surface
+
+        self._content_frame = PackFrame(self._tk_toplevel, **frame_kwargs)
+        self._content_frame.pack(fill="both", expand=True)
+
+        self._internal = self._tk_toplevel
+
+    def _child_master(self) -> Any:
+        return self._content_frame
+
+    def _default_layout_method(self) -> str:
+        return "pack"
+
+    def _merge_layout_options(self, child: Any, layout_kw: dict) -> tuple[str, dict]:
+        options = {k: v for k, v in layout_kw.items() if k in PACK_KEYS}
+        return ("pack", options)
+
+    # ----- Lifecycle -----
+
+    def show(self) -> "Window":
+        """Show the window and apply any modal grab.
+
+        Returns:
+            `self` — allows chaining: ``win = Window(...).show()``.
+        """
+        self._tk_toplevel.show()
+        return self
+
+    def close(self) -> None:
+        """Destroy the window."""
+        self._tk_toplevel.destroy()
+
+    def block_until_closed(self) -> Any:
+        """Show the window and block until it is destroyed.
+
+        Returns:
+            The value of `result` at the time the window was closed.
+        """
+        return self._tk_toplevel.block_until_closed()
+
+    def add_close_handler(self, callback: Callable[[], bool | None]) -> None:
+        """Register an additional close handler.
+
+        Args:
+            callback: Called when the user attempts to close the window.
+                Return `False` to veto the close.
+        """
+        self._tk_toplevel.add_close_handler(callback)
+
+    def remove_close_handler(self, callback: Callable) -> None:
+        """Remove a previously registered close handler.
+
+        Args:
+            callback: The same callable passed to `add_close_handler()`.
+        """
+        self._tk_toplevel.remove_close_handler(callback)
+
+    # ----- Properties -----
+
+    @property
+    def result(self) -> Any:
+        """Value set before closing, returned by `block_until_closed()`."""
+        return self._tk_toplevel.result
+
+    @result.setter
+    def result(self, value: Any) -> None:
+        self._tk_toplevel.result = value

--- a/tests/features/appshell_public.py
+++ b/tests/features/appshell_public.py
@@ -1,0 +1,68 @@
+"""Visual test for public AppShell and Window."""
+from bootstack.widgets.public import (
+    AppShell, Window,
+    VStack, HStack, Label, Button, Separator, TextField, ToggleGroup,
+)
+from bootstack.signals import Signal
+
+
+def main():
+    with AppShell(
+        title="Public AppShell",
+        size=(960, 640),
+        nav_accent="primary",
+    ) as shell:
+
+        # Toolbar extras
+        theme_sig = Signal("Light")
+
+        def toggle_theme():
+            import bootstack as bs
+            bs.toggle_theme()
+
+        shell.toolbar.add_button(icon="sun", command=toggle_theme)
+
+        # --- Home page ---
+        with shell.add_page("home", text="Home", icon="house"):
+            with VStack(padding=24, gap=12, fill="both", expand=True):
+                Label("Welcome", font="heading-lg")
+                Label("This is the Home page.")
+                Separator(fill="x")
+                Button("Open Window", on_click=lambda: _open_window())
+
+        # --- Inputs page ---
+        with shell.add_page("inputs", text="Inputs", icon="input-cursor-text"):
+            with VStack(padding=24, gap=10, fill="both", expand=True):
+                Label("Text inputs", font="heading-md")
+                name_sig = Signal("")
+                TextField(text_signal=name_sig, label="Name", fill="x")
+                Label("Toggle group:")
+                tg = ToggleGroup(options=["Option A", "Option B", "Option C"])
+
+        # --- Settings page (footer) ---
+        with shell.add_page("settings", text="Settings", icon="gear", is_footer=True):
+            with VStack(padding=24, gap=10, fill="both", expand=True):
+                Label("Settings", font="heading-md")
+                Label("Application settings go here.")
+
+    def _open_window():
+        with Window(
+            title="Details",
+            size=(400, 280),
+            modal=True,
+            center_on_parent=True,
+            padding=20,
+            gap=10,
+        ) as win:
+            Label("Secondary Window", font="heading-md")
+            Separator(fill="x")
+            Label("This is a modal Window opened from a page.")
+            with HStack(gap=8, anchor="e"):
+                Button("Close", on_click=win.close)
+        win.show()
+
+    shell.run()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- **`AppShell`** — wraps internal `AppShell`; `add_page()` returns a `_PageFrame` context-manager proxy so page content uses the standard `with`-block parenting pattern; exposes `toolbar`, `nav`, `pages`, `current_page`, `navigate()`, `on_page_changed()`; note `shell.toolbar` returns the internal composite (uses `command=` not `on_click=`)
- **`Window`** — wraps `Toplevel` as a `PublicContainer` with an internal `PackFrame` content frame; supports `show()` (returns `self`), `block_until_closed()`, `result`, `add_close_handler()`; `min_size=`/`max_size=` replace `minsize=`/`maxsize=`; `undecorated=` replaces `overrideredirect=`
- Visual test: `tests/features/appshell_public.py` (3-page AppShell + modal Window)

## Test plan

- [ ] Run `tests/features/appshell_public.py` — sidebar nav, page switching, toolbar button, modal Window all work
- [ ] `pytest tests/widgets/public/test_base_layer.py -m "not gui"` — 11 non-GUI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)