### PR TITLE
feat(data): unified data bag — carry non-scalar/undisplayed record fields

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -320,6 +320,52 @@ chevron is just an icon button.
 
 ---
 
+## Next initiative — Large-file streaming + pluggable formats (PLANNED 2026-06-07)
+
+Design settled, not started. Full rationale + checkpoints in memory
+`project_file_source_streaming`. Builds on the data bag (`feat/data-bag`,
+unpushed-merge pending) and the change hub (`project_datasource_change_events`).
+
+**Problem:** data scientists open CSV/JSON files with 100k–millions of rows.
+`FileDataSource` currently **extends `MemoryDataSource`** and loads the WHOLE file
+into a Python list of dicts → huge RAM + slow first-paint. Its `loading_strategy=
+'lazy'|'hybrid'` both **silently fall back to eager** (dishonest API).
+
+**Core decision:** stream-ingest the file into a **SQLite working store** (stdlib,
+zero dep) instead of a RAM list; `FileDataSource` becomes a thin streaming
+importer over `SqliteDataSource`, not a `MemoryDataSource` subclass. (Rejected:
+re-scan-per-page and in-memory offset index — both reinvent a DB to support
+sort/filter.)
+
+**Persistence model (settled w/ user):** original source file = **read-only
+input**, never silently written back (CSV isn't transactional; editing row N
+rewrites the whole file). Live CRUD is already uniform (protocol-level); what
+differs is **durability of the working store**, chosen by the store:
+`FileDataSource(path)` = temp on-disk SQLite, auto-cleaned, edits volatile;
+`FileDataSource(path, cache="x.db")` = named/persistent, edits survive, re-open
+skips re-ingest via mtime; `:memory:` = compact but RAM-bound. Saving edits =
+**explicit `export`** to a NEW file. Progressive paint: chunked ingest on a
+background thread, first chunk shows immediately, grid fills via the change hub.
+
+**Pluggable streaming format readers/writers** (extension-keyed registry; each is
+a streaming `iter_chunks(...)` feeding the chunked ingest; data bag handles
+non-scalar cells): stdlib **csv/tsv/jsonl/json/xml** always; optional
+**parquet/feather** (`bootstack[parquet]`→pyarrow), **hdf5**
+(`bootstack[hdf5]`→tables/h5py). `bootstack[excel]` already exists for export. Add
+`save(path)` inferring format from extension.
+
+**Checkpoints:** (1) streaming chunked `load()` on SqliteDataSource (accept an
+Iterable, `executemany` per chunk — today it needs a materialized Sequence); (2)
+pluggable streaming reader registry; (3) rebuild FileDataSource on a SQLite store
+(temp/cache/:memory:, bg-thread ingest, mtime cache, collapse the 5-strategy
+config — clean break); (4) streaming export (`SqliteDataSource.export_csv` still
+`fetchall()`s — make it chunked) + writer registry + DataTable export-menu format
+list; (5) docs/tests/examples + pyproject extras. **Deferred perf:** keyset
+pagination for deep scroll (OFFSET scans+discards); auto-index sorted/filtered
+columns.
+
+---
+
 ## Prior initiative — Sphinx docs + public API audit (MERGED)
 
 **Branch:** `feat/docs-api-improvements` (merged to `main`)

--- a/docs/reference/data-sources.rst
+++ b/docs/reference/data-sources.rst
@@ -54,6 +54,42 @@ with a ``FileSourceConfig``:
    ds = bs.FileDataSource("people.csv", config=config)
    bs.DataTable(data_source=ds)
 
+.. _carrying-extra-data:
+
+Carrying extra data
+-------------------
+
+A record can hold more than the widget shows. The columns of a ``DataTable`` or
+the template of a ``ListView`` are a *view* over the record — fields you don't
+display are still carried through, and event handlers get the whole record back,
+not a stripped-down shadow:
+
+.. code-block:: python
+
+   rows = [
+       {"id": 1, "name": "Ada", "role": "Engineer",
+        "tags": ["math", "logic"], "profile": {"era": 1840}},
+   ]
+   table = bs.DataTable(rows=rows, columns=["name", "role"])  # tags/profile hidden
+
+   table.on_row_click(lambda e: print(e.record["tags"]))      # → ['math', 'logic']
+
+This works the same on every source, but *what* a field may hold depends on
+where the records live:
+
+- **In-memory** (``MemoryDataSource``, ``FileDataSource``, and the default
+  ``ListView`` source) holds **anything**, including live Python objects, by
+  reference. The field you put in is the object you get back.
+- **SQLite** (``SqliteDataSource``) is persistent. Scalar fields (text, numbers,
+  booleans) become real columns you can filter and sort on. Non-scalar fields
+  (lists, dicts) are carried as JSON automatically and merged back transparently
+  on read — so records still read flat and complete. Because they ride a JSON
+  blob, **bagged fields are preserved but not queryable** via ``where`` / ``order``
+  (keep anything you need to filter on as a scalar field). Values must be
+  JSON-serializable; handing a live object to a SQLite-backed source raises
+  :class:`SerializationError <bootstack.errors.SerializationError>` — use an in-memory
+  source for those.
+
 Filtering and sorting
 ---------------------
 

--- a/docs/reference/data-sources.rst
+++ b/docs/reference/data-sources.rst
@@ -46,7 +46,12 @@ File-backed data
 ----------------
 
 ``FileDataSource`` loads records from CSV, JSON, or other formats, configured
-with a ``FileSourceConfig``:
+with a ``FileSourceConfig``. It reads the file into memory and treats the original
+as **read-only input** — edits live in memory only and are not written back, and
+``reload()`` re-reads the file. To save changes, export them to a new file
+(:meth:`export_csv <bootstack.data.SqliteDataSource.export_csv>` or the
+:class:`DataTable <bootstack.widgets.datatable.DataTable>` export menu). Only
+``SqliteDataSource`` (file-backed) persists changes in place:
 
 .. code-block:: python
 

--- a/docs/reference/errors.rst
+++ b/docs/reference/errors.rst
@@ -32,3 +32,7 @@ API reference
 .. autoclass:: bootstack.errors.DuplicateIdError
    :members:
    :undoc-members:
+
+.. autoclass:: bootstack.errors.SerializationError
+   :members:
+   :undoc-members:

--- a/docs/widgets/datatable.rst
+++ b/docs/widgets/datatable.rst
@@ -101,6 +101,23 @@ get an id assigned automatically. Point at a different field with
 ``id_field="employee_id"``, and replace the whole dataset later with
 ``table.set_rows(rows)``.
 
+Carrying extra data
+~~~~~~~~~~~~~~~~~~~~
+
+Columns are a *view* over the record, not the record itself. Fields you don't
+put in ``columns=`` are still carried through and handed back — a row event's
+``record`` is the full domain record, including the undisplayed fields:
+
+.. code-block:: python
+
+   rows = [{"id": 1, "name": "Ada", "tags": ["math"], "profile": {"era": 1840}}]
+   table = bs.DataTable(rows=rows, columns=["name"])      # tags/profile hidden
+   table.on_row_click(lambda e: print(e.record["tags"]))  # → ['math']
+
+On the default ``SqliteDataSource``, non-scalar fields (lists, dicts) are carried
+automatically and read back flat; on an in-memory source a field can hold any
+object. See :ref:`carrying-extra-data` for the storage-tiered details.
+
 Column visibility
 ~~~~~~~~~~~~~~~~~
 

--- a/docs/widgets/listview.rst
+++ b/docs/widgets/listview.rst
@@ -37,9 +37,6 @@ Each record is a plain ``dict``. The displayed fields are:
    * - ``'badge'``
      - Short label displayed on the right.
 
-Extra keys are stored and returned by ``get_selected()`` and events but
-are not rendered.
-
 .. code-block:: python
 
    bs.ListView(items=[
@@ -50,6 +47,24 @@ are not rendered.
            "icon":  "person-fill",
        },
    ])
+
+Carrying extra data
+~~~~~~~~~~~~~~~~~~~~
+
+The keys above are a *view* over the record, not the record itself. Extra keys
+are still carried through and handed back — ``get_selected()`` and the item
+events return the full record dict, including the undisplayed fields:
+
+.. code-block:: python
+
+   lv = bs.ListView(items=[
+       {"id": 1, "title": "Alice", "icon": "person-fill", "tags": ["vip"]},
+   ], selection_mode="multi")
+   lv.on_item_click(lambda e: print(e["tags"]))   # → ['vip']
+
+The default source is in-memory, so a field can hold any Python object; back the
+list with a persistent source and the same storage tiers apply. See
+:ref:`carrying-extra-data` for the details.
 
 Data source
 ~~~~~~~~~~~

--- a/docs/widgets/tree.rst
+++ b/docs/widgets/tree.rst
@@ -83,10 +83,14 @@ node, depth-first), or ``find(predicate)``:
 
 .. _tree-data:
 
-Whatever you don't spend on a display key rides along on the node's ``data``
-dict — passed as ``data=``, as extra keyword arguments to ``add()``, or as extra
-keys in a ``nodes=`` spec. Nothing is stripped, so a handler always gets your
-own domain object back:
+Carrying extra data
+~~~~~~~~~~~~~~~~~~~~
+
+The display keys (``label``, ``icon`` …) are a *view* over the node, not the node
+itself. Whatever you don't spend on a display key rides along on the node's
+``data`` dict — passed as ``data=``, as extra keyword arguments to ``add()``, or
+as extra keys in a ``nodes=`` spec. Nothing is stripped, so a handler always gets
+your own domain object back:
 
 .. code-block:: python
 
@@ -94,6 +98,10 @@ own domain object back:
    node.data["record_id"]   # 42
 
    tree.on_activate(lambda n: open_record(n.data["record_id"]))
+
+A tree is always in-memory, so ``data`` can hold any Python object — the same
+principle :doc:`datatable` and :doc:`listview` records follow
+(see :ref:`carrying-extra-data`).
 
 Expanding and lazy loading
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/bootstack/__init__.py
+++ b/src/bootstack/__init__.py
@@ -63,7 +63,7 @@ from bootstack.widgets.types import (
 )
 
 # ── Public widget layer ───────────────────────────────────────────────────────
-from bootstack.errors import BootstackError, UnknownEventError, ParentResolutionError, DuplicateIdError
+from bootstack.errors import BootstackError, UnknownEventError, ParentResolutionError, DuplicateIdError, SerializationError
 # The typed event payloads (ChangeEvent, SliderEvent, …) live in the
 # `bootstack.events` catalog — import them from there, not the top level.
 from bootstack.events import Event, Subscription
@@ -156,6 +156,7 @@ __all__ = [
     # Events, streams, scheduling, errors
     "Event", "Subscription", "Stream", "Handle", "Schedule", "Job",
     "BootstackError", "UnknownEventError", "ParentResolutionError", "DuplicateIdError",
+    "SerializationError",
     # App, shortcuts, images
     "AppSettings", "get_app_settings", "get_current_app",
     "Shortcuts", "Shortcut", "get_shortcuts", "Image",

--- a/src/bootstack/data/sqlite_source.py
+++ b/src/bootstack/data/sqlite_source.py
@@ -29,18 +29,27 @@ Example:
 from __future__ import annotations
 
 import csv
+import json
 import sqlite3
-from typing import Any, Dict, List, Optional, Union, Sequence
+from typing import Any, Dict, List, Optional, Tuple, Union, Sequence
 
 from bootstack.data.base import BaseDataSource
 from bootstack.data.query import Condition, SortKey, normalize_sort_keys
 from bootstack.data.types import Primitive
-from bootstack.errors import DuplicateIdError
+from bootstack.errors import DuplicateIdError, SerializationError
 from bootstack.events import DataChangeEvent
 
 # Internal column names — reserved by SqliteDataSource, never exposed to user data.
 _ROW_ID = "_bs_row_id"
 _ROW_SEL = "_bs_selected"
+# Hidden JSON column carrying every non-scalar record field (the data bag). SQL
+# columns are scalar-only, so lists/dicts/etc. ride here and are merged back into
+# the record transparently on read. See `_split_for_write` / `_row_to_record`.
+_ROW_DATA = "_bs_data"
+_INTERNAL_COLUMNS = (_ROW_ID, _ROW_SEL, _ROW_DATA)
+
+# Values storable directly in a SQL column. Everything else is bagged as JSON.
+_SCALAR_TYPES = (str, bytes, bytearray, bool, int, float, type(None))
 
 
 class SqliteDataSource(BaseDataSource):
@@ -120,6 +129,83 @@ class SqliteDataSource(BaseDataSource):
         text = str(name).replace('"', '""')
         return f'"{text}"'
 
+    # ---- data bag (hidden JSON column) ----------------------------------
+
+    @staticmethod
+    def _is_scalar(value: Any) -> bool:
+        """Whether a value can live directly in a SQL column (vs. the JSON bag)."""
+        return isinstance(value, _SCALAR_TYPES)
+
+    @staticmethod
+    def _dumps_bag(bag: Dict[str, Any]) -> Optional[str]:
+        """Serialize the non-scalar field bag to JSON (or None when empty)."""
+        if not bag:
+            return None
+        try:
+            return json.dumps(bag)
+        except (TypeError, ValueError) as exc:
+            raise SerializationError(
+                f"A record field could not be stored in this SQLite-backed source: "
+                f"{exc}. Persistent sources carry non-scalar fields as JSON, so values "
+                f"must be JSON-serializable (scalars, lists, dicts). To carry arbitrary "
+                f"Python objects, use an in-memory source instead."
+            ) from exc
+
+    def _split_for_write(
+        self, record: Dict[str, Any], column_fields: Sequence[str], default_id: Any = None
+    ) -> Tuple[Dict[str, Any], Dict[str, Any], Any]:
+        """Split a record into (scalar column values, JSON bag, row id).
+
+        Scalar values for known column fields stay as real columns; every other
+        field — non-scalar values, or keys without a column — rides the JSON bag.
+
+        Args:
+            record: The user record to write.
+            column_fields: Field names backed by real (scalar) columns.
+            default_id: Row id to use when the record carries none.
+
+        Returns:
+            A `(column_values, bag, row_id)` tuple.
+        """
+        col_set = set(column_fields)
+        col_vals: Dict[str, Any] = {}
+        bag: Dict[str, Any] = {}
+        for key, value in record.items():
+            if key in _INTERNAL_COLUMNS:
+                continue
+            if key in col_set and self._is_scalar(value):
+                col_vals[key] = value
+            else:
+                bag[key] = value
+
+        if record.get(_ROW_ID) is not None:
+            row_id = record[_ROW_ID]
+        elif self._id_field in record and self._is_scalar(record[self._id_field]):
+            row_id = record[self._id_field]
+        else:
+            row_id = default_id
+        return col_vals, bag, row_id
+
+    def _row_to_record(self, row: Any) -> Dict[str, Any]:
+        """Convert a raw SQL row to a record, merging the JSON bag back in.
+
+        Keeps the internal identity/selection columns (widgets read them); only
+        the JSON bag column is consumed — its keys are merged in where the row
+        has no scalar value, so the record reads back flat and complete.
+        """
+        rec = dict(row)
+        blob = rec.pop(_ROW_DATA, None)
+        if blob:
+            try:
+                extra = json.loads(blob)
+            except (TypeError, ValueError):
+                extra = None
+            if isinstance(extra, dict):
+                for key, value in extra.items():
+                    if rec.get(key) is None:
+                        rec[key] = value
+        return rec
+
     def _query(self, condition: Optional[Condition], sort_keys: List[SortKey]) -> List[Dict[str, Any]]:
         """Run a one-off filtered/sorted read without touching view state."""
         where, params = "", []
@@ -135,7 +221,7 @@ class SqliteDataSource(BaseDataSource):
             order = " ORDER BY " + ", ".join(terms)
         try:
             cursor = self.conn.execute(f"SELECT * FROM {self._table}{where}{order}", params)
-            return [dict(row) for row in cursor.fetchall()]
+            return [self._row_to_record(row) for row in cursor.fetchall()]
         except sqlite3.OperationalError:
             # Table does not exist yet (no data loaded).
             return []
@@ -166,62 +252,49 @@ class SqliteDataSource(BaseDataSource):
         except Exception:
             pass
 
-        # Normalize into a common structure: either dicts or row tuples with provided keys
+        # Normalize every input shape into a list of dicts (copies — we never
+        # mutate the caller's records).
         first = records[0]
-        using_dicts = isinstance(first, dict)
-        # Turn primitives into dicts
-        if not using_dicts and not isinstance(first, (list, tuple)):
-            records = [dict(text=str(x)) for x in records]
-            using_dicts = True
-
-        if using_dicts:
-            # Ensure internal helper columns. Adopt the record's own id field as the
-            # row identity when present, so callers' ids survive into selection/events.
-            for i, record in enumerate(records):
-                if _ROW_ID not in record:
-                    record[_ROW_ID] = record[self._id_field] if self._id_field in record else i
-                if _ROW_SEL not in record:
-                    record[_ROW_SEL] = 0
-
-            self._columns = list(records[0].keys())
-            col_types = {col: self._infer_type(records[0][col]) for col in self._columns}
-            rows_to_insert = [tuple(row.get(col) for col in self._columns) for row in records]
+        if isinstance(first, dict):
+            dict_records = [dict(r) for r in records]
+        elif isinstance(first, (list, tuple)):
+            keys = list(column_keys or [str(i) for i in range(len(first))])
+            dict_records = []
+            for row in records:
+                values = list(row)
+                if len(values) < len(keys):
+                    values += [None] * (len(keys) - len(values))
+                dict_records.append(dict(zip(keys, values)))
         else:
-            # Sequence rows with provided column keys
-            keys = list(column_keys or [])
-            if not keys:
-                keys = [str(i) for i in range(len(first))]
-            need_id = _ROW_ID not in keys
-            need_sel = _ROW_SEL not in keys
-            if need_id:
-                keys.append(_ROW_ID)
-            if need_sel:
-                keys.append(_ROW_SEL)
-            self._columns = keys
+            dict_records = [dict(text=str(x)) for x in records]
 
-            # Adopt the caller's id field (a data column) as the row identity if present.
-            user_id_idx = keys.index(self._id_field) if self._id_field in keys else None
+        # Real (scalar) columns come from the first record; every other field —
+        # non-scalar values, and keys absent from the first record — rides the
+        # hidden JSON data column instead.
+        first_rec = dict_records[0]
+        column_fields = [
+            k for k, v in first_rec.items()
+            if k not in _INTERNAL_COLUMNS and self._is_scalar(v)
+        ]
+        self._columns = column_fields + list(_INTERNAL_COLUMNS)
 
-            # Infer types from first row (pad to keys length)
-            padded_first = list(first) + [None] * (len(keys) - len(first))
-            if need_id and _ROW_ID in keys:
-                # Type the identity from the adopted id value (e.g. TEXT for UUIDs), else int.
-                padded_first[keys.index(_ROW_ID)] = padded_first[user_id_idx] if user_id_idx is not None else 0
-            if need_sel and _ROW_SEL in keys:
-                padded_first[keys.index(_ROW_SEL)] = 0
-            col_types = {col: self._infer_type(padded_first[idx]) for idx, col in enumerate(keys)}
+        col_types = {col: self._infer_type(first_rec.get(col)) for col in column_fields}
+        if self._id_field in column_fields:
+            # Type the identity from the adopted id value (e.g. TEXT for UUIDs).
+            col_types[_ROW_ID] = self._infer_type(first_rec.get(self._id_field))
+        else:
+            col_types[_ROW_ID] = "INTEGER"
+        col_types[_ROW_SEL] = "INTEGER"
+        col_types[_ROW_DATA] = "TEXT"
 
-            rows_to_insert = []
-            id_idx = keys.index(_ROW_ID) if _ROW_ID in keys else None
-            sel_idx = keys.index(_ROW_SEL) if _ROW_SEL in keys else None
-            value_len = len(keys)
-            for i, row in enumerate(records):
-                base_values = list(row[: value_len]) + [""] * (value_len - len(row))
-                if id_idx is not None:
-                    base_values[id_idx] = base_values[user_id_idx] if user_id_idx is not None else i
-                if sel_idx is not None:
-                    base_values[sel_idx] = 0
-                rows_to_insert.append(tuple(base_values))
+        rows_to_insert = []
+        for i, record in enumerate(dict_records):
+            col_vals, bag, row_id = self._split_for_write(record, column_fields, default_id=i)
+            values = [col_vals.get(col) for col in column_fields]
+            values.append(row_id)
+            values.append(0)
+            values.append(self._dumps_bag(bag))
+            rows_to_insert.append(tuple(values))
 
         col_definitions = ", ".join(
             f"{self._quote_identifier(col)} {col_types[col]}" + (" PRIMARY KEY" if col == _ROW_ID else "")
@@ -275,7 +348,7 @@ class SqliteDataSource(BaseDataSource):
             f" LIMIT {self.page_size} OFFSET {offset}"
         )
         cursor = self.conn.execute(query, params)
-        return [dict(row) for row in cursor.fetchall()]
+        return [self._row_to_record(row) for row in cursor.fetchall()]
 
     def next_page(self) -> List[Dict[str, Any]]:
         """Advance to next page and return its records."""
@@ -302,42 +375,56 @@ class SqliteDataSource(BaseDataSource):
 
     def insert(self, record: Dict[str, Any]) -> int:
         """Create new record and return its ID."""
-        if _ROW_ID not in record:
-            # Adopt the caller's id field as the identity, else auto-assign.
-            record[_ROW_ID] = record[self._id_field] if self._id_field in record else self._generate_new_id()
+        # Field names backed by real columns: the established schema, or — for a
+        # still-empty source — this record's own scalar fields.
+        if self._user_column_fields:
+            column_fields = self._user_column_fields
+        else:
+            column_fields = [
+                k for k, v in record.items()
+                if k not in _INTERNAL_COLUMNS and self._is_scalar(v)
+            ]
 
-        if _ROW_SEL not in record:
-            record[_ROW_SEL] = 0
+        col_vals, bag, row_id = self._split_for_write(record, column_fields)
+        if row_id is None:
+            row_id = self._generate_new_id()
 
         # Ensure table exists (handles empty datasources)
-        self._ensure_table_for_record(record)
+        self._ensure_table(column_fields, sample=record)
 
-        keys = list(record.keys())
+        keys = list(col_vals.keys()) + list(_INTERNAL_COLUMNS)
+        values = [col_vals[k] for k in col_vals] + [row_id, 0, self._dumps_bag(bag)]
         cols = ", ".join(self._quote_identifier(k) for k in keys)
         placeholders = ", ".join("?" for _ in keys)
-        values = tuple(record[col] for col in keys)
 
         try:
             with self.conn:
-                self.conn.execute(f"INSERT INTO {self._table} ({cols}) VALUES ({placeholders})", values)
+                self.conn.execute(
+                    f"INSERT INTO {self._table} ({cols}) VALUES ({placeholders})", tuple(values)
+                )
         except sqlite3.IntegrityError as exc:
             raise DuplicateIdError(
-                f"A record with id {record[_ROW_ID]!r} already exists — record ids "
+                f"A record with id {row_id!r} already exists — record ids "
                 f"must be unique. ({exc})"
             ) from exc
-        self._hub.emit(DataChangeEvent(kind="insert", id=record[_ROW_ID], record=dict(record)))
-        return record[_ROW_ID]
+        self._hub.emit(DataChangeEvent(kind="insert", id=row_id, record=dict(record)))
+        return row_id
 
     def get(self, record_id: Any) -> Optional[Dict[str, Any]]:
         """Retrieve single record by ID."""
         cursor = self.conn.execute(f"SELECT * FROM {self._table} WHERE {_ROW_ID} = ?", (record_id,))
         row = cursor.fetchone()
-        return dict(row) if row else None
+        return self._row_to_record(row) if row else None
+
+    @property
+    def _user_column_fields(self) -> List[str]:
+        """The real (scalar) column field names, excluding internal columns."""
+        return [c for c in self._columns if c not in _INTERNAL_COLUMNS]
 
     # ---------- row identity ----------
     def _internal_fields(self) -> "frozenset[str]":
-        """Hide the internal identity and selection columns from users."""
-        return frozenset({_ROW_ID, _ROW_SEL})
+        """Hide the internal identity, selection, and data-bag columns from users."""
+        return frozenset(_INTERNAL_COLUMNS)
 
     def _record_id(self, record: Any) -> Any:
         """Identity is the internal `_bs_row_id` column."""
@@ -349,10 +436,52 @@ class SqliteDataSource(BaseDataSource):
         """Update record fields by ID."""
         if not updates:
             return False
-        set_clause = ", ".join(f"{self._quote_identifier(k)} = ?" for k in updates)
-        values = tuple(updates.values()) + (record_id,)
+
+        col_set = set(self._user_column_fields)
+        set_parts: List[str] = []
+        params: List[Any] = []
+        bag_updates: Dict[str, Any] = {}
+        for key, value in updates.items():
+            if key in _INTERNAL_COLUMNS:
+                continue
+            if key in col_set and self._is_scalar(value):
+                set_parts.append(f"{self._quote_identifier(key)} = ?")
+                params.append(value)
+            else:
+                # A non-scalar value (or a field without a column) rides the bag.
+                # If the field also has a real column, null it so the bag wins on read.
+                if key in col_set:
+                    set_parts.append(f"{self._quote_identifier(key)} = NULL")
+                bag_updates[key] = value
+
+        if bag_updates:
+            self._ensure_data_column()
+            row = self.conn.execute(
+                f"SELECT {_ROW_DATA} FROM {self._table} WHERE {_ROW_ID} = ?", (record_id,)
+            ).fetchone()
+            if row is None:
+                return False
+            existing: Dict[str, Any] = {}
+            blob = row[0]
+            if blob:
+                try:
+                    parsed = json.loads(blob)
+                    if isinstance(parsed, dict):
+                        existing = parsed
+                except (TypeError, ValueError):
+                    pass
+            existing.update(bag_updates)
+            set_parts.append(f"{self._quote_identifier(_ROW_DATA)} = ?")
+            params.append(self._dumps_bag(existing))
+
+        if not set_parts:
+            return False
+
+        params.append(record_id)
         with self.conn:
-            cur = self.conn.execute(f"UPDATE {self._table} SET {set_clause} WHERE {_ROW_ID} = ?", values)
+            cur = self.conn.execute(
+                f"UPDATE {self._table} SET {', '.join(set_parts)} WHERE {_ROW_ID} = ?", params
+            )
             changed = cur.rowcount > 0
         if changed:
             self._hub.emit(DataChangeEvent(kind="update", id=record_id, record=dict(updates)))
@@ -385,8 +514,13 @@ class SqliteDataSource(BaseDataSource):
         return max_id + 1
 
     # ------------------------------------------------------------------ helpers
-    def _ensure_table_for_record(self, record: Dict[str, Any]) -> None:
-        """Create the table if it does not yet exist, inferring columns from record."""
+    def _ensure_table(self, column_fields: Sequence[str], sample: Dict[str, Any]) -> None:
+        """Create the table if it does not yet exist, inferring scalar columns.
+
+        Args:
+            column_fields: Scalar field names that become real columns.
+            sample: A representative record used for column-type inference.
+        """
         try:
             # Quick existence check
             self.conn.execute(f"SELECT 1 FROM {self._table} LIMIT 1")
@@ -394,21 +528,22 @@ class SqliteDataSource(BaseDataSource):
         except Exception:
             pass
 
-        cols = list(self._columns) if self._columns else list(record.keys())
-        if _ROW_ID not in cols:
-            cols.append(_ROW_ID)
-        if _ROW_SEL not in cols:
-            cols.append(_ROW_SEL)
+        cols = list(column_fields) + list(_INTERNAL_COLUMNS)
         self._columns = cols
 
-        col_types = {}
+        col_types: Dict[str, str] = {}
         for c in cols:
-            if c == _ROW_ID:
+            if c == _ROW_SEL:
                 col_types[c] = "INTEGER"
-            elif c == _ROW_SEL:
-                col_types[c] = "INTEGER"
+            elif c == _ROW_DATA:
+                col_types[c] = "TEXT"
+            elif c == _ROW_ID:
+                if self._id_field in sample and self._is_scalar(sample[self._id_field]):
+                    col_types[c] = self._infer_type(sample[self._id_field])
+                else:
+                    col_types[c] = "INTEGER"
             else:
-                col_types[c] = self._infer_type(record.get(c))
+                col_types[c] = self._infer_type(sample.get(c))
 
         col_definitions = ", ".join(
             f"{self._quote_identifier(col)} {col_types[col]}" + (" PRIMARY KEY" if col == _ROW_ID else "")
@@ -416,6 +551,18 @@ class SqliteDataSource(BaseDataSource):
         )
         with self.conn:
             self.conn.execute(f"CREATE TABLE IF NOT EXISTS {self._table} ({col_definitions})")
+
+    def _ensure_data_column(self) -> None:
+        """Add the hidden JSON data column if it is missing (legacy tables)."""
+        if _ROW_DATA in self._columns:
+            return
+        try:
+            with self.conn:
+                self.conn.execute(f"ALTER TABLE {self._table} ADD COLUMN {_ROW_DATA} TEXT")
+        except sqlite3.OperationalError:
+            pass  # no table yet, or column already present
+        if _ROW_DATA not in self._columns:
+            self._columns.append(_ROW_DATA)
 
     # === SELECTION ====
 
@@ -495,7 +642,7 @@ class SqliteDataSource(BaseDataSource):
             query += f" LIMIT {self.page_size} OFFSET {offset}"
 
         cursor = self.conn.execute(query)
-        return [dict(row) for row in cursor.fetchall()]
+        return [self._row_to_record(row) for row in cursor.fetchall()]
 
     def _ensure_selected_column(self):
         """Add selection column to table if it doesn't exist."""
@@ -540,11 +687,22 @@ class SqliteDataSource(BaseDataSource):
         if not rows:
             return
 
+        # Emit public records — internal columns stripped, the JSON bag merged
+        # back into flat fields — over the union of all keys.
+        records = [self._public_record(self._row_to_record(row)) for row in rows]
+        fieldnames: List[str] = []
+        seen: set = set()
+        for rec in records:
+            for key in rec.keys():
+                if key not in seen:
+                    seen.add(key)
+                    fieldnames.append(key)
+
         with open(filepath, mode='w', newline='', encoding='utf-8') as f:
-            writer = csv.DictWriter(f, fieldnames=rows[0].keys())
+            writer = csv.DictWriter(f, fieldnames=fieldnames)
             writer.writeheader()
-            for row in rows:
-                writer.writerow(dict(row))
+            for rec in records:
+                writer.writerow({k: rec.get(k) for k in fieldnames})
 
     def page_slice(self, start_index: int, count: int) -> List[Dict[str, Any]]:
         """Get records by start index and count (respects filter/sort)."""
@@ -554,7 +712,7 @@ class SqliteDataSource(BaseDataSource):
             f" LIMIT {count} OFFSET {start_index}"
         )
         cursor = self.conn.execute(query, params)
-        return [dict(row) for row in cursor.fetchall()]
+        return [self._row_to_record(row) for row in cursor.fetchall()]
 
     def get_distinct_values(self, column: str, limit: int = 1000) -> List[Any]:
         """Get distinct values for a column.

--- a/src/bootstack/errors.py
+++ b/src/bootstack/errors.py
@@ -20,9 +20,19 @@ class DuplicateIdError(BootstackError):
     """
 
 
+class SerializationError(BootstackError):
+    """Raised when a persistent data source receives a value it cannot store.
+
+    File- and database-backed sources carry non-scalar record fields as JSON,
+    so those values must be JSON-serializable (scalars, lists, dicts). Store
+    arbitrary Python objects in an in-memory source instead.
+    """
+
+
 __all__ = [
     "BootstackError",
     "DuplicateIdError",
     "ParentResolutionError",
+    "SerializationError",
     "UnknownEventError",
 ]

--- a/tests/data/test_data_bag.py
+++ b/tests/data/test_data_bag.py
@@ -1,0 +1,202 @@
+"""Tests for the unified data bag — undisplayed / non-scalar record fields.
+
+A record should never lose user data: fields the widget does not display are
+still carried through and handed back. Fidelity is tiered by storage:
+
+- In-memory sources (``MemoryDataSource``, ``FileDataSource``) hold *anything*,
+  including live Python objects, by reference.
+- ``SqliteDataSource`` is persistent: SQL columns are scalar-only, so non-scalar
+  fields (lists/dicts) ride a hidden JSON column and round-trip transparently.
+  Values must be JSON-serializable; live objects raise ``SerializationError``.
+
+These are headless (no App) — the data layer is App-independent.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from bootstack import col
+from bootstack.data import FileDataSource, MemoryDataSource, SqliteDataSource
+from bootstack.errors import SerializationError
+
+
+# ---------------------------------------------------------------------------
+# Cross-source: undisplayed scalar fields are never dropped
+# ---------------------------------------------------------------------------
+
+ALL_SOURCES = [MemoryDataSource, SqliteDataSource]
+
+
+@pytest.mark.parametrize("cls", ALL_SOURCES)
+def test_undisplayed_scalar_field_survives(cls):
+    ds = cls().load([{"id": 1, "name": "Alice", "secret": 42}])
+    rec = ds.get(1)
+    assert rec["name"] == "Alice"
+    assert rec["secret"] == 42  # not a "display" field, still carried
+
+
+@pytest.mark.parametrize("cls", ALL_SOURCES)
+def test_nonscalar_fields_roundtrip(cls):
+    ds = cls().load(
+        [
+            {"id": 1, "name": "Alice", "tags": ["vip", "beta"], "meta": {"score": 9}},
+            {"id": 2, "name": "Bob", "tags": [], "meta": {"score": 3}},
+        ]
+    )
+    rec = ds.get(1)
+    assert rec["tags"] == ["vip", "beta"]
+    assert rec["meta"] == {"score": 9}
+
+    # And through paging / index slicing.
+    page = ds.page(0)
+    assert page[0]["tags"] == ["vip", "beta"]
+    sliced = ds.page_slice(0, 2)
+    assert sliced[1]["meta"] == {"score": 3}
+
+
+@pytest.mark.parametrize("cls", ALL_SOURCES)
+def test_public_record_keeps_bag_strips_internals(cls):
+    ds = cls().load([{"id": 7, "name": "Alice", "tags": ["x"]}])
+    raw = ds.get(7)
+    pub = ds._public_record(raw)
+    assert pub["id"] == 7
+    assert pub["name"] == "Alice"
+    assert pub["tags"] == ["x"]
+    # No bookkeeping leaks into the public-facing record.
+    for f in ds._internal_fields():
+        assert f not in pub
+
+
+@pytest.mark.parametrize("cls", ALL_SOURCES)
+def test_scalar_fields_stay_queryable_with_bag_present(cls):
+    ds = cls().load(
+        [
+            {"id": 1, "name": "Alice", "age": 30, "tags": ["a"]},
+            {"id": 2, "name": "Bob", "age": 20, "tags": ["b"]},
+            {"id": 3, "name": "Carol", "age": 40, "tags": ["c"]},
+        ]
+    )
+    ds.where(col("age") >= 30).order("-age")
+    rows = ds.page(0)
+    assert [r["name"] for r in rows] == ["Carol", "Alice"]
+    # The bag rode along through the filtered/sorted read.
+    assert rows[0]["tags"] == ["c"]
+
+
+@pytest.mark.parametrize("cls", ALL_SOURCES)
+def test_insert_with_nonscalar(cls):
+    ds = cls().load([{"id": 1, "name": "Alice", "tags": ["x"]}])
+    rid = ds.insert({"name": "Bob", "tags": ["y", "z"], "meta": {"k": 1}})
+    rec = ds.get(rid)
+    assert rec["tags"] == ["y", "z"]
+    assert rec["meta"] == {"k": 1}
+
+
+@pytest.mark.parametrize("cls", ALL_SOURCES)
+def test_update_bag_field(cls):
+    ds = cls().load([{"id": 1, "name": "Alice", "tags": ["x"], "meta": {"k": 1}}])
+    assert ds.update(1, {"tags": ["x", "y"]}) is True
+    assert ds.get(1)["tags"] == ["x", "y"]
+    # An untouched bag field is preserved across the update.
+    assert ds.get(1)["meta"] == {"k": 1}
+
+
+@pytest.mark.parametrize("cls", ALL_SOURCES)
+def test_update_scalar_preserves_bag(cls):
+    ds = cls().load([{"id": 1, "name": "Alice", "tags": ["x"]}])
+    assert ds.update(1, {"name": "Alice B."}) is True
+    rec = ds.get(1)
+    assert rec["name"] == "Alice B."
+    assert rec["tags"] == ["x"]
+
+
+@pytest.mark.parametrize("cls", ALL_SOURCES)
+def test_selected_records_carry_bag(cls):
+    ds = cls().load(
+        [
+            {"id": 1, "name": "Alice", "tags": ["x"]},
+            {"id": 2, "name": "Bob", "tags": ["y"]},
+        ]
+    )
+    ds.select(2)
+    sel = ds.selected()
+    assert len(sel) == 1
+    assert sel[0]["tags"] == ["y"]
+
+
+# ---------------------------------------------------------------------------
+# SqliteDataSource specifics — JSON storage, scalar columns, error contract
+# ---------------------------------------------------------------------------
+
+
+def test_sqlite_scalar_stays_real_column():
+    ds = SqliteDataSource()
+    ds.load([{"id": 1, "name": "Alice", "tags": ["x"]}])
+    # A scalar field is a real column (filterable); the non-scalar one is bagged.
+    cols = ds._user_column_fields
+    assert "name" in cols
+    assert "tags" not in cols
+
+
+def test_sqlite_stores_bag_as_json_blob():
+    ds = SqliteDataSource()
+    ds.load([{"id": 1, "name": "Alice", "tags": ["x", "y"]}])
+    blob = ds.conn.execute("SELECT _bs_data FROM records WHERE _bs_row_id = 1").fetchone()[0]
+    assert json.loads(blob) == {"tags": ["x", "y"]}
+
+
+def test_sqlite_extra_scalar_key_after_load_is_bagged():
+    # A scalar key absent from the schema-defining first row has no column, so it
+    # rides the bag rather than being dropped.
+    ds = SqliteDataSource()
+    ds.load([{"id": 1, "name": "Alice"}])
+    rid = ds.insert({"name": "Bob", "nickname": "Bobby"})
+    assert ds.get(rid)["nickname"] == "Bobby"
+
+
+def test_sqlite_live_object_raises_serialization_error():
+    class Widget:
+        pass
+
+    ds = SqliteDataSource()
+    with pytest.raises(SerializationError):
+        ds.load([{"id": 1, "name": "Alice", "obj": Widget()}])
+
+
+def test_sqlite_insert_live_object_raises_serialization_error():
+    class Widget:
+        pass
+
+    ds = SqliteDataSource().load([{"id": 1, "name": "Alice", "tags": ["x"]}])
+    with pytest.raises(SerializationError):
+        ds.insert({"name": "Bob", "obj": Widget()})
+
+
+# ---------------------------------------------------------------------------
+# In-memory fidelity — live objects by reference
+# ---------------------------------------------------------------------------
+
+
+def test_memory_carries_live_object_by_reference():
+    class Widget:
+        pass
+
+    obj = Widget()
+    ds = MemoryDataSource().load([{"id": 1, "name": "Alice", "obj": obj}])
+    assert ds.get(1)["obj"] is obj
+    assert ds._public_record(ds.get(1))["obj"] is obj
+
+
+def test_file_source_carries_lists_and_dicts(tmp_path):
+    path = tmp_path / "data.json"
+    path.write_text(
+        json.dumps([{"id": 1, "name": "Alice", "tags": ["x", "y"], "meta": {"k": 1}}]),
+        encoding="utf-8",
+    )
+    ds = FileDataSource(str(path))
+    ds.load()
+    rec = ds.get(1)
+    assert rec["tags"] == ["x", "y"]
+    assert rec["meta"] == {"k": 1}

--- a/tests/widgets/public/test_datatable.py
+++ b/tests/widgets/public/test_datatable.py
@@ -127,6 +127,32 @@ def test_sqlite_source_default_still_works(shown_app):
         assert "_bs_row_id" not in r and "_bs_selected" not in r
 
 
+# --------------------------------------------------------------------------- data bag
+
+
+@pytest.mark.gui
+def test_nonscalar_fields_survive_default_source(shown_app):
+    """Undisplayed, non-scalar fields ride the data bag and come back intact,
+    even on the default (Sqlite) source where columns are scalar-only."""
+    table = bs.DataTable(
+        rows=[
+            {"id": 1, "name": "Ada", "tags": ["math", "eng"], "meta": {"era": 1840}},
+            {"id": 2, "name": "Boole", "tags": ["logic"], "meta": {"era": 1850}},
+        ],
+        columns=["name"],  # tags/meta are not displayed
+        page_size=10,
+    )
+    _pump(shown_app)
+
+    rows = {r["id"]: r for r in table.to_rows("all")}
+    assert rows[1]["tags"] == ["math", "eng"]
+    assert rows[1]["meta"] == {"era": 1840}
+    assert rows[2]["tags"] == ["logic"]
+    # No bookkeeping columns leak.
+    for r in table.to_rows("all"):
+        assert "_bs_data" not in r and "_bs_row_id" not in r
+
+
 # --------------------------------------------------------------------------- appearance
 
 

--- a/tests/widgets/public/test_listview.py
+++ b/tests/widgets/public/test_listview.py
@@ -1,0 +1,60 @@
+"""GUI tests for the public ListView widget — data-bag fidelity.
+
+ListView is in-memory (its default source is a ``MemoryDataSource``), so a record
+carries *every* user field — including ones the item template never displays and
+arbitrary live objects — and hands them back from ``get_selected()``.
+"""
+from __future__ import annotations
+
+import pytest
+
+import bootstack as bs
+
+
+@pytest.fixture(scope="module")
+def shown_app():
+    """A single shown App so child widgets get mapped and styles build."""
+    app = bs.App()
+    app.__enter__()
+    root = app._tk_root
+    root.deiconify()
+    root.update_idletasks()
+    try:
+        yield app
+    finally:
+        try:
+            app.__exit__(None, None, None)
+        except Exception:
+            pass
+        try:
+            root.destroy()
+        except Exception:
+            pass
+
+
+def _pump(app) -> None:
+    root = app._tk_root
+    root.update_idletasks()
+    root.update()
+
+
+@pytest.mark.gui
+def test_undisplayed_fields_survive(shown_app):
+    payload = object()
+    lv = bs.ListView(
+        items=[
+            {"id": 1, "title": "Alice", "tags": ["vip"], "handle": payload},
+            {"id": 2, "title": "Bob", "tags": ["beta"], "handle": payload},
+        ],
+        selection_mode="multi",
+    )
+    _pump(shown_app)
+
+    lv.select_all()
+    _pump(shown_app)
+
+    selected = {r["id"]: r for r in lv.get_selected()}
+    assert selected[1]["tags"] == ["vip"]
+    # In-memory: an arbitrary live object rides along by reference.
+    assert selected[1]["handle"] is payload
+    assert selected[2]["title"] == "Bob"


### PR DESCRIPTION
## Summary
Adds a **unified data bag** across Tree, DataTable, and ListView: a record's display config (columns / item template / Tree display keys) is a non-destructive *view*, so fields the widget doesn't show are still carried through and handed back in event handlers.

Fidelity is tiered by storage, stated in the contract:
- **In-memory** (`MemoryDataSource`, `FileDataSource`, default ListView source, Tree nodes) holds anything, including live Python objects, by reference.
- **`SqliteDataSource`** (DataTable's default) gains a hidden `_bs_data` JSON column: scalar fields stay real, queryable columns; non-scalar fields (list/dict) are auto-serialized and merged back transparently on read, so records read flat and complete. Always-on, no flag. Bagged fields are preserved but not `where`/`order`-queryable (inherent — SQL can't query a list). Non-JSON values raise the new `bs.SerializationError`.

## Design decisions
- **Transparent-flat, always-on, no flag.** Unification is the *principle* ("you always get your full domain data back"), not a literal shared `.data` key — the two widget families have different identity models (Tree = object-handle → `node.data`; DataTable/ListView = dict-record → the whole flat record).

## Tests
- `tests/data/test_data_bag.py` — 23 headless, parametrized across Memory + Sqlite.
- `tests/widgets/public/test_listview.py` (new) + a DataTable bag test.
- Existing data + datatable suites unaffected.

## Docs
- Standardized "Carrying extra data" subsection across datatable/listview/tree pages.
- Canonical reference in `data-sources.rst` + `SerializationError` documented.
- Clarified `FileDataSource` read-only-input persistence semantics.
- Handoff: planned the follow-on large-file streaming initiative in CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)