### PR TITLE
fix(public): reconcile public API against v2 proposal; fix SelectBox bugs

### DIFF
--- a/src/bootstack/widgets/composites/selectbox.py
+++ b/src/bootstack/widgets/composites/selectbox.py
@@ -101,11 +101,14 @@ class SelectBox(Field):
 
     def _bind_readonly_selection_on_click(self):
         """Bind entry click to show popup when in readonly mode."""
+        self.entry_widget.configure(cursor="hand2")
         self.entry_widget.bind('<Button-1>', lambda _: self.after_idle(self._show_selection_options), add='+')
 
     def _show_selection_options(self):
         """Create and display the popup list of selectable items."""
         if not self._items or self._popup_open:
+            return
+        if self.entry_widget.instate(['disabled']):
             return
 
         self._popup_open = True

--- a/src/bootstack/widgets/public/__init__.py
+++ b/src/bootstack/widgets/public/__init__.py
@@ -27,10 +27,10 @@ from bootstack.widgets.public.primitives.groupbox import GroupBox
 from bootstack.widgets.public.primitives.label import Badge, Label
 from bootstack.widgets.public.primitives.listview import ListView
 from bootstack.widgets.public.primitives.menubutton import MenuButton
-from bootstack.widgets.public.primitives.numericentry import NumericEntry
+from bootstack.widgets.public.primitives.numberfield import NumberField
 from bootstack.widgets.public.primitives.pagestack import PageStack
 from bootstack.widgets.public.primitives.pathfield import PathField
-from bootstack.widgets.public.primitives.passwordentry import PasswordEntry
+from bootstack.widgets.public.primitives.passwordfield import PasswordField
 from bootstack.widgets.public.primitives.progressbar import ProgressBar
 from bootstack.widgets.public.primitives.radio_variants import Radio, RadioToggleButton
 from bootstack.widgets.public.primitives.radiogroup import RadioGroup
@@ -41,10 +41,10 @@ from bootstack.widgets.public.primitives.sizegrip import SizeGrip
 from bootstack.widgets.public.primitives.splitview import SplitView
 from bootstack.widgets.public.primitives.slider import RangeSlider, Slider
 from bootstack.widgets.public.primitives.spinbox import Spinbox
-from bootstack.widgets.public.primitives.tableview import TableView, TableSelectionEventData, TableRowEventData, TableRowsEventData
+from bootstack.widgets.public.primitives.table import Table, TableSelectionEventData, TableRowEventData, TableRowsEventData
 from bootstack.widgets.public.primitives.tabs import TabChangeEventData, TabRef, Tabs
 from bootstack.widgets.public.primitives.textarea import TextArea
-from bootstack.widgets.public.primitives.treeview import TreeView
+from bootstack.widgets.public.primitives.tree import Tree
 from bootstack.widgets.public.primitives.textfield import TextField
 from bootstack.widgets.public.primitives.toast import Toast, toast
 from bootstack.widgets.public.primitives.togglegroup import ToggleGroup
@@ -84,11 +84,11 @@ __all__ = [
     "Label",
     "ListView",
     "MenuButton",
-    "NumericEntry",
+    "NumberField",
     "PageStack",
     "ParentResolutionError",
     "PathField",
-    "PasswordEntry",
+    "PasswordField",
     "ProgressBar",
     "PublicContainer",
     "PublicWidgetBase",
@@ -108,12 +108,12 @@ __all__ = [
     "TabChangeEventData",
     "TabRef",
     "Tabs",
-    "TableView",
+    "Table",
     "TableSelectionEventData",
     "TableRowEventData",
     "TableRowsEventData",
     "TextArea",
-    "TreeView",
+    "Tree",
     "TextField",
     "Toast",
     "toast",

--- a/src/bootstack/widgets/public/primitives/__init__.py
+++ b/src/bootstack/widgets/public/primitives/__init__.py
@@ -11,9 +11,9 @@ from bootstack.widgets.public.primitives.groupbox import GroupBox
 from bootstack.widgets.public.primitives.label import Badge, Label
 from bootstack.widgets.public.primitives.listview import ListView
 from bootstack.widgets.public.primitives.menubutton import MenuButton
-from bootstack.widgets.public.primitives.numericentry import NumericEntry
+from bootstack.widgets.public.primitives.numberfield import NumberField
 from bootstack.widgets.public.primitives.pagestack import PageStack
-from bootstack.widgets.public.primitives.passwordentry import PasswordEntry
+from bootstack.widgets.public.primitives.passwordfield import PasswordField
 from bootstack.widgets.public.primitives.pathfield import PathField
 from bootstack.widgets.public.primitives.progressbar import ProgressBar
 from bootstack.widgets.public.primitives.radio_variants import Radio, RadioToggleButton
@@ -25,10 +25,10 @@ from bootstack.widgets.public.primitives.sizegrip import SizeGrip
 from bootstack.widgets.public.primitives.splitview import SplitView
 from bootstack.widgets.public.primitives.slider import RangeSlider, Slider
 from bootstack.widgets.public.primitives.spinbox import Spinbox
-from bootstack.widgets.public.primitives.tableview import TableView, TableSelectionEventData, TableRowEventData, TableRowsEventData
+from bootstack.widgets.public.primitives.table import Table, TableSelectionEventData, TableRowEventData, TableRowsEventData
 from bootstack.widgets.public.primitives.tabs import TabChangeEventData, TabRef, Tabs
 from bootstack.widgets.public.primitives.textarea import TextArea
-from bootstack.widgets.public.primitives.treeview import TreeView
+from bootstack.widgets.public.primitives.tree import Tree
 from bootstack.widgets.public.primitives.textfield import TextField
 from bootstack.widgets.public.primitives.toast import Toast, toast
 from bootstack.widgets.public.primitives.togglegroup import ToggleGroup
@@ -38,13 +38,13 @@ from bootstack.widgets.public.primitives.tooltip import Tooltip
 __all__ = [
     "Accordion", "Badge", "Button", "ButtonGroup", "Card", "Checkbox", "CodeEditor",
     "ContextMenu", "Expander", "Gauge",
-    "Label", "ListView", "NumericEntry", "PasswordEntry", "ProgressBar",
+    "Label", "ListView", "NumberField", "PasswordField", "ProgressBar",
     "Radio", "RadioGroup", "RadioToggleButton",
     "RangeSlider", "Select", "Separator", "Slider", "Spinbox", "Switch",
     "DateField", "GroupBox", "MenuButton", "PageStack", "PathField", "SplitView",
-    "TabChangeEventData", "TabRef", "Tabs", "TableView",
+    "TabChangeEventData", "TabRef", "Tabs", "Table",
     "TableSelectionEventData", "TableRowEventData", "TableRowsEventData",
     "TextArea", "TextField", "Toast",
     "toast", "ToggleButton", "ToggleGroup", "Toolbar", "Tooltip",
-    "TreeView", "Scrollbar", "SizeGrip",
+    "Tree", "Scrollbar", "SizeGrip",
 ]

--- a/src/bootstack/widgets/public/primitives/gauge.py
+++ b/src/bootstack/widgets/public/primitives/gauge.py
@@ -20,10 +20,10 @@ class Gauge(PublicWidgetBase):
         value_format: Format string for the value (e.g. `'{:.1f}'`).
         size: Diameter in pixels. Default `200`.
         thickness: Arc width in pixels. Default `10`.
-        style: `'full'` (default) for a full circle or `'semi'` for a semicircle.
+        meter_type: `'full'` (default) for a full circle or `'semi'` for a semicircle.
         segment_width: Segment width for a dashed/segmented arc. `0` means solid.
         interactive: If True, the user can click/drag to change the value.
-        step_size: Increment used in interactive mode.
+        step: Increment used in interactive mode.
         show_text: If False, hides the value text.
         accent: Accent token for the arc colour.
         parent: Override the context-stack parent.
@@ -41,10 +41,10 @@ class Gauge(PublicWidgetBase):
         value_format: str = "{:.0f}",
         size: int = 200,
         thickness: int = 10,
-        style: str = "full",
+        meter_type: str = "full",
         segment_width: int = 0,
         interactive: bool = False,
-        step_size: int | float = 1,
+        step: int | float = 1,
         show_text: bool = True,
         accent: str | None = None,
         parent: Any = None,
@@ -62,10 +62,10 @@ class Gauge(PublicWidgetBase):
             "value_format": value_format,
             "size": size,
             "thickness": thickness,
-            "meter_type": style,
+            "meter_type": meter_type,
             "segment_width": segment_width,
             "interactive": interactive,
-            "step_size": step_size,
+            "step_size": step,
             "show_text": show_text,
         }
         if subtitle is not None:

--- a/src/bootstack/widgets/public/primitives/listview.py
+++ b/src/bootstack/widgets/public/primitives/listview.py
@@ -22,14 +22,14 @@ class ListView(PublicWidgetBase):
 
     Args:
         items: Initial list of record dicts.
-        datasource: `DataSourceProtocol` implementation for data access.
+        data_source: `DataSourceProtocol` implementation for data access.
         selection_mode: `'none'` (default), `'single'`, or `'multi'`.
         show_selection_controls: Show checkboxes/radio buttons alongside items.
         show_chevron: Show a chevron indicator on each item.
-        enable_removing: Show a remove button on each item.
-        enable_dragging: Show a drag handle and allow row reordering.
+        allow_remove: Show a remove button on each item.
+        allow_reorder: Show a drag handle and allow row reordering.
         striped: Alternate row background colors.
-        show_separator: Show a separator line between items.
+        show_separators: Show a separator line between items.
         scrollbar_visibility: `'always'` (default) or `'never'`.
         density: Item density — `'default'` or `'compact'`.
         accent: Accent token for selection and drag indicator.
@@ -40,14 +40,14 @@ class ListView(PublicWidgetBase):
         self,
         *,
         items: list | None = None,
-        datasource: Any = None,
+        data_source: Any = None,
         selection_mode: Literal["none", "single", "multi"] = "none",
         show_selection_controls: bool = False,
         show_chevron: bool = False,
-        enable_removing: bool = False,
-        enable_dragging: bool = False,
+        allow_remove: bool = False,
+        allow_reorder: bool = False,
         striped: bool = False,
-        show_separator: bool = True,
+        show_separators: bool = True,
         scrollbar_visibility: Literal["always", "never"] = "always",
         density: str = "default",
         accent: str | None = None,
@@ -62,17 +62,17 @@ class ListView(PublicWidgetBase):
             "selection_mode": selection_mode,
             "show_selection_controls": show_selection_controls,
             "show_chevron": show_chevron,
-            "enable_removing": enable_removing,
-            "enable_dragging": enable_dragging,
+            "enable_removing": allow_remove,
+            "enable_dragging": allow_reorder,
             "striped": striped,
-            "show_separator": show_separator,
+            "show_separator": show_separators,
             "scrollbar_visibility": scrollbar_visibility,
             "density": density,
         }
         if items is not None:
             internal_kwargs["items"] = items
-        if datasource is not None:
-            internal_kwargs["datasource"] = datasource
+        if data_source is not None:
+            internal_kwargs["datasource"] = data_source
         if accent is not None:
             internal_kwargs["accent"] = accent
         internal_kwargs.update(kwargs)
@@ -238,6 +238,6 @@ class ListView(PublicWidgetBase):
     # ----- Properties -----
 
     @property
-    def datasource(self) -> Any:
+    def data_source(self) -> Any:
         """The underlying `DataSourceProtocol` instance."""
         return self._internal.get_datasource()

--- a/src/bootstack/widgets/public/primitives/numberfield.py
+++ b/src/bootstack/widgets/public/primitives/numberfield.py
@@ -3,28 +3,30 @@ from __future__ import annotations
 import tkinter
 from typing import Any, Callable
 
-from bootstack.widgets.composites.passwordentry import PasswordEntry as _InternalPasswordEntry
+from bootstack.widgets.composites.numericentry import NumericEntry as _InternalNumericEntry
 from bootstack.widgets.public.base import PublicWidgetBase
 from bootstack.widgets.public.events import register_widget_events
 from bootstack.widgets.public.subscription import Subscription
 from bootstack.widgets.public.primitives.textfield import _INNER_ENTRY_SEQUENCES
 
-_PASSWORD_EVENTS: dict[str, str] = {
+_NUMBER_FIELD_EVENTS: dict[str, str] = {
     "change": "<<Change>>",
     "submit": "<Return>",
 }
 
 
-class PasswordEntry(PublicWidgetBase):
-    """A masked text field for password input with an optional visibility toggle.
+class NumberField(PublicWidgetBase):
+    """A numeric input field with optional stepper buttons.
 
     Args:
-        value: Initial password value (displayed masked).
+        value: Initial numeric value.
         label: Label displayed above the field.
         message: Hint text displayed below the field.
+        min_value: Minimum allowed value (inclusive).
+        max_value: Maximum allowed value (inclusive).
+        step: Increment/decrement step size.
+        show_steppers: If False, hides the +/− stepper buttons.
         required: If True, field cannot be left empty.
-        mask_char: Character used to mask input. Default `'•'`.
-        show_toggle: If True (default), shows the eye-icon visibility button.
         disabled: If True, field is non-interactive.
         read_only: If True, value is visible but not editable.
         width: Width in character cells.
@@ -35,13 +37,15 @@ class PasswordEntry(PublicWidgetBase):
 
     def __init__(
         self,
-        value: str = "",
+        value: int | float = 0,
         *,
         label: str | None = None,
         message: str | None = None,
+        min_value: int | float | None = None,
+        max_value: int | float | None = None,
+        step: int | float = 1,
+        show_steppers: bool = True,
         required: bool = False,
-        mask_char: str = "•",
-        show_toggle: bool = True,
         disabled: bool = False,
         read_only: bool = False,
         width: int | None = None,
@@ -56,15 +60,18 @@ class PasswordEntry(PublicWidgetBase):
         tk_master = self._parent._child_master() if self._parent else None
 
         internal_kwargs: dict[str, Any] = {
-            "show": mask_char,
-            "show_visibility_toggle": show_toggle,
+            "value": value,
+            "increment": step,
+            "show_spin_buttons": show_steppers,
         }
-        if value:
-            internal_kwargs["value"] = value
         if label is not None:
             internal_kwargs["label"] = label
         if message is not None:
             internal_kwargs["message"] = message
+        if min_value is not None:
+            internal_kwargs["minvalue"] = min_value
+        if max_value is not None:
+            internal_kwargs["maxvalue"] = max_value
         if required:
             internal_kwargs["required"] = True
         if disabled:
@@ -79,7 +86,7 @@ class PasswordEntry(PublicWidgetBase):
             internal_kwargs["density"] = density
         internal_kwargs.update(kwargs)
 
-        self._internal = _InternalPasswordEntry(tk_master, **internal_kwargs)
+        self._internal = _InternalNumericEntry(tk_master, **internal_kwargs)
         self._attach_to_parent(layout_kw)
 
     # ----- Event routing -----
@@ -97,11 +104,11 @@ class PasswordEntry(PublicWidgetBase):
     # ----- Properties -----
 
     @property
-    def value(self) -> str:
+    def value(self) -> int | float | None:
         return self._internal.value
 
     @value.setter
-    def value(self, v: str) -> None:
+    def value(self, v: int | float) -> None:
         self._internal.value = v
 
     @property
@@ -114,13 +121,13 @@ class PasswordEntry(PublicWidgetBase):
 
     # ----- Methods -----
 
-    def reveal(self) -> None:
-        """Remove character masking to show the password in plain text."""
-        self._internal.reveal()
+    def increment(self, steps: int = 1) -> None:
+        """Increment the value by `steps` × step size."""
+        self._internal.step(steps)
 
-    def hide(self) -> None:
-        """Restore character masking."""
-        self._internal.hide()
+    def decrement(self, steps: int = 1) -> None:
+        """Decrement the value by `steps` × step size."""
+        self._internal.step(-steps)
 
     # ----- Event shorthands -----
 
@@ -132,5 +139,13 @@ class PasswordEntry(PublicWidgetBase):
         """
         return self.on("change", handler)
 
+    def on_submit(self, handler: Callable[[tkinter.Event], Any]) -> Subscription:
+        """Register a callback fired on Enter key.
 
-register_widget_events(PasswordEntry, _PASSWORD_EVENTS)
+        Returns:
+            Subscription — call `.cancel()` to unsubscribe.
+        """
+        return self.on("submit", handler)
+
+
+register_widget_events(NumberField, _NUMBER_FIELD_EVENTS)

--- a/src/bootstack/widgets/public/primitives/passwordfield.py
+++ b/src/bootstack/widgets/public/primitives/passwordfield.py
@@ -3,30 +3,28 @@ from __future__ import annotations
 import tkinter
 from typing import Any, Callable
 
-from bootstack.widgets.composites.numericentry import NumericEntry as _InternalNumericEntry
+from bootstack.widgets.composites.passwordentry import PasswordEntry as _InternalPasswordEntry
 from bootstack.widgets.public.base import PublicWidgetBase
 from bootstack.widgets.public.events import register_widget_events
 from bootstack.widgets.public.subscription import Subscription
 from bootstack.widgets.public.primitives.textfield import _INNER_ENTRY_SEQUENCES
 
-_NUMERIC_ENTRY_EVENTS: dict[str, str] = {
+_PASSWORD_FIELD_EVENTS: dict[str, str] = {
     "change": "<<Change>>",
     "submit": "<Return>",
 }
 
 
-class NumericEntry(PublicWidgetBase):
-    """A numeric input field with optional spin buttons.
+class PasswordField(PublicWidgetBase):
+    """A masked text field for password input with an optional visibility toggle.
 
     Args:
-        value: Initial numeric value.
+        value: Initial password value (displayed masked).
         label: Label displayed above the field.
         message: Hint text displayed below the field.
-        min_value: Minimum allowed value (inclusive).
-        max_value: Maximum allowed value (inclusive).
-        step: Increment/decrement step size.
-        show_spin_buttons: If False, hides the +/− buttons.
         required: If True, field cannot be left empty.
+        mask_char: Character used to mask input. Default `'•'`.
+        show_visibility_toggle: If True (default), shows the eye-icon visibility button.
         disabled: If True, field is non-interactive.
         read_only: If True, value is visible but not editable.
         width: Width in character cells.
@@ -37,15 +35,13 @@ class NumericEntry(PublicWidgetBase):
 
     def __init__(
         self,
-        value: int | float = 0,
+        value: str = "",
         *,
         label: str | None = None,
         message: str | None = None,
-        min_value: int | float | None = None,
-        max_value: int | float | None = None,
-        step: int | float = 1,
-        show_spin_buttons: bool = True,
         required: bool = False,
+        mask_char: str = "•",
+        show_visibility_toggle: bool = True,
         disabled: bool = False,
         read_only: bool = False,
         width: int | None = None,
@@ -60,18 +56,15 @@ class NumericEntry(PublicWidgetBase):
         tk_master = self._parent._child_master() if self._parent else None
 
         internal_kwargs: dict[str, Any] = {
-            "value": value,
-            "increment": step,
-            "show_spin_buttons": show_spin_buttons,
+            "show": mask_char,
+            "show_visibility_toggle": show_visibility_toggle,
         }
+        if value:
+            internal_kwargs["value"] = value
         if label is not None:
             internal_kwargs["label"] = label
         if message is not None:
             internal_kwargs["message"] = message
-        if min_value is not None:
-            internal_kwargs["minvalue"] = min_value
-        if max_value is not None:
-            internal_kwargs["maxvalue"] = max_value
         if required:
             internal_kwargs["required"] = True
         if disabled:
@@ -86,7 +79,7 @@ class NumericEntry(PublicWidgetBase):
             internal_kwargs["density"] = density
         internal_kwargs.update(kwargs)
 
-        self._internal = _InternalNumericEntry(tk_master, **internal_kwargs)
+        self._internal = _InternalPasswordEntry(tk_master, **internal_kwargs)
         self._attach_to_parent(layout_kw)
 
     # ----- Event routing -----
@@ -104,11 +97,11 @@ class NumericEntry(PublicWidgetBase):
     # ----- Properties -----
 
     @property
-    def value(self) -> int | float | None:
+    def value(self) -> str:
         return self._internal.value
 
     @value.setter
-    def value(self, v: int | float) -> None:
+    def value(self, v: str) -> None:
         self._internal.value = v
 
     @property
@@ -121,13 +114,13 @@ class NumericEntry(PublicWidgetBase):
 
     # ----- Methods -----
 
-    def increment(self, steps: int = 1) -> None:
-        """Increment the value by `steps` × step size."""
-        self._internal.step(steps)
+    def reveal(self) -> None:
+        """Remove character masking to show the password in plain text."""
+        self._internal.reveal()
 
-    def decrement(self, steps: int = 1) -> None:
-        """Decrement the value by `steps` × step size."""
-        self._internal.step(-steps)
+    def hide(self) -> None:
+        """Restore character masking."""
+        self._internal.hide()
 
     # ----- Event shorthands -----
 
@@ -139,13 +132,5 @@ class NumericEntry(PublicWidgetBase):
         """
         return self.on("change", handler)
 
-    def on_submit(self, handler: Callable[[tkinter.Event], Any]) -> Subscription:
-        """Register a callback fired on Enter key.
 
-        Returns:
-            Subscription — call `.cancel()` to unsubscribe.
-        """
-        return self.on("submit", handler)
-
-
-register_widget_events(NumericEntry, _NUMERIC_ENTRY_EVENTS)
+register_widget_events(PasswordField, _PASSWORD_FIELD_EVENTS)

--- a/src/bootstack/widgets/public/primitives/progressbar.py
+++ b/src/bootstack/widgets/public/primitives/progressbar.py
@@ -12,7 +12,7 @@ class ProgressBar(PublicWidgetBase):
 
     Args:
         value: Initial progress value.
-        maximum: Value that represents 100% progress. Default `100`.
+        max_value: Value that represents 100% progress. Default `100`.
         mode: `'determinate'` (default) shows a fixed percentage;
             `'indeterminate'` animates continuously.
         orient: `'horizontal'` (default) or `'vertical'`.
@@ -26,7 +26,7 @@ class ProgressBar(PublicWidgetBase):
         self,
         value: float = 0,
         *,
-        maximum: float = 100,
+        max_value: float = 100,
         mode: str = "determinate",
         orient: str = "horizontal",
         signal: Any = None,
@@ -42,7 +42,7 @@ class ProgressBar(PublicWidgetBase):
 
         internal_kwargs: dict[str, Any] = {
             "value": value,
-            "maximum": maximum,
+            "maximum": max_value,
             "mode": mode,
             "orient": orient,
         }

--- a/src/bootstack/widgets/public/primitives/radiogroup.py
+++ b/src/bootstack/widgets/public/primitives/radiogroup.py
@@ -25,7 +25,7 @@ class RadioGroup(PublicWidgetBase):
         signal: Reactive `Signal` that holds the selected value.
         value: Initially selected value.
         orient: `'horizontal'` (default) or `'vertical'`.
-        label: Group label displayed above (or beside) the buttons.
+        title: Group label displayed above (or beside) the buttons.
         accent: Accent token applied to all buttons, e.g. `'primary'`.
         disabled: If True, all buttons are non-interactive.
         parent: Override the context-stack parent.
@@ -38,7 +38,7 @@ class RadioGroup(PublicWidgetBase):
         signal: Any = None,
         value: Any = None,
         orient: str = "horizontal",
-        label: str | None = None,
+        title: str | None = None,
         accent: str | None = None,
         disabled: bool = False,
         parent: Any = None,
@@ -54,8 +54,8 @@ class RadioGroup(PublicWidgetBase):
             internal_kwargs["signal"] = signal
         if value is not None:
             internal_kwargs["value"] = value
-        if label is not None:
-            internal_kwargs["text"] = label
+        if title is not None:
+            internal_kwargs["text"] = title
         if accent is not None:
             internal_kwargs["accent"] = accent
         if disabled:

--- a/src/bootstack/widgets/public/primitives/select.py
+++ b/src/bootstack/widgets/public/primitives/select.py
@@ -25,7 +25,7 @@ class Select(PublicWidgetBase):
         message: Hint text displayed below the field.
         required: If True, field cannot be left empty.
         searchable: If True, typing filters the option list.
-        allow_custom: If True, users may type values not in `options`.
+        allow_custom_values: If True, users may type values not in `options`.
         disabled: If True, field is non-interactive.
         read_only: If True, value is visible but the popup cannot be opened.
         width: Width in character cells.
@@ -44,7 +44,7 @@ class Select(PublicWidgetBase):
         message: str | None = None,
         required: bool = False,
         searchable: bool = False,
-        allow_custom: bool = False,
+        allow_custom_values: bool = False,
         disabled: bool = False,
         read_only: bool = False,
         width: int | None = None,
@@ -61,7 +61,7 @@ class Select(PublicWidgetBase):
         internal_kwargs: dict[str, Any] = {
             "items": options or [],
             "enable_search": searchable,
-            "allow_custom_values": allow_custom,
+            "allow_custom_values": allow_custom_values,
         }
         if value is not None:
             internal_kwargs["value"] = value

--- a/src/bootstack/widgets/public/primitives/slider.py
+++ b/src/bootstack/widgets/public/primitives/slider.py
@@ -26,7 +26,7 @@ class Slider(PublicWidgetBase):
         orient: `'horizontal'` (default) or `'vertical'`.
         show_value: Show a floating badge displaying the current value.
         show_minmax: Show min/max labels at the track ends.
-        tick_interval: Spacing between major tick marks. `None` disables ticks.
+        tick_step: Spacing between major tick marks. `None` disables ticks.
         minor_ticks: Number of minor ticks between each major tick.
         tick_labels: Show numeric labels at major tick positions.
         tick_format: Format string for tick and badge labels, e.g. `'{:.1f}°C'`.
@@ -43,7 +43,7 @@ class Slider(PublicWidgetBase):
         orient: str = "horizontal",
         show_value: bool = False,
         show_minmax: bool = False,
-        tick_interval: float | None = None,
+        tick_step: float | None = None,
         minor_ticks: int = 0,
         tick_labels: bool = True,
         tick_format: str = "{:.0f}",
@@ -62,7 +62,7 @@ class Slider(PublicWidgetBase):
             "orient": orient,
             "show_value": show_value,
             "show_minmax": show_minmax,
-            "tick_interval": tick_interval,
+            "tick_interval": tick_step,
             "minor_ticks": minor_ticks,
             "tick_labels": tick_labels,
             "tick_format": tick_format,
@@ -112,15 +112,15 @@ class RangeSlider(PublicWidgetBase):
     """A two-handle slider for selecting a low/high value range.
 
     Args:
-        lo_value: Initial low-handle value. Default `0`.
-        hi_value: Initial high-handle value. Default `100`.
+        low_value: Initial low-handle value. Default `0`.
+        high_value: Initial high-handle value. Default `100`.
         min_value: Minimum of the range. Default `0`.
         max_value: Maximum of the range. Default `100`.
-        lo_signal: Reactive `Signal[float]` linked to the low handle.
-        hi_signal: Reactive `Signal[float]` linked to the high handle.
+        low_signal: Reactive `Signal[float]` linked to the low handle.
+        high_signal: Reactive `Signal[float]` linked to the high handle.
         orient: `'horizontal'` (default) or `'vertical'`.
         show_value: Show floating badges on both handles.
-        tick_interval: Spacing between major tick marks.
+        tick_step: Spacing between major tick marks.
         minor_ticks: Number of minor ticks between each major tick.
         tick_labels: Show numeric labels at major tick positions.
         tick_format: Format string for tick and badge labels.
@@ -129,16 +129,16 @@ class RangeSlider(PublicWidgetBase):
 
     def __init__(
         self,
-        lo_value: float = 0,
-        hi_value: float = 100,
+        low_value: float = 0,
+        high_value: float = 100,
         *,
         min_value: float = 0,
         max_value: float = 100,
-        lo_signal: Any = None,
-        hi_signal: Any = None,
+        low_signal: Any = None,
+        high_signal: Any = None,
         orient: str = "horizontal",
         show_value: bool = False,
-        tick_interval: float | None = None,
+        tick_step: float | None = None,
         minor_ticks: int = 0,
         tick_labels: bool = True,
         tick_format: str = "{:.0f}",
@@ -151,21 +151,21 @@ class RangeSlider(PublicWidgetBase):
         tk_master = self._parent._child_master() if self._parent else None
 
         internal_kwargs: dict[str, Any] = {
-            "lovalue": lo_value,
-            "hivalue": hi_value,
+            "lovalue": low_value,
+            "hivalue": high_value,
             "minvalue": min_value,
             "maxvalue": max_value,
             "orient": orient,
             "show_value": show_value,
-            "tick_interval": tick_interval,
+            "tick_interval": tick_step,
             "minor_ticks": minor_ticks,
             "tick_labels": tick_labels,
             "tick_format": tick_format,
         }
-        if lo_signal is not None:
-            internal_kwargs["lo_signal"] = lo_signal
-        if hi_signal is not None:
-            internal_kwargs["hi_signal"] = hi_signal
+        if low_signal is not None:
+            internal_kwargs["lo_signal"] = low_signal
+        if high_signal is not None:
+            internal_kwargs["hi_signal"] = high_signal
         internal_kwargs.update(kwargs)
 
         self._internal = _InternalRangeSlider(tk_master, **internal_kwargs)
@@ -174,24 +174,24 @@ class RangeSlider(PublicWidgetBase):
     # ----- Properties -----
 
     @property
-    def lo(self) -> float:
+    def low_value(self) -> float:
         return self._internal.lovalue
 
-    @lo.setter
-    def lo(self, v: float) -> None:
+    @low_value.setter
+    def low_value(self, v: float) -> None:
         self._internal._lo_signal.set(float(v))
 
     @property
-    def hi(self) -> float:
+    def high_value(self) -> float:
         return self._internal.hivalue
 
-    @hi.setter
-    def hi(self, v: float) -> None:
+    @high_value.setter
+    def high_value(self, v: float) -> None:
         self._internal._hi_signal.set(float(v))
 
     @property
     def value(self) -> tuple[float, float]:
-        """Current `(lo, hi)` values as a tuple."""
+        """Current `(low, high)` values as a tuple."""
         return (self._internal.lovalue, self._internal.hivalue)
 
     # ----- Event shorthands -----

--- a/src/bootstack/widgets/public/primitives/table.py
+++ b/src/bootstack/widgets/public/primitives/table.py
@@ -11,33 +11,33 @@ from bootstack.widgets.composites.tableview.tableview import (
 from bootstack.widgets.public.base import PublicWidgetBase
 
 
-class TableView(PublicWidgetBase):
+class Table(PublicWidgetBase):
     """A feature-rich data table with sorting, filtering, search, and grouping.
 
     Backed by an in-memory `SqliteDataSource`. Supply `rows=` to pre-load
-    data, or pass an existing `datasource=` for a shared data source.
+    data, or pass an existing `data_source=` for a shared data source.
 
-    Note: `datasource` must be a `SqliteDataSource`. `MemoryDataSource` and
+    Note: `data_source` must be a `SqliteDataSource`. `MemoryDataSource` and
     `FileDataSource` are not accepted.
 
     Args:
         columns: Column definitions — list of column-ID strings or dicts with
             keys `'text'`, `'key'`, `'width'`, and `'minwidth'`.
         rows: Initial data rows (list of dicts or sequences).
-        datasource: Existing `SqliteDataSource` to use instead of creating one.
+        data_source: Existing `SqliteDataSource` to use instead of creating one.
         selection_mode: `'none'`, `'single'` (default), or `'multi'`.
         sorting_mode: `'single'` (default) or `'none'`.
-        enable_search: Show the search bar. Default `True`.
-        enable_filtering: Enable column filtering. Default `True`.
+        searchable: Show the search bar. Default `True`.
+        allow_filter: Enable column filtering. Default `True`.
         paging_mode: `'standard'` (default, paginated) or `'virtual'`.
         page_size: Rows per page in standard paging mode. Default `25`.
-        enable_adding: Allow adding rows via a form dialog. Default `False`.
-        enable_editing: Allow editing rows via a form dialog. Default `False`.
-        enable_deleting: Allow deleting rows. Default `False`.
-        enable_exporting: Enable CSV/Excel export. Default `False`.
+        allow_add: Allow adding rows via a form dialog. Default `False`.
+        allow_edit: Allow editing rows via a form dialog. Default `False`.
+        allow_delete: Allow deleting rows. Default `False`.
+        allow_export: Enable CSV/Excel export. Default `False`.
         striped: Alternate row background colors. Default `False`.
-        allow_grouping: Allow grouping rows by a column. Default `False`.
-        show_table_status: Show filter/sort/group status and pager. Default `True`.
+        allow_group: Allow grouping rows by a column. Default `False`.
+        show_status_bar: Show filter/sort/group status and pager. Default `True`.
         parent: Override the context-stack parent.
     """
 
@@ -46,20 +46,20 @@ class TableView(PublicWidgetBase):
         *,
         columns: list[str | dict] | None = None,
         rows: list | None = None,
-        datasource: Any = None,
+        data_source: Any = None,
         selection_mode: Literal["none", "single", "multi"] = "single",
         sorting_mode: Literal["single", "none"] = "single",
-        enable_search: bool = True,
-        enable_filtering: bool = True,
+        searchable: bool = True,
+        allow_filter: bool = True,
         paging_mode: Literal["standard", "virtual"] = "standard",
         page_size: int = 25,
-        enable_adding: bool = False,
-        enable_editing: bool = False,
-        enable_deleting: bool = False,
-        enable_exporting: bool = False,
+        allow_add: bool = False,
+        allow_edit: bool = False,
+        allow_delete: bool = False,
+        allow_export: bool = False,
         striped: bool = False,
-        allow_grouping: bool = False,
-        show_table_status: bool = True,
+        allow_group: bool = False,
+        show_status_bar: bool = True,
         show_column_chooser: bool = False,
         parent: Any = None,
         **kwargs: Any,
@@ -71,25 +71,25 @@ class TableView(PublicWidgetBase):
         internal_kwargs: dict[str, Any] = {
             "selection_mode": selection_mode,
             "sorting_mode": sorting_mode,
-            "enable_search": enable_search,
-            "enable_filtering": enable_filtering,
+            "enable_search": searchable,
+            "enable_filtering": allow_filter,
             "paging_mode": paging_mode,
             "page_size": page_size,
-            "enable_adding": enable_adding,
-            "enable_editing": enable_editing,
-            "enable_deleting": enable_deleting,
-            "enable_exporting": enable_exporting,
+            "enable_adding": allow_add,
+            "enable_editing": allow_edit,
+            "enable_deleting": allow_delete,
+            "enable_exporting": allow_export,
             "striped": striped,
-            "allow_grouping": allow_grouping,
-            "show_table_status": show_table_status,
+            "allow_grouping": allow_group,
+            "show_table_status": show_status_bar,
             "show_column_chooser": show_column_chooser,
         }
         if columns is not None:
             internal_kwargs["columns"] = columns
         if rows is not None:
             internal_kwargs["rows"] = rows
-        if datasource is not None:
-            internal_kwargs["datasource"] = datasource
+        if data_source is not None:
+            internal_kwargs["datasource"] = data_source
         internal_kwargs.update(kwargs)
 
         self._internal = _InternalTableView(tk_master, **internal_kwargs)

--- a/src/bootstack/widgets/public/primitives/tabs.py
+++ b/src/bootstack/widgets/public/primitives/tabs.py
@@ -55,9 +55,9 @@ class Tabs(PublicWidgetBase):
         show_divider: Show a divider line between the tab bar and the page area.
         tab_width: Fixed tab width in pixels, `'stretch'` to fill available space, or
             `None` (default, size to content).
-        enable_closing: Show close buttons on tabs. `True` = always, `False` = never,
+        allow_close: Show close buttons on tabs. `True` = always, `False` = never,
             `'hover'` = on hover. Default `False`.
-        enable_adding: Show an add-tab button that fires the `tab_add` event.
+        allow_add: Show an add-tab button that fires the `tab_add` event.
         accent: Accent token for the tab bar.
         parent: Override the context-stack parent.
     """
@@ -68,8 +68,8 @@ class Tabs(PublicWidgetBase):
         orient: Literal["horizontal", "vertical"] = "horizontal",
         show_divider: bool | None = None,
         tab_width: int | Literal["stretch"] | None = None,
-        enable_closing: bool | Literal["hover"] = False,
-        enable_adding: bool = False,
+        allow_close: bool | Literal["hover"] = False,
+        allow_add: bool = False,
         accent: str | None = None,
         parent: Any = None,
         **kwargs: Any,
@@ -81,8 +81,8 @@ class Tabs(PublicWidgetBase):
 
         internal_kwargs: dict[str, Any] = {
             "orient": orient,
-            "enable_closing": enable_closing,
-            "enable_adding": enable_adding,
+            "enable_closing": allow_close,
+            "enable_adding": allow_add,
         }
         if show_divider is not None:
             internal_kwargs["show_divider"] = show_divider
@@ -115,7 +115,7 @@ class Tabs(PublicWidgetBase):
         self,
         key: str,
         *,
-        text: str = "",
+        label: str = "",
         icon: str | None = None,
         closable: bool | Literal["hover"] | None = None,
         close_command: Callable | None = None,
@@ -124,12 +124,12 @@ class Tabs(PublicWidgetBase):
 
         Usage::
 
-            with tabs.add("home", text="Home"):
+            with tabs.add("home", label="Home"):
                 bs.Label("Content goes here")
 
         Args:
             key: Unique identifier for the tab/page.
-            text: Label displayed on the tab.
+            label: Label displayed on the tab.
             icon: Icon name displayed on the tab.
             closable: Close-button visibility for this tab. Overrides `enable_closing`.
             close_command: Called when the close button is clicked. Defaults to
@@ -146,7 +146,7 @@ class Tabs(PublicWidgetBase):
         if close_command is not None:
             add_kwargs["close_command"] = close_command
 
-        page_widget = self._internal.add(key, text=text, **add_kwargs)
+        page_widget = self._internal.add(key, text=label, **add_kwargs)
         return _TabPage(page_widget)
 
     def select(self, key: str) -> None:

--- a/src/bootstack/widgets/public/primitives/toast.py
+++ b/src/bootstack/widgets/public/primitives/toast.py
@@ -19,18 +19,18 @@ class Toast:
     Args:
         title: Header text. Shown larger when there is no message.
         message: Main body text. Shown below the title when both are provided.
-        memo: Small muted metadata string (e.g. `"just now"`).
+        detail: Small muted metadata string (e.g. `"just now"`).
         icon: Icon name string, or an `IconSpec` dict with `name`, `size`, `color`.
         duration: Auto-dismiss delay in milliseconds. `None` = no auto-dismiss.
         accent: Accent token for the container (e.g. `'success'`, `'danger'`).
         show_close_button: Show the × close button. Default `True`.
-        buttons: Sequence of button kwargs dicts. Each dict is passed to an
+        actions: Sequence of button kwargs dicts. Each dict is passed to an
             internal Button. Clicking a button dismisses the toast and passes
-            the button's dict to `on_dismissed`.
+            the button's dict to `on_dismiss`.
         position: Tkinter geometry offset string (e.g. `'-25-75'`). `None` uses
             platform defaults (bottom-right on Windows/macOS, top-right on Linux).
-        alert: Play a system bell when shown.
-        on_dismissed: Callback invoked on dismiss. Receives the button dict when
+        play_sound: Play a system bell when shown.
+        on_dismiss: Callback invoked on dismiss. Receives the button dict when
             dismissed via a button, or `None` otherwise.
     """
 
@@ -39,28 +39,28 @@ class Toast:
         *,
         title: str | None = None,
         message: str | None = None,
-        memo: str | None = None,
+        detail: str | None = None,
         icon: str | dict | None = None,
         duration: int | None = None,
         accent: str | None = None,
         show_close_button: bool = True,
-        buttons: Sequence[dict[str, Any]] | None = None,
+        actions: Sequence[dict[str, Any]] | None = None,
         position: str | None = None,
-        alert: bool = False,
-        on_dismissed: Callable[[Any], None] | None = None,
+        play_sound: bool = False,
+        on_dismiss: Callable[[Any], None] | None = None,
     ) -> None:
         self._internal = _InternalToast(
             title=title,
             message=message,
-            memo=memo,
+            memo=detail,
             icon=icon,
             duration=duration,
             accent=accent,
             show_close_button=show_close_button,
-            buttons=buttons,
+            buttons=actions,
             position=position,
-            alert=alert,
-            on_dismissed=on_dismissed,
+            alert=play_sound,
+            on_dismissed=on_dismiss,
         )
 
     def show(self) -> None:
@@ -83,7 +83,7 @@ def toast(
     duration: int = 3000,
     accent: str | None = None,
     icon: str | dict | None = None,
-    on_dismissed: Callable[[Any], None] | None = None,
+    on_dismiss: Callable[[Any], None] | None = None,
 ) -> None:
     """Show a simple notification toast and return immediately.
 
@@ -93,7 +93,7 @@ def toast(
         duration: Auto-dismiss delay in milliseconds. Default `3000`.
         accent: Accent token (e.g. `'success'`, `'danger'`).
         icon: Icon name or `IconSpec` dict.
-        on_dismissed: Called when the toast is dismissed.
+        on_dismiss: Called when the toast is dismissed.
     """
     t = Toast(
         message=message,
@@ -101,6 +101,6 @@ def toast(
         duration=duration,
         accent=accent,
         icon=icon,
-        on_dismissed=on_dismissed,
+        on_dismiss=on_dismiss,
     )
     t.show()

--- a/src/bootstack/widgets/public/primitives/tooltip.py
+++ b/src/bootstack/widgets/public/primitives/tooltip.py
@@ -18,7 +18,7 @@ class Tooltip:
         text: Tooltip text content.
         delay: Milliseconds before the tooltip appears. Default `250`.
         accent: Accent token for tooltip styling.
-        wraplength: Maximum line width in pixels before text wraps. Default `None` (no wrap).
+        wrap_width: Maximum line width in pixels before text wraps. Default `None` (no wrap).
         justify: Text alignment — `'left'` (default), `'center'`, or `'right'`.
         anchor_point: Widget anchor for tooltip positioning (e.g. `'n'`, `'se'`).
         window_point: Tooltip anchor matched to `anchor_point`.
@@ -32,7 +32,7 @@ class Tooltip:
         *,
         delay: int = 250,
         accent: str | None = None,
-        wraplength: int | None = None,
+        wrap_width: int | None = None,
         justify: Literal["left", "center", "right"] = "left",
         anchor_point: str | None = None,
         window_point: str | None = None,
@@ -48,8 +48,8 @@ class Tooltip:
         }
         if accent is not None:
             internal_kwargs["accent"] = accent
-        if wraplength is not None:
-            internal_kwargs["wraplength"] = wraplength
+        if wrap_width is not None:
+            internal_kwargs["wraplength"] = wrap_width
         if anchor_point is not None:
             internal_kwargs["anchor_point"] = anchor_point
         if window_point is not None:

--- a/src/bootstack/widgets/public/primitives/tree.py
+++ b/src/bootstack/widgets/public/primitives/tree.py
@@ -8,16 +8,16 @@ from bootstack.widgets.public.events import register_widget_events
 from bootstack.widgets.public.subscription import Subscription
 
 
-_TREEVIEW_EVENTS: dict[str, str] = {
+_TREE_EVENTS: dict[str, str] = {
     "select":   "<<TreeviewSelect>>",
     "open":     "<<TreeviewOpen>>",
     "close":    "<<TreeviewClose>>",
 }
 
-register_widget_events(_InternalTreeView, _TREEVIEW_EVENTS)
+register_widget_events(_InternalTreeView, _TREE_EVENTS)
 
 
-class TreeView(PublicWidgetBase):
+class Tree(PublicWidgetBase):
     """A hierarchical tree/table widget backed by `ttk.Treeview`.
 
     Displays data in a tree structure (with optional columns). Rows are

--- a/tests/features/data_display_public.py
+++ b/tests/features/data_display_public.py
@@ -1,7 +1,7 @@
-"""Visual test for public ListView, TreeView, and TableView."""
+"""Visual test for public ListView, Tree, and Table."""
 from bootstack.widgets.public import (
     App, VStack, HStack, Label, Button, Separator, Tabs,
-    ListView, TreeView, TableView,
+    ListView, Tree, Table,
 )
 
 
@@ -30,7 +30,7 @@ def main():
         tabs = Tabs(fill="both", expand=True)
 
         # --- ListView tab ---
-        with tabs.add("listview", text="ListView"):
+        with tabs.add("listview", label="ListView"):
             with VStack(padding=16, gap=10, fill="both", expand=True):
                 Label("Virtual-scrolling list (multi-select, removable):",
                       font="heading-sm")
@@ -39,7 +39,7 @@ def main():
                     items=PEOPLE,
                     selection_mode="multi",
                     show_selection_controls=True,
-                    enable_removing=True,
+                    allow_remove=True,
                     striped=True,
                     fill="both",
                     expand=True,
@@ -49,7 +49,7 @@ def main():
 
                 def show_selection(_event=None):
                     selected = lv.get_selected()
-                    lbl_sel.value = f"Selected: {[r['name'] for r in selected]}"
+                    lbl_sel.text = f"Selected: {[r['name'] for r in selected]}"
 
                 lv.on_selection_changed(show_selection)
 
@@ -59,12 +59,12 @@ def main():
                     Button("Scroll Top",    on_click=lv.scroll_to_top)
                     Button("Scroll Bottom", on_click=lv.scroll_to_bottom)
 
-        # --- TreeView tab ---
-        with tabs.add("treeview", text="TreeView"):
+        # --- Tree tab ---
+        with tabs.add("tree", label="Tree"):
             with VStack(padding=16, gap=10, fill="both", expand=True):
                 Label("Hierarchical tree with columns:", font="heading-sm")
 
-                tv = TreeView(
+                tv = Tree(
                     columns=["role", "dept"],
                     show="tree headings",
                     fill="both",
@@ -92,7 +92,7 @@ def main():
                     sel = tv.selection()
                     if sel:
                         it = tv.item(sel[0])
-                        lbl_tv.value = f"Selected: {it['text']}"
+                        lbl_tv.text = f"Selected: {it['text']}"
 
                 tv.on_select(on_tv_select)
 
@@ -104,17 +104,17 @@ def main():
                            on_click=lambda: [tv.collapse(i)
                                              for i in tv.get_children()])
 
-        # --- TableView tab ---
-        with tabs.add("tableview", text="TableView"):
+        # --- Table tab ---
+        with tabs.add("table", label="Table"):
             with VStack(padding=16, gap=10, fill="both", expand=True):
                 Label("Sortable / filterable table:", font="heading-sm")
 
-                tbl = TableView(
+                tbl = Table(
                     columns=["name", "role", "dept"],
                     rows=PEOPLE,
                     selection_mode="multi",
-                    enable_search=True,
-                    enable_filtering=True,
+                    searchable=True,
+                    allow_filter=True,
                     striped=True,
                     fill="both",
                     expand=True,
@@ -124,7 +124,7 @@ def main():
 
                 def on_tbl_click(event):
                     rec = event.data.get("record", {})
-                    lbl_tbl.value = f"Clicked: {rec.get('name', '?')}"
+                    lbl_tbl.text = f"Clicked: {rec.get('name', '?')}"
 
                 tbl.on_row_click(on_tbl_click)
 

--- a/tests/features/password_textarea.py
+++ b/tests/features/password_textarea.py
@@ -1,25 +1,25 @@
-"""Visual test for public PasswordEntry and TextArea widgets."""
-from bootstack.widgets.public import App, VStack, HStack, Label, PasswordEntry, TextArea, Button
+"""Visual test for public PasswordField and TextArea widgets."""
+from bootstack.widgets.public import App, VStack, HStack, Label, PasswordField, TextArea, Button
 
 
 def main():
-    with App(title="PasswordEntry + TextArea — visual test", minsize=(480, 100), padding=24, gap=14) as app:
+    with App(title="PasswordField + TextArea — visual test", minsize=(480, 100), padding=24, gap=14) as app:
 
-        # PasswordEntry variants
-        Label("PasswordEntry — basic (with visibility toggle)")
-        PasswordEntry(label="Password")
+        # PasswordField variants
+        Label("PasswordField — basic (with visibility toggle)")
+        PasswordField(label="Password")
 
-        Label("PasswordEntry — custom mask character")
-        PasswordEntry("secret", label="API key", mask_char="*")
+        Label("PasswordField — custom mask character")
+        PasswordField("secret", label="API key", mask_char="*")
 
-        Label("PasswordEntry — no visibility toggle")
-        PasswordEntry(label="PIN", show_toggle=False)
+        Label("PasswordField — no visibility toggle")
+        PasswordField(label="PIN", show_visibility_toggle=False)
 
-        Label("PasswordEntry — required")
-        PasswordEntry(label="Required password", required=True)
+        Label("PasswordField — required")
+        PasswordField(label="Required password", required=True)
 
-        Label("PasswordEntry — disabled")
-        PasswordEntry("hidden", label="Disabled", disabled=True)
+        Label("PasswordField — disabled")
+        PasswordField("hidden", label="Disabled", disabled=True)
 
         # TextArea variants
         Label("TextArea — basic")

--- a/tests/features/progressbar_gauge.py
+++ b/tests/features/progressbar_gauge.py
@@ -7,7 +7,7 @@ from bootstack.widgets.public import (
 def main():
     with App(title="ProgressBar + Gauge — visual test", minsize=(560, 100), padding=24, gap=16) as app:
 
-        pb = ProgressBar(0, maximum=100, accent="primary", fill="x", expand=True)
+        pb = ProgressBar(0, max_value=100, accent="primary", fill="x", expand=True)
 
         # ProgressBar variants
         Label("ProgressBar — accents")
@@ -38,9 +38,9 @@ def main():
 
         Label("Gauge — semi-circle")
         with HStack(gap=24):
-            Gauge(60, style="semi", value_suffix="°C", subtitle="Temp",
+            Gauge(60, meter_type="semi", value_suffix="°C", subtitle="Temp",
                   accent="danger", size=150, thickness=14)
-            Gauge(33, style="semi", value_suffix="%", subtitle="Load",
+            Gauge(33, meter_type="semi", value_suffix="%", subtitle="Load",
                   size=150, thickness=14)
 
     app.run()

--- a/tests/features/select_numeric.py
+++ b/tests/features/select_numeric.py
@@ -1,12 +1,12 @@
-"""Visual test for public Select and NumericEntry widgets."""
+"""Visual test for public Select and NumberField widgets."""
 from bootstack.widgets.public import (
-    App, VStack, HStack, Label, Select, NumericEntry, Button
+    App, VStack, HStack, Label, Select, NumberField, Button
 )
 from bootstack.signals import Signal
 
 
 def main():
-    with App(title="Select + NumericEntry — visual test", minsize=(480, 100), padding=24, gap=14) as app:
+    with App(title="Select + NumberField — visual test", minsize=(480, 100), padding=24, gap=14) as app:
 
         readout = Signal("(nothing committed yet)")
 
@@ -24,26 +24,26 @@ def main():
             searchable=True,
         )
 
-        # Allow custom
+        # Allow custom values
         Label("Select — allow custom values")
-        Select(["Option A", "Option B"], label="Custom allowed", allow_custom=True)
+        Select(["Option A", "Option B"], label="Custom allowed", allow_custom_values=True)
 
         # Disabled
         Label("Select — disabled")
         Select(["One", "Two", "Three"], value="Two", disabled=True)
 
-        # NumericEntry — basic
-        Label("NumericEntry — basic")
-        num = NumericEntry(10, label="Quantity", min_value=0, max_value=100, step=5)
+        # NumberField — basic
+        Label("NumberField — basic")
+        num = NumberField(10, label="Quantity", min_value=0, max_value=100, step=5)
         num.on_change(lambda e: readout.set(f"qty: {num.value}"))
 
-        # NumericEntry — no spin buttons
-        Label("NumericEntry — no spin buttons")
-        NumericEntry(3.14, label="Float value", step=0.1, show_spin_buttons=False)
+        # NumberField — no steppers
+        Label("NumberField — no steppers")
+        NumberField(3.14, label="Float value", step=0.1, show_steppers=False)
 
-        # NumericEntry — disabled
-        Label("NumericEntry — disabled")
-        NumericEntry(99, label="Disabled", disabled=True)
+        # NumberField — disabled
+        Label("NumberField — disabled")
+        NumberField(99, label="Disabled", disabled=True)
 
         # Inline controls
         with HStack(gap=8, anchor_items="center"):

--- a/tests/features/slider.py
+++ b/tests/features/slider.py
@@ -18,7 +18,7 @@ def main():
         Slider(
             25, min_value=0, max_value=100,
             show_value=True,
-            tick_interval=25,
+            tick_step=25,
             fill="x", expand=True,
         )
 
@@ -41,14 +41,14 @@ def main():
         # RangeSlider
         Label("RangeSlider — basic")
         r1 = RangeSlider(20, 75, min_value=0, max_value=100, fill="x", expand=True)
-        r1.on_change(lambda e: readout.set(f"range: {r1.lo:.0f} – {r1.hi:.0f}"))
+        r1.on_change(lambda e: readout.set(f"range: {r1.low_value:.0f} – {r1.high_value:.0f}"))
 
         # RangeSlider with value badges and ticks
         Label("RangeSlider — show_value + ticks")
         RangeSlider(
             10, 90, min_value=0, max_value=100,
             show_value=True,
-            tick_interval=10,
+            tick_step=10,
             fill="x", expand=True,
         )
 

--- a/tests/features/toast_tooltip_card.py
+++ b/tests/features/toast_tooltip_card.py
@@ -33,7 +33,7 @@ def main():
             Tooltip(b2, "Anchored below the button.", anchor_point="s", window_point="n", delay=200)
 
             b3 = Button("Long tip", variant="ghost")
-            Tooltip(b3, "This is a longer tooltip that will wrap when it exceeds the wraplength.", wraplength=180, delay=200)
+            Tooltip(b3, "This is a longer tooltip that will wrap when it exceeds the wrap_width.", wrap_width=180, delay=200)
 
         Separator(fill="x")
 
@@ -69,17 +69,17 @@ def main():
 
         with HStack(gap=8):
             Button(
-                "With buttons",
+                "With actions",
                 variant="outline",
                 on_click=lambda: Toast(
                     title="Delete item?",
                     message="This action cannot be undone.",
                     accent="warning",
-                    buttons=[
+                    actions=[
                         {"text": "Cancel", "variant": "ghost"},
                         {"text": "Delete", "accent": "danger"},
                     ],
-                    on_dismissed=lambda btn: print(f"Dismissed via: {btn}"),
+                    on_dismiss=lambda btn: print(f"Dismissed via: {btn}"),
                 ).show(),
             )
             Button(
@@ -88,7 +88,7 @@ def main():
                 on_click=lambda: Toast(
                     title="Persistent toast",
                     message="Close me manually.",
-                    memo="no timeout",
+                    detail="no timeout",
                     duration=None,
                 ).show(),
             )


### PR DESCRIPTION
## Summary

- Audited all public wrappers against `development/v2_api_proposal.md` and fixed widespread class/kwarg name drift
- File renames: `NumericEntry` → `NumberField`, `PasswordEntry` → `PasswordField`, `TreeView` → `Tree`, `TableView` → `Table`
- Kwarg renames across 10 widgets: `Gauge`, `ProgressBar`, `Slider`, `RangeSlider`, `RadioGroup`, `Select`, `Tabs`, `ListView`, `Toast`, `Tooltip`
- Fixed two `SelectBox` internal bugs: disabled state no longer opens popup; readonly entry shows `hand2` cursor
- Updated all visual test files to use renamed classes and kwargs

## Test plan

- [ ] Run existing test suite — no regressions
- [ ] Smoke-test visual test files that reference renamed widgets
- [ ] Verify disabled `Select` does not open popup on click
- [ ] Verify readonly `Select` shows pointer cursor on hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)