### PR TITLE
feat(containers): layout engine + public pane types for all container widgets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -523,8 +523,8 @@ See memory `project_api_gaps.md` for full list. Key items:
 - `value=` silently ignored when `signal=`/`variable=` also passed (all boolean widgets)
 - `ToggleGroup` solid (default) variant has poor contrast — selected button text is hard to read against the filled background; user handling `src/bootstack/style/builders/toolbutton.py`
 - `Style._tk_widgets` grows forever — destroyed widgets never removed; causes theme-change slowdown *(partially resolved in Session 26 — WeakSet + visibility guard; remaining issue is pages are never destroyed)*
-- `TextField` `placeholder=` not supported — `TextEntry` composite (single-line) was never given placeholder logic; `TextArea` has it, `TextField` does not
-- `TabView` pill variant — never implemented; removed from type signatures and docstrings (Session 39)
+- ~~`TextField` `placeholder=` not supported~~ — fixed (Session 39)
+- ~~`TabView` pill variant~~ — removed (Session 39)
 - `Label`/`Badge` use `.text` (not `.value`) — this is settled and intentional; `.value` is for data-bearing widgets only
 
 ---
@@ -942,11 +942,103 @@ first navigation; `Select` dropdown, dialogs, and toasts all work correctly.
 **Remaining work:**
 - ToggleGroup solid variant contrast — user handling
   `src/bootstack/style/builders/toolbutton.py`
-- `TextField` `placeholder=` not supported (only `TextArea` has it)
-- `TabView` pill variant crash — builder not registered
+- ~~`TextField` `placeholder=` not supported~~ — done (Session 39)
+- ~~`TabView` pill variant crash~~ — removed (variant never existed; Session 39)
 - `Meter`/`Gauge` deprecated param names still in source
 - `ListView` hover blends with striped rows
 - `examples/` legacy demos — separate effort
+
+### Session 39 — Bug fixes, API cleanup, layout improvements (2026-05-29/30)
+
+All work committed directly to `main`.
+
+**`TextField` placeholder support:**
+- `placeholder=` added to `TextEntryPart`, `FieldOptions`, and `TextField`
+- Uses textvariable detach/reattach so the Signal is never set to placeholder text
+- `_handle_change` hides placeholder when Signal is set externally to a non-empty value
+- `commit()` guards against placeholder text being parsed as user input
+
+**`TabView` pill variant removed:**
+- `Literal['pill', 'bar']` → `Literal['bar']` in `tabs.py` and `tabitem.py` type hints
+  and docstrings; variant was never implemented
+
+**`GroupBox` reverted to `ttk.LabelFrame`:**
+- Custom composite (PackFrame + Label + card Frame) replaced with a simple wrapper
+  around the internal `LabelFrame` primitive
+- Card-surface approach abandoned: title-above-border is just a Label + bordered VStack,
+  not a true GroupBox; `ttk.LabelFrame` gives the classic embedded-title fieldset look
+- Layout engine (PackFrame/GridFrame) still lives inside the LabelFrame
+- `surface=` kwarg removed (not meaningful for LabelFrame)
+
+**`PathField` redesign:**
+- `dialog=` renamed to `mode=` with clean values: `'open'`, `'open_multiple'`,
+  `'save'`, `'directory'`
+- `dialog_options=` dict replaced with explicit typed kwargs:
+  `dialog_title=`, `start_dir=`, `file_filters=`, `default_extension=`,
+  `default_filename=` — each maps to the native `filedialog` kwarg internally
+- Browse button uses `folder` icon for all modes
+- Internal `_show_file_chooser` uses `_build_dialog_kwargs()` dict builder
+
+**Field frame minimum width:**
+- `width=200` set on `_field` frame (the `TField`-styled container) so addon
+  buttons (steppers, browse icon) live inside the minimum rather than adding to
+  it — prevents `NumberField` from pushing grid columns wider than plain `TextField`
+- Reverted short-lived `kwargs.setdefault('width', 1)` approach which collapsed
+  fields to unusable size when not in a fill layout
+
+**`margin=` layout kwarg:**
+- Added `'margin'` to `PACK_KEYS` and `GRID_KEYS` so it is stripped from widget
+  kwargs and converted to `padx=`/`pady=` in `guide_layout` via `_expand_margin()`
+- Convention: ttk order `(left, top, right, bottom)` for 4-value shorthand;
+  `(x, y)` for 2-value; `int` for uniform
+
+**Meter theme fix:**
+- `_handle_theme_changed` deferred via `after_idle` → `_apply_theme_update` so
+  `b.color()` reads the new theme's colors after `_rebuild_all_styles()` completes;
+  fixes gauge canvas staying at the previous theme's background on theme switch
+
+**Visual tests updated:** `tests/features/textfield.py` — placeholder test cases added.
+
+**Remaining work:**
+- ToggleGroup solid variant contrast — user handling
+  `src/bootstack/style/builders/toolbutton.py`
+- `Meter`/`Gauge` deprecated param names still in source
+- `ListView` hover blends with striped rows
+- `examples/` legacy demos — separate effort
+
+### Session 40 — Container pane layout engine (2026-05-30)
+
+**Branch:** `feat/container-pane-layout` → `main` (PR pending)
+
+**Core change:** Every container widget's `add()` method now returns a proper public
+type backed by a `PackFrame`/`GridFrame` layout engine. Previously all pane wrappers
+were private `_*` classes that hardcoded `pack()` with no guidance. Now they accept
+the same layout kwargs as `VStack`/`HStack`/`Grid`/`GroupBox`.
+
+**New public types** (replacing private `_` prefixed wrappers):
+- `AccordionSection` (was `_AccordionSection`) — returned by `Accordion.add()`
+- `SplitPane` (was `_SplitPane`) — returned by `SplitView.add()`
+- `StackPage` (was `_StackPage`) — returned by `PageStack.add()`
+- `TabPage` (was `_TabPage`) — returned by `Tabs.add()`
+
+All exported from `bs.*`.
+
+**Layout kwargs available on all pane types and `Expander`:**
+`layout=` (`'vstack'`/`'hstack'`/`'grid'`), `padding=`, `gap=`,
+`fill_items=`, `expand_items=`, `anchor_items=`,
+`columns=`, `rows=`, `sticky_items=`, `auto_flow=`
+
+**`Expander` additions:**
+- `show_border=`, `variant=` (`'default'`/`'solid'`), `icon_position=`,
+  `highlight=` now explicit kwargs (were buried in `**kwargs`)
+
+**`Accordion` additions:**
+- `show_separators=`, `show_border=`, `variant=`, `padding=` now explicit kwargs
+
+**`Expander` style builder fix** (`style/builders/expander.py`):
+- `b.elevate(surface_token, 1)` → `b.elevate(b.color(surface_token), 1)` —
+  `b.elevate()` expects a resolved color, not a token name
+- Removed stray `print()` debug statement
 
 ### Session 34 — Bug fixes, public API gaps, secondary token (2026-05-29)
 

--- a/src/bootstack/__init__.py
+++ b/src/bootstack/__init__.py
@@ -79,6 +79,7 @@ from bootstack.widgets.stacks import HStack, VStack
 from bootstack.widgets.grid import Grid
 from bootstack.widgets.boolean_controls import Checkbox, Switch, ToggleButton
 from bootstack.widgets.button import Button
+from bootstack.widgets.card import Card
 from bootstack.widgets.buttongroup import ButtonGroup
 from bootstack.widgets.codeeditor import CodeEditor
 from bootstack.widgets.contextmenu import ContextMenu, ContextMenuItem

--- a/src/bootstack/__init__.py
+++ b/src/bootstack/__init__.py
@@ -84,7 +84,7 @@ from bootstack.widgets.codeeditor import CodeEditor
 from bootstack.widgets.contextmenu import ContextMenu, ContextMenuItem
 from bootstack.widgets.datefield import DateField
 from bootstack.widgets._impl.composites.textarea.filter import EditFilter
-from bootstack.widgets.expander import Accordion, Expander
+from bootstack.widgets.expander import Accordion, AccordionSection, Expander
 from bootstack.widgets.gauge import Gauge
 from bootstack.widgets.groupbox import GroupBox
 from bootstack.widgets.label import Badge, Label
@@ -92,7 +92,7 @@ from bootstack.widgets.listview import ListView
 from bootstack.widgets.menubar import MenuBar
 from bootstack.widgets.menubutton import MenuButton
 from bootstack.widgets.numberfield import NumberField
-from bootstack.widgets.pagestack import PageStack
+from bootstack.widgets.pagestack import PageStack, StackPage
 from bootstack.widgets.pathfield import PathField
 from bootstack.widgets.passwordfield import PasswordField
 from bootstack.widgets.progressbar import ProgressBar
@@ -103,12 +103,12 @@ from bootstack.widgets.scrollview import ScrollView
 from bootstack.widgets.select import Select
 from bootstack.widgets.separator import Separator
 from bootstack.widgets.sizegrip import SizeGrip
-from bootstack.widgets.splitview import SplitView
+from bootstack.widgets.splitview import SplitView, SplitPane
 from bootstack.widgets.slider import RangeSlider, Slider
 from bootstack.widgets.spinbox import Spinbox
 from bootstack.widgets.spinnerfield import SpinnerField
 from bootstack.widgets.table import Table, TableSelectionEventData, TableRowEventData, TableRowsEventData
-from bootstack.widgets.tabs import TabChangeEventData, TabRef, Tabs
+from bootstack.widgets.tabs import TabChangeEventData, TabPage, TabRef, Tabs
 from bootstack.widgets.textarea import TextArea
 from bootstack.widgets.timefield import TimeField
 from bootstack.widgets.tree import Tree

--- a/src/bootstack/cli/demo.py
+++ b/src/bootstack/cli/demo.py
@@ -380,7 +380,7 @@ def _build_layout_page():
                 ("Revenue", "$45,678",       "success"),
                 ("Errors",  "12 today",      "danger"),
             ]:
-                with bs.VStack(variant='card', padding=16):
+                with bs.Card(accent=color):
                     bs.Label(title, accent=color, font="body[bold]")
                     bs.Label(body, font="heading-lg")
 

--- a/src/bootstack/cli/demo.py
+++ b/src/bootstack/cli/demo.py
@@ -204,12 +204,12 @@ def _build_selection_page():
             bs.Switch("Disabled",      disabled=True)
 
         with bs.GroupBox("RadioGroup", fill="horizontal"):
-            rg = bs.RadioGroup(value="opt1", accent="primary", fill="horizontal")
+            rg = bs.RadioGroup(value="opt1", accent="primary")
             rg.add("Option 1", value="opt1")
             rg.add("Option 2", value="opt2")
             rg.add("Option 3", value="opt3")
 
-        with bs.GroupBox("ToggleGroup", fill="horizontal", gap=6):
+        with bs.GroupBox("ToggleGroup", fill="horizontal", gap=6, layout="grid", columns=2):
             with bs.VStack():
                 bs.Label("Single select:")
                 tg = bs.ToggleGroup(mode="single", accent="primary", variant="outline", value="B")
@@ -305,14 +305,13 @@ def _build_data_page():
             for color in ("primary", "secondary", "success", "warning", "danger"):
                 bs.Label(color.title(), accent=color, padding=(8, 4))
 
-        with bs.GroupBox("Badges", fill="horizontal", gap=6):
-            with bs.HStack(gap=8):
-                for color in ("primary", "success", "warning", "danger"):
-                    bs.Badge(color.title(), accent=color)
-            with bs.HStack(gap=8):
-                bs.Badge("Pill",  accent="primary", variant="pill")
-                bs.Badge("99+",   accent="danger",  variant="pill")
-                bs.Badge("New",   accent="success")
+        with bs.GroupBox("Badges", fill="x", gap=16, layout="hstack"):
+            for color in ("primary", "secondary", "success", "warning", "danger"):
+                bs.Badge(color.title(), accent=color)
+
+            bs.Badge("Pill",  accent="primary", variant="pill")
+            bs.Badge("99+",   accent="danger",  variant="pill")
+            bs.Badge("New",   accent="success")
 
         with bs.GroupBox("Tree", fill="both", expand=True):
             columns = ("name", "status", "progress")
@@ -347,7 +346,7 @@ def _build_progress_page():
         with bs.GroupBox("Slider (drag to control progress bars)", fill="horizontal"):
             bs.Slider(min_value=0, max_value=100, signal=slider_value, fill="horizontal")
 
-        with bs.GroupBox("ProgressBar", fill="horizontal", gap=6):
+        with bs.GroupBox("ProgressBar", fill="horizontal", gap=8):
             bs.ProgressBar(signal=slider_value, max_value=100, fill="horizontal")
             bs.ProgressBar(value=75,  max_value=100, accent="success", fill="horizontal")
             bs.ProgressBar(value=45,  max_value=100, accent="danger",  fill="horizontal")
@@ -375,25 +374,24 @@ def _build_layout_page():
         bs.Label("Layout", font="heading-xl")
         bs.Label("Containers, expandable panels, and split panes.", accent="secondary")
 
-        with bs.GroupBox("Card", fill="horizontal"):
-            with bs.HStack(gap=8, fill="horizontal", fill_items="horizontal", expand_items=True):
-                for title, body, color in [
-                    ("Users",   "1,234 active", "primary"),
-                    ("Revenue", "$45,678",       "success"),
-                    ("Errors",  "12 today",      "danger"),
-                ]:
-                    with bs.VStack(variant='card', padding=16):
-                        bs.Label(title, accent=color, font="body[bold]")
-                        bs.Label(body, font="heading-lg")
+        with bs.GroupBox("Card", fill="horizontal", layout="hstack", fill_items="x", expand_items=True, gap=16):
+            for title, body, color in [
+                ("Users",   "1,234 active", "primary"),
+                ("Revenue", "$45,678",       "success"),
+                ("Errors",  "12 today",      "danger"),
+            ]:
+                with bs.VStack(variant='card', padding=16):
+                    bs.Label(title, accent=color, font="body[bold]")
+                    bs.Label(body, font="heading-lg")
 
         with bs.GroupBox("Expander", fill="horizontal"):
-            with bs.Expander("Click to expand", expanded=False, fill="horizontal"):
-                bs.Label("This content is revealed when the expander is opened.", padding=10)
-            with bs.Expander("Already expanded", expanded=True, fill="horizontal"):
-                bs.Label("Expanders can start open or closed.", padding=10)
+            with bs.Expander("Click to expand", expanded=False, fill="horizontal", padding=10):
+                bs.Label("This content is revealed when the expander is opened.")
+            with bs.Expander("Already expanded", expanded=True, fill="horizontal", padding=10):
+                bs.Label("Expanders can start open or closed.")
 
         with bs.GroupBox("Accordion", fill="horizontal"):
-            acc = bs.Accordion(fill="horizontal")
+            acc = bs.Accordion(fill="horizontal", show_border=True, show_separators=True)
             with acc.add("Section 1"):
                 bs.Label("Content for section one.", padding=10)
             with acc.add("Section 2"):
@@ -403,14 +401,12 @@ def _build_layout_page():
 
         with bs.GroupBox("SplitView", fill="both", expand=True):
             sv = bs.SplitView(orient="horizontal", fill="both", expand=True)
-            with sv.add():
-                with bs.VStack(padding=10, anchor_items="center", expand=True, fill="both"):
-                    bs.Label("Left Pane")
-                    bs.Label("Drag the sash to resize", accent="secondary", font="caption")
-            with sv.add():
-                with bs.VStack(padding=10, anchor_items="center", expand=True, fill="both"):
-                    bs.Label("Right Pane")
-                    bs.Label("Both panes are resizable", accent="secondary", font="caption")
+            with sv.add(padding=10, anchor_items="center"):
+                bs.Label("Left Pane")
+                bs.Label("Drag the sash to resize", accent="secondary", font="caption")
+            with sv.add(padding=10, anchor_items="center"):
+                bs.Label("Right Pane")
+                bs.Label("Both panes are resizable", accent="secondary", font="caption")
 
         with bs.GroupBox("Separator", fill="horizontal", gap=8):
             bs.Separator(fill="horizontal")

--- a/src/bootstack/style/builders/expander.py
+++ b/src/bootstack/style/builders/expander.py
@@ -1,12 +1,15 @@
 """Style builders for the Expander widget."""
+from typing import Optional
 
 from bootstack.style.bootstyle_builder_ttk import BootstyleBuilderTTk
 from bootstack.style.builders.utils import apply_icon_mapping
 
 
 @BootstyleBuilderTTk.register_builder('solid', 'Expander.TFrame')
-def build_solid_expander_header_style(b: BootstyleBuilderTTk, ttk_style: str, accent: str = None, **options):
-    background = b.color(accent or 'primary')
+def build_solid_expander_header_style(b: BootstyleBuilderTTk, ttk_style: str, accent: Optional[str] = None, **options):
+    accent = b.default(accent)
+    surface_token = options.get('surface', 'content')
+    background = b.color(accent) if accent is not None else b.elevate(b.color(surface_token), 1)
     active = b.active(background)
     pressed = b.pressed(background)
     focus_border = b.focus_border(active)
@@ -45,9 +48,11 @@ def build_solid_expander_header_style(b: BootstyleBuilderTTk, ttk_style: str, ac
 
 
 @BootstyleBuilderTTk.register_builder('solid', 'Expander.TLabel')
-def build_solid_expander_header_label_style(b: BootstyleBuilderTTk, ttk_style: str, accent: str = None, **options):
+def build_solid_expander_header_label_style(b: BootstyleBuilderTTk, ttk_style: str, accent: Optional[str] = None, **options):
     """Expander header label style with state-aware foreground."""
-    background = b.color(accent or 'primary')
+    accent = b.default(accent)
+    surface_token = options.get('surface', 'content')
+    background = b.color(accent) if accent is not None else b.elevate(b.color(surface_token), 1)
     active = b.active(background)
     pressed = b.pressed(background)
     selected = b.selected(active)

--- a/src/bootstack/style/builders/frame.py
+++ b/src/bootstack/style/builders/frame.py
@@ -27,10 +27,10 @@ def build_frame(b: BootstyleBuilderTTk, ttk_style: str, _: Optional[str] = None,
 
 @BootstyleBuilderTTk.register_builder('card', 'TFrame')
 def build_card(b: BootstyleBuilderTTk, ttk_style: str, accent: Optional[str] = None, **options):
-    surface_token = options.get('surface') or accent or 'card'
+    surface_token = options.get('surface') or 'card'
     show_border = options.get('show_border', True)
     surface = b.color(surface_token)
-    stroke = b.color('stroke') if show_border else surface
+    stroke = b.color(accent) if (show_border and accent) else (b.color('stroke') if show_border else surface)
 
     b.configure_style(
         ttk_style,

--- a/src/bootstack/widgets/_impl/composites/accordion.py
+++ b/src/bootstack/widgets/_impl/composites/accordion.py
@@ -55,7 +55,7 @@ class Accordion(Frame):
         """
 
         if 'show_border' in kwargs:
-            kwargs.setdefault('padding', 3)  # required to avoid clipping corners
+            kwargs.setdefault('padding', 1)  # required to avoid clipping corners
 
         super().__init__(master, **kwargs)
 

--- a/src/bootstack/widgets/_impl/primitives/frame.py
+++ b/src/bootstack/widgets/_impl/primitives/frame.py
@@ -56,7 +56,9 @@ class Frame(TTKWrapperBase, WidgetCapabilitiesMixin, TtkStateMixin, ttk.Frame):
             show_border: Draw a border around the frame.
             style_options: Optional dict forwarded to the style builder.
         """
-        kwargs.update(style_options=self._capture_style_options(['show_border'], kwargs))
+        existing = kwargs.pop('style_options', {})
+        captured = self._capture_style_options(['show_border'], kwargs)
+        kwargs['style_options'] = {**existing, **captured}
         super().__init__(master, **kwargs)
 
     def configure_style_options(self, value=None, **kwargs):

--- a/src/bootstack/widgets/card.py
+++ b/src/bootstack/widgets/card.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import tkinter
+from typing import Any
+
+from bootstack.widgets._impl.primitives.packframe import PackFrame
+from bootstack.widgets._impl.primitives.gridframe import GridFrame
+from bootstack.widgets._core.container import (
+    PublicContainer, PACK_KEYS, GRID_KEYS, normalize_fill,
+)
+
+
+class Card(PublicContainer):
+    """A card-surface container that groups content with an elevated background and border.
+
+    Uses the `card` surface token so nested cards step up automatically
+    (background → card → overlay). Children are laid out according to `layout`.
+
+    Args:
+        layout: Internal layout manager — `'vstack'` (default), `'hstack'`,
+            or `'grid'`.
+        padding: Space between the card border and the content. Default `16`.
+        gap: Space between children in pixels.
+        fill_items: Default fill direction applied to each child.
+        expand_items: Whether children expand to fill available space.
+        anchor_items: Default anchor applied to each child.
+        columns: Column definitions for `'grid'` layout.
+        rows: Row definitions for `'grid'` layout.
+        sticky_items: Default sticky value for grid children.
+        auto_flow: Grid auto-flow direction.
+        accent: Accent token for the card border color.
+        fill: Self-placement fill direction in parent.
+        expand: Self-placement expand flag.
+        anchor: Self-placement anchor.
+        parent: Override the context-stack parent.
+    """
+
+    def __init__(
+        self,
+        *,
+        layout: str = "vstack",
+        padding: Any = 16,
+        gap: int = 0,
+        fill_items: str | None = None,
+        expand_items: bool | None = None,
+        anchor_items: str | None = None,
+        columns: int | list | None = None,
+        rows: int | list | None = None,
+        sticky_items: str | None = None,
+        auto_flow: str = "row",
+        accent: str | None = None,
+        fill: str | None = None,
+        expand: bool | None = None,
+        anchor: str | None = None,
+        parent: Any = None,
+        **extra_kw: Any,
+    ) -> None:
+        self._parent = self._resolve_parent(parent)
+        self._layout = layout
+
+        layout_kw: dict[str, Any] = {}
+        if fill is not None:
+            layout_kw["fill"] = normalize_fill(fill)
+        if expand is not None:
+            layout_kw["expand"] = expand
+        if anchor is not None:
+            layout_kw["anchor"] = anchor
+        layout_kw.update(self._split_layout_kwargs(extra_kw))
+
+        tk_master = self._parent._child_master() if self._parent else None
+
+        # Determine the surface children will sit on:
+        # - With accent: children sit on the subtle accent surface (accent[subtle])
+        # - Without accent: step up from the parent surface (background→card→overlay)
+        _SURFACE_STEPS = {"background": "card", "content": "card",
+                          "card": "overlay", "overlay": "overlay"}
+        parent_surface = getattr(tk_master, '_surface', 'background') or 'background'
+        effective_surface = f'{accent}[subtle]' if accent is not None else _SURFACE_STEPS.get(parent_surface, 'card')
+
+        if layout in ("vstack", "hstack"):
+            self._internal = PackFrame(
+                tk_master,
+                direction="vertical" if layout == "vstack" else "horizontal",
+                variant="card",
+                show_border=True,
+                surface=effective_surface,
+                **({"accent": accent} if accent is not None else {}),
+                padding=padding,
+                gap=gap,
+                fill_items=normalize_fill(fill_items),
+                expand_items=expand_items,
+                anchor_items=anchor_items,
+            )
+        elif layout == "grid":
+            self._internal = GridFrame(
+                tk_master,
+                variant="card",
+                show_border=True,
+                surface=effective_surface,
+                **({"accent": accent} if accent is not None else {}),
+                padding=padding,
+                columns=columns,
+                rows=rows,
+                gap=gap,
+                sticky_items=sticky_items,
+                auto_flow=auto_flow,
+            )
+        else:
+            raise ValueError(
+                f"Card layout must be 'vstack', 'hstack', or 'grid', got {layout!r}"
+            )
+
+        self._fill_items = normalize_fill(fill_items)
+        self._expand_items = expand_items
+        self._anchor_items = anchor_items
+        self._sticky_items = sticky_items
+        self._attach_to_parent(layout_kw)
+
+    def _child_master(self) -> tkinter.Misc:
+        return self._internal
+
+    def _default_layout_method(self) -> str:
+        return "grid" if self._layout == "grid" else "pack"
+
+    def _merge_layout_options(self, child: Any, layout_kw: dict) -> tuple[str, dict]:
+        if self._layout == "grid":
+            options = {k: v for k, v in layout_kw.items() if k in GRID_KEYS}
+            if "sticky" not in options and self._sticky_items:
+                options["sticky"] = self._sticky_items
+            return ("grid", options)
+        options = {k: v for k, v in layout_kw.items() if k in PACK_KEYS}
+        if "fill" not in options and self._fill_items:
+            options["fill"] = self._fill_items
+        if "expand" not in options and self._expand_items is not None:
+            options["expand"] = self._expand_items
+        if "anchor" not in options and self._anchor_items:
+            options["anchor"] = self._anchor_items
+        return ("pack", options)

--- a/src/bootstack/widgets/expander.py
+++ b/src/bootstack/widgets/expander.py
@@ -1,11 +1,15 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 
 import tkinter
 from typing import Any, Callable
 
 from bootstack.widgets._impl.composites.expander import Expander as _InternalExpander
 from bootstack.widgets._impl.composites.accordion import Accordion as _InternalAccordion
-from bootstack.widgets._core.container import PublicContainer, PACK_KEYS
+from bootstack.widgets._impl.primitives.packframe import PackFrame
+from bootstack.widgets._impl.primitives.gridframe import GridFrame
+from bootstack.widgets._core.container import (
+    PublicContainer, PACK_KEYS, GRID_KEYS, normalize_fill,
+)
 from bootstack.widgets._core.base import PublicWidgetBase
 from bootstack.widgets._core.context import push_container, pop_container
 from bootstack.widgets._core.events import register_widget_events
@@ -21,13 +25,29 @@ _EXPANDER_EVENTS: dict[str, str] = {
 class Expander(PublicContainer):
     """A collapsible container with a clickable header.
 
-    Children placed inside the context block go into the expandable body.
+    Children placed inside the context block go into the expandable body,
+    laid out according to `layout`.
 
     Args:
         title: Header text.
+        layout: Internal layout manager — `'vstack'` (default), `'hstack'`,
+            or `'grid'`.
+        padding: Space between the expander border and its content.
+        gap: Space between children in pixels.
+        fill_items: Default fill direction applied to each child.
+        expand_items: Whether children expand to fill available space.
+        anchor_items: Default anchor applied to each child.
+        columns: Column definitions for `'grid'` layout.
+        rows: Row definitions for `'grid'` layout.
+        sticky_items: Default sticky value for grid children.
+        auto_flow: Grid auto-flow direction.
         expanded: If True (default), body is visible on creation.
         collapsible: If False, the header cannot be clicked to collapse.
-        icon: Icon displayed in the header (left of title).
+        show_border: If True, draws a border around the entire expander.
+        variant: Header style — `'default'` (ghost/transparent) or `'solid'`.
+        icon: Icon displayed in the header.
+        icon_position: Where the chevron sits — `'after'` (default) or `'before'`.
+        highlight: If True, header shows selected state when expanded.
         accent: Accent token for header styling.
         parent: Override the context-stack parent.
     """
@@ -36,14 +56,29 @@ class Expander(PublicContainer):
         self,
         title: str = "",
         *,
+        layout: str = "vstack",
+        padding: Any = None,
+        gap: int = 0,
+        fill_items: str | None = None,
+        expand_items: bool | None = None,
+        anchor_items: str | None = None,
+        columns: int | list | None = None,
+        rows: int | list | None = None,
+        sticky_items: str | None = None,
+        auto_flow: str = "row",
         expanded: bool = True,
         collapsible: bool = True,
+        show_border: bool = False,
+        variant: str | None = None,
         icon: str | None = None,
+        icon_position: str = "after",
+        highlight: bool = False,
         accent: str | None = None,
         parent: Any = None,
         **kwargs: Any,
     ) -> None:
         self._parent = self._resolve_parent(parent)
+        self._layout = layout
         layout_kw = self._split_layout_kwargs(kwargs)
 
         tk_master = self._parent._child_master() if self._parent else None
@@ -52,7 +87,13 @@ class Expander(PublicContainer):
             "title": title,
             "expanded": expanded,
             "collapsible": collapsible,
+            "icon_position": icon_position,
+            "highlight": highlight,
         }
+        if show_border:
+            internal_kwargs["show_border"] = True
+        if variant is not None:
+            internal_kwargs["variant"] = variant
         if icon is not None:
             internal_kwargs["icon"] = icon
         if accent is not None:
@@ -60,16 +101,60 @@ class Expander(PublicContainer):
         internal_kwargs.update(kwargs)
 
         self._internal = _InternalExpander(tk_master, **internal_kwargs)
+
+        content = self._internal._content_frame
+        if layout in ("vstack", "hstack"):
+            self._layout_frame = PackFrame(
+                content,
+                direction="vertical" if layout == "vstack" else "horizontal",
+                padding=padding,
+                gap=gap,
+                fill_items=normalize_fill(fill_items),
+                expand_items=expand_items,
+                anchor_items=anchor_items,
+            )
+        elif layout == "grid":
+            self._layout_frame = GridFrame(
+                content,
+                columns=columns,
+                rows=rows,
+                padding=padding,
+                gap=gap,
+                sticky_items=sticky_items,
+                auto_flow=auto_flow,
+            )
+        else:
+            raise ValueError(
+                f"Expander layout must be 'vstack', 'hstack', or 'grid', got {layout!r}"
+            )
+
+        self._fill_items = normalize_fill(fill_items)
+        self._expand_items = expand_items
+        self._anchor_items = anchor_items
+        self._sticky_items = sticky_items
+        self._layout_frame.pack(fill="both", expand=True)
         self._attach_to_parent(layout_kw)
 
     def _child_master(self) -> tkinter.Misc:
-        return self._internal._content_frame
+        return self._layout_frame
 
     def _default_layout_method(self) -> str:
-        return "pack"
+        return "grid" if self._layout == "grid" else "pack"
 
     def _merge_layout_options(self, child: Any, layout_kw: dict) -> tuple[str, dict]:
-        return ("pack", {k: v for k, v in layout_kw.items() if k in PACK_KEYS})
+        if self._layout == "grid":
+            options = {k: v for k, v in layout_kw.items() if k in GRID_KEYS}
+            if "sticky" not in options and self._sticky_items:
+                options["sticky"] = self._sticky_items
+            return ("grid", options)
+        options = {k: v for k, v in layout_kw.items() if k in PACK_KEYS}
+        if "fill" not in options and self._fill_items:
+            options["fill"] = self._fill_items
+        if "expand" not in options and self._expand_items is not None:
+            options["expand"] = self._expand_items
+        if "anchor" not in options and self._anchor_items:
+            options["anchor"] = self._anchor_items
+        return ("pack", options)
 
     # ----- Properties -----
 
@@ -105,25 +190,84 @@ class Expander(PublicContainer):
 register_widget_events(Expander, _EXPANDER_EVENTS)
 
 
-# ---------------------------------------------------------------------------
-# _AccordionSection — lightweight context-manager wrapper returned by
-# Accordion.add(). Not part of the public API directly.
-# ---------------------------------------------------------------------------
+class AccordionSection:
+    """Context-manager container returned by `Accordion.add()`.
 
-class _AccordionSection:
-    """Context-manager wrapper around an Accordion section body."""
+    Accepts the same layout kwargs as `Expander` — `layout=`, `gap=`,
+    `fill_items=`, `expand_items=`, `anchor_items=`, `columns=`, `rows=`,
+    `sticky_items=`, `auto_flow=`.
+    """
 
-    def __init__(self, internal_expander: _InternalExpander) -> None:
+    def __init__(
+        self,
+        internal_expander: _InternalExpander,
+        *,
+        layout: str = "vstack",
+        padding: Any = None,
+        gap: int = 0,
+        fill_items: str | None = None,
+        expand_items: bool | None = None,
+        anchor_items: str | None = None,
+        columns: int | list | None = None,
+        rows: int | list | None = None,
+        sticky_items: str | None = None,
+        auto_flow: str = "row",
+    ) -> None:
         self._expander = internal_expander
+        self._layout = layout
+
+        content = internal_expander._content_frame
+        if layout in ("vstack", "hstack"):
+            self._layout_frame = PackFrame(
+                content,
+                direction="vertical" if layout == "vstack" else "horizontal",
+                padding=padding,
+                gap=gap,
+                fill_items=normalize_fill(fill_items),
+                expand_items=expand_items,
+                anchor_items=anchor_items,
+            )
+        elif layout == "grid":
+            self._layout_frame = GridFrame(
+                content,
+                columns=columns,
+                rows=rows,
+                padding=padding,
+                gap=gap,
+                sticky_items=sticky_items,
+                auto_flow=auto_flow,
+            )
+        else:
+            raise ValueError(
+                f"AccordionSection layout must be 'vstack', 'hstack', or 'grid', got {layout!r}"
+            )
+
+        self._fill_items = normalize_fill(fill_items)
+        self._expand_items = expand_items
+        self._anchor_items = anchor_items
+        self._sticky_items = sticky_items
+        self._layout_frame.pack(fill="both", expand=True)
 
     def _child_master(self) -> tkinter.Misc:
-        return self._expander._content_frame
+        return self._layout_frame
 
     def guide_layout(self, child: PublicWidgetBase, **layout_kw: Any) -> None:
+        if self._layout == "grid":
+            options = {k: v for k, v in layout_kw.items() if k in GRID_KEYS}
+            if "sticky" not in options and self._sticky_items:
+                options["sticky"] = self._sticky_items
+            child._internal.grid(in_=self._child_master(), **options)
+            return
         options = {k: v for k, v in layout_kw.items() if k in PACK_KEYS}
+        if "fill" not in options and self._fill_items:
+            options["fill"] = self._fill_items
+        if "expand" not in options and self._expand_items is not None:
+            options["expand"] = self._expand_items
+        if "anchor" not in options and self._anchor_items:
+            options["anchor"] = self._anchor_items
         child._internal.pack(in_=self._child_master(), **options)
 
-    def __enter__(self) -> "_AccordionSection":
+    def __enter__(self) -> "AccordionSection":
         push_container(self)
         return self
 
@@ -138,7 +282,12 @@ class Accordion(PublicWidgetBase):
         allow_multiple: If True, multiple sections can be expanded simultaneously.
             Default `False` (only one section open at a time).
         allow_collapse_all: If True, all sections can be collapsed. Default `True`.
+        show_separators: If True, draws a separator line between sections.
+        show_border: If True, wraps the accordion in a bordered frame.
+        variant: Style variant applied to each section header — `'default'`
+            (ghost, transparent header) or `'solid'`.
         accent: Accent token for section headers.
+        padding: Internal padding around the accordion content.
         parent: Override the context-stack parent.
     """
 
@@ -147,7 +296,11 @@ class Accordion(PublicWidgetBase):
         *,
         allow_multiple: bool = False,
         allow_collapse_all: bool = True,
+        show_separators: bool = False,
+        show_border: bool = False,
+        variant: str | None = None,
         accent: str | None = None,
+        padding: Any = None,
         parent: Any = None,
         **kwargs: Any,
     ) -> None:
@@ -159,9 +312,16 @@ class Accordion(PublicWidgetBase):
         internal_kwargs: dict[str, Any] = {
             "allow_multiple": allow_multiple,
             "allow_collapse_all": allow_collapse_all,
+            "show_separators": show_separators,
         }
+        if show_border:
+            internal_kwargs["show_border"] = True
+        if variant is not None:
+            internal_kwargs["variant"] = variant
         if accent is not None:
             internal_kwargs["accent"] = accent
+        if padding is not None:
+            internal_kwargs["padding"] = padding
         internal_kwargs.update(kwargs)
 
         self._internal = _InternalAccordion(tk_master, **internal_kwargs)
@@ -171,23 +331,55 @@ class Accordion(PublicWidgetBase):
         self,
         title: str,
         *,
+        layout: str = "vstack",
+        padding: Any = None,
+        gap: int = 0,
+        fill_items: str | None = None,
+        expand_items: bool | None = None,
+        anchor_items: str | None = None,
+        columns: int | list | None = None,
+        rows: int | list | None = None,
+        sticky_items: str | None = None,
+        auto_flow: str = "row",
         expanded: bool | None = None,
         icon: str | None = None,
-    ) -> _AccordionSection:
+    ) -> AccordionSection:
         """Add a section and return a context manager for placing its children.
 
-        Usage::
-
-            with acc.add("Section title") as section:
-                Label("Content goes here")
+        Args:
+            title: Section header text.
+            layout: Internal layout — `'vstack'` (default), `'hstack'`, or `'grid'`.
+            gap: Space between children in pixels.
+            fill_items: Default fill direction applied to each child.
+            expand_items: Whether children expand to fill available space.
+            anchor_items: Default anchor applied to each child.
+            columns: Column definitions for `'grid'` layout.
+            rows: Row definitions for `'grid'` layout.
+            sticky_items: Default sticky value for grid children.
+            auto_flow: Grid auto-flow direction.
+            expanded: Whether the section starts expanded. Defaults to the
+                accordion's own default.
+            icon: Icon displayed in the section header.
 
         Returns:
-            `_AccordionSection` — use as a context manager to place children.
+            `AccordionSection` — use as a context manager to place children.
         """
-        kwargs: dict[str, Any] = {}
+        exp_kwargs: dict[str, Any] = {}
         if expanded is not None:
-            kwargs["expanded"] = expanded
+            exp_kwargs["expanded"] = expanded
         if icon is not None:
-            kwargs["icon"] = icon
-        internal_exp = self._internal.add(title=title, **kwargs)
-        return _AccordionSection(internal_exp)
+            exp_kwargs["icon"] = icon
+        internal_exp = self._internal.add(title=title, **exp_kwargs)
+        return AccordionSection(
+            internal_exp,
+            layout=layout,
+            padding=padding,
+            gap=gap,
+            fill_items=fill_items,
+            expand_items=expand_items,
+            anchor_items=anchor_items,
+            columns=columns,
+            rows=rows,
+            sticky_items=sticky_items,
+            auto_flow=auto_flow,
+        )

--- a/src/bootstack/widgets/pagestack.py
+++ b/src/bootstack/widgets/pagestack.py
@@ -4,8 +4,10 @@ import tkinter
 from typing import Any, Callable
 
 from bootstack.widgets._impl.composites.pagestack import PageStack as _InternalPageStack
+from bootstack.widgets._impl.primitives.packframe import PackFrame
+from bootstack.widgets._impl.primitives.gridframe import GridFrame
 from bootstack.widgets._core.base import PublicWidgetBase
-from bootstack.widgets._core.container import PACK_KEYS, normalize_fill
+from bootstack.widgets._core.container import PACK_KEYS, GRID_KEYS, normalize_fill
 from bootstack.widgets._core.context import push_container, pop_container
 from bootstack.widgets._core.events import register_widget_events
 from bootstack.widgets._core.subscription import Subscription
@@ -16,20 +18,83 @@ _PAGESTACK_EVENTS: dict[str, str] = {
 }
 
 
-class _StackPage:
-    """Context-manager for placing children inside a PageStack page."""
+class StackPage:
+    """Context-manager container returned by `PageStack.add()`.
 
-    def __init__(self, page_widget: tkinter.Widget) -> None:
+    Accepts the same layout kwargs as `Expander` — `layout=`, `gap=`,
+    `fill_items=`, `expand_items=`, `anchor_items=`, `columns=`, `rows=`,
+    `sticky_items=`, `auto_flow=`.
+    """
+
+    def __init__(
+        self,
+        page_widget: tkinter.Widget,
+        *,
+        layout: str = "vstack",
+        padding: Any = None,
+        gap: int = 0,
+        fill_items: str | None = None,
+        expand_items: bool | None = None,
+        anchor_items: str | None = None,
+        columns: int | list | None = None,
+        rows: int | list | None = None,
+        sticky_items: str | None = None,
+        auto_flow: str = "row",
+    ) -> None:
         self._page = page_widget
+        self._layout = layout
+
+        if layout in ("vstack", "hstack"):
+            self._layout_frame = PackFrame(
+                page_widget,
+                direction="vertical" if layout == "vstack" else "horizontal",
+                padding=padding,
+                gap=gap,
+                fill_items=normalize_fill(fill_items),
+                expand_items=expand_items,
+                anchor_items=anchor_items,
+            )
+        elif layout == "grid":
+            self._layout_frame = GridFrame(
+                page_widget,
+                columns=columns,
+                rows=rows,
+                padding=padding,
+                gap=gap,
+                sticky_items=sticky_items,
+                auto_flow=auto_flow,
+            )
+        else:
+            raise ValueError(
+                f"StackPage layout must be 'vstack', 'hstack', or 'grid', got {layout!r}"
+            )
+
+        self._fill_items = normalize_fill(fill_items)
+        self._expand_items = expand_items
+        self._anchor_items = anchor_items
+        self._sticky_items = sticky_items
+        self._layout_frame.pack(fill="both", expand=True)
 
     def _child_master(self) -> tkinter.Widget:
-        return self._page
+        return self._layout_frame
 
     def guide_layout(self, child: PublicWidgetBase, **layout_kw: Any) -> None:
+        if self._layout == "grid":
+            options = {k: v for k, v in layout_kw.items() if k in GRID_KEYS}
+            if "sticky" not in options and self._sticky_items:
+                options["sticky"] = self._sticky_items
+            child._internal.grid(in_=self._child_master(), **options)
+            return
         options = {k: v for k, v in layout_kw.items() if k in PACK_KEYS}
-        child._internal.pack(in_=self._page, **options)
+        if "fill" not in options and self._fill_items:
+            options["fill"] = self._fill_items
+        if "expand" not in options and self._expand_items is not None:
+            options["expand"] = self._expand_items
+        if "anchor" not in options and self._anchor_items:
+            options["anchor"] = self._anchor_items
+        child._internal.pack(in_=self._child_master(), **options)
 
-    def __enter__(self) -> "_StackPage":
+    def __enter__(self) -> "StackPage":
         push_container(self)
         return self
 
@@ -101,22 +166,46 @@ class PageStack(PublicWidgetBase):
 
     # ----- Page management -----
 
-    def add(self, key: str) -> _StackPage:
+    def add(
+        self,
+        key: str,
+        *,
+        layout: str = "vstack",
+        padding: Any = None,
+        gap: int = 0,
+        fill_items: str | None = None,
+        expand_items: bool | None = None,
+        anchor_items: str | None = None,
+        columns: int | list | None = None,
+        rows: int | list | None = None,
+        sticky_items: str | None = None,
+        auto_flow: str = "row",
+    ) -> StackPage:
         """Add a page and return a context manager for placing its children.
-
-        Usage::
-
-            with ps.add("home"):
-                bs.Label("Welcome")
 
         Args:
             key: Unique identifier for this page.
+            layout: Internal layout — `'vstack'` (default), `'hstack'`, or `'grid'`.
+            gap: Space between children in pixels.
+            fill_items: Default fill direction applied to each child.
+            expand_items: Whether children expand to fill available space.
+            anchor_items: Default anchor applied to each child.
+            columns: Column definitions for `'grid'` layout.
+            rows: Row definitions for `'grid'` layout.
+            sticky_items: Default sticky value for grid children.
+            auto_flow: Grid auto-flow direction.
 
         Returns:
-            `_StackPage` — use as a context manager to place children.
+            `StackPage` — use as a context manager to place children.
         """
         page_widget = self._internal.add(key)
-        return _StackPage(page_widget)
+        return StackPage(
+            page_widget,
+            layout=layout, padding=padding, gap=gap, fill_items=fill_items,
+            expand_items=expand_items, anchor_items=anchor_items,
+            columns=columns, rows=rows, sticky_items=sticky_items,
+            auto_flow=auto_flow,
+        )
 
     def remove(self, key: str) -> None:
         """Remove a page and destroy its widget."""

--- a/src/bootstack/widgets/splitview.py
+++ b/src/bootstack/widgets/splitview.py
@@ -5,25 +5,90 @@ from typing import Any
 
 from bootstack.widgets._impl.primitives.panedwindow import PanedWindow as _InternalPanedWindow
 from bootstack.widgets._impl.primitives.frame import Frame as _InternalFrame
+from bootstack.widgets._impl.primitives.packframe import PackFrame
+from bootstack.widgets._impl.primitives.gridframe import GridFrame
 from bootstack.widgets._core.base import PublicWidgetBase
-from bootstack.widgets._core.container import PACK_KEYS, normalize_fill
+from bootstack.widgets._core.container import PACK_KEYS, GRID_KEYS, normalize_fill
 from bootstack.widgets._core.context import push_container, pop_container
 
 
-class _SplitPane:
-    """Context-manager for placing children inside a SplitView pane."""
+class SplitPane:
+    """Context-manager container returned by `SplitView.add()`.
 
-    def __init__(self, frame: tkinter.Widget) -> None:
+    Accepts the same layout kwargs as `Expander` — `layout=`, `gap=`,
+    `fill_items=`, `expand_items=`, `anchor_items=`, `columns=`, `rows=`,
+    `sticky_items=`, `auto_flow=`.
+    """
+
+    def __init__(
+        self,
+        frame: tkinter.Widget,
+        *,
+        layout: str = "vstack",
+        padding: Any = None,
+        gap: int = 0,
+        fill_items: str | None = None,
+        expand_items: bool | None = None,
+        anchor_items: str | None = None,
+        columns: int | list | None = None,
+        rows: int | list | None = None,
+        sticky_items: str | None = None,
+        auto_flow: str = "row",
+    ) -> None:
         self._frame = frame
+        self._layout = layout
+
+        if layout in ("vstack", "hstack"):
+            self._layout_frame = PackFrame(
+                frame,
+                direction="vertical" if layout == "vstack" else "horizontal",
+                padding=padding,
+                gap=gap,
+                fill_items=normalize_fill(fill_items),
+                expand_items=expand_items,
+                anchor_items=anchor_items,
+            )
+        elif layout == "grid":
+            self._layout_frame = GridFrame(
+                frame,
+                columns=columns,
+                rows=rows,
+                padding=padding,
+                gap=gap,
+                sticky_items=sticky_items,
+                auto_flow=auto_flow,
+            )
+        else:
+            raise ValueError(
+                f"SplitPane layout must be 'vstack', 'hstack', or 'grid', got {layout!r}"
+            )
+
+        self._fill_items = normalize_fill(fill_items)
+        self._expand_items = expand_items
+        self._anchor_items = anchor_items
+        self._sticky_items = sticky_items
+        self._layout_frame.pack(fill="both", expand=True)
 
     def _child_master(self) -> tkinter.Widget:
-        return self._frame
+        return self._layout_frame
 
     def guide_layout(self, child: PublicWidgetBase, **layout_kw: Any) -> None:
+        if self._layout == "grid":
+            options = {k: v for k, v in layout_kw.items() if k in GRID_KEYS}
+            if "sticky" not in options and self._sticky_items:
+                options["sticky"] = self._sticky_items
+            child._internal.grid(in_=self._child_master(), **options)
+            return
         options = {k: v for k, v in layout_kw.items() if k in PACK_KEYS}
-        child._internal.pack(in_=self._frame, **options)
+        if "fill" not in options and self._fill_items:
+            options["fill"] = self._fill_items
+        if "expand" not in options and self._expand_items is not None:
+            options["expand"] = self._expand_items
+        if "anchor" not in options and self._anchor_items:
+            options["anchor"] = self._anchor_items
+        child._internal.pack(in_=self._child_master(), **options)
 
-    def __enter__(self) -> "_SplitPane":
+    def __enter__(self) -> "SplitPane":
         push_container(self)
         return self
 
@@ -99,28 +164,52 @@ class SplitView(PublicWidgetBase):
 
     # ----- Pane management -----
 
-    def add(self, *, weight: int = 1, min_size: int | None = None) -> _SplitPane:
+    def add(
+        self,
+        *,
+        weight: int = 1,
+        min_size: int | None = None,
+        layout: str = "vstack",
+        padding: Any = None,
+        gap: int = 0,
+        fill_items: str | None = None,
+        expand_items: bool | None = None,
+        anchor_items: str | None = None,
+        columns: int | list | None = None,
+        rows: int | list | None = None,
+        sticky_items: str | None = None,
+        auto_flow: str = "row",
+    ) -> SplitPane:
         """Add a pane and return a context manager for placing its children.
-
-        Usage::
-
-            with sv.add(weight=1):
-                bs.Label("Content")
 
         Args:
             weight: Relative size weight when the container is resized.
-                Higher values take proportionally more space.
             min_size: Minimum pane size in pixels.
+            layout: Internal layout — `'vstack'` (default), `'hstack'`, or `'grid'`.
+            gap: Space between children in pixels.
+            fill_items: Default fill direction applied to each child.
+            expand_items: Whether children expand to fill available space.
+            anchor_items: Default anchor applied to each child.
+            columns: Column definitions for `'grid'` layout.
+            rows: Row definitions for `'grid'` layout.
+            sticky_items: Default sticky value for grid children.
+            auto_flow: Grid auto-flow direction.
 
         Returns:
-            `_SplitPane` — use as a context manager to place children.
+            `SplitPane` — use as a context manager to place children.
         """
         frame = _InternalFrame(self._internal)
         add_kw: dict[str, Any] = {"weight": weight}
         if min_size is not None:
             add_kw["minsize"] = min_size
         self._internal.add(frame, **add_kw)
-        return _SplitPane(frame)
+        return SplitPane(
+            frame,
+            layout=layout, padding=padding, gap=gap, fill_items=fill_items,
+            expand_items=expand_items, anchor_items=anchor_items,
+            columns=columns, rows=rows, sticky_items=sticky_items,
+            auto_flow=auto_flow,
+        )
 
     # ----- Sash control -----
 

--- a/src/bootstack/widgets/tabs.py
+++ b/src/bootstack/widgets/tabs.py
@@ -5,8 +5,10 @@ from typing import Any, Callable, Literal
 
 from bootstack.widgets._impl.composites.tabs.tabview import TabView as _InternalTabView
 from bootstack.widgets._impl.composites.tabs.events import TabChangeEventData, TabRef
+from bootstack.widgets._impl.primitives.packframe import PackFrame
+from bootstack.widgets._impl.primitives.gridframe import GridFrame
 from bootstack.widgets._core.base import PublicWidgetBase
-from bootstack.widgets._core.container import PACK_KEYS
+from bootstack.widgets._core.container import PACK_KEYS, GRID_KEYS, normalize_fill
 from bootstack.widgets._core.context import push_container, pop_container
 from bootstack.widgets._core.events import register_widget_events, resolve_event
 from bootstack.widgets._core.subscription import Subscription
@@ -18,20 +20,83 @@ _TABS_EVENTS: dict[str, str] = {
 }
 
 
-class _TabPage:
-    """Context-manager for placing children inside a tab's page frame."""
+class TabPage:
+    """Context-manager container returned by `Tabs.add()`.
 
-    def __init__(self, page_widget: tkinter.Widget) -> None:
+    Accepts the same layout kwargs as `Expander` — `layout=`, `gap=`,
+    `fill_items=`, `expand_items=`, `anchor_items=`, `columns=`, `rows=`,
+    `sticky_items=`, `auto_flow=`.
+    """
+
+    def __init__(
+        self,
+        page_widget: tkinter.Widget,
+        *,
+        layout: str = "vstack",
+        padding: Any = None,
+        gap: int = 0,
+        fill_items: str | None = None,
+        expand_items: bool | None = None,
+        anchor_items: str | None = None,
+        columns: int | list | None = None,
+        rows: int | list | None = None,
+        sticky_items: str | None = None,
+        auto_flow: str = "row",
+    ) -> None:
         self._page = page_widget
+        self._layout = layout
+
+        if layout in ("vstack", "hstack"):
+            self._layout_frame = PackFrame(
+                page_widget,
+                direction="vertical" if layout == "vstack" else "horizontal",
+                padding=padding,
+                gap=gap,
+                fill_items=normalize_fill(fill_items),
+                expand_items=expand_items,
+                anchor_items=anchor_items,
+            )
+        elif layout == "grid":
+            self._layout_frame = GridFrame(
+                page_widget,
+                columns=columns,
+                rows=rows,
+                padding=padding,
+                gap=gap,
+                sticky_items=sticky_items,
+                auto_flow=auto_flow,
+            )
+        else:
+            raise ValueError(
+                f"TabPage layout must be 'vstack', 'hstack', or 'grid', got {layout!r}"
+            )
+
+        self._fill_items = normalize_fill(fill_items)
+        self._expand_items = expand_items
+        self._anchor_items = anchor_items
+        self._sticky_items = sticky_items
+        self._layout_frame.pack(fill="both", expand=True)
 
     def _child_master(self) -> tkinter.Widget:
-        return self._page
+        return self._layout_frame
 
     def guide_layout(self, child: PublicWidgetBase, **layout_kw: Any) -> None:
+        if self._layout == "grid":
+            options = {k: v for k, v in layout_kw.items() if k in GRID_KEYS}
+            if "sticky" not in options and self._sticky_items:
+                options["sticky"] = self._sticky_items
+            child._internal.grid(in_=self._child_master(), **options)
+            return
         options = {k: v for k, v in layout_kw.items() if k in PACK_KEYS}
-        child._internal.pack(in_=self._page, **options)
+        if "fill" not in options and self._fill_items:
+            options["fill"] = self._fill_items
+        if "expand" not in options and self._expand_items is not None:
+            options["expand"] = self._expand_items
+        if "anchor" not in options and self._anchor_items:
+            options["anchor"] = self._anchor_items
+        child._internal.pack(in_=self._child_master(), **options)
 
-    def __enter__(self) -> "_TabPage":
+    def __enter__(self) -> "TabPage":
         push_container(self)
         return self
 
@@ -119,24 +184,37 @@ class Tabs(PublicWidgetBase):
         icon: str | None = None,
         closable: bool | Literal["hover"] | None = None,
         close_command: Callable | None = None,
-    ) -> _TabPage:
+        layout: str = "vstack",
+        padding: Any = None,
+        gap: int = 0,
+        fill_items: str | None = None,
+        expand_items: bool | None = None,
+        anchor_items: str | None = None,
+        columns: int | list | None = None,
+        rows: int | list | None = None,
+        sticky_items: str | None = None,
+        auto_flow: str = "row",
+    ) -> TabPage:
         """Add a tab and return a context manager for placing its children.
-
-        Usage::
-
-            with tabs.add("home", label="Home"):
-                bs.Label("Content goes here")
 
         Args:
             key: Unique identifier for the tab/page.
             label: Label displayed on the tab.
             icon: Icon name displayed on the tab.
-            closable: Close-button visibility for this tab. Overrides `enable_closing`.
-            close_command: Called when the close button is clicked. Defaults to
-                removing the tab via `forget_tab()`.
+            closable: Close-button visibility for this tab. Overrides `allow_close`.
+            close_command: Called when the close button is clicked.
+            layout: Internal layout — `'vstack'` (default), `'hstack'`, or `'grid'`.
+            gap: Space between children in pixels.
+            fill_items: Default fill direction applied to each child.
+            expand_items: Whether children expand to fill available space.
+            anchor_items: Default anchor applied to each child.
+            columns: Column definitions for `'grid'` layout.
+            rows: Row definitions for `'grid'` layout.
+            sticky_items: Default sticky value for grid children.
+            auto_flow: Grid auto-flow direction.
 
         Returns:
-            `_TabPage` — use as a context manager to place children.
+            `TabPage` — use as a context manager to place children.
         """
         add_kwargs: dict[str, Any] = {}
         if icon is not None:
@@ -147,7 +225,13 @@ class Tabs(PublicWidgetBase):
             add_kwargs["close_command"] = close_command
 
         page_widget = self._internal.add(key, text=label, **add_kwargs)
-        return _TabPage(page_widget)
+        return TabPage(
+            page_widget,
+            layout=layout, padding=padding, gap=gap, fill_items=fill_items,
+            expand_items=expand_items, anchor_items=anchor_items,
+            columns=columns, rows=rows, sticky_items=sticky_items,
+            auto_flow=auto_flow,
+        )
 
     def select(self, key: str) -> None:
         """Select the tab identified by `key`."""
@@ -209,4 +293,4 @@ class Tabs(PublicWidgetBase):
 
 register_widget_events(Tabs, _TABS_EVENTS)
 
-__all__ = ["Tabs", "TabChangeEventData", "TabRef"]
+__all__ = ["Tabs", "TabPage", "TabChangeEventData", "TabRef"]

--- a/tests/features/form_demo.py
+++ b/tests/features/form_demo.py
@@ -13,7 +13,7 @@ with bs.App(title="Create Account", size=(680, 760)) as app:
             bs.Label("Fill in the details below to get started.", font="body")
 
             # ── Personal information ────────────────────────────────────
-            with bs.VStack(variant='card', gap=12, fill_items="horizontal"):
+            with bs.Card(gap=12, fill_items="horizontal"):
                 bs.Label("Personal information", font="body[bold]")
                 with bs.Grid(columns=2, gap=12, sticky_items="ew"):
                     bs.TextField(label="First name")
@@ -23,7 +23,7 @@ with bs.App(title="Create Account", size=(680, 760)) as app:
                     bs.PasswordField(label="Password")
 
             # ── Location & language ─────────────────────────────────────
-            with bs.VStack(variant='card', gap=12, fill_items="horizontal"):
+            with bs.Card(gap=12, fill_items="horizontal"):
                 bs.Label("Location & language", font="body[bold]")
                 with bs.Grid(columns=2, gap=12, sticky_items="ew"):
                     countries = ["United States", "United Kingdom", "Canada",
@@ -38,7 +38,7 @@ with bs.App(title="Create Account", size=(680, 760)) as app:
                     bs.NumberField(label="Age", min_value=18, max_value=120)
 
             # ── Plan ───────────────────────────────────────────────────
-            with bs.VStack(variant='card', gap=8, fill_items="horizontal"):
+            with bs.Card(gap=8, fill_items="horizontal"):
                 bs.Label("Choose your plan", font="body[bold]")
                 rg = bs.RadioGroup(orient="vertical")
                 rg.add("Free — basic features, up to 3 projects", value="free")
@@ -47,7 +47,7 @@ with bs.App(title="Create Account", size=(680, 760)) as app:
                 rg.value = "free"
 
             # ── Notifications ───────────────────────────────────────────
-            with bs.VStack(variant='card', gap=8):
+            with bs.Card(gap=8):
                 bs.Label("Notifications", font="body[bold]")
                 with bs.HStack(gap=32):
                     bs.Switch("Email")
@@ -56,7 +56,7 @@ with bs.App(title="Create Account", size=(680, 760)) as app:
                     bs.Switch("Marketing")
 
             # ── Budget ─────────────────────────────────────────────────
-            with bs.VStack(variant='card', gap=8, fill_items="horizontal"):
+            with bs.Card(gap=8, fill_items="horizontal"):
                 bs.Label("Budget settings", font="body[bold]")
                 bs.Label("Monthly spend limit", font="body")
                 bs.Slider(
@@ -72,7 +72,7 @@ with bs.App(title="Create Account", size=(680, 760)) as app:
                 )
 
             # ── Agreement ───────────────────────────────────────────────
-            with bs.VStack(variant='card', gap=8, fill_items='horizontal'):
+            with bs.Card(gap=8, fill_items='horizontal'):
                 bs.Checkbox("I agree to the Terms of Service and Privacy Policy")
                 bs.Checkbox("I confirm I am 18 years of age or older")
 


### PR DESCRIPTION
## Summary

- All container `add()` methods (`Accordion.add()`, `SplitView.add()`, `PageStack.add()`, `Tabs.add()`) now return proper public types backed by a `PackFrame`/`GridFrame` layout engine — consistent with `VStack`/`HStack`/`Grid`/`GroupBox`
- Private `_AccordionSection`, `_SplitPane`, `_StackPage`, `_TabPage` replaced by public `AccordionSection`, `SplitPane`, `StackPage`, `TabPage` — all exported from `bs.*`
- `Expander` body gains the same layout kwargs; `show_border=`, `variant=`, `icon_position=`, `highlight=` promoted to explicit params
- `Accordion` gains `show_separators=`, `show_border=`, `variant=`, `padding=` as explicit kwargs
- `Card` widget reinstated as a semantic container with `accent=` support — background uses `accent[subtle]` token, border uses `b.color(accent)`, children inherit the subtle surface
- Expander style builder bugfix: `b.elevate(surface_token)` → `b.elevate(b.color(surface_token))`
- `Frame.__init__` now merges caller-supplied `style_options` with captured ones

## Layout kwargs available on all pane types

```python
with tabs.add("home", label="Home", layout="grid", columns=[1, 2], gap=8, padding=16):
    bs.Label("Left")
    bs.Label("Right")

with acc.add("Section", layout="hstack", gap=12, fill_items="x"):
    bs.TextField(label="First name")
    bs.TextField(label="Last name")

with bs.Card(accent="primary", gap=8):
    bs.Label("Users", accent="primary", font="body[bold]")
    bs.Label("1,234 active", font="heading-lg")
```

## Test plan

- [ ] Existing gallery pages load without errors (layout defaults to `'vstack'` — no regressions)
- [ ] `Expander` with `layout='hstack'`, `gap=8` lays out children horizontally
- [ ] `Accordion.add()` with `layout='grid'` places children in grid
- [ ] `show_separators=True` on Accordion renders separator lines
- [ ] `Card()` default — card surface background, stroke border
- [ ] `Card(accent='primary')` — subtle primary background, primary border, children inherit subtle surface
- [ ] Theme switch updates card backgrounds correctly
- [ ] `SplitView.add(padding=16)` adds padding inside pane

🤖 Generated with [Claude Code](https://claude.com/claude-code)