### PR TITLE
fix: public API gaps, bug fixes, and secondary color token

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -518,7 +518,6 @@ See memory `project_api_gaps.md` for full list. Key items:
 - `Meter` deprecated param names (`amountused`, `amounttotal`, `subtext`, `stripethickness`) not yet removed from source
 - `ToggleGroup`/`RadioGroup` need `options=` constructor parameter
 - `value=` silently ignored when `signal=`/`variable=` also passed (all boolean widgets)
-- `on_changed`/`on_input` callback shape inconsistency vs `on_valid`/`on_invalid`
 - `Field` message label (`_message_lbl`) shows gray background when `required=True` auto-enables `show_message` and validation first fires — background doesn't match surface
 - `TextArea` uses the raw Tk Text widget border instead of the Field-style themed border — should adopt the same focus-ring/border approach as other Field composites
 - `ToggleGroup` solid (default) variant has poor contrast — selected button text is hard to read against the filled background; user handling `src/bootstack/style/builders/toolbutton.py`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -518,7 +518,6 @@ See memory `project_api_gaps.md` for full list. Key items:
 - `Meter` deprecated param names (`amountused`, `amounttotal`, `subtext`, `stripethickness`) not yet removed from source
 - `ToggleGroup`/`RadioGroup` need `options=` constructor parameter
 - `value=` silently ignored when `signal=`/`variable=` also passed (all boolean widgets)
-- `TabView(variant='pill')` crashes — no pill style builder for `TabItem.TFrame`
 - `on_changed`/`on_input` callback shape inconsistency vs `on_valid`/`on_invalid`
 - `Field` message label (`_message_lbl`) shows gray background when `required=True` auto-enables `show_message` and validation first fires — background doesn't match surface
 - `TextArea` uses the raw Tk Text widget border instead of the Field-style themed border — should adopt the same focus-ring/border approach as other Field composites
@@ -795,7 +794,6 @@ fully superseded by merged PRs; style-asset branch had pre-Session-31 CLAUDE.md 
 - `DateField` — review against `development/v2_api_proposal.md`
 - `TextArea` border — adopt Field-style focus-ring/border instead of raw Tk Text border
 - `Field` message label gray background on `required=True`
-- `TabView(variant='pill')` crash — no pill style builder for `TabItem.TFrame`
 - Spinbox, GroupBox, PathField, MenuButton, ButtonGroup, SplitView, PageStack —
   confirm public wrappers exist and are correct
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -518,7 +518,6 @@ See memory `project_api_gaps.md` for full list. Key items:
 - `Meter` deprecated param names (`amountused`, `amounttotal`, `subtext`, `stripethickness`) not yet removed from source
 - `ToggleGroup`/`RadioGroup` need `options=` constructor parameter
 - `value=` silently ignored when `signal=`/`variable=` also passed (all boolean widgets)
-- `Field` message label (`_message_lbl`) shows gray background when `required=True` auto-enables `show_message` and validation first fires — background doesn't match surface
 - `TextArea` uses the raw Tk Text widget border instead of the Field-style themed border — should adopt the same focus-ring/border approach as other Field composites
 - `ToggleGroup` solid (default) variant has poor contrast — selected button text is hard to read against the filled background; user handling `src/bootstack/style/builders/toolbutton.py`
 - `Style._tk_widgets` grows forever — destroyed widgets never removed; causes theme-change slowdown *(partially resolved in Session 26 — WeakSet + visibility guard; remaining issue is pages are never destroyed)*
@@ -685,7 +684,6 @@ wrap the highest-level internal, rename Tk-isms, add a visual test under
 **Known issues logged (see Open source bugs above):**
 - `TextArea` border: raw Tk Text border instead of Field-style themed border
 - `ToggleGroup` solid variant: poor contrast on selected buttons
-- `Field` message label gray background on `required=True` fields
 - Field composite default width grows with addon slots (gap #13)
 
 **Next steps after Session 30:** `Tabs`, `Toast`, `Tooltip`, `Card`, `ListView`,
@@ -792,7 +790,6 @@ fully superseded by merged PRs; style-asset branch had pre-Session-31 CLAUDE.md 
 **Remaining work (next session):**
 - `DateField` — review against `development/v2_api_proposal.md`
 - `TextArea` border — adopt Field-style focus-ring/border instead of raw Tk Text border
-- `Field` message label gray background on `required=True`
 - Spinbox, GroupBox, PathField, MenuButton, ButtonGroup, SplitView, PageStack —
   confirm public wrappers exist and are correct
 

--- a/src/bootstack/assets/themes/amber-dark.json
+++ b/src/bootstack/assets/themes/amber-dark.json
@@ -21,6 +21,7 @@
   },
   "semantic": {
     "primary": "orange[400]",
+    "secondary": "yellow[400]",
     "success": "green[400]",
     "warning": "yellow[400]",
     "danger": "red[400]"

--- a/src/bootstack/assets/themes/amber-light.json
+++ b/src/bootstack/assets/themes/amber-light.json
@@ -21,6 +21,7 @@
   },
   "semantic": {
     "primary": "orange[600]",
+    "secondary": "yellow[600]",
     "success": "green[600]",
     "warning": "yellow[600]",
     "danger": "red[600]"

--- a/src/bootstack/assets/themes/aurora-dark.json
+++ b/src/bootstack/assets/themes/aurora-dark.json
@@ -21,6 +21,7 @@
   },
   "semantic": {
     "primary": "teal[400]",
+    "secondary": "purple[400]",
     "success": "green[400]",
     "warning": "yellow[400]",
     "danger": "pink[400]"

--- a/src/bootstack/assets/themes/aurora-light.json
+++ b/src/bootstack/assets/themes/aurora-light.json
@@ -21,6 +21,7 @@
   },
   "semantic": {
     "primary": "teal[600]",
+    "secondary": "purple[600]",
     "success": "green[600]",
     "warning": "yellow[600]",
     "danger": "pink[600]"

--- a/src/bootstack/assets/themes/bootstrap-dark.json
+++ b/src/bootstack/assets/themes/bootstrap-dark.json
@@ -21,6 +21,7 @@
   },
   "semantic": {
     "primary": "blue[400]",
+    "secondary": "gray[400]",
     "success": "green[400]",
     "warning": "yellow[400]",
     "danger": "red[400]"

--- a/src/bootstack/assets/themes/bootstrap-light.json
+++ b/src/bootstack/assets/themes/bootstrap-light.json
@@ -21,6 +21,7 @@
   },
   "semantic": {
     "primary": "blue[600]",
+    "secondary": "gray[700]",
     "success": "green[600]",
     "warning": "yellow[600]",
     "danger": "red[600]"

--- a/src/bootstack/assets/themes/forest-dark.json
+++ b/src/bootstack/assets/themes/forest-dark.json
@@ -21,6 +21,7 @@
   },
   "semantic": {
     "primary": "green[400]",
+    "secondary": "teal[400]",
     "success": "green[400]",
     "warning": "yellow[400]",
     "danger": "red[400]"

--- a/src/bootstack/assets/themes/forest-light.json
+++ b/src/bootstack/assets/themes/forest-light.json
@@ -21,6 +21,7 @@
   },
   "semantic": {
     "primary": "green[600]",
+    "secondary": "teal[600]",
     "success": "green[600]",
     "warning": "yellow[600]",
     "danger": "red[600]"

--- a/src/bootstack/assets/themes/ocean-dark.json
+++ b/src/bootstack/assets/themes/ocean-dark.json
@@ -21,6 +21,7 @@
   },
   "semantic": {
     "primary": "cyan[400]",
+    "secondary": "blue[400]",
     "success": "teal[400]",
     "warning": "yellow[400]",
     "danger": "red[400]"

--- a/src/bootstack/assets/themes/ocean-light.json
+++ b/src/bootstack/assets/themes/ocean-light.json
@@ -21,6 +21,7 @@
   },
   "semantic": {
     "primary": "cyan[600]",
+    "secondary": "blue[600]",
     "success": "teal[600]",
     "warning": "yellow[600]",
     "danger": "red[600]"

--- a/src/bootstack/assets/themes/rose-dark.json
+++ b/src/bootstack/assets/themes/rose-dark.json
@@ -21,6 +21,7 @@
   },
   "semantic": {
     "primary": "pink[400]",
+    "secondary": "red[400]",
     "success": "green[400]",
     "warning": "yellow[400]",
     "danger": "red[400]"

--- a/src/bootstack/assets/themes/rose-light.json
+++ b/src/bootstack/assets/themes/rose-light.json
@@ -21,6 +21,7 @@
   },
   "semantic": {
     "primary": "pink[600]",
+    "secondary": "red[600]",
     "success": "green[600]",
     "warning": "yellow[600]",
     "danger": "red[600]"

--- a/src/bootstack/cli/add.py
+++ b/src/bootstack/cli/add.py
@@ -386,6 +386,7 @@ def _render_theme(name: str, mode: str) -> str:
         "shades": _BASE_SHADES,
         "semantic": {
             "primary": f"blue[{step}]",
+            "secondary": f"gray[{step}]",
             "success": f"green[{step}]",
             "warning": f"yellow[{step}]",
             "danger": f"red[{step}]",

--- a/src/bootstack/style/builders/field.py
+++ b/src/bootstack/style/builders/field.py
@@ -243,7 +243,12 @@ def build_field_addon_style(b: BootstyleBuilderTTk, ttk_style: str, accent: Opti
     # if not icon only, then must show button, otherwise accent will decide whether button is shown.
     show_button = (accent is None and not icon_only) or accent is not None
 
-    bg_normal = input_background if not show_button else b.elevate(input_background, 1)
+    if not show_button:
+        bg_normal = input_background
+    elif accent is not None:
+        bg_normal = b.color(accent)
+    else:
+        bg_normal = b.elevate(input_background, 1)
     bg_active = b.active(bg_normal)
     bg_pressed = b.pressed(bg_normal)
 

--- a/src/bootstack/style/builders/listview.py
+++ b/src/bootstack/style/builders/listview.py
@@ -26,8 +26,9 @@ def build_list_frame_style(b: BootstyleBuilderTTk, ttk_style: str, accent: str =
     hoverable = options.get('hoverable', True)
     accent_token = accent or 'primary'
     surface_token = options.get('surface', 'content')
+    base_token = surface_token.split('[')[0]
     background = b.color(surface_token)
-    active = b.elevate(background, 1)
+    active = b.elevate(b.color(base_token), 2)
     pressed = b.pressed(background)
     selected = b.subtle(accent_token, background)
     b.configure_style(ttk_style, background=background, relief='flat')
@@ -64,11 +65,12 @@ def build_list_item_style(
 
     hoverable = options.get('hoverable', True)
     surface_token = options.get('surface', 'content')
+    base_token = surface_token.split('[')[0]
     accent_token = accent or 'primary'
 
     background = b.color(surface_token)
     indicator = b.color(accent_token)
-    active = b.elevate(background, 1)
+    active = b.elevate(b.color(base_token), 2)
     pressed = b.pressed(background)
     selected = b.subtle(accent_token, background)
 
@@ -113,10 +115,11 @@ def build_list_item_style(
 def build_list_item_button_style(b: BootstyleBuilderTTk, ttk_style: str, accent: str = None, **options):
     hoverable = options.get('hoverable', True)
     surface_token = options.get('surface', 'content')
+    base_token = surface_token.split('[')[0]
     density = normalize_button_density(options.get('density', 'default'))
 
     background = b.color(surface_token)
-    active = b.elevate(background, 1)
+    active = b.elevate(b.color(base_token), 2)
     pressed = b.pressed(background)
     selected = b.subtle(accent or 'primary', background)
 
@@ -177,10 +180,11 @@ def _list_icon_size(b: BootstyleBuilderTTk, density: str) -> int:
 def build_list_icon(b: BootstyleBuilderTTk, ttk_style: str, accent: str = None, **options):
     hoverable = options.get('hoverable', True)
     surface_token = options.get('surface', 'content')
+    base_token = surface_token.split('[')[0]
     density = normalize_button_density(options.get('density', 'default'))
 
     background = b.color(surface_token)
-    active = b.elevate(background, 1)
+    active = b.elevate(b.color(base_token), 2)
     pressed = b.pressed(background)
     selected = b.subtle(accent or 'primary', background)
     on_background = b.on_color(background)
@@ -244,10 +248,11 @@ def build_list_item_label(b: BootstyleBuilderTTk, ttk_style: str, accent: str = 
     """
     hoverable = options.get('hoverable', True)
     surface_token = options.get('surface', 'content')
+    base_token = surface_token.split('[')[0]
     foreground_token = options.get('foreground', None)
 
     background = b.color(surface_token)
-    active = b.elevate(background, 1)
+    active = b.elevate(b.color(base_token), 2)
     pressed = b.pressed(background)
     selected = b.subtle(accent or 'primary', background)
     on_selected = b.on_color(selected)

--- a/src/bootstack/style/token_maps.py
+++ b/src/bootstack/style/token_maps.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 COLOR_TOKENS = {
-    'primary', 'success', 'warning', 'danger',
+    'primary', 'secondary', 'success', 'warning', 'danger',
     'foreground', 'background', 'white', 'black',
     'muted',
     'blue', 'indigo', 'purple', 'red', 'orange',

--- a/src/bootstack/widgets/composites/field.py
+++ b/src/bootstack/widgets/composites/field.py
@@ -231,7 +231,7 @@ class Field(EntryMixin, Frame):
             text=f"{label_text}*" if required else label_text,
             font="label[normal]"
         )
-        self._message_lbl = Label(self, localize=self._localize, text=message or '', font="caption", accent="muted")
+        self._message_lbl = Label(self, localize=self._localize, text=message or '', font="caption", accent="secondary")
 
         # field container & field - pass density for styling via style_options
         field_padding = 5
@@ -615,7 +615,7 @@ class Field(EntryMixin, Frame):
     def _clear_error(self, _: Any) -> None:
         """Clear the error message and restore the original message text."""
         self._message_lbl['text'] = self._message_text or ''
-        self._message_lbl['accent'] = "default"
+        self._message_lbl['accent'] = "secondary"
 
     def _set_addons_state(self, disabled: bool) -> None:
         """Configure addon widgets based on whether the entry is interactive."""

--- a/src/bootstack/widgets/composites/field.py
+++ b/src/bootstack/widgets/composites/field.py
@@ -415,13 +415,12 @@ class Field(EntryMixin, Frame):
         """
         self._entry.off_enter(bind_id)
 
-    def on_valid(self, callback: Callable[[ValidationEventData], None]) -> None:
+    def on_valid(self, callback: Callable) -> None:
         """Register a callback for `<<Valid>>` events (fires when validation passes).
 
         Args:
-            callback: Receives a `ValidationEventData` dict with keys
-                `value` (committed value), `is_valid` (`True`), and
-                `message` (empty string on pass).
+            callback: Receives the event; `event.data` is a `ValidationEventData`
+                dict with keys `value`, `is_valid` (`True`), and `message`.
         """
         self._entry.on_valid(callback)
 
@@ -434,13 +433,12 @@ class Field(EntryMixin, Frame):
         """
         self._entry.off_valid(bind_id)
 
-    def on_invalid(self, callback: Callable[[ValidationEventData], None]) -> None:
+    def on_invalid(self, callback: Callable) -> None:
         """Register a callback for `<<Invalid>>` events (fires when validation fails).
 
         Args:
-            callback: Receives a `ValidationEventData` dict with keys
-                `value` (committed value), `is_valid` (`False`), and
-                `message` (validation error text).
+            callback: Receives the event; `event.data` is a `ValidationEventData`
+                dict with keys `value`, `is_valid` (`False`), and `message`.
         """
         self._entry.on_invalid(callback)
 
@@ -453,13 +451,12 @@ class Field(EntryMixin, Frame):
         """
         self._entry.off_invalid(bind_id)
 
-    def on_validated(self, callback: Callable[[ValidationEventData], None]) -> None:
+    def on_validated(self, callback: Callable) -> None:
         """Register a callback for `<<Validate>>` events (fires after any validation).
 
         Args:
-            callback: Receives a `ValidationEventData` dict with keys
-                `value` (committed value), `is_valid` (bool), and
-                `message` (validation message or empty string).
+            callback: Receives the event; `event.data` is a `ValidationEventData`
+                dict with keys `value`, `is_valid` (bool), and `message`.
         """
         self._entry.on_validated(callback)
 

--- a/src/bootstack/widgets/composites/pathentry.py
+++ b/src/bootstack/widgets/composites/pathentry.py
@@ -37,8 +37,6 @@ class PathEntry(Field):
             value: str | None = None,
             dialog: FileDialogType = "openfilename",
             dialog_options: dict[str, Any] | None = None,
-            button_text: str = "Browse",
-            button_accent: str = None,
             label: str = None,
             message: str = None,
             **kwargs: Unpack[FieldOptions]
@@ -61,9 +59,6 @@ class PathEntry(Field):
             dialog_options: Dictionary of options to pass to the file dialog.
                 Common options: title, initialdir, initialfile, filetypes,
                 defaultextension, multiple.
-            button_text: Text to display on the browse button. Default is "Browse".
-                Can be changed at runtime via `configure(button_text=...)`.
-            button_accent: Accent color for the browse button. Defaults to None (neutral elevated style).
             label: Label text to display above the entry field (from FieldOptions).
             message: Message text to display below the field.
 
@@ -87,18 +82,16 @@ class PathEntry(Field):
         self._dialog = dialog
         self._dialog_options = dialog_options
         self._dialog_result = None
-        self._button_text = button_text
-        self._button_accent = button_accent
         self._prev_value: str | None = value
 
         super().__init__(master=master, label=label, message=message, value=value, **kwargs)
 
         self.insert_addon(
             Button,
-            position="before",
+            position="after",
             name="dialog-button",
-            text=self._button_text,
-            accent=self._button_accent,
+            icon="folder2-open",
+            icon_only=True,
             command=self._show_file_chooser
         )
 

--- a/src/bootstack/widgets/composites/textarea/codeeditor.py
+++ b/src/bootstack/widgets/composites/textarea/codeeditor.py
@@ -52,6 +52,8 @@ class CodeEditor(Frame):
         show_indent_guides: bool = False,
         scrollbars: ScrollbarMode = "both",
         font: str = "TkFixedFont",
+        show_border: bool = True,
+        accent: str = "primary",
         extensions: list[EditFilter] | None = None,
         on_change: Callable | None = None,
         on_cursor_move: Callable | None = None,
@@ -84,10 +86,17 @@ class CodeEditor(Frame):
                 font (`"TkFixedFont"`).
             extensions: Additional `EditFilter` instances to install
                 on top of the built-in set.
+            show_border: If True (default), styles the editor frame as a
+                themed border that gains a focus ring on interaction.
+            accent: Accent token for the focus border. Defaults to `"primary"`.
             on_change: Callback for `<<Change>>` events.
             on_cursor_move: Callback for cursor movement events.
         """
-        super().__init__(master)
+        frame_kw = (
+            {"ttk_class": "TField", "accent": accent, "padding": 5}
+            if show_border else {}
+        )
+        super().__init__(master, **frame_kw)
 
         self._language = language
         self._pygments_style = pygments_style
@@ -104,6 +113,14 @@ class CodeEditor(Frame):
             font=font,
             read_only=read_only,
         )
+
+        if show_border:
+            self._core.text.bind(
+                "<FocusIn>", lambda _: self.state(["focus"]), add="+",
+            )
+            self._core.text.bind(
+                "<FocusOut>", lambda _: self.state(["!focus"]), add="+",
+            )
 
         # ── search overlay ────────────────────────────────────────────────
         self._search = SearchOverlay(self, self._core)

--- a/src/bootstack/widgets/composites/textarea/core.py
+++ b/src/bootstack/widgets/composites/textarea/core.py
@@ -46,7 +46,7 @@ class _MultilineCore(tk.Frame):
         read_only: bool = False,
         **text_kwargs,
     ) -> None:
-        super().__init__(master)
+        super().__init__(master, highlightthickness=0, borderwidth=0)
 
         self._scrollbar_mode = scrollbars
         self._read_only = read_only
@@ -66,6 +66,8 @@ class _MultilineCore(tk.Frame):
             height=height,
             font=font,
             undo=False,
+            borderwidth=0,
+            highlightthickness=0,
             **text_kwargs,
         )
 

--- a/src/bootstack/widgets/composites/textarea/textarea.py
+++ b/src/bootstack/widgets/composites/textarea/textarea.py
@@ -438,7 +438,7 @@ class TextArea(GridFrame):
         """
         self._core.text.unbind("<FocusOut>", bind_id)
 
-    def on_valid(self, callback: Callable[[TextAreaValidationEventData], None]) -> str:
+    def on_valid(self, callback: Callable) -> str:
         """Register a callback for `<<Valid>>` events.
 
         Fires after all validation rules pass.
@@ -460,7 +460,7 @@ class TextArea(GridFrame):
         """
         self.unbind("<<Valid>>", bind_id)
 
-    def on_invalid(self, callback: Callable[[TextAreaValidationEventData], None]) -> str:
+    def on_invalid(self, callback: Callable) -> str:
         """Register a callback for `<<Invalid>>` events.
 
         Fires when any validation rule fails.
@@ -482,7 +482,7 @@ class TextArea(GridFrame):
         """
         self.unbind("<<Invalid>>", bind_id)
 
-    def on_validated(self, callback: Callable[[TextAreaValidationEventData], None]) -> str:
+    def on_validated(self, callback: Callable) -> str:
         """Register a callback for `<<Validate>>` events.
 
         Fires after any validation pass, whether the result is valid or not.

--- a/src/bootstack/widgets/composites/textarea/textarea.py
+++ b/src/bootstack/widgets/composites/textarea/textarea.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import tkinter as tk
 from typing import Callable, TypedDict
 
+from bootstack.widgets.primitives.frame import Frame
 from bootstack.widgets.primitives.gridframe import GridFrame
 from bootstack.widgets.primitives.label import Label
 from bootstack.widgets.composites.textarea.core import _MultilineCore, ScrollbarMode
@@ -13,15 +14,6 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from bootstack.signals import Signal
     from bootstack.validation.validation_rules import ValidationRule
-
-
-def _resolve_color(token: str, fallback: str) -> str:
-    """Resolve a bootstack color token to a hex string."""
-    try:
-        from bootstack.style.style import get_theme_provider
-        return get_theme_provider().colors.get(token, fallback)
-    except Exception:
-        return fallback
 
 
 class TextAreaInputEventData(TypedDict):
@@ -68,6 +60,7 @@ class TextArea(GridFrame):
         scrollbars: ScrollbarMode = "auto",
         font: str = "body",
         accent: AccentToken | str = "primary",
+        show_border: bool = True,
         on_input: Callable | None = None,
         on_changed: Callable | None = None,
         on_blur: Callable | None = None,
@@ -100,6 +93,8 @@ class TextArea(GridFrame):
                 needed), `"vertical"`, `"both"`, or `"none"`.
             font: Font token. Defaults to `"body"`.
             accent: Accent token for the focus border. Defaults to `"primary"`.
+            show_border: If True (default), wraps the text area in a themed
+                border that gains a focus ring on interaction.
             on_input: Callback invoked on every edit. Receives `event.data`
                 of type `TextAreaInputEventData`.
             on_changed: Callback invoked when the widget loses focus. Receives
@@ -129,12 +124,22 @@ class TextArea(GridFrame):
         if label:
             _lbl_text = f"{label} *" if required else label
             Label(self, text=_lbl_text, font="caption").grid(
-                row=0, column=0, sticky="w",
+                row=0, column=0, sticky="w", padx=(4, 0),
             )
 
         # ── core (row 1) ──────────────────────────────────────────────────
+        if show_border:
+            self._field_frame = Frame(
+                self, accent=accent, padding=5, ttk_class="TField",
+            )
+            self._field_frame.grid(row=1, column=0, sticky="nsew")
+            core_parent = self._field_frame
+        else:
+            self._field_frame = None
+            core_parent = self
+
         self._core = _MultilineCore(
-            self,
+            core_parent,
             value=value,
             wrap=wrap,
             height=height,
@@ -142,7 +147,21 @@ class TextArea(GridFrame):
             font=font,
             read_only=read_only,
         )
-        self._core.grid(row=1, column=0, sticky="nsew")
+
+        if show_border:
+            self._core.pack(fill="both", expand=True)
+            self._core.text.bind(
+                "<FocusIn>",
+                lambda _: self._field_frame.state(["focus"]),
+                add="+",
+            )
+            self._core.text.bind(
+                "<FocusOut>",
+                lambda _: self._field_frame.state(["!focus"]),
+                add="+",
+            )
+        else:
+            self._core.grid(row=1, column=0, sticky="nsew")
 
         # ── message label (row 2) ─────────────────────────────────────────
         self._message_lbl = Label(self, text=message or "", font="caption",
@@ -152,39 +171,6 @@ class TextArea(GridFrame):
 
         if show_message or message or required:
             self._show_message_area()
-
-        # ── border via tk.Frame highlightthickness ────────────────────────
-        # _MultilineCore is a tk.Frame, so highlightthickness gives a native
-        # border that wraps the entire textarea (text + scrollbars) without
-        # clipping issues from a ttk wrapper frame.
-        self._border_inactive = _resolve_color("gray[300]", "#cccccc")
-        self._border_active = _resolve_color(accent, "#0d6efd")
-        self._border_error = _resolve_color("danger", "#dc3545")
-        self._core.configure(
-            highlightthickness=2,
-            highlightbackground=self._border_inactive,
-            highlightcolor=self._border_inactive,
-        )
-
-        self._core.text.bind(
-            "<FocusIn>",
-            lambda _: self._core.configure(
-                highlightbackground=self._border_active,
-                highlightcolor=self._border_active,
-            ),
-            add="+",
-        )
-        self._core.text.bind(
-            "<FocusOut>",
-            lambda _: self._core.configure(
-                highlightbackground=self._border_inactive,
-                highlightcolor=self._border_inactive,
-            ),
-            add="+",
-        )
-        self._core.text.bind(
-            "<<ThemeChanged>>", self._on_theme_changed, add="+"
-        )
 
         # ── signal binding ────────────────────────────────────────────────
         if textsignal is not None:
@@ -262,26 +248,9 @@ class TextArea(GridFrame):
     def _show_error(self, message: str) -> None:
         self._show_message_area()
         self._message_lbl.configure(text=message, accent="danger")
-        self._core.configure(
-            highlightbackground=self._border_error,
-            highlightcolor=self._border_error,
-        )
 
     def _clear_error(self) -> None:
         self._message_lbl.configure(text=self._original_message, accent="muted")
-        self._core.configure(
-            highlightbackground=self._border_inactive,
-            highlightcolor=self._border_inactive,
-        )
-
-    def _on_theme_changed(self, _event: tk.Event = None) -> None:
-        self._border_inactive = _resolve_color("gray[300]", "#cccccc")
-        self._border_active = _resolve_color(self._accent, "#0d6efd")
-        self._border_error = _resolve_color("danger", "#dc3545")
-        # Reapply current border color without changing focus state
-        focused = self._core.text == self._core.text.focus_get()
-        color = self._border_active if focused else self._border_inactive
-        self._core.configure(highlightbackground=color, highlightcolor=color)
 
     # ── validation ────────────────────────────────────────────────────────
 

--- a/src/bootstack/widgets/composites/textarea/textarea.py
+++ b/src/bootstack/widgets/composites/textarea/textarea.py
@@ -165,7 +165,7 @@ class TextArea(GridFrame):
 
         # ── message label (row 2) ─────────────────────────────────────────
         self._message_lbl = Label(self, text=message or "", font="caption",
-                                  accent="muted")
+                                  accent="secondary")
         self._message_lbl.grid(row=2, column=0, sticky="w")
         self._message_lbl.grid_remove()
 
@@ -250,7 +250,7 @@ class TextArea(GridFrame):
         self._message_lbl.configure(text=message, accent="danger")
 
     def _clear_error(self) -> None:
-        self._message_lbl.configure(text=self._original_message, accent="muted")
+        self._message_lbl.configure(text=self._original_message, accent="secondary")
 
     # ── validation ────────────────────────────────────────────────────────
 

--- a/src/bootstack/widgets/mixins/validation_mixin.py
+++ b/src/bootstack/widgets/mixins/validation_mixin.py
@@ -43,9 +43,9 @@ class ValidationMixin(Widget):
         self._debounce_ids: dict[str, str] = {}
 
         # Optional convenience callbacks
-        self._on_invalid_command: Callable[[dict[str, Any]], None] | None = None
-        self._on_valid_command: Callable[[dict[str, Any]], None] | None = None
-        self._on_validated_command: Callable[[dict[str, Any]], None] | None = None
+        self._on_invalid_command: Callable | None = None
+        self._on_valid_command: Callable | None = None
+        self._on_validated_command: Callable | None = None
 
         super().__init__(*args, **kwargs)  # next in MRO must be a Tk/ttk widget
         self._setup_validation_binds()
@@ -120,8 +120,8 @@ class ValidationMixin(Widget):
         return ran_rule
 
     # Optional: ergonomic callback registration
-    def on_invalid(self, func: Callable[[dict[str, Any]], None]) -> None:
-        """Register callback for invalid validation."""
+    def on_invalid(self, func: Callable) -> None:
+        """Register callback for `<<Invalid>>`. Callback receives the event; `event.data` is a `ValidationEventData` dict."""
         self._on_invalid_command = func
 
     def off_invalid(self, bind_id: str | None = None) -> None:
@@ -132,8 +132,8 @@ class ValidationMixin(Widget):
         """
         self.unbind('<<Invalid>>', bind_id)
 
-    def on_valid(self, func: Callable[[dict[str, Any]], None]) -> None:
-        """Register callback for valid validation."""
+    def on_valid(self, func: Callable) -> None:
+        """Register callback for `<<Valid>>`. Callback receives the event; `event.data` is a `ValidationEventData` dict."""
         self._on_valid_command = func
 
     def off_valid(self, bind_id: str | None = None) -> None:
@@ -144,8 +144,8 @@ class ValidationMixin(Widget):
         """
         self.unbind('<<Valid>>', bind_id)
 
-    def on_validated(self, func: Callable[[dict[str, Any]], None]) -> None:
-        """Register callback for any validation (valid or invalid)."""
+    def on_validated(self, func: Callable) -> None:
+        """Register callback for `<<Validate>>`. Callback receives the event; `event.data` is a `ValidationEventData` dict."""
         self._on_validated_command = func
 
     def off_validated(self, bind_id: str | None = None) -> None:
@@ -197,16 +197,13 @@ class ValidationMixin(Widget):
     # ----- optional dispatchers for on_* convenience -----
 
     def _dispatch_validated(self, event: tkinter.Event) -> None:
-        """Forward `<<Validate>>` event data to the `on_validated` callback."""
         if self._on_validated_command:
-            self._on_validated_command(event.data)
+            self._on_validated_command(event)
 
     def _dispatch_valid(self, event: tkinter.Event) -> None:
-        """Forward `<<Valid>>` event data to the `on_valid` callback."""
         if self._on_valid_command:
-            self._on_valid_command(event.data)
+            self._on_valid_command(event)
 
     def _dispatch_invalid(self, event: tkinter.Event) -> None:
-        """Forward `<<Invalid>>` event data to the `on_invalid` callback."""
         if self._on_invalid_command:
-            self._on_invalid_command(event.data)
+            self._on_invalid_command(event)

--- a/src/bootstack/widgets/public/primitives/buttongroup.py
+++ b/src/bootstack/widgets/public/primitives/buttongroup.py
@@ -106,6 +106,19 @@ class ButtonGroup(PublicWidgetBase):
 
     # ----- Properties -----
 
+    def item(self, key: str) -> Any:
+        """Return the button item object for `key`.
+
+        Args:
+            key: Key returned by `add()`.
+        """
+        return self._internal.item(key)
+
+    @property
+    def items(self) -> tuple[Any, ...]:
+        """All button items in insertion order."""
+        return self._internal.items()
+
     @property
     def keys(self) -> tuple[str, ...]:
         """Keys of all buttons in insertion order."""

--- a/src/bootstack/widgets/public/primitives/codeeditor.py
+++ b/src/bootstack/widgets/public/primitives/codeeditor.py
@@ -49,6 +49,9 @@ class CodeEditor(PublicWidgetBase):
         scrollbars: Scrollbar visibility — `'both'` (default), `'auto'`,
             `'vertical'`, or `'none'`.
         font: Font for the editor. Default `'TkFixedFont'`.
+        show_border: If True (default), styles the editor frame as a themed
+            border with a focus ring.
+        accent: Accent token for the focus border. Default `'primary'`.
         extensions: Additional `EditFilter` instances to install on top of
             the built-in set.
         parent: Override the context-stack parent.
@@ -70,6 +73,8 @@ class CodeEditor(PublicWidgetBase):
         show_indent_guides: bool = False,
         scrollbars: str = "both",
         font: str = "TkFixedFont",
+        show_border: bool = True,
+        accent: str = "primary",
         extensions: list[EditFilter] | None = None,
         parent: Any = None,
         **kwargs: Any,
@@ -92,6 +97,8 @@ class CodeEditor(PublicWidgetBase):
             "show_indent_guides": show_indent_guides,
             "scrollbars": scrollbars,
             "font": font,
+            "show_border": show_border,
+            "accent": accent,
         }
         if text_signal is not None:
             internal_kwargs["textsignal"] = text_signal

--- a/src/bootstack/widgets/public/primitives/datefield.py
+++ b/src/bootstack/widgets/public/primitives/datefield.py
@@ -131,6 +131,11 @@ class DateField(PublicWidgetBase):
     # ----- Properties -----
 
     @property
+    def picker_button(self):
+        """The calendar picker button widget, or `None` if hidden."""
+        return self._internal.addons.get('date-picker')
+
+    @property
     def value(self) -> "date | tuple[date, date] | None":
         """Selected date, or `(start, end)` tuple in range mode."""
         return self._internal.value

--- a/src/bootstack/widgets/public/primitives/menubutton.py
+++ b/src/bootstack/widgets/public/primitives/menubutton.py
@@ -20,6 +20,8 @@ class MenuButton(PublicWidgetBase):
         icon: Icon shown on the button.
         icon_only: If True, hides the label (icon only).
         show_arrow: If True (default), shows the dropdown chevron.
+        menu_options: Extra kwargs forwarded to the underlying `ContextMenu`
+            (e.g. `{'anchor': 'se', 'offset': 4}`).
         disabled: If True, button is non-interactive.
         accent: Accent token, e.g. `'primary'`, `'danger'`.
         variant: Style variant, e.g. `'outline'`, `'ghost'`.
@@ -36,6 +38,7 @@ class MenuButton(PublicWidgetBase):
         icon: str | None = None,
         icon_only: bool = False,
         show_arrow: bool = True,
+        menu_options: dict[str, Any] | None = None,
         disabled: bool = False,
         accent: str | None = None,
         variant: str | None = None,
@@ -50,6 +53,8 @@ class MenuButton(PublicWidgetBase):
         internal_kwargs: dict[str, Any] = {
             "show_dropdown_button": show_arrow,
         }
+        if menu_options is not None:
+            internal_kwargs["popdown_options"] = menu_options
         if label:
             internal_kwargs["text"] = label
         if items is not None:
@@ -137,6 +142,35 @@ class MenuButton(PublicWidgetBase):
         result = self._internal.add_checkbutton(**kw)
         return result.key if hasattr(result, "key") else key or label
 
+    def add_radio_item(
+        self,
+        label: str,
+        *,
+        value: Any = None,
+        on_click: Callable[[], Any] | None = None,
+        key: str | None = None,
+    ) -> str:
+        """Add a radio-button item to the dropdown.
+
+        Args:
+            label: Item label text.
+            value: Value associated with this radio item.
+            on_click: Callback fired on selection.
+            key: Unique string key. Auto-generated if omitted.
+
+        Returns:
+            The key assigned to this item.
+        """
+        kw: dict[str, Any] = {"text": label}
+        if value is not None:
+            kw["value"] = value
+        if on_click is not None:
+            kw["command"] = on_click
+        if key is not None:
+            kw["key"] = key
+        result = self._internal.add_radiobutton(**kw)
+        return result.key if hasattr(result, "key") else key or label
+
     def add_separator(self, *, key: str | None = None) -> None:
         """Add a horizontal separator to the dropdown."""
         kw: dict[str, Any] = {}
@@ -166,6 +200,19 @@ class MenuButton(PublicWidgetBase):
         self._internal.show_menu()
 
     # ----- Properties -----
+
+    def item(self, key: str) -> Any:
+        """Return the item object for `key`.
+
+        Args:
+            key: Key returned by an `add_*` method.
+        """
+        return self._internal.context_menu.item(key)
+
+    @property
+    def items(self) -> list[Any]:
+        """All menu items in insertion order."""
+        return self._internal.items() or []
 
     @property
     def keys(self) -> tuple[str, ...]:

--- a/src/bootstack/widgets/public/primitives/pathfield.py
+++ b/src/bootstack/widgets/public/primitives/pathfield.py
@@ -28,8 +28,6 @@ class PathField(PublicWidgetBase):
             `'directory'`, or `'openfilenames'` (multiple files).
         dialog_options: Extra kwargs forwarded to the native dialog
             (e.g. `{'filetypes': [('Images', '*.png')]}`).
-        button_label: Browse button label. Default `'Browse'`.
-        button_accent: Accent token for the browse button.
         label: Label displayed above the field.
         message: Hint text displayed below the field.
         required: Mark field as required.
@@ -46,8 +44,6 @@ class PathField(PublicWidgetBase):
         *,
         dialog: str = "openfilename",
         dialog_options: dict[str, Any] | None = None,
-        button_label: str = "Browse",
-        button_accent: str | None = None,
         label: str | None = None,
         message: str | None = None,
         required: bool = False,
@@ -63,16 +59,11 @@ class PathField(PublicWidgetBase):
 
         tk_master = self._parent._child_master() if self._parent else None
 
-        internal_kwargs: dict[str, Any] = {
-            "dialog": dialog,
-            "button_text": button_label,
-        }
+        internal_kwargs: dict[str, Any] = {"dialog": dialog}
         if value:
             internal_kwargs["value"] = value
         if dialog_options is not None:
             internal_kwargs["dialog_options"] = dialog_options
-        if button_accent is not None:
-            internal_kwargs["button_accent"] = button_accent
         if label is not None:
             internal_kwargs["label"] = label
         if message is not None:

--- a/src/bootstack/widgets/public/primitives/spinbox.py
+++ b/src/bootstack/widgets/public/primitives/spinbox.py
@@ -27,6 +27,7 @@ class Spinbox(PublicWidgetBase):
         max_value: Maximum numeric value.
         step: Increment between values. Default `1`.
         wrap: If True, wraps from max back to min and vice versa.
+        value_format: Display format string (e.g. `'%.2f'`).
         text_signal: Reactive `Signal` linked to the displayed text.
         width: Width in character cells.
         disabled: If True, widget is non-interactive.
@@ -44,6 +45,7 @@ class Spinbox(PublicWidgetBase):
         max_value: float | None = None,
         step: float = 1,
         wrap: bool = False,
+        value_format: str | None = None,
         text_signal: Any = None,
         width: int | None = None,
         disabled: bool = False,
@@ -66,6 +68,8 @@ class Spinbox(PublicWidgetBase):
             if max_value is not None:
                 internal_kwargs["to"] = max_value
             internal_kwargs["increment"] = step
+        if value_format is not None:
+            internal_kwargs["format"] = value_format
         if text_signal is not None:
             internal_kwargs["textsignal"] = text_signal
         if width is not None:

--- a/src/bootstack/widgets/public/primitives/splitview.py
+++ b/src/bootstack/widgets/public/primitives/splitview.py
@@ -99,7 +99,7 @@ class SplitView(PublicWidgetBase):
 
     # ----- Pane management -----
 
-    def add(self, *, weight: int = 1) -> _SplitPane:
+    def add(self, *, weight: int = 1, min_size: int | None = None) -> _SplitPane:
         """Add a pane and return a context manager for placing its children.
 
         Usage::
@@ -110,15 +110,25 @@ class SplitView(PublicWidgetBase):
         Args:
             weight: Relative size weight when the container is resized.
                 Higher values take proportionally more space.
+            min_size: Minimum pane size in pixels.
 
         Returns:
             `_SplitPane` — use as a context manager to place children.
         """
         frame = _InternalFrame(self._internal)
-        self._internal.add(frame, weight=weight)
+        add_kw: dict[str, Any] = {"weight": weight}
+        if min_size is not None:
+            add_kw["minsize"] = min_size
+        self._internal.add(frame, **add_kw)
         return _SplitPane(frame)
 
     # ----- Sash control -----
+
+    @property
+    def sash_positions(self) -> list[int]:
+        """Current position of every sash in pixels, in order."""
+        n = len(self._internal.panes())
+        return [self._internal.sashpos(i) for i in range(max(0, n - 1))]
 
     def sash_position(self, index: int, position: int | None = None) -> int | None:
         """Get or set the position of a sash.

--- a/src/bootstack/widgets/public/primitives/textarea.py
+++ b/src/bootstack/widgets/public/primitives/textarea.py
@@ -32,6 +32,8 @@ class TextArea(PublicWidgetBase):
             `'both'`, or `'none'`.
         font: Font token. Default `'body'`.
         accent: Accent token for the focus border.
+        show_border: If True (default), wraps the text area in a themed
+            border with a focus ring.
         parent: Override the context-stack parent.
     """
 
@@ -51,6 +53,7 @@ class TextArea(PublicWidgetBase):
         scrollbars: str = "auto",
         font: Any = "body",
         accent: str = "primary",
+        show_border: bool = True,
         parent: Any = None,
         **kwargs: Any,
     ) -> None:
@@ -65,6 +68,7 @@ class TextArea(PublicWidgetBase):
             "wrap": wrap,
             "height": height,
             "scrollbars": scrollbars,
+            "show_border": show_border,
             "font": font,
             "accent": accent,
         }

--- a/src/bootstack/widgets/types.py
+++ b/src/bootstack/widgets/types.py
@@ -49,7 +49,7 @@ WidgetDensity = Literal['default', 'compact']
 # bootstack styling tokens
 # ---------------------------------------------------------------------------
 
-AccentToken = Literal['default', 'primary', 'success', 'warning', 'danger', 'muted']
+AccentToken = Literal['default', 'primary', 'secondary', 'success', 'warning', 'danger', 'muted']
 """Semantic color accent token. Accepts modifiers: `'primary[+1]'`, `'primary[500]'`, `'primary[subtle]'`."""
 
 VariantToken = Literal['solid', 'outline', 'ghost', 'toggle']

--- a/tests/features/input_fields.py
+++ b/tests/features/input_fields.py
@@ -60,7 +60,6 @@ def main():
                 Label("Select directory")
                 pf_dir = PathField(
                     dialog="directory",
-                    button_label="Browse…",
                     label="Directory",
                     message="Pick a folder",
                 )

--- a/tests/widget_styles/style_buttons.py
+++ b/tests/widget_styles/style_buttons.py
@@ -24,7 +24,7 @@ def button_style_frame(bootstyle, widget_name):
         icon="bootstrap",
     ).pack(padx=5, pady=5, fill='both')
 
-    for color in ['primary', 'success', 'warning', 'danger']:
+    for color in ['primary', 'secondary', 'success', 'warning', 'danger']:
         bs.Button(
             master=frame,
             text=color.title(),
@@ -47,7 +47,7 @@ def button_style_frame(bootstyle, widget_name):
 
 if __name__ == '__main__':
     # create visual widget style tests
-    root = bs.App(theme="ocean-dark")
+    root = bs.App(theme="dark")
 
     button_style_frame('solid', 'Solid Button').pack(side='left')
     button_style_frame('outline', 'Outline Button').pack(side='left')


### PR DESCRIPTION
## Summary

- **Public API gaps**: `DateField.picker_button`, `Spinbox.value_format`, `SplitView.sash_positions`/`min_size`, `MenuButton.add_radio_item`/`item`/`items`/`menu_options`, `ButtonGroup.item`/`items`
- **TextArea/CodeEditor border**: replace raw `highlightthickness` with themed `TField` frame; both now have consistent focus ring matching Field composites; `show_border=True` default on both
- **Validation callbacks**: standardise `on_valid`/`on_invalid`/`on_validated` to pass Tkinter Event (not unwrapped dict), matching `on_input`/`on_changed` shape
- **Secondary color token**: restore `secondary` as a first-class semantic token across all 12 themes, `COLOR_TOKENS`, and `AccentToken`; field addon style builder now uses accent color for button background
- **PathField browse button**: replaced text button with `folder2-open` icon-only button (position after), matching DateField's calendar picker pattern
- **Field message label**: use `accent="secondary"` instead of `"muted"`/`"default"` — fixes gray background mismatch on `required=True` fields
- **ListView hover**: compute hover from base surface at elevation 2 (not from each row's background), giving a single consistent hover color across striped and unstriped rows
- **TabView pill variant**: removed from open bugs — `variant=` never existed on the widget

## Test plan

- [ ] Run `tests/features/input_fields.py` — DateField, PathField icon button, field message labels
- [ ] Run `tests/features/password_textarea.py` — TextArea TField border and focus ring
- [ ] Run `tests/features/code_editor_public.py` — CodeEditor TField border
- [ ] Run `tests/features/data_display_public.py` — ListView striped hover consistency
- [ ] Run `tests/widget_styles/style_buttons.py` — secondary accent on buttons and addon buttons
- [ ] Theme switch to confirm secondary resolves correctly across themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)