### PR TITLE
feat(public): add ScrollView, SpinnerField, TimeField, MenuBar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -364,7 +364,7 @@ their methods become module-level `bs.*` functions. Internal singletons
   params still in source). Renamed to `Gauge` to drop ttkbootstrap association.
 - **`Combobox` → removed.** Replaced by `Select` (was `SelectBox`). Covers
   the use case with a better API and popup list.
-- **`Spinbox` → kept.** Distinct form factor from `NumericEntry` — cycles
+- **`Spinbox` → kept.** Distinct form factor from `NumberField` — cycles
   through a fixed list of text or numeric values; different visual and use case.
 
 ### Pre-work before implementation starts
@@ -491,13 +491,13 @@ font="body"  |  font="heading-lg[bold]"  |  font="body+2[italic]"
 - **`bs.Form` uses `col_count=`, not `columns=`.**
 - **`Form.validate()` only fires rules with trigger `always` or `manual`.** `blur`/`key` rules are skipped.
 - **`Dialog.show()` / `FormDialog.show()` return `None`** — set `self.result`. Use `dlg.show(); if dlg.result: ...`
-- **`bs.TableView` only accepts `SqliteDataSource`**, not `MemoryDataSource` or `FileDataSource`.
-- **`bs.SelectBox` emits `<<Change>>`**, not `<<SelectionChange>>`.
+- **`bs.Table` only accepts `SqliteDataSource`**, not `MemoryDataSource` or `FileDataSource`.
+- **`bs.Select` (internal `SelectBox`) emits `<<Change>>`**, not `<<SelectionChange>>`.
 - **All Field-based widgets emit `<<Change>>`** (not `<<Changed>>`) and `<<Validate>>`** (not `<<Validated>>`).
 - **`on_changed`/`on_input` callbacks receive a Tkinter event object** (`event.data["value"]`).
   **`on_valid`/`on_invalid`/`on_validated` callbacks receive a plain dict** (`data["value"]`).
 - **`text=Signal(...)` does NOT work for reactive labels.** Use `textsignal=signal` instead.
-- **`bs.TreeView` not `bs.Treeview`.** Capital V.
+- **`bs.Label` uses `.text` not `.value`** to get/set the display string. All other widgets use `.value`. Planned to unify as `.value` in a future session.
 - **`value=` is ignored when `signal=` or `variable=` is also passed** on CheckButton,
   CheckToggle, Switch, RadioButton, RadioToggle. Seed the Signal directly: `bs.Signal(True)`.
 - **`ToggleGroup(padding=N)` raises `TypeError`** — source bug, do not pass `padding=`.
@@ -524,6 +524,8 @@ See memory `project_api_gaps.md` for full list. Key items:
 - `TextArea` uses the raw Tk Text widget border instead of the Field-style themed border — should adopt the same focus-ring/border approach as other Field composites
 - `ToggleGroup` solid (default) variant has poor contrast — selected button text is hard to read against the filled background; needs a style-builder fix
 - `Style._tk_widgets` grows forever — destroyed widgets never removed; causes theme-change slowdown *(partially resolved in Session 26 — WeakSet + visibility guard; remaining issue is pages are never destroyed)*
+- `ListView` hover state blends with striped rows — hover highlight too similar to alternate row background; needs contrast bump in ListView style builder
+- `Label.text` vs `.value` inconsistency — all other public widgets use `.value`; `Label`/`Badge` use `.text`. Planned fix: make `.value` primary, keep `.text` as alias
 
 ---
 
@@ -652,16 +654,16 @@ wrap the highest-level internal, rename Tk-isms, add a visual test under
 - **PR #57** — `Checkbox`, `Switch`, `ToggleButton` (shared `_BooleanControlBase`;
   `command=` wired to generate `<<Change>>`/`<<ToggleOn>>`/`<<ToggleOff>>`)
 - **PR #58** — `RadioGroup` (fixes `options=` gap; signal trace → `<<Change>>`)
-- **PR #59** — `Select` (wraps `SelectBox`), `NumericEntry` (wraps `NumericEntry`;
+- **PR #59** — `Select` (wraps `SelectBox`), `NumberField` (wraps `NumericEntry`;
   `min_value=`/`max_value=`/`step=` replace `minvalue=`/`maxvalue=`/`increment=`)
 - **PR #60** — `Slider`, `RangeSlider` (canvas-based; events fire on widget directly;
   value setters coerce to float; `RangeSlider.value` → `(lo, hi)` tuple)
 - **PR #61** — `ProgressBar`, `Gauge` (wraps `Meter`; **fixes Progressbar setter
   infinite recursion** — `get()`/`set()` now call `ttk.Progressbar` directly);
-  `style=` replaces `meter_type=`
+  `meter_type=` replaces internal `meter_type=` (public name settled as `meter_type=`)
 - **PR #62** — `Spinbox`, `Separator`; **fill= aliases** (`"horizontal"`→`"x"`,
   `"vertical"`→`"y"`, `"all"`→`"both"`) in `container.py`/`stacks.py`/`app.py`
-- **PR #63** — `PasswordEntry` (`mask_char=`, `show_toggle=`, `reveal()`/`hide()`),
+- **PR #63** — `PasswordField` (`mask_char=`, `show_visibility_toggle=`, `reveal()`/`hide()`),
   `TextArea` (`_core.text` event routing; `placeholder=` supported; `select_all()`
   fix: `focus_set()` + `end-1c`)
 - **PR #64** — `Expander` (`PublicContainer`; children → `_content_frame`),
@@ -669,7 +671,7 @@ wrap the highest-level internal, rename Tk-isms, add a visual test under
   (fixes `options=` gap; `mode='single'|'multi'`)
 
 **Key patterns established:**
-- Field-composite wrappers (TextField, Select, NumericEntry, PasswordEntry) override
+- Field-composite wrappers (TextField, Select, NumberField, PasswordField) override
   `on()` to route input events to `self._internal._entry`
 - TextArea routes events to `self._internal._core.text`
 - Canvas/frame widgets (Slider, ProgressBar, Expander) bind directly on `self._internal`
@@ -688,9 +690,81 @@ wrap the highest-level internal, rename Tk-isms, add a visual test under
 - `Field` message label gray background on `required=True` fields
 - Field composite default width grows with addon slots (gap #13)
 
-**Next step:** `Tabs` (TabView composite), then `Toast`, `Tooltip`, `Card`.
-`Tabs` wraps `composites/tabs/` — check `TabView.__init__` and `<<TabChanged>>`
-event routing before implementing. Branch off `main` as `feat/public-tabs`.
+**Next steps after Session 30:** `Tabs`, `Toast`, `Tooltip`, `Card`, `ListView`,
+`TreeView`, `TableView`, `AppShell`, `Window` — all completed in subsequent sessions
+(see PRs #65–75). API drift cleanup and misc-widgets batch followed (Session 31).
+
+### Session 31 — API drift cleanup + SelectBox bug fixes (2026-05-28)
+
+Full audit of all public wrappers against `development/v2_api_proposal.md` revealed
+widespread drift in class names and kwarg names. All drift fixed in `fix/public-api-drift`
+branch (commit a857ef2) before continuing misc-widgets work.
+
+**Class renames (file renames + rewrites):**
+- `NumericEntry` → `NumberField` (`numericentry.py` → `numberfield.py`)
+- `PasswordEntry` → `PasswordField` (`passwordentry.py` → `passwordfield.py`);
+  `show_toggle=` → `show_visibility_toggle=`
+- `TreeView` → `Tree` (`treeview.py` → `tree.py`)
+- `TableView` → `Table` (`tableview.py` → `table.py`)
+
+**Kwarg renames across 10 widgets:**
+- `Gauge`: `style=` → `meter_type=`, `step_size=` → `step=`
+- `ProgressBar`: `maximum=` → `max_value=`
+- `Slider`: `tick_interval=` → `tick_step=`
+- `RangeSlider`: `lo_value/hi_value` → `low_value/high_value`; `lo_signal/hi_signal` →
+  `low_signal/high_signal`; `.lo`/`.hi` properties → `.low_value`/`.high_value`
+- `RadioGroup`: `label=` → `title=` (group border label; still maps to internal `text=`)
+- `Select`: `allow_custom=` → `allow_custom_values=`
+- `Tabs`: `enable_closing=` → `allow_close=`, `enable_adding=` → `allow_add=`,
+  `add()` `text=` → `label=`
+- `ListView`: `datasource=` → `data_source=`, `enable_removing=` → `allow_remove=`,
+  `enable_dragging=` → `allow_reorder=`, `show_separator=` → `show_separators=`,
+  `.datasource` property → `.data_source`
+- `Toast`: `memo=` → `detail=`, `buttons=` → `actions=`, `alert=` → `play_sound=`,
+  `on_dismissed=` → `on_dismiss=`
+- `Tooltip`: `wraplength=` → `wrap_width=`
+
+**SelectBox internal bug fixes** (in `widgets/composites/selectbox.py`):
+- Disabled `Select` no longer opens popup on field click — `_show_selection_options`
+  now checks `entry_widget.instate(['disabled'])` and returns early.
+- Readonly entry (non-searchable, non-custom mode) now shows `hand2` pointer cursor
+  set in `_bind_readonly_selection_on_click`.
+
+**Naming convention confirmed:** "Field" suffix is correct for all text-input widgets
+(matches MUI, Radix, SwiftUI, Compose). `DateField` could arguably be `DatePicker`
+(more universal) but not urgent. `TimeEntry`/`SpinnerEntry` pending migration as
+`TimeField`/`SpinnerField` in misc-widgets batch.
+
+**Known issue logged:** `Label.text` vs `.value` inconsistency — all other widgets
+use `.value`; `Label`/`Badge` use `.text`. Agreed to unify as `.value` in a future
+session (`.text` kept as alias).
+
+**PR #76** (`fix/public-api-drift` → `main`) — merged.
+
+### Session 32 — Misc-widgets batch (2026-05-28)
+
+Added `ScrollView`, `SpinnerField`, `TimeField`, and `MenuBar` to the public layer
+on `feat/public-misc-widgets` (PR #77).
+
+**Files created under `src/bootstack/widgets/public/primitives/`:**
+- `scrollview.py` — `ScrollView` (`PublicContainer`; children → `_internal.add()` content
+  frame; exposes `scroll_to_top/bottom/left/right`, `yview/xview_moveto`,
+  `enable/disable_scrolling`, `refresh_bindings`)
+- `spinnerfield.py` — `SpinnerField` (two modes: fixed `options=` list or numeric range
+  via `min_value=`/`max_value=`/`step=`; `wrap=`; maps to internal `SpinnerEntry`)
+- `timefield.py` — `TimeField` (time-input with searchable interval dropdown;
+  `value_format=`, `interval=`, `min_time=`/`max_time=`; maps to internal `TimeEntry`)
+- `menubar.py` — `MenuBar` (three-region bar: `before`/`center`/`after`;
+  `add_button`, `add_label`, `add_menu`)
+
+Both `SpinnerField` and `TimeField` override `on()` to route `<<Change>>`/`<Return>`
+events to `self._internal._entry` (same pattern as `TextField`, `Select`, `NumberField`).
+
+**Visual test:** `tests/features/misc_widgets.py`
+
+**Next steps:** Merge PR #77, then determine remaining widgets to migrate.
+Notable gaps: `DateField` needs review against v2 proposal; `Label.text` → `.value`
+unification (alias `.text` to `.value`); open bugs from the known-issues list.
 
 ### Session 26 — Performance fixes (2026-05-28)
 

--- a/src/bootstack/widgets/public/__init__.py
+++ b/src/bootstack/widgets/public/__init__.py
@@ -34,13 +34,17 @@ from bootstack.widgets.public.primitives.passwordfield import PasswordField
 from bootstack.widgets.public.primitives.progressbar import ProgressBar
 from bootstack.widgets.public.primitives.radio_variants import Radio, RadioToggleButton
 from bootstack.widgets.public.primitives.radiogroup import RadioGroup
+from bootstack.widgets.public.primitives.menubar import MenuBar
 from bootstack.widgets.public.primitives.scrollbar import Scrollbar
+from bootstack.widgets.public.primitives.scrollview import ScrollView
 from bootstack.widgets.public.primitives.select import Select
 from bootstack.widgets.public.primitives.separator import Separator
 from bootstack.widgets.public.primitives.sizegrip import SizeGrip
 from bootstack.widgets.public.primitives.splitview import SplitView
 from bootstack.widgets.public.primitives.slider import RangeSlider, Slider
 from bootstack.widgets.public.primitives.spinbox import Spinbox
+from bootstack.widgets.public.primitives.spinnerfield import SpinnerField
+from bootstack.widgets.public.primitives.timefield import TimeField
 from bootstack.widgets.public.primitives.table import Table, TableSelectionEventData, TableRowEventData, TableRowsEventData
 from bootstack.widgets.public.primitives.tabs import TabChangeEventData, TabRef, Tabs
 from bootstack.widgets.public.primitives.textarea import TextArea
@@ -96,13 +100,16 @@ __all__ = [
     "RadioGroup",
     "RadioToggleButton",
     "RangeSlider",
+    "MenuBar",
     "Scrollbar",
+    "ScrollView",
     "Select",
     "Separator",
     "SizeGrip",
     "SplitView",
     "Slider",
     "Spinbox",
+    "SpinnerField",
     "Subscription",
     "Switch",
     "TabChangeEventData",
@@ -113,6 +120,7 @@ __all__ = [
     "TableRowEventData",
     "TableRowsEventData",
     "TextArea",
+    "TimeField",
     "Tree",
     "TextField",
     "Toast",

--- a/src/bootstack/widgets/public/primitives/__init__.py
+++ b/src/bootstack/widgets/public/primitives/__init__.py
@@ -18,13 +18,17 @@ from bootstack.widgets.public.primitives.pathfield import PathField
 from bootstack.widgets.public.primitives.progressbar import ProgressBar
 from bootstack.widgets.public.primitives.radio_variants import Radio, RadioToggleButton
 from bootstack.widgets.public.primitives.radiogroup import RadioGroup
+from bootstack.widgets.public.primitives.menubar import MenuBar
 from bootstack.widgets.public.primitives.scrollbar import Scrollbar
+from bootstack.widgets.public.primitives.scrollview import ScrollView
 from bootstack.widgets.public.primitives.select import Select
 from bootstack.widgets.public.primitives.separator import Separator
 from bootstack.widgets.public.primitives.sizegrip import SizeGrip
 from bootstack.widgets.public.primitives.splitview import SplitView
 from bootstack.widgets.public.primitives.slider import RangeSlider, Slider
 from bootstack.widgets.public.primitives.spinbox import Spinbox
+from bootstack.widgets.public.primitives.spinnerfield import SpinnerField
+from bootstack.widgets.public.primitives.timefield import TimeField
 from bootstack.widgets.public.primitives.table import Table, TableSelectionEventData, TableRowEventData, TableRowsEventData
 from bootstack.widgets.public.primitives.tabs import TabChangeEventData, TabRef, Tabs
 from bootstack.widgets.public.primitives.textarea import TextArea
@@ -38,13 +42,13 @@ from bootstack.widgets.public.primitives.tooltip import Tooltip
 __all__ = [
     "Accordion", "Badge", "Button", "ButtonGroup", "Card", "Checkbox", "CodeEditor",
     "ContextMenu", "Expander", "Gauge",
-    "Label", "ListView", "NumberField", "PasswordField", "ProgressBar",
+    "Label", "ListView", "MenuBar", "NumberField", "PasswordField", "ProgressBar",
     "Radio", "RadioGroup", "RadioToggleButton",
-    "RangeSlider", "Select", "Separator", "Slider", "Spinbox", "Switch",
-    "DateField", "GroupBox", "MenuButton", "PageStack", "PathField", "SplitView",
+    "RangeSlider", "Select", "Separator", "Slider", "Spinbox", "SpinnerField", "Switch",
+    "DateField", "GroupBox", "MenuButton", "PageStack", "PathField", "ScrollView", "SplitView",
     "TabChangeEventData", "TabRef", "Tabs", "Table",
     "TableSelectionEventData", "TableRowEventData", "TableRowsEventData",
-    "TextArea", "TextField", "Toast",
+    "TextArea", "TextField", "TimeField", "Toast",
     "toast", "ToggleButton", "ToggleGroup", "Toolbar", "Tooltip",
     "Tree", "Scrollbar", "SizeGrip",
 ]

--- a/src/bootstack/widgets/public/primitives/menubar.py
+++ b/src/bootstack/widgets/public/primitives/menubar.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from typing import Any, Callable, Literal
+
+from bootstack.widgets.composites.menubar import MenuBar as _InternalMenuBar
+from bootstack.widgets.public.base import PublicWidgetBase
+
+Region = Literal["before", "center", "after"]
+
+
+class MenuBar(PublicWidgetBase):
+    """A horizontal menu bar with three layout regions.
+
+    Items are placed into one of three regions: `'before'` (left-aligned),
+    `'center'` (stays visually centered), or `'after'` (right-aligned).
+
+    Args:
+        gap: Default gap between items in all regions. Default `0`.
+        region_gap: Per-region gap override — a dict with keys `'before'`,
+            `'center'`, `'after'`, or a 3-tuple `(before, center, after)`.
+        chevron: Show a dropdown chevron on menu buttons. Default `False`.
+        parent: Override the context-stack parent.
+    """
+
+    def __init__(
+        self,
+        *,
+        gap: int = 0,
+        region_gap: dict[str, int] | tuple[int, int, int] | None = None,
+        chevron: bool = False,
+        parent: Any = None,
+        **kwargs: Any,
+    ) -> None:
+        self._parent = self._resolve_parent(parent)
+        layout_kw = self._split_layout_kwargs(kwargs)
+        tk_master = self._parent._child_master() if self._parent else None
+
+        internal_kwargs: dict[str, Any] = {
+            "gap": gap,
+            "chevron": chevron,
+        }
+        if region_gap is not None:
+            internal_kwargs["region_gap"] = region_gap
+        internal_kwargs.update(kwargs)
+
+        self._internal = _InternalMenuBar(tk_master, **internal_kwargs)
+        self._attach_to_parent(layout_kw)
+
+    # ----- Content -----
+
+    def add_button(
+        self,
+        text: str,
+        *,
+        region: Region = "before",
+        icon: str | None = None,
+        on_click: Callable[[], Any] | None = None,
+        accent: str | None = None,
+        disabled: bool = False,
+        **kwargs: Any,
+    ) -> None:
+        """Add a button to the specified region.
+
+        Args:
+            text: Button label text.
+            region: Target region — `'before'`, `'center'`, or `'after'`.
+            icon: Icon name.
+            on_click: Callback fired when clicked.
+            accent: Accent token override.
+            disabled: If True, button is non-interactive.
+        """
+        kw: dict[str, Any] = {}
+        if icon is not None:
+            kw["icon"] = icon
+        if on_click is not None:
+            kw["command"] = on_click
+        if accent is not None:
+            kw["accent"] = accent
+        if disabled:
+            kw["state"] = "disabled"
+        kw.update(kwargs)
+        self._internal.add_button(text, region=region, **kw)
+
+    def add_label(
+        self,
+        text: str,
+        *,
+        region: Region = "before",
+        **kwargs: Any,
+    ) -> None:
+        """Add a text label to the specified region.
+
+        Args:
+            text: Label text.
+            region: Target region — `'before'`, `'center'`, or `'after'`.
+        """
+        self._internal.add_label(text, region=region, **kwargs)
+
+    def add_menu(
+        self,
+        text: str,
+        items: list | None = None,
+        *,
+        region: Region = "before",
+        icon: str | None = None,
+        accent: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Add a dropdown menu button to the specified region.
+
+        Args:
+            text: Menu button label text.
+            items: List of `ContextMenuItem` entries for the dropdown.
+            region: Target region — `'before'`, `'center'`, or `'after'`.
+            icon: Icon name shown on the button.
+            accent: Accent token override.
+        """
+        kw: dict[str, Any] = {}
+        if icon is not None:
+            kw["icon"] = icon
+        if accent is not None:
+            kw["accent"] = accent
+        kw.update(kwargs)
+        self._internal.add_menu(text, items, region=region, **kw)

--- a/src/bootstack/widgets/public/primitives/scrollview.py
+++ b/src/bootstack/widgets/public/primitives/scrollview.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import tkinter
+from typing import Any, Literal
+
+from bootstack.widgets.composites.scrollview import ScrollView as _InternalScrollView
+from bootstack.widgets.public.container import PublicContainer, PACK_KEYS
+
+
+class ScrollView(PublicContainer):
+    """A canvas-based scrollable container.
+
+    Place children inside the context block; they are laid out vertically
+    inside the scrollable area. Mouse-wheel scrolling is automatically
+    enabled for all descendants.
+
+    Args:
+        scroll_direction: Which axis to scroll — `'vertical'`, `'horizontal'`,
+            or `'both'` (default).
+        scrollbar_visibility: When scrollbars appear — `'always'` (default),
+            `'never'`, `'hover'` (appears on mouse enter), or `'scroll'`
+            (auto-hides after `autohide_delay` ms of inactivity).
+        autohide_delay: Milliseconds before scrollbars hide in `'scroll'` mode.
+            Default `1000`.
+        scrollbar_variant: Scrollbar variant token (e.g. `'round'`).
+        parent: Override the context-stack parent.
+    """
+
+    def __init__(
+        self,
+        *,
+        scroll_direction: Literal["vertical", "horizontal", "both"] = "both",
+        scrollbar_visibility: Literal["always", "never", "hover", "scroll"] = "always",
+        autohide_delay: int = 1000,
+        scrollbar_variant: str = "default",
+        parent: Any = None,
+        **kwargs: Any,
+    ) -> None:
+        self._parent = self._resolve_parent(parent)
+        layout_kw = self._split_layout_kwargs(kwargs)
+        tk_master = self._parent._child_master() if self._parent else None
+
+        internal_kwargs: dict[str, Any] = {
+            "scroll_direction": scroll_direction,
+            "scrollbar_visibility": scrollbar_visibility,
+            "autohide_delay": autohide_delay,
+            "scrollbar_variant": scrollbar_variant,
+        }
+        internal_kwargs.update(kwargs)
+
+        self._internal = _InternalScrollView(tk_master, **internal_kwargs)
+        self._content_frame = self._internal.add()
+        self._attach_to_parent(layout_kw)
+
+    def _child_master(self) -> tkinter.Misc:
+        return self._content_frame
+
+    def _default_layout_method(self) -> str:
+        return "pack"
+
+    def _merge_layout_options(self, child: Any, layout_kw: dict) -> tuple[str, dict]:
+        options = {k: v for k, v in layout_kw.items() if k in PACK_KEYS}
+        return ("pack", options)
+
+    # ----- Scrolling -----
+
+    def enable_scrolling(self) -> None:
+        """Enable mouse-wheel scrolling on the canvas and all children."""
+        self._internal.enable_scrolling()
+
+    def disable_scrolling(self) -> None:
+        """Disable mouse-wheel scrolling on the canvas and all children."""
+        self._internal.disable_scrolling()
+
+    def refresh_bindings(self) -> None:
+        """Refresh scroll bindings after dynamically adding many children."""
+        self._internal.refresh_bindings()
+
+    def scroll_to_top(self) -> None:
+        """Scroll to the top of the content."""
+        self._internal.yview_moveto(0.0)
+
+    def scroll_to_bottom(self) -> None:
+        """Scroll to the bottom of the content."""
+        self._internal.yview_moveto(1.0)
+
+    def scroll_to_left(self) -> None:
+        """Scroll to the left edge of the content."""
+        self._internal.xview_moveto(0.0)
+
+    def scroll_to_right(self) -> None:
+        """Scroll to the right edge of the content."""
+        self._internal.xview_moveto(1.0)
+
+    def yview_moveto(self, fraction: float) -> None:
+        """Scroll to a vertical position.
+
+        Args:
+            fraction: 0.0 (top) to 1.0 (bottom).
+        """
+        self._internal.yview_moveto(fraction)
+
+    def xview_moveto(self, fraction: float) -> None:
+        """Scroll to a horizontal position.
+
+        Args:
+            fraction: 0.0 (left) to 1.0 (right).
+        """
+        self._internal.xview_moveto(fraction)

--- a/src/bootstack/widgets/public/primitives/spinnerfield.py
+++ b/src/bootstack/widgets/public/primitives/spinnerfield.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import tkinter
+from typing import Any, Callable
+
+from bootstack.widgets.composites.spinnerentry import SpinnerEntry as _InternalSpinnerEntry
+from bootstack.widgets.public.base import PublicWidgetBase
+from bootstack.widgets.public.events import register_widget_events
+from bootstack.widgets.public.subscription import Subscription
+from bootstack.widgets.public.primitives.textfield import _INNER_ENTRY_SEQUENCES
+
+_SPINNER_FIELD_EVENTS: dict[str, str] = {
+    "change": "<<Change>>",
+    "submit": "<Return>",
+}
+
+
+class SpinnerField(PublicWidgetBase):
+    """A text-entry field with spin buttons for stepping through values.
+
+    Supports two modes: a fixed list of text values (`options=`) or a numeric
+    range (`min_value=` / `max_value=`). Exactly one mode should be used.
+
+    Args:
+        value: Initial value — a string (text mode) or number (numeric mode).
+        options: Fixed list of string values to step through (text mode).
+        min_value: Minimum value for numeric range mode.
+        max_value: Maximum value for numeric range mode.
+        step: Increment step size for numeric mode. Default `1`.
+        wrap: If True, values wrap around at the boundaries.
+        label: Label displayed above the field.
+        message: Hint text displayed below the field.
+        required: If True, field cannot be left empty.
+        disabled: If True, field is non-interactive.
+        width: Width in character cells.
+        accent: Accent token for the focus ring.
+        parent: Override the context-stack parent.
+    """
+
+    def __init__(
+        self,
+        value: int | float | str = "",
+        *,
+        options: list[str] | None = None,
+        min_value: int | float | None = None,
+        max_value: int | float | None = None,
+        step: int | float = 1,
+        wrap: bool = False,
+        label: str | None = None,
+        message: str | None = None,
+        required: bool = False,
+        disabled: bool = False,
+        width: int | None = None,
+        accent: str | None = None,
+        parent: Any = None,
+        **kwargs: Any,
+    ) -> None:
+        self._parent = self._resolve_parent(parent)
+        layout_kw = self._split_layout_kwargs(kwargs)
+        tk_master = self._parent._child_master() if self._parent else None
+
+        internal_kwargs: dict[str, Any] = {
+            "value": value,
+            "increment": step,
+            "wrap": wrap,
+        }
+        if options is not None:
+            internal_kwargs["values"] = options
+        if min_value is not None:
+            internal_kwargs["minvalue"] = min_value
+        if max_value is not None:
+            internal_kwargs["maxvalue"] = max_value
+        if label is not None:
+            internal_kwargs["label"] = label
+        if message is not None:
+            internal_kwargs["message"] = message
+        if required:
+            internal_kwargs["required"] = True
+        if disabled:
+            internal_kwargs["state"] = "disabled"
+        if width is not None:
+            internal_kwargs["width"] = width
+        if accent is not None:
+            internal_kwargs["accent"] = accent
+        internal_kwargs.update(kwargs)
+
+        self._internal = _InternalSpinnerEntry(tk_master, **internal_kwargs)
+        self._attach_to_parent(layout_kw)
+
+    # ----- Event routing -----
+
+    def _entry_widget(self) -> tkinter.Misc:
+        return self._internal._entry
+
+    def on(self, event: str, handler: Callable[[tkinter.Event], Any]) -> Subscription:
+        from bootstack.widgets.public.events import resolve_event
+        sequence = resolve_event(self, str(event))
+        widget = self._entry_widget() if sequence in _INNER_ENTRY_SEQUENCES else self._internal
+        bind_id = widget.bind(sequence, handler, add="+")
+        return Subscription(widget, sequence, bind_id)
+
+    # ----- Properties -----
+
+    @property
+    def value(self) -> str:
+        """Current value as a string."""
+        return self._internal.value
+
+    @value.setter
+    def value(self, v: Any) -> None:
+        self._internal.value = v
+
+    @property
+    def options(self) -> list[str] | None:
+        """The fixed list of text values, or `None` in numeric mode."""
+        return self._internal._values
+
+    @options.setter
+    def options(self, v: list[str]) -> None:
+        self._internal.configure(values=v)
+
+    @property
+    def disabled(self) -> bool:
+        return str(self._internal._entry.cget("state")) == "disabled"
+
+    @disabled.setter
+    def disabled(self, v: bool) -> None:
+        self._internal.configure(state="disabled" if v else "normal")
+
+    # ----- Event shorthands -----
+
+    def on_change(self, handler: Callable[[tkinter.Event], Any]) -> Subscription:
+        """Register a callback fired when the value changes.
+
+        Returns:
+            Subscription — call `.cancel()` to unsubscribe.
+        """
+        return self.on("change", handler)
+
+    def on_submit(self, handler: Callable[[tkinter.Event], Any]) -> Subscription:
+        """Register a callback fired when Enter is pressed.
+
+        Returns:
+            Subscription — call `.cancel()` to unsubscribe.
+        """
+        return self.on("submit", handler)
+
+
+register_widget_events(SpinnerField, _SPINNER_FIELD_EVENTS)

--- a/src/bootstack/widgets/public/primitives/timefield.py
+++ b/src/bootstack/widgets/public/primitives/timefield.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import datetime
+import tkinter
+from typing import Any, Callable
+
+from bootstack.widgets.composites.timeentry import TimeEntry as _InternalTimeEntry
+from bootstack.widgets.public.base import PublicWidgetBase
+from bootstack.widgets.public.events import register_widget_events
+from bootstack.widgets.public.subscription import Subscription
+from bootstack.widgets.public.primitives.textfield import _INNER_ENTRY_SEQUENCES
+
+_TIME_FIELD_EVENTS: dict[str, str] = {
+    "change": "<<Change>>",
+    "submit": "<Return>",
+}
+
+
+class TimeField(PublicWidgetBase):
+    """A time-input field with a searchable dropdown of time intervals.
+
+    Displays a formatted time value and shows a dropdown list of times at
+    the specified `interval`. The user can type a custom time or pick from
+    the list.
+
+    Args:
+        value: Initial time value (`datetime.time` or `'HH:MM'` string).
+            Defaults to the current time.
+        value_format: ICU time format preset or pattern. Common values:
+            `'shortTime'` (default, e.g. `'3:30 PM'`), `'mediumTime'`,
+            `'HH:mm'`, `'h:mm a'`.
+        interval: Minute interval for dropdown entries. Default `30`.
+        min_time: Earliest time shown in the dropdown.
+        max_time: Latest time shown in the dropdown.
+        label: Label displayed above the field.
+        message: Hint text displayed below the field.
+        required: If True, field cannot be left empty.
+        disabled: If True, field is non-interactive.
+        width: Width in character cells.
+        accent: Accent token for the focus ring.
+        parent: Override the context-stack parent.
+    """
+
+    def __init__(
+        self,
+        value: datetime.time | str | None = None,
+        *,
+        value_format: str = "shortTime",
+        interval: int = 30,
+        min_time: datetime.time | str | None = None,
+        max_time: datetime.time | str | None = None,
+        label: str | None = None,
+        message: str | None = None,
+        required: bool = False,
+        disabled: bool = False,
+        width: int | None = None,
+        accent: str | None = None,
+        parent: Any = None,
+        **kwargs: Any,
+    ) -> None:
+        self._parent = self._resolve_parent(parent)
+        layout_kw = self._split_layout_kwargs(kwargs)
+        tk_master = self._parent._child_master() if self._parent else None
+
+        internal_kwargs: dict[str, Any] = {
+            "value_format": value_format,
+            "interval": interval,
+        }
+        if value is not None:
+            internal_kwargs["value"] = value
+        if min_time is not None:
+            internal_kwargs["min_time"] = min_time
+        if max_time is not None:
+            internal_kwargs["max_time"] = max_time
+        if label is not None:
+            internal_kwargs["label"] = label
+        if message is not None:
+            internal_kwargs["message"] = message
+        if required:
+            internal_kwargs["required"] = True
+        if disabled:
+            internal_kwargs["state"] = "disabled"
+        if width is not None:
+            internal_kwargs["width"] = width
+        if accent is not None:
+            internal_kwargs["accent"] = accent
+        internal_kwargs.update(kwargs)
+
+        self._internal = _InternalTimeEntry(tk_master, **internal_kwargs)
+        self._attach_to_parent(layout_kw)
+
+    # ----- Event routing -----
+
+    def _entry_widget(self) -> tkinter.Misc:
+        return self._internal._entry
+
+    def on(self, event: str, handler: Callable[[tkinter.Event], Any]) -> Subscription:
+        from bootstack.widgets.public.events import resolve_event
+        sequence = resolve_event(self, str(event))
+        widget = self._entry_widget() if sequence in _INNER_ENTRY_SEQUENCES else self._internal
+        bind_id = widget.bind(sequence, handler, add="+")
+        return Subscription(widget, sequence, bind_id)
+
+    # ----- Properties -----
+
+    @property
+    def value(self) -> str:
+        """Current time value as a formatted string."""
+        return self._internal.value
+
+    @value.setter
+    def value(self, v: datetime.time | str) -> None:
+        self._internal.value = v
+
+    @property
+    def disabled(self) -> bool:
+        return str(self._internal._entry.cget("state")) == "disabled"
+
+    @disabled.setter
+    def disabled(self, v: bool) -> None:
+        self._internal.configure(state="disabled" if v else "normal")
+
+    # ----- Event shorthands -----
+
+    def on_change(self, handler: Callable[[tkinter.Event], Any]) -> Subscription:
+        """Register a callback fired when the time value changes.
+
+        Returns:
+            Subscription — call `.cancel()` to unsubscribe.
+        """
+        return self.on("change", handler)
+
+    def on_submit(self, handler: Callable[[tkinter.Event], Any]) -> Subscription:
+        """Register a callback fired when Enter is pressed.
+
+        Returns:
+            Subscription — call `.cancel()` to unsubscribe.
+        """
+        return self.on("submit", handler)
+
+
+register_widget_events(TimeField, _TIME_FIELD_EVENTS)

--- a/tests/features/misc_widgets.py
+++ b/tests/features/misc_widgets.py
@@ -1,0 +1,68 @@
+"""Visual test for ScrollView, SpinnerField, TimeField, and MenuBar."""
+from bootstack.widgets.public import (
+    App, VStack, HStack, Label, Button,
+    MenuBar, ScrollView, SpinnerField, TimeField,
+)
+from bootstack.signals import Signal
+
+
+def main():
+    with App(title="Misc Widgets — visual test", size=(680, 600), padding=0, gap=0) as app:
+
+        # --- MenuBar ---
+        mb = MenuBar(fill="x")
+        mb.add_button("File", region="before", on_click=lambda: print("File"))
+        mb.add_button("Edit", region="before", on_click=lambda: print("Edit"))
+        mb.add_label("bootstack demo", region="center")
+        mb.add_button("Help", region="after", on_click=lambda: print("Help"))
+
+        # --- Body ---
+        with VStack(padding=16, gap=16, fill="both", expand=True):
+
+            # SpinnerField — text mode
+            Label("SpinnerField — text mode (options=)")
+            spin_text = SpinnerField(
+                options=["Small", "Medium", "Large", "X-Large"],
+                value="Medium",
+                label="T-Shirt Size",
+                wrap=True,
+            )
+
+            # SpinnerField — numeric mode
+            Label("SpinnerField — numeric mode")
+            spin_num = SpinnerField(
+                value=5,
+                min_value=0,
+                max_value=20,
+                step=1,
+                label="Quantity",
+                wrap=False,
+            )
+
+            # TimeField
+            Label("TimeField")
+            with HStack(gap=8):
+                tf = TimeField(label="Meeting time", interval=30)
+                TimeField(label="End time", value_format="HH:mm", interval=15, disabled=True)
+
+            # Readout
+            status = Signal("(interact with fields above)")
+            Label(textsignal=status)
+
+            spin_text.on_change(lambda e: status.set(f"size: {spin_text.value}"))
+            spin_num.on_change(lambda e: status.set(f"qty: {spin_num.value}"))
+            tf.on_change(lambda e: status.set(f"time: {tf.value}"))
+
+            # ScrollView
+            Label("ScrollView (10 rows, fixed height)")
+            with ScrollView(scroll_direction="vertical", fill="x") as sv:
+                for i in range(10):
+                    with HStack(gap=8, padding=4, fill="x"):
+                        Label(f"Row {i + 1}", width=8)
+                        Button(f"Action {i + 1}", on_click=lambda i=i: status.set(f"clicked row {i + 1}"))
+
+    app.run()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- `ScrollView` — canvas-based scrollable container (`PublicContainer`); wraps internal `ScrollView`; children placed into `_content_frame` via `add()`; exposes `scroll_to_top/bottom/left/right`, `yview_moveto`, `xview_moveto`, `enable/disable_scrolling`, `refresh_bindings`
- `SpinnerField` — text-entry with spin buttons; two modes: fixed `options=` list or numeric range (`min_value`/`max_value`/`step`); renames `SpinnerEntry` → `SpinnerField` per Session 31 naming decision
- `TimeField` — time-input with searchable interval dropdown; `value_format=`, `interval=`, `min_time=`/`max_time=`; renames `TimeEntry` → `TimeField`
- `MenuBar` — three-region horizontal menu bar (`before`/`center`/`after`); `add_button`, `add_label`, `add_menu`

All four wired into `primitives/__init__.py` and `widgets/public/__init__.py`.

## Test plan

- [ ] Run `tests/features/misc_widgets.py` — verify all four widgets render
- [ ] `MenuBar`: click File/Edit/Help buttons; confirm center label is visible
- [ ] `SpinnerField` (text mode): spin through sizes; confirm `on_change` fires
- [ ] `SpinnerField` (numeric mode): spin quantity 0–20; confirm step/wrap behavior
- [ ] `TimeField`: open dropdown; pick a time; confirm `on_change` fires; verify disabled field is non-interactive
- [ ] `ScrollView`: scroll through 10 rows; click action buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)