### PR TITLE
feat(public): add ListView, TreeView, and TableView

### DIFF
--- a/src/bootstack/widgets/public/__init__.py
+++ b/src/bootstack/widgets/public/__init__.py
@@ -25,6 +25,7 @@ from bootstack.widgets.public.primitives.expander import Accordion, Expander
 from bootstack.widgets.public.primitives.gauge import Gauge
 from bootstack.widgets.public.primitives.groupbox import GroupBox
 from bootstack.widgets.public.primitives.label import Badge, Label
+from bootstack.widgets.public.primitives.listview import ListView
 from bootstack.widgets.public.primitives.menubutton import MenuButton
 from bootstack.widgets.public.primitives.numericentry import NumericEntry
 from bootstack.widgets.public.primitives.pagestack import PageStack
@@ -40,8 +41,10 @@ from bootstack.widgets.public.primitives.sizegrip import SizeGrip
 from bootstack.widgets.public.primitives.splitview import SplitView
 from bootstack.widgets.public.primitives.slider import RangeSlider, Slider
 from bootstack.widgets.public.primitives.spinbox import Spinbox
+from bootstack.widgets.public.primitives.tableview import TableView, TableSelectionEventData, TableRowEventData, TableRowsEventData
 from bootstack.widgets.public.primitives.tabs import TabChangeEventData, TabRef, Tabs
 from bootstack.widgets.public.primitives.textarea import TextArea
+from bootstack.widgets.public.primitives.treeview import TreeView
 from bootstack.widgets.public.primitives.textfield import TextField
 from bootstack.widgets.public.primitives.toast import Toast, toast
 from bootstack.widgets.public.primitives.togglegroup import ToggleGroup
@@ -79,6 +82,7 @@ __all__ = [
     "GroupBox",
     "HStack",
     "Label",
+    "ListView",
     "MenuButton",
     "NumericEntry",
     "PageStack",
@@ -104,7 +108,12 @@ __all__ = [
     "TabChangeEventData",
     "TabRef",
     "Tabs",
+    "TableView",
+    "TableSelectionEventData",
+    "TableRowEventData",
+    "TableRowsEventData",
     "TextArea",
+    "TreeView",
     "TextField",
     "Toast",
     "toast",

--- a/src/bootstack/widgets/public/primitives/__init__.py
+++ b/src/bootstack/widgets/public/primitives/__init__.py
@@ -9,6 +9,7 @@ from bootstack.widgets.public.primitives.expander import Accordion, Expander
 from bootstack.widgets.public.primitives.gauge import Gauge
 from bootstack.widgets.public.primitives.groupbox import GroupBox
 from bootstack.widgets.public.primitives.label import Badge, Label
+from bootstack.widgets.public.primitives.listview import ListView
 from bootstack.widgets.public.primitives.menubutton import MenuButton
 from bootstack.widgets.public.primitives.numericentry import NumericEntry
 from bootstack.widgets.public.primitives.pagestack import PageStack
@@ -24,8 +25,10 @@ from bootstack.widgets.public.primitives.sizegrip import SizeGrip
 from bootstack.widgets.public.primitives.splitview import SplitView
 from bootstack.widgets.public.primitives.slider import RangeSlider, Slider
 from bootstack.widgets.public.primitives.spinbox import Spinbox
+from bootstack.widgets.public.primitives.tableview import TableView, TableSelectionEventData, TableRowEventData, TableRowsEventData
 from bootstack.widgets.public.primitives.tabs import TabChangeEventData, TabRef, Tabs
 from bootstack.widgets.public.primitives.textarea import TextArea
+from bootstack.widgets.public.primitives.treeview import TreeView
 from bootstack.widgets.public.primitives.textfield import TextField
 from bootstack.widgets.public.primitives.toast import Toast, toast
 from bootstack.widgets.public.primitives.togglegroup import ToggleGroup
@@ -35,10 +38,13 @@ from bootstack.widgets.public.primitives.tooltip import Tooltip
 __all__ = [
     "Accordion", "Badge", "Button", "ButtonGroup", "Card", "Checkbox", "CodeEditor",
     "ContextMenu", "Expander", "Gauge",
-    "Label", "NumericEntry", "PasswordEntry", "ProgressBar",
+    "Label", "ListView", "NumericEntry", "PasswordEntry", "ProgressBar",
     "Radio", "RadioGroup", "RadioToggleButton",
     "RangeSlider", "Select", "Separator", "Slider", "Spinbox", "Switch",
     "DateField", "GroupBox", "MenuButton", "PageStack", "PathField", "SplitView",
-    "TabChangeEventData", "TabRef", "Tabs", "TextArea", "TextField", "Toast",
-    "toast", "ToggleButton", "ToggleGroup", "Toolbar", "Tooltip", "Scrollbar", "SizeGrip",
+    "TabChangeEventData", "TabRef", "Tabs", "TableView",
+    "TableSelectionEventData", "TableRowEventData", "TableRowsEventData",
+    "TextArea", "TextField", "Toast",
+    "toast", "ToggleButton", "ToggleGroup", "Toolbar", "Tooltip",
+    "TreeView", "Scrollbar", "SizeGrip",
 ]

--- a/src/bootstack/widgets/public/primitives/listview.py
+++ b/src/bootstack/widgets/public/primitives/listview.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+from typing import Any, Callable, Literal
+
+from bootstack.widgets.composites.list.listview import ListView as _InternalListView
+from bootstack.widgets.public.base import PublicWidgetBase
+
+
+class ListView(PublicWidgetBase):
+    """A virtual-scrolling list for efficiently displaying large datasets.
+
+    Renders only visible rows, making it suitable for thousands of records.
+    Populate via `items=` (a plain list of dicts) or `datasource=` (a
+    `DataSourceProtocol` for database-backed or API-backed data).
+
+    Each record dict should have an `'id'` key; one is auto-generated if absent.
+
+    Args:
+        items: Initial list of record dicts.
+        datasource: `DataSourceProtocol` implementation for data access.
+        selection_mode: `'none'` (default), `'single'`, or `'multi'`.
+        show_selection_controls: Show checkboxes/radio buttons alongside items.
+        show_chevron: Show a chevron indicator on each item.
+        enable_removing: Show a remove button on each item.
+        enable_dragging: Show a drag handle and allow row reordering.
+        striped: Alternate row background colors.
+        show_separator: Show a separator line between items.
+        scrollbar_visibility: `'always'` (default) or `'never'`.
+        density: Item density — `'default'` or `'compact'`.
+        accent: Accent token for selection and drag indicator.
+        parent: Override the context-stack parent.
+    """
+
+    def __init__(
+        self,
+        *,
+        items: list | None = None,
+        datasource: Any = None,
+        selection_mode: Literal["none", "single", "multi"] = "none",
+        show_selection_controls: bool = False,
+        show_chevron: bool = False,
+        enable_removing: bool = False,
+        enable_dragging: bool = False,
+        striped: bool = False,
+        show_separator: bool = True,
+        scrollbar_visibility: Literal["always", "never"] = "always",
+        density: str = "default",
+        accent: str | None = None,
+        parent: Any = None,
+        **kwargs: Any,
+    ) -> None:
+        self._parent = self._resolve_parent(parent)
+        layout_kw = self._split_layout_kwargs(kwargs)
+        tk_master = self._parent._child_master() if self._parent else None
+
+        internal_kwargs: dict[str, Any] = {
+            "selection_mode": selection_mode,
+            "show_selection_controls": show_selection_controls,
+            "show_chevron": show_chevron,
+            "enable_removing": enable_removing,
+            "enable_dragging": enable_dragging,
+            "striped": striped,
+            "show_separator": show_separator,
+            "scrollbar_visibility": scrollbar_visibility,
+            "density": density,
+        }
+        if items is not None:
+            internal_kwargs["items"] = items
+        if datasource is not None:
+            internal_kwargs["datasource"] = datasource
+        if accent is not None:
+            internal_kwargs["accent"] = accent
+        internal_kwargs.update(kwargs)
+
+        self._internal = _InternalListView(tk_master, **internal_kwargs)
+        self._attach_to_parent(layout_kw)
+
+    # ----- Data -----
+
+    def insert_item(self, data: dict) -> None:
+        """Insert a new record into the list.
+
+        Args:
+            data: Record dict. An `'id'` is auto-generated if absent.
+        """
+        self._internal.insert_item(data)
+
+    def update_item(self, record_id: Any, data: dict) -> None:
+        """Update an existing record.
+
+        Args:
+            record_id: ID of the record to update.
+            data: Fields to merge into the existing record.
+        """
+        self._internal.update_item(record_id, data)
+
+    def delete_item(self, record_id: Any) -> None:
+        """Delete a record by ID.
+
+        Args:
+            record_id: ID of the record to delete.
+        """
+        self._internal.delete_item(record_id)
+
+    def reload(self) -> None:
+        """Reload data from the datasource and refresh the display."""
+        self._internal.reload()
+
+    # ----- Selection -----
+
+    def get_selected(self) -> list[dict]:
+        """Return currently selected records as a list of dicts."""
+        return self._internal.get_selected()
+
+    def select_all(self) -> None:
+        """Select all items. Only effective when `selection_mode='multi'`."""
+        self._internal.select_all()
+
+    def clear_selection(self) -> None:
+        """Deselect all items."""
+        self._internal.clear_selection()
+
+    # ----- Scrolling -----
+
+    def scroll_to_top(self) -> None:
+        """Scroll to the first item."""
+        self._internal.scroll_to_top()
+
+    def scroll_to_bottom(self) -> None:
+        """Scroll to the last item."""
+        self._internal.scroll_to_bottom()
+
+    # ----- Events -----
+
+    def on_item_click(self, callback: Callable) -> str:
+        """Register a callback for `<<ItemClick>>` events.
+
+        Args:
+            callback: Receives `event.data` — the record dict with `selected`,
+                `focused`, and `item_index` injected.
+
+        Returns:
+            Bind ID — pass to `off_item_click()` to unsubscribe.
+        """
+        return self._internal.on_item_click(callback)
+
+    def off_item_click(self, bind_id: str | None = None) -> None:
+        """Unsubscribe from `<<ItemClick>>`.
+
+        Args:
+            bind_id: ID returned by `on_item_click()`. If `None`, removes all.
+        """
+        self._internal.off_item_click(bind_id)
+
+    def on_selection_changed(self, callback: Callable) -> str:
+        """Register a callback for `<<SelectionChange>>` events.
+
+        Args:
+            callback: Called when selection changes. Use `get_selected()` to
+                read the current selection.
+
+        Returns:
+            Bind ID — pass to `off_selection_changed()` to unsubscribe.
+        """
+        return self._internal.on_selection_changed(callback)
+
+    def off_selection_changed(self, bind_id: str | None = None) -> None:
+        """Unsubscribe from `<<SelectionChange>>`.
+
+        Args:
+            bind_id: ID returned by `on_selection_changed()`. If `None`, removes all.
+        """
+        self._internal.off_selection_changed(bind_id)
+
+    def on_item_delete(self, callback: Callable) -> str:
+        """Register a callback for `<<ItemDelete>>` events.
+
+        Args:
+            callback: Receives `event.data` — the deleted record dict.
+
+        Returns:
+            Bind ID — pass to `off_item_delete()` to unsubscribe.
+        """
+        return self._internal.on_item_delete(callback)
+
+    def off_item_delete(self, bind_id: str | None = None) -> None:
+        """Unsubscribe from `<<ItemDelete>>`.
+
+        Args:
+            bind_id: ID returned by `on_item_delete()`. If `None`, removes all.
+        """
+        self._internal.off_item_delete(bind_id)
+
+    def on_item_insert(self, callback: Callable) -> str:
+        """Register a callback for `<<ItemInsert>>` events.
+
+        Args:
+            callback: Receives `event.data` — the inserted record dict.
+
+        Returns:
+            Bind ID — pass to `off_item_insert()` to unsubscribe.
+        """
+        return self._internal.on_item_insert(callback)
+
+    def off_item_insert(self, bind_id: str | None = None) -> None:
+        """Unsubscribe from `<<ItemInsert>>`.
+
+        Args:
+            bind_id: ID returned by `on_item_insert()`. If `None`, removes all.
+        """
+        self._internal.off_item_insert(bind_id)
+
+    def on_item_drag_end(self, callback: Callable) -> str:
+        """Register a callback for `<<ItemDragEnd>>` events.
+
+        Args:
+            callback: Receives `event.data` — record dict plus `source_index`,
+                `target_index`, `moved`, `y_start`, and `y_end`.
+
+        Returns:
+            Bind ID — pass to `off_item_drag_end()` to unsubscribe.
+        """
+        return self._internal.on_item_drag_end(callback)
+
+    def off_item_drag_end(self, bind_id: str | None = None) -> None:
+        """Unsubscribe from `<<ItemDragEnd>>`.
+
+        Args:
+            bind_id: ID returned by `on_item_drag_end()`. If `None`, removes all.
+        """
+        self._internal.off_item_drag_end(bind_id)
+
+    # ----- Properties -----
+
+    @property
+    def datasource(self) -> Any:
+        """The underlying `DataSourceProtocol` instance."""
+        return self._internal.get_datasource()

--- a/src/bootstack/widgets/public/primitives/listview.py
+++ b/src/bootstack/widgets/public/primitives/listview.py
@@ -15,6 +15,11 @@ class ListView(PublicWidgetBase):
 
     Each record dict should have an `'id'` key; one is auto-generated if absent.
 
+    Note: `ListItem` renders only the `'title'`, `'text'`, `'caption'`, `'icon'`,
+    and `'badge'` keys. Other keys are stored and returned by `get_selected()` /
+    events but are not displayed. Map your data to these keys, or supply a custom
+    `row_factory` via `.tk` for fully custom row rendering.
+
     Args:
         items: Initial list of record dicts.
         datasource: `DataSourceProtocol` implementation for data access.

--- a/src/bootstack/widgets/public/primitives/tableview.py
+++ b/src/bootstack/widgets/public/primitives/tableview.py
@@ -1,0 +1,311 @@
+from __future__ import annotations
+
+from typing import Any, Callable, Literal
+
+from bootstack.widgets.composites.tableview.tableview import (
+    TableView as _InternalTableView,
+    TableSelectionEventData,
+    TableRowEventData,
+    TableRowsEventData,
+)
+from bootstack.widgets.public.base import PublicWidgetBase
+
+
+class TableView(PublicWidgetBase):
+    """A feature-rich data table with sorting, filtering, search, and grouping.
+
+    Backed by an in-memory `SqliteDataSource`. Supply `rows=` to pre-load
+    data, or pass an existing `datasource=` for a shared data source.
+
+    Note: `datasource` must be a `SqliteDataSource`. `MemoryDataSource` and
+    `FileDataSource` are not accepted.
+
+    Args:
+        columns: Column definitions — list of column-ID strings or dicts with
+            keys `'text'`, `'key'`, `'width'`, and `'minwidth'`.
+        rows: Initial data rows (list of dicts or sequences).
+        datasource: Existing `SqliteDataSource` to use instead of creating one.
+        selection_mode: `'none'`, `'single'` (default), or `'multi'`.
+        sorting_mode: `'single'` (default) or `'none'`.
+        enable_search: Show the search bar. Default `True`.
+        enable_filtering: Enable column filtering. Default `True`.
+        paging_mode: `'standard'` (default, paginated) or `'virtual'`.
+        page_size: Rows per page in standard paging mode. Default `25`.
+        enable_adding: Allow adding rows via a form dialog. Default `False`.
+        enable_editing: Allow editing rows via a form dialog. Default `False`.
+        enable_deleting: Allow deleting rows. Default `False`.
+        enable_exporting: Enable CSV/Excel export. Default `False`.
+        striped: Alternate row background colors. Default `False`.
+        allow_grouping: Allow grouping rows by a column. Default `False`.
+        show_table_status: Show filter/sort/group status and pager. Default `True`.
+        parent: Override the context-stack parent.
+    """
+
+    def __init__(
+        self,
+        *,
+        columns: list[str | dict] | None = None,
+        rows: list | None = None,
+        datasource: Any = None,
+        selection_mode: Literal["none", "single", "multi"] = "single",
+        sorting_mode: Literal["single", "none"] = "single",
+        enable_search: bool = True,
+        enable_filtering: bool = True,
+        paging_mode: Literal["standard", "virtual"] = "standard",
+        page_size: int = 25,
+        enable_adding: bool = False,
+        enable_editing: bool = False,
+        enable_deleting: bool = False,
+        enable_exporting: bool = False,
+        striped: bool = False,
+        allow_grouping: bool = False,
+        show_table_status: bool = True,
+        show_column_chooser: bool = False,
+        parent: Any = None,
+        **kwargs: Any,
+    ) -> None:
+        self._parent = self._resolve_parent(parent)
+        layout_kw = self._split_layout_kwargs(kwargs)
+        tk_master = self._parent._child_master() if self._parent else None
+
+        internal_kwargs: dict[str, Any] = {
+            "selection_mode": selection_mode,
+            "sorting_mode": sorting_mode,
+            "enable_search": enable_search,
+            "enable_filtering": enable_filtering,
+            "paging_mode": paging_mode,
+            "page_size": page_size,
+            "enable_adding": enable_adding,
+            "enable_editing": enable_editing,
+            "enable_deleting": enable_deleting,
+            "enable_exporting": enable_exporting,
+            "striped": striped,
+            "allow_grouping": allow_grouping,
+            "show_table_status": show_table_status,
+            "show_column_chooser": show_column_chooser,
+        }
+        if columns is not None:
+            internal_kwargs["columns"] = columns
+        if rows is not None:
+            internal_kwargs["rows"] = rows
+        if datasource is not None:
+            internal_kwargs["datasource"] = datasource
+        internal_kwargs.update(kwargs)
+
+        self._internal = _InternalTableView(tk_master, **internal_kwargs)
+        self._attach_to_parent(layout_kw)
+
+    # ----- Data -----
+
+    def insert_rows(self, rows: list) -> None:
+        """Insert new rows.
+
+        Args:
+            rows: List of dicts or sequences to insert.
+        """
+        self._internal.insert_rows(rows)
+
+    def update_rows(self, rows: list[dict]) -> None:
+        """Update existing rows by merging the given dicts.
+
+        Args:
+            rows: List of dicts, each with an `'id'` key and updated fields.
+        """
+        self._internal.update_rows(rows)
+
+    def delete_rows(self, rows_or_ids: list) -> None:
+        """Delete rows by IID or by record dict.
+
+        Args:
+            rows_or_ids: List of IID strings or record dicts with an `'id'` key.
+        """
+        self._internal.delete_rows(rows_or_ids)
+
+    # ----- Selection -----
+
+    def select_rows(self, iids: list[str]) -> None:
+        """Programmatically select rows by IID.
+
+        Args:
+            iids: List of Treeview internal IDs to select.
+        """
+        self._internal.select_rows(iids)
+
+    def select_all(self) -> None:
+        """Select all rows in the current view."""
+        self._internal.select_all()
+
+    @property
+    def selected_rows(self) -> list[dict]:
+        """Currently selected record dicts."""
+        return self._internal.selected_rows
+
+    # ----- Scroll -----
+
+    def scroll_to_row(self, iid: str) -> None:
+        """Scroll the table so the given row is visible.
+
+        Args:
+            iid: Treeview internal ID of the row.
+        """
+        self._internal.scroll_to_row(iid)
+
+    # ----- Filter / sort / group -----
+
+    def get_filters(self) -> str:
+        """Return the current filter expression string."""
+        return self._internal.get_filters()
+
+    def clear_filters(self) -> None:
+        """Remove all active column filters."""
+        self._internal.clear_filters()
+
+    def get_sorting(self) -> dict[str, bool]:
+        """Return the current sort state as `{column_key: ascending}` dict."""
+        return self._internal.get_sorting()
+
+    def clear_sorting(self) -> None:
+        """Remove all active sort orders."""
+        self._internal.clear_sorting()
+
+    def get_grouping(self) -> str | None:
+        """Return the currently grouped column key, or `None`."""
+        return self._internal.get_grouping()
+
+    def clear_grouping(self) -> None:
+        """Remove the active grouping."""
+        self._internal.clear_grouping()
+
+    # ----- Events -----
+
+    def on_selection_changed(
+        self, callback: Callable[["TableSelectionEventData"], None]
+    ) -> str:
+        """Register a callback for `<<SelectionChange>>` events.
+
+        Args:
+            callback: Receives `event.data` — a `TableSelectionEventData` dict
+                with `records` and `iids`.
+
+        Returns:
+            Bind ID — pass to `off_selection_changed()` to unsubscribe.
+        """
+        return self._internal.on_selection_changed(callback)
+
+    def off_selection_changed(self, bind_id: str | None = None) -> None:
+        """Unsubscribe from `<<SelectionChange>>`.
+
+        Args:
+            bind_id: ID returned by `on_selection_changed()`. If `None`, removes all.
+        """
+        self._internal.off_selection_changed(bind_id)
+
+    def on_row_click(
+        self, callback: Callable[["TableRowEventData"], None]
+    ) -> str:
+        """Register a callback for `<<RowClick>>` events.
+
+        Args:
+            callback: Receives `event.data` — a `TableRowEventData` dict
+                with `record` and `iid`.
+
+        Returns:
+            Bind ID — pass to `off_row_click()` to unsubscribe.
+        """
+        return self._internal.on_row_click(callback)
+
+    def off_row_click(self, bind_id: str | None = None) -> None:
+        """Unsubscribe from `<<RowClick>>`.
+
+        Args:
+            bind_id: ID returned by `on_row_click()`. If `None`, removes all.
+        """
+        self._internal.off_row_click(bind_id)
+
+    def on_row_double_click(
+        self, callback: Callable[["TableRowEventData"], None]
+    ) -> str:
+        """Register a callback for `<<RowDoubleClick>>` events.
+
+        Args:
+            callback: Receives `event.data` — a `TableRowEventData` dict
+                with `record` and `iid`.
+
+        Returns:
+            Bind ID — pass to `off_row_double_click()` to unsubscribe.
+        """
+        return self._internal.on_row_double_click(callback)
+
+    def off_row_double_click(self, bind_id: str | None = None) -> None:
+        """Unsubscribe from `<<RowDoubleClick>>`.
+
+        Args:
+            bind_id: ID returned by `on_row_double_click()`. If `None`, removes all.
+        """
+        self._internal.off_row_double_click(bind_id)
+
+    def on_row_right_click(
+        self, callback: Callable[["TableRowEventData"], None]
+    ) -> str:
+        """Register a callback for `<<RowRightClick>>` events.
+
+        Args:
+            callback: Receives `event.data` — a `TableRowEventData` dict
+                with `record` and `iid`.
+
+        Returns:
+            Bind ID — pass to `off_row_right_click()` to unsubscribe.
+        """
+        return self._internal.on_row_right_click(callback)
+
+    def off_row_right_click(self, bind_id: str | None = None) -> None:
+        """Unsubscribe from `<<RowRightClick>>`.
+
+        Args:
+            bind_id: ID returned by `on_row_right_click()`. If `None`, removes all.
+        """
+        self._internal.off_row_right_click(bind_id)
+
+    def on_row_deleted(
+        self, callback: Callable[["TableRowsEventData"], None]
+    ) -> str:
+        """Register a callback for `<<RowDelete>>` events.
+
+        Args:
+            callback: Receives `event.data` — a `TableRowsEventData` dict
+                with `records`.
+
+        Returns:
+            Bind ID — pass to `off_row_deleted()` to unsubscribe.
+        """
+        return self._internal.on_row_deleted(callback)
+
+    def off_row_deleted(self, bind_id: str | None = None) -> None:
+        """Unsubscribe from `<<RowDelete>>`.
+
+        Args:
+            bind_id: ID returned by `on_row_deleted()`. If `None`, removes all.
+        """
+        self._internal.off_row_deleted(bind_id)
+
+    def on_row_inserted(
+        self, callback: Callable[["TableRowsEventData"], None]
+    ) -> str:
+        """Register a callback for `<<RowInsert>>` events.
+
+        Args:
+            callback: Receives `event.data` — a `TableRowsEventData` dict
+                with `records`.
+
+        Returns:
+            Bind ID — pass to `off_row_inserted()` to unsubscribe.
+        """
+        return self._internal.on_row_inserted(callback)
+
+    def off_row_inserted(self, bind_id: str | None = None) -> None:
+        """Unsubscribe from `<<RowInsert>>`.
+
+        Args:
+            bind_id: ID returned by `on_row_inserted()`. If `None`, removes all.
+        """
+        self._internal.off_row_inserted(bind_id)

--- a/src/bootstack/widgets/public/primitives/treeview.py
+++ b/src/bootstack/widgets/public/primitives/treeview.py
@@ -1,0 +1,346 @@
+from __future__ import annotations
+
+from typing import Any, Callable, Literal
+
+from bootstack.widgets.primitives.treeview import TreeView as _InternalTreeView
+from bootstack.widgets.public.base import PublicWidgetBase
+from bootstack.widgets.public.events import register_widget_events
+from bootstack.widgets.public.subscription import Subscription
+
+
+_TREEVIEW_EVENTS: dict[str, str] = {
+    "select":   "<<TreeviewSelect>>",
+    "open":     "<<TreeviewOpen>>",
+    "close":    "<<TreeviewClose>>",
+}
+
+register_widget_events(_InternalTreeView, _TREEVIEW_EVENTS)
+
+
+class TreeView(PublicWidgetBase):
+    """A hierarchical tree/table widget backed by `ttk.Treeview`.
+
+    Displays data in a tree structure (with optional columns). Rows are
+    called *items*; each item has a unique IID, optional text, optional
+    icon, optional column values, and optional child items.
+
+    Args:
+        columns: Sequence of column IDs to define. Omit for tree-only mode.
+        show: Which parts to render — `'tree headings'` (default), `'tree'`,
+            or `'headings'`.
+        height: Number of visible rows.
+        selection_mode: `'extended'` (default, multi-select), `'browse'`
+            (single), or `'none'`.
+        show_border: Draw a border around the widget.
+        density: Visual density — `'default'` or `'compact'`.
+        parent: Override the context-stack parent.
+    """
+
+    def __init__(
+        self,
+        *,
+        columns: list[str] | None = None,
+        show: str = "tree headings",
+        height: int | None = None,
+        selection_mode: Literal["extended", "browse", "none"] = "extended",
+        show_border: bool = False,
+        density: str | None = None,
+        accent: str | None = None,
+        parent: Any = None,
+        **kwargs: Any,
+    ) -> None:
+        self._parent = self._resolve_parent(parent)
+        layout_kw = self._split_layout_kwargs(kwargs)
+        tk_master = self._parent._child_master() if self._parent else None
+
+        internal_kwargs: dict[str, Any] = {
+            "show": show,
+            "selectmode": selection_mode,
+            "show_border": show_border,
+        }
+        if columns is not None:
+            internal_kwargs["columns"] = columns
+        if height is not None:
+            internal_kwargs["height"] = height
+        if density is not None:
+            internal_kwargs["density"] = density
+        if accent is not None:
+            internal_kwargs["accent"] = accent
+        internal_kwargs.update(kwargs)
+
+        self._internal = _InternalTreeView(tk_master, **internal_kwargs)
+        self._attach_to_parent(layout_kw)
+
+    def on(self, event: str, handler: Callable) -> Subscription:
+        from bootstack.widgets.public.events import resolve_event
+        sequence = resolve_event(self._internal, str(event))
+        bind_id = self._internal.bind(sequence, handler, add="+")
+        return Subscription(self._internal, sequence, bind_id)
+
+    # ----- Item management -----
+
+    def insert(
+        self,
+        parent: str = "",
+        index: str | int = "end",
+        *,
+        iid: str | None = None,
+        text: str = "",
+        values: tuple | list | None = None,
+        open: bool = False,
+        image: Any = None,
+        tags: str | tuple | None = None,
+    ) -> str:
+        """Insert a new item into the tree.
+
+        Args:
+            parent: IID of the parent item, or `''` for a root item.
+            index: Position among siblings — `'end'` (default) or an integer.
+            iid: Explicit IID. Auto-generated if omitted.
+            text: Label text shown in the tree column.
+            values: Sequence of column values (in column-definition order).
+            open: Whether the item is expanded initially.
+            image: Icon image.
+            tags: Tag or tuple of tags.
+
+        Returns:
+            The IID assigned to the new item.
+        """
+        kw: dict[str, Any] = {"text": text, "open": open}
+        if iid is not None:
+            kw["iid"] = iid
+        if values is not None:
+            kw["values"] = values
+        if image is not None:
+            kw["image"] = image
+        if tags is not None:
+            kw["tags"] = tags
+        return self._internal.insert(parent, index, **kw)
+
+    def delete(self, *items: str) -> None:
+        """Delete one or more items (and their descendants) by IID.
+
+        Args:
+            *items: IIDs to delete.
+        """
+        self._internal.delete(*items)
+
+    def detach(self, *items: str) -> None:
+        """Remove items from the display without deleting them.
+
+        They can be re-attached via `move()`.
+
+        Args:
+            *items: IIDs to detach.
+        """
+        self._internal.detach(*items)
+
+    def move(self, item: str, parent: str, index: str | int) -> None:
+        """Move an item to a new parent/position.
+
+        Args:
+            item: IID of the item to move.
+            parent: IID of the new parent, or `''` for root level.
+            index: Position among siblings.
+        """
+        self._internal.move(item, parent, index)
+
+    def clear(self) -> None:
+        """Delete all items."""
+        self._internal.delete(*self._internal.get_children())
+
+    # ----- Item access -----
+
+    def item(self, item: str, **options: Any) -> Any:
+        """Get or set options on an item.
+
+        Called with no extra kwargs, returns a dict of the item's current options.
+
+        Args:
+            item: IID.
+            **options: Options to set (`text`, `values`, `open`, `image`, `tags`).
+        """
+        return self._internal.item(item, **options)
+
+    def set(self, item: str, column: str | None = None, value: Any = None) -> Any:
+        """Get or set a column value for an item.
+
+        Args:
+            item: IID.
+            column: Column ID. If omitted, returns all column values as a dict.
+            value: New value to set. If omitted, returns the current value.
+        """
+        if column is None:
+            return self._internal.set(item)
+        if value is None:
+            return self._internal.set(item, column)
+        return self._internal.set(item, column, value)
+
+    def get_children(self, item: str = "") -> tuple[str, ...]:
+        """Return the IIDs of an item's direct children.
+
+        Args:
+            item: IID of the parent, or `''` for root items.
+        """
+        return self._internal.get_children(item)
+
+    def exists(self, item: str) -> bool:
+        """Return `True` if an item with the given IID exists.
+
+        Args:
+            item: IID to check.
+        """
+        return self._internal.exists(item)
+
+    def see(self, item: str) -> None:
+        """Scroll the tree so `item` is visible.
+
+        Args:
+            item: IID to scroll to.
+        """
+        self._internal.see(item)
+
+    def focus(self, item: str | None = None) -> str:
+        """Get or set the focused item.
+
+        Args:
+            item: IID to focus. Omit to return the currently focused IID.
+
+        Returns:
+            Currently focused IID when called without an argument.
+        """
+        if item is None:
+            return self._internal.focus()
+        return self._internal.focus(item)
+
+    # ----- Column / heading config -----
+
+    def column(self, column: str, **options: Any) -> Any:
+        """Configure a column.
+
+        Args:
+            column: Column ID.
+            **options: Column options — `width`, `minwidth`, `anchor`,
+                `stretch`, `id`.
+        """
+        return self._internal.column(column, **options)
+
+    def heading(self, column: str, **options: Any) -> Any:
+        """Configure a column heading.
+
+        Args:
+            column: Column ID.
+            **options: Heading options — `text`, `anchor`, `image`, `command`.
+        """
+        return self._internal.heading(column, **options)
+
+    # ----- Selection -----
+
+    def selection(self) -> tuple[str, ...]:
+        """Return the IIDs of all selected items."""
+        return self._internal.selection()
+
+    def selection_set(self, *items: str) -> None:
+        """Set the selection to exactly these items.
+
+        Args:
+            *items: IIDs to select (replaces any existing selection).
+        """
+        self._internal.selection_set(*items)
+
+    def selection_add(self, *items: str) -> None:
+        """Add items to the current selection.
+
+        Args:
+            *items: IIDs to add.
+        """
+        self._internal.selection_add(*items)
+
+    def selection_remove(self, *items: str) -> None:
+        """Remove items from the current selection.
+
+        Args:
+            *items: IIDs to remove.
+        """
+        self._internal.selection_remove(*items)
+
+    def selection_clear(self) -> None:
+        """Deselect all items."""
+        self._internal.selection_set()
+
+    # ----- Expand / collapse -----
+
+    def expand(self, item: str) -> None:
+        """Expand an item to show its children.
+
+        Args:
+            item: IID to expand.
+        """
+        self._internal.item(item, open=True)
+
+    def collapse(self, item: str) -> None:
+        """Collapse an item to hide its children.
+
+        Args:
+            item: IID to collapse.
+        """
+        self._internal.item(item, open=False)
+
+    # ----- Events -----
+
+    def on_select(self, callback: Callable) -> str:
+        """Register a callback for `<<TreeviewSelect>>` events.
+
+        Args:
+            callback: Called when the selection changes.
+
+        Returns:
+            Bind ID — pass to `off_select()` to unsubscribe.
+        """
+        return self._internal.bind("<<TreeviewSelect>>", callback, add="+")
+
+    def off_select(self, bind_id: str | None = None) -> None:
+        """Unsubscribe from `<<TreeviewSelect>>`.
+
+        Args:
+            bind_id: ID returned by `on_select()`. If `None`, removes all.
+        """
+        self._internal.unbind("<<TreeviewSelect>>", bind_id)
+
+    def on_open(self, callback: Callable) -> str:
+        """Register a callback for `<<TreeviewOpen>>` events (item expanded).
+
+        Args:
+            callback: Called when an item is opened/expanded.
+
+        Returns:
+            Bind ID — pass to `off_open()` to unsubscribe.
+        """
+        return self._internal.bind("<<TreeviewOpen>>", callback, add="+")
+
+    def off_open(self, bind_id: str | None = None) -> None:
+        """Unsubscribe from `<<TreeviewOpen>>`.
+
+        Args:
+            bind_id: ID returned by `on_open()`. If `None`, removes all.
+        """
+        self._internal.unbind("<<TreeviewOpen>>", bind_id)
+
+    def on_close(self, callback: Callable) -> str:
+        """Register a callback for `<<TreeviewClose>>` events (item collapsed).
+
+        Args:
+            callback: Called when an item is closed/collapsed.
+
+        Returns:
+            Bind ID — pass to `off_close()` to unsubscribe.
+        """
+        return self._internal.bind("<<TreeviewClose>>", callback, add="+")
+
+    def off_close(self, bind_id: str | None = None) -> None:
+        """Unsubscribe from `<<TreeviewClose>>`.
+
+        Args:
+            bind_id: ID returned by `on_close()`. If `None`, removes all.
+        """
+        self._internal.unbind("<<TreeviewClose>>", bind_id)

--- a/tests/features/data_display_public.py
+++ b/tests/features/data_display_public.py
@@ -1,0 +1,135 @@
+"""Visual test for public ListView, TreeView, and TableView."""
+from bootstack.widgets.public import (
+    App, VStack, HStack, Label, Button, Separator, Tabs,
+    ListView, TreeView, TableView,
+)
+
+
+PEOPLE = [
+    {"id": i, "name": n, "role": r, "dept": d}
+    for i, (n, r, d) in enumerate([
+        ("Alice Chen",    "Engineer",  "Engineering"),
+        ("Bob Smith",     "Designer",  "Design"),
+        ("Carol White",   "Manager",   "Engineering"),
+        ("David Lee",     "Engineer",  "Data"),
+        ("Eva Brown",     "Analyst",   "Data"),
+        ("Frank Kim",     "Designer",  "Design"),
+        ("Grace Patel",   "Engineer",  "Engineering"),
+        ("Henry Zhao",    "Manager",   "Product"),
+        ("Irene Torres",  "Analyst",   "Data"),
+        ("James Wilson",  "Engineer",  "Engineering"),
+        ("Karen Adams",   "Designer",  "Design"),
+        ("Leo Martinez",  "Engineer",  "Data"),
+    ], start=1)
+]
+
+
+def main():
+    with App(title="Data Display", minsize=(900, 620), padding=0, gap=0) as app:
+
+        tabs = Tabs(fill="both", expand=True)
+
+        # --- ListView tab ---
+        with tabs.add("listview", text="ListView"):
+            with VStack(padding=16, gap=10, fill="both", expand=True):
+                Label("Virtual-scrolling list (multi-select, removable):",
+                      font="heading-sm")
+
+                lv = ListView(
+                    items=PEOPLE,
+                    selection_mode="multi",
+                    show_selection_controls=True,
+                    enable_removing=True,
+                    striped=True,
+                    fill="both",
+                    expand=True,
+                )
+
+                lbl_sel = Label("Selected: []")
+
+                def show_selection(_event=None):
+                    selected = lv.get_selected()
+                    lbl_sel.value = f"Selected: {[r['name'] for r in selected]}"
+
+                lv.on_selection_changed(show_selection)
+
+                with HStack(gap=8):
+                    Button("Select All",    on_click=lv.select_all)
+                    Button("Clear",         on_click=lv.clear_selection)
+                    Button("Scroll Top",    on_click=lv.scroll_to_top)
+                    Button("Scroll Bottom", on_click=lv.scroll_to_bottom)
+
+        # --- TreeView tab ---
+        with tabs.add("treeview", text="TreeView"):
+            with VStack(padding=16, gap=10, fill="both", expand=True):
+                Label("Hierarchical tree with columns:", font="heading-sm")
+
+                tv = TreeView(
+                    columns=["role", "dept"],
+                    show="tree headings",
+                    fill="both",
+                    expand=True,
+                )
+                tv.heading("#0",    text="Name")
+                tv.heading("role",  text="Role")
+                tv.heading("dept",  text="Department")
+                tv.column("#0",    width=200)
+                tv.column("role",  width=120)
+                tv.column("dept",  width=120)
+
+                depts: dict[str, str] = {}
+                for p in PEOPLE:
+                    dept = p["dept"]
+                    if dept not in depts:
+                        iid = tv.insert("", "end", text=dept, open=True)
+                        depts[dept] = iid
+                    tv.insert(depts[dept], "end",
+                              text=p["name"], values=(p["role"], p["dept"]))
+
+                lbl_tv = Label("(click an item)")
+
+                def on_tv_select(_event=None):
+                    sel = tv.selection()
+                    if sel:
+                        it = tv.item(sel[0])
+                        lbl_tv.value = f"Selected: {it['text']}"
+
+                tv.on_select(on_tv_select)
+
+                with HStack(gap=8):
+                    Button("Expand All",
+                           on_click=lambda: [tv.expand(i)
+                                             for i in tv.get_children()])
+                    Button("Collapse All",
+                           on_click=lambda: [tv.collapse(i)
+                                             for i in tv.get_children()])
+
+        # --- TableView tab ---
+        with tabs.add("tableview", text="TableView"):
+            with VStack(padding=16, gap=10, fill="both", expand=True):
+                Label("Sortable / filterable table:", font="heading-sm")
+
+                tbl = TableView(
+                    columns=["name", "role", "dept"],
+                    rows=PEOPLE,
+                    selection_mode="multi",
+                    enable_search=True,
+                    enable_filtering=True,
+                    striped=True,
+                    fill="both",
+                    expand=True,
+                )
+
+                lbl_tbl = Label("(click a row)")
+
+                def on_tbl_click(event):
+                    rec = event.data.get("record", {})
+                    lbl_tbl.value = f"Clicked: {rec.get('name', '?')}"
+
+                tbl.on_row_click(on_tbl_click)
+
+    app.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/features/data_display_public.py
+++ b/tests/features/data_display_public.py
@@ -6,7 +6,7 @@ from bootstack.widgets.public import (
 
 
 PEOPLE = [
-    {"id": i, "name": n, "role": r, "dept": d}
+    {"id": i, "title": n, "text": r, "caption": d, "name": n, "role": r, "dept": d}
     for i, (n, r, d) in enumerate([
         ("Alice Chen",    "Engineer",  "Engineering"),
         ("Bob Smith",     "Designer",  "Design"),


### PR DESCRIPTION
## Summary

- **`ListView`** — wraps the virtual-scrolling list composite; forwards CRUD, selection, scroll, and drag event methods; `datasource` property returns the underlying `DataSourceProtocol`
- **`TreeView`** — wraps `ttk.Treeview` primitive; exposes `insert`, `delete`, `detach`, `move`, `clear`, `item`, `set`, `column`, `heading`, `selection*`, `expand`/`collapse`, `see`, `focus`, `get_children`, `exists`, `on_select`/`on_open`/`on_close`
- **`TableView`** — wraps the `SqliteDataSource`-backed composite; exposes data CRUD, selection, scroll, filter/sort/group query+clear, and row event methods; re-exports `TableSelectionEventData`, `TableRowEventData`, `TableRowsEventData`

**Known `ListView` field contract** (documented in docstring): `ListItem` renders only `title`, `text`, `caption`, `icon`, `badge` keys. Other keys are stored and returned by events/`get_selected()` but not displayed. Users must map domain data to these keys, or supply a custom `row_factory` via `.tk`.

## Test plan

- [ ] Run `tests/features/data_display_public.py` — all three tabs render correctly; ListView shows names/roles, buttons work; TreeView shows dept tree with expand/collapse; TableView shows sortable table with search
- [ ] `pytest tests/widgets/public/test_base_layer.py -m "not gui"` — 11 non-GUI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)