### PR TITLE
fix(toolbar): hide maximize when not resizable; fix minimize on override_redirect

### DIFF
--- a/src/bootstack/widgets/composites/toolbar.py
+++ b/src/bootstack/widgets/composites/toolbar.py
@@ -130,15 +130,43 @@ class Toolbar(Frame):
         )
         self._close_btn.pack(side='left', padx=2)
 
+        # Disable maximize if window is not resizable (checked after idle so
+        # the window geometry is finalised).
+        self.after_idle(self._sync_maximize_state)
+
+    def _sync_maximize_state(self) -> None:
+        """Hide the maximize button when the window is not resizable."""
+        try:
+            w, h = self.winfo_toplevel().resizable()
+            if not w and not h:
+                self._maximize_btn.pack_forget()
+        except Exception:
+            pass
+
     def _on_minimize(self):
         """Handle minimize button click."""
         window = self.winfo_toplevel()
-        window.iconify()
+        # override_redirect windows cannot be iconified directly — temporarily
+        # lift the flag, iconify, then restore it once the window is shown again.
+        if window.overrideredirect():
+            window.overrideredirect(False)
+            window.iconify()
+            window.bind('<Map>', self._on_restore_override_redirect, add='+')
+        else:
+            window.iconify()
+
+    def _on_restore_override_redirect(self, _event=None) -> None:
+        """Restore override_redirect after the window is deiconified."""
+        window = self.winfo_toplevel()
+        window.overrideredirect(True)
+        window.unbind('<Map>')
 
     def _on_maximize(self):
         """Handle maximize/restore button click."""
         window = self.winfo_toplevel()
-        # Check current state and toggle
+        w, h = window.resizable()
+        if not w and not h:
+            return
         if window.state() == 'zoomed':
             window.state('normal')
             self._maximize_btn.configure(icon='fullscreen')

--- a/tests/features/issue_40_repro.py
+++ b/tests/features/issue_40_repro.py
@@ -1,0 +1,48 @@
+"""Reproduction for issue #40 — two bugs with AppShell window controls.
+
+Bug 1: resizable=(False, False) + show_window_controls=True
+  → clicking Maximize still zooms the window (should be a no-op / button disabled)
+
+Bug 2: undecorated=True + show_window_controls=True
+  → clicking Minimize raises TclError:
+    cannot iconify ".": override-redirect flag is set
+"""
+from bootstack.widgets.public import AppShell, VStack, Label, Button, Separator
+
+
+def repro_bug1():
+    """resizable=False window — maximize button should be disabled/no-op."""
+    with AppShell(
+        title="Bug 1 — resizable=False (click Maximize)",
+        size=(700, 400),
+        resizable=(False, False),
+        show_window_controls=True,
+    ) as shell:
+        with shell.add_page("home", text="Home", icon="house"):
+            with VStack(padding=24, gap=8):
+                Label("resizable=(False, False)", font="heading-md")
+                Label("Click the maximize button — it should do nothing.")
+    shell.run()
+
+
+def repro_bug2():
+    """undecorated=True — minimize button crashes with TclError."""
+    with AppShell(
+        title="Bug 2 — undecorated (click Minimize)",
+        size=(700, 400),
+        undecorated=True,
+    ) as shell:
+        with shell.add_page("home", text="Home", icon="house"):
+            with VStack(padding=24, gap=8):
+                Label("undecorated=True", font="heading-md")
+                Label("Click the minimize (dash) button — it should crash.")
+    shell.run()
+
+
+if __name__ == "__main__":
+    import sys
+    bug = sys.argv[1] if len(sys.argv) > 1 else "1"
+    if bug == "2":
+        repro_bug2()
+    else:
+        repro_bug1()


### PR DESCRIPTION
Fixes #40

## Changes

- **Maximize button hidden** when `resizable=(False, False)` — checked via `after_idle` once window geometry is finalised. Hiding is cleaner than disabling in a custom chrome context (no ghost button occupying space).
- **Maximize guard** — `_on_maximize` returns early if window is not resizable (belt-and-suspenders alongside the hidden button).
- **Minimize on override_redirect** — `window.iconify()` raises `TclError` on override_redirect windows. Fix temporarily lifts the flag, iconifies, then restores `overrideredirect(True)` on the next `<Map>` event when the window is shown again.

## Test plan

- [x] Run `tests/features/issue_40_repro.py 1` — maximize button should be hidden with `resizable=(False, False)`
- [x] Run `tests/features/issue_40_repro.py 2` — minimize button should work without crashing with `undecorated=True`

🤖 Generated with [Claude Code](https://claude.com/claude-code)