### PR TITLE
feat(data): large-file streaming — chunked load + pluggable reader registry (cp1–cp2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -364,6 +364,23 @@ list; (5) docs/tests/examples + pyproject extras. **Deferred perf:** keyset
 pagination for deep scroll (OFFSET scans+discards); auto-index sorted/filtered
 columns.
 
+### Related follow-up — Tree data-source backing (PLANNED, parked behind this)
+
+Full design in memory `project_tree_datasource_backing`. The hierarchical sibling
+of file streaming ("fetch on demand"). **Decision:** hierarchy is a *projection*
+over a FLAT adjacency-list source (every row has `parent_id`), NOT a storage mode
+or a runtime flag — a bare `structure='tree'` flag adds no methods to the flat
+protocol. Reuse Tree's existing per-node `loader` seam: `Tree(data_source=src,
+parent_field="parent_id")` issues `src.where(col(parent_field)==node.id).page(...)`
+per expand, so a million-node tree loads branch-by-branch (only expanded nodes are
+queried). No flat-protocol change; any `DataSourceProtocol` can back a tree;
+consistent with the columns/data-bag "view over records" philosophy and the
+DataTable↔Tree litmus. Optional later: a native `TreeDataSourceProtocol`
+(`roots`/`children`/`has_children`) for genuinely tree-shaped stores (filesystem,
+graph DB) — the honest "capability" version of the flag; the flat adapter is built
+on top of it. Defaults: adjacency list (not materialized path); filtering-a-tree
+scoped out of v1. Do AFTER the file-streaming checkpoints.
+
 ---
 
 ## Prior initiative — Sphinx docs + public API audit (MERGED)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -354,15 +354,29 @@ non-scalar cells): stdlib **csv/tsv/jsonl/json/xml** always; optional
 (`bootstack[hdf5]`→tables/h5py). `bootstack[excel]` already exists for export. Add
 `save(path)` inferring format from extension.
 
-**Checkpoints:** (1) streaming chunked `load()` on SqliteDataSource (accept an
-Iterable, `executemany` per chunk — today it needs a materialized Sequence); (2)
-pluggable streaming reader registry; (3) rebuild FileDataSource on a SQLite store
-(temp/cache/:memory:, bg-thread ingest, mtime cache, collapse the 5-strategy
-config — clean break); (4) streaming export (`SqliteDataSource.export_csv` still
-`fetchall()`s — make it chunked) + writer registry + DataTable export-menu format
-list; (5) docs/tests/examples + pyproject extras. **Deferred perf:** keyset
-pagination for deep scroll (OFFSET scans+discards); auto-index sorted/filtered
-columns.
+**Checkpoints:** (1) DONE — streaming chunked `load()` on SqliteDataSource
+(commit 2e1d4447; accepts an Iterable, `executemany` per chunk, atomic via explicit
+BEGIN). (2) DONE — pluggable streaming reader registry `data/readers.py`
+(bde6776c; csv/tsv/json/jsonl/xml stdlib + parquet/feather/hdf5 gated;
+register_reader/read_records/get_reader/supported_extensions). (3) rebuild
+FileDataSource on a SQLite store (temp/cache/:memory:, bg-thread ingest, mtime
+cache, collapse the 5-strategy config — clean break). (4) streaming export
+(`SqliteDataSource.export_csv` still `fetchall()`s — make it chunked) + writer
+registry + DataTable export-menu format list; (5) docs/tests/examples + pyproject
+extras (`[parquet]`/`[hdf5]` already added in cp2).
+
+**Data-layer review findings folded into CP3 (2026-06-07; full list in memory
+`project_file_source_streaming`):** add `SqliteDataSource.close()` (+ ctx-mgr) for
+temp-DB cleanup — none exists, blocker for temp files; `readers.read_json` ignores
+`config.json_orient` (decide: implement orient or drop it as a pandas-ism); widen
+`FileSourceConfig.file_format` Literal to include xml/parquet/feather/hdf5; align
+empty `load()` (Memory clears+emits, Sqlite no-ops). Already fixed in review
+(3dd1016d): `MemoryDataSource.load` accepts any iterable; `_bs_data` documented.
+Noted/non-blocking: change-hub subscriptions are strong refs (leak vector if a
+widget never cancels `on_change`/`observe` on destroy).
+
+**Deferred perf:** keyset pagination for deep scroll (OFFSET scans+discards);
+auto-index sorted/filtered columns.
 
 ### Related follow-up — Tree data-source backing (PLANNED, parked behind this)
 

--- a/docs/reference/data-sources.rst
+++ b/docs/reference/data-sources.rst
@@ -2,15 +2,15 @@ Data Sources
 ============
 
 A data source is the bridge between your records and the data-bound widgets —
-:class:`ListView <bootstack.widgets.listview.ListView>` and :class:`DataTable
-<bootstack.widgets.datatable.DataTable>`. It owns the rows and serves them a page
-at a time, so the same widget works whether the data lives in a Python list, a
-SQLite database, or a file on disk.
+:doc:`/widgets/listview` and :doc:`/widgets/datatable`. It owns the records and
+serves them a page at a time, so the same widget works whether your data lives in
+memory, a SQLite database, or a file on disk. (:doc:`/widgets/tree` isn't
+data-source-backed — it holds its own nodes in memory — but shares the same
+record and :ref:`data bag <carrying-extra-data>` model.)
 
-For small lists you often don't touch a data source at all — pass ``items=`` /
-``rows=`` and the widget builds one for you. Reach for an explicit source when
-you want to share data between widgets, back it with a database, or load it from
-a file.
+You often don't touch a data source at all — pass ``items=`` / ``rows=`` and the
+widget builds one for you. Reach for an explicit source when you want to share
+data between widgets, back it with a database, or load it from a file.
 
 In-memory data
 --------------
@@ -45,7 +45,7 @@ supply your own to back the table with a database file:
 File-backed data
 ----------------
 
-``FileDataSource`` loads records from CSV, JSON, or other formats, configured
+``FileDataSource`` loads records from CSV, TSV, JSON, and JSONL files, configured
 with a ``FileSourceConfig``. It reads the file into memory and treats the original
 as **read-only input** — edits live in memory only and are not written back, and
 ``reload()`` re-reads the file. To save changes, export them to a new file
@@ -58,6 +58,13 @@ as **read-only input** — edits live in memory only and are not written back, a
    config = bs.FileSourceConfig(file_format="csv", has_header=True)
    ds = bs.FileDataSource("people.csv", config=config)
    bs.DataTable(data_source=ds)
+
+.. note::
+
+   **Planned:** support for columnar and scientific formats — Parquet, Feather,
+   and HDF5 (plus XML) — via optional extras (``pip install bootstack[parquet]``,
+   ``bootstack[hdf5]``). Each will be a streaming reader that ingests large files
+   in chunks with bounded memory, rather than loading the whole file at once.
 
 .. _carrying-extra-data:
 

--- a/docs/reference/data-sources.rst
+++ b/docs/reference/data-sources.rst
@@ -232,6 +232,27 @@ Records are plain dicts — :data:`Record <bootstack.data.Record>` is
 the set of values a cell may hold (``str``, ``int``, ``float``, ``bool``,
 ``None``).
 
+Honoring the data bag
+~~~~~~~~~~~~~~~~~~~~~~
+
+The :ref:`data bag <carrying-extra-data>` is a *contract*, not a mechanism, so
+participating takes almost nothing:
+
+- Return **complete records** from ``page`` / ``page_slice`` / ``get`` —
+  including fields the widget doesn't display. Don't strip anything.
+- Declare any bookkeeping keys you add (an internal id, a selection flag) by
+  overriding ``_internal_fields()``. The inherited ``_public_record`` /
+  ``_record_id`` then hide them and surface ``id`` for you.
+
+That's the whole contract. *How* a field survives is your backend's concern:
+an in-memory or document store (e.g. MongoDB's BSON) holds nested values and live
+objects natively, so it honors the contract for free. A store with scalar-only
+columns has to serialize non-scalar fields itself — that is exactly what
+``SqliteDataSource`` does with a hidden JSON column, and why it raises
+:class:`SerializationError <bootstack.errors.SerializationError>` for values it
+can't serialize. None of that machinery is required of a custom source; only
+sources that genuinely serialize need it.
+
 See also
 --------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,15 @@ dependencies = [
 excel = [
     "XlsxWriter>=3",
 ]
+# Columnar formats — read/write Parquet and Feather/Arrow via pyarrow.
+parquet = [
+    "pyarrow>=14",
+]
+# Scientific tabular format — read/write HDF5 via pandas + PyTables.
+hdf5 = [
+    "pandas>=2",
+    "tables>=3.8",
+]
 docs = [
     "sphinx>=7.2",
     "sphinx-autodoc-typehints",

--- a/src/bootstack/data/__init__.py
+++ b/src/bootstack/data/__init__.py
@@ -40,6 +40,12 @@ from bootstack.data.sqlite_source import SqliteDataSource
 from bootstack.data.file_source import FileDataSource, FileSourceConfig
 from bootstack.data.query import col, Column, Condition, SortKey, any_of, all_of
 from bootstack.data.types import DataSourceProtocol, Record, Primitive
+from bootstack.data.readers import (
+    register_reader,
+    read_records,
+    get_reader,
+    supported_extensions,
+)
 
 __all__ = [
     'BaseDataSource',
@@ -56,4 +62,8 @@ __all__ = [
     'SortKey',
     'any_of',
     'all_of',
+    'register_reader',
+    'read_records',
+    'get_reader',
+    'supported_extensions',
 ]

--- a/src/bootstack/data/file_source.py
+++ b/src/bootstack/data/file_source.py
@@ -73,6 +73,8 @@ class FileSourceConfig:
         has_header: Whether the first row contains column names.
         json_lines: True for line-delimited JSON (JSONL/NDJSON format).
         json_orient: Pandas-like orientation for JSON arrays.
+        xml_record_tag: Element tag that marks one record (None = direct children of the root).
+        hdf5_key: Dataset/table key to read from an HDF5 file (None = the first key).
         column_renames: Map {old_name: new_name} for renaming columns.
         column_types: Map {column: type} for type conversions.
         column_transforms: Map {column: func} for custom transformations.
@@ -107,6 +109,8 @@ class FileSourceConfig:
     has_header: bool = True
     json_lines: bool = False
     json_orient: Literal['records', 'index', 'columns', 'values'] = 'records'
+    xml_record_tag: Optional[str] = None
+    hdf5_key: Optional[str] = None
     column_renames: Optional[Dict[str, str]] = None
     column_types: Optional[Dict[str, type]] = None
     column_transforms: Optional[Dict[str, Callable[[Any], Any]]] = None

--- a/src/bootstack/data/memory_source.py
+++ b/src/bootstack/data/memory_source.py
@@ -152,15 +152,22 @@ class MemoryDataSource(BaseDataSource):
         rows = [r for r in self._data if condition is None or condition.matches(r)]
         return [dict(r) for r in self._sort_rows(rows, sort_keys)]
 
-    def load(self, records: Union[Sequence[Primitive], Sequence[Dict[str, Any]]]) -> "MemoryDataSource":
+    def load(
+        self, records: "Iterable[Primitive] | Iterable[Dict[str, Any]]"
+    ) -> "MemoryDataSource":
         """Load records into datasource.
 
         Args:
-            records: Sequence of dicts or primitives (auto-wrapped as {"text": str(x)})
+            records: An iterable of dicts or primitives (auto-wrapped as
+                {"text": str(x)}) — a list, a generator, or any other iterable.
 
         Returns:
             Self for method chaining
         """
+        # Materialize any iterable (e.g. a streaming reader generator) — an
+        # in-memory source holds the whole set anyway, and this keeps load()
+        # accepting the same inputs as SqliteDataSource.load().
+        records = list(records)
         if not records:
             self._data = []
             self._columns = []
@@ -168,7 +175,7 @@ class MemoryDataSource(BaseDataSource):
             self._hub.emit(DataChangeEvent(kind="load"))
             return self
 
-        if records and not self._is_mapping(records[0]):
+        if not self._is_mapping(records[0]):
             records = [dict(text=str(x)) for x in records]
 
         data: List[Dict[str, Any]] = []

--- a/src/bootstack/data/readers.py
+++ b/src/bootstack/data/readers.py
@@ -1,0 +1,276 @@
+"""Streaming record readers for file-backed data sources.
+
+A *reader* turns a file into a lazy iterator of record dicts, parsed a row at a
+time so large files stream with bounded memory rather than loading all at once.
+Readers are keyed by file extension in a registry: the stdlib formats
+(CSV / TSV / JSON / JSONL / XML) are always available, and the optional columnar
+and scientific formats (Parquet / Feather / HDF5) register too but raise a clear
+"install the extra" error when used without their dependency.
+
+The reader contract is intentionally small — `reader(path, config) ->
+Iterator[Record]` — so it composes directly with the streaming
+`SqliteDataSource.load(...)`, which chunks the iterator itself.
+
+Register a custom reader for your own extension::
+
+    from bootstack.data.readers import register_reader
+
+    @register_reader(".myfmt")
+    def read_myfmt(path, config):
+        for record in parse(path):
+            yield record
+"""
+
+from __future__ import annotations
+
+import csv
+import importlib
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING, Callable, Dict, Iterator, List, Optional
+
+from bootstack.data.types import Record
+
+if TYPE_CHECKING:
+    from bootstack.data.file_source import FileSourceConfig
+
+# A reader yields record dicts lazily: (path, config) -> Iterator[Record].
+Reader = Callable[..., Iterator[Record]]
+
+_READERS: Dict[str, Reader] = {}
+
+# Format-name aliases (FileSourceConfig.file_format) → canonical extension.
+_FORMAT_ALIASES: Dict[str, str] = {
+    "csv": ".csv",
+    "tsv": ".tsv",
+    "json": ".json",
+    "jsonl": ".jsonl",
+    "ndjson": ".jsonl",
+    "xml": ".xml",
+    "parquet": ".parquet",
+    "feather": ".feather",
+    "hdf5": ".h5",
+}
+
+
+def _norm_ext(ext: str) -> str:
+    """Normalize an extension to lowercase with a leading dot."""
+    ext = ext.lower()
+    return ext if ext.startswith(".") else "." + ext
+
+
+def register_reader(*extensions: str, reader: Optional[Reader] = None):
+    """Register a reader for one or more file extensions.
+
+    Use as a decorator (`@register_reader(".csv", ".tsv")`) or call directly with
+    `reader=`. Extensions may be given with or without the leading dot.
+
+    Args:
+        extensions: File extensions the reader handles.
+        reader: The reader callable, when not used as a decorator.
+
+    Returns:
+        The reader (so it works as a decorator).
+    """
+
+    def _apply(fn: Reader) -> Reader:
+        for ext in extensions:
+            _READERS[_norm_ext(ext)] = fn
+        return fn
+
+    return _apply(reader) if reader is not None else _apply
+
+
+def supported_extensions() -> List[str]:
+    """Return the sorted list of registered file extensions."""
+    return sorted(_READERS)
+
+
+def get_reader(path_or_ext: "str | Path") -> Reader:
+    """Resolve the reader for a path or extension.
+
+    Args:
+        path_or_ext: A file path or a bare extension (e.g. `".csv"` or `"csv"`).
+
+    Returns:
+        The registered reader callable.
+
+    Raises:
+        ValueError: If no reader is registered for the extension.
+    """
+    suffix = Path(str(path_or_ext)).suffix or str(path_or_ext)
+    ext = _norm_ext(suffix)
+    try:
+        return _READERS[ext]
+    except KeyError:
+        raise ValueError(
+            f"No reader registered for {ext!r}. Supported formats: "
+            f"{', '.join(supported_extensions())}."
+        ) from None
+
+
+def read_records(path: "str | Path", config: "Optional[FileSourceConfig]" = None) -> Iterator[Record]:
+    """Stream records from a file, choosing the reader by format or extension.
+
+    Honors `config.file_format` when set to something other than `'auto'`,
+    otherwise resolves the reader from the path's extension.
+
+    Args:
+        path: Path to the data file.
+        config: Parsing configuration (a default `FileSourceConfig` is used if
+            omitted).
+
+    Returns:
+        A lazy iterator of record dicts.
+    """
+    from bootstack.data.file_source import FileSourceConfig
+
+    cfg = config or FileSourceConfig()
+    fmt = getattr(cfg, "file_format", "auto")
+    if fmt and fmt != "auto":
+        reader = get_reader(_FORMAT_ALIASES.get(fmt, fmt))
+    else:
+        reader = get_reader(path)
+    return reader(path, cfg)
+
+
+def _require(module: str, extra: str):
+    """Import an optional dependency or raise a clear install hint."""
+    try:
+        return importlib.import_module(module)
+    except ImportError as exc:
+        raise ImportError(
+            f"Reading this format needs the optional {module!r} dependency. "
+            f"Install it with:  pip install bootstack[{extra}]"
+        ) from exc
+
+
+# --------------------------------------------------------------------------- stdlib
+
+
+@register_reader(".csv", ".tsv", ".txt")
+def read_csv(path: "str | Path", config: "FileSourceConfig") -> Iterator[Record]:
+    """Stream records from a CSV/TSV file, one row at a time."""
+    delimiter = config.delimiter
+    if delimiter is None:
+        delimiter = "\t" if _norm_ext(Path(path).suffix) == ".tsv" else ","
+    with open(path, "r", encoding=config.encoding, newline="") as f:
+        for _ in range(config.skip_rows or 0):
+            next(f, None)
+        reader = csv.DictReader(f, delimiter=delimiter, quotechar=config.quotechar)
+        for row in reader:
+            yield dict(row)
+
+
+@register_reader(".jsonl", ".ndjson")
+def read_jsonl(path: "str | Path", config: "FileSourceConfig") -> Iterator[Record]:
+    """Stream records from a line-delimited JSON file (one object per line)."""
+    with open(path, "r", encoding=config.encoding) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            obj = json.loads(line)
+            yield obj if isinstance(obj, dict) else {"value": obj}
+
+
+@register_reader(".json")
+def read_json(path: "str | Path", config: "FileSourceConfig") -> Iterator[Record]:
+    """Read records from a JSON file.
+
+    A JSON *array* is parsed in full (the stdlib parser cannot stream an array —
+    prefer JSONL for very large data). An object with a `"records"` key yields
+    that list; any other object is treated as a single record.
+    """
+    if getattr(config, "json_lines", False):
+        yield from read_jsonl(path, config)
+        return
+    with open(path, "r", encoding=config.encoding) as f:
+        data = json.load(f)
+    if isinstance(data, list):
+        for item in data:
+            yield item if isinstance(item, dict) else {"value": item}
+    elif isinstance(data, dict):
+        if isinstance(data.get("records"), list):
+            for item in data["records"]:
+                if isinstance(item, dict):
+                    yield item
+        else:
+            yield data
+
+
+@register_reader(".xml")
+def read_xml(path: "str | Path", config: "FileSourceConfig") -> Iterator[Record]:
+    """Stream records from an XML file using incremental parsing.
+
+    Each record element (those matching `config.xml_record_tag`, or the direct
+    children of the root when it is unset) becomes one record: its attributes and
+    the text of its leaf child elements become fields. Parsed elements are cleared
+    so memory stays bounded. Nested/repeated children are skipped in this version.
+    """
+    import xml.etree.ElementTree as ET
+
+    record_tag = getattr(config, "xml_record_tag", None)
+    depth = 0
+    root = None
+    for event, elem in ET.iterparse(path, events=("start", "end")):
+        if event == "start":
+            if depth == 0:
+                root = elem
+            depth += 1
+            continue
+        # end event
+        depth -= 1
+        is_record = (elem.tag == record_tag) if record_tag else (depth == 1)
+        if not is_record:
+            continue
+        record: Record = dict(elem.attrib)
+        for child in elem:
+            if len(child) == 0:  # leaf element → a scalar field
+                record[child.tag] = child.text
+        yield record
+        elem.clear()
+        if root is not None:
+            root.clear()  # drop processed siblings to keep memory bounded
+
+
+# --------------------------------------------------------------------------- optional
+
+
+@register_reader(".parquet")
+def read_parquet(path: "str | Path", config: "FileSourceConfig") -> Iterator[Record]:
+    """Stream records from a Parquet file in row-group batches (needs pyarrow)."""
+    pq = _require("pyarrow.parquet", "parquet")
+    parquet_file = pq.ParquetFile(str(path))
+    for batch in parquet_file.iter_batches():
+        for row in batch.to_pylist():
+            yield row
+
+
+@register_reader(".feather", ".arrow")
+def read_feather(path: "str | Path", config: "FileSourceConfig") -> Iterator[Record]:
+    """Stream records from a Feather/Arrow IPC file in batches (needs pyarrow)."""
+    feather = _require("pyarrow.feather", "parquet")
+    table = feather.read_table(str(path))
+    for batch in table.to_batches():
+        for row in batch.to_pylist():
+            yield row
+
+
+@register_reader(".h5", ".hdf5", ".hdf")
+def read_hdf5(path: "str | Path", config: "FileSourceConfig") -> Iterator[Record]:
+    """Stream records from a tabular HDF5 file in chunks (needs pandas + tables)."""
+    pd = _require("pandas", "hdf5")
+    key = getattr(config, "hdf5_key", None)
+    store = pd.HDFStore(str(path), mode="r")
+    try:
+        if key is None:
+            keys = store.keys()
+            if not keys:
+                return
+            key = keys[0]
+        for chunk in store.select(key, chunksize=10_000):
+            for record in chunk.to_dict(orient="records"):
+                yield record
+    finally:
+        store.close()

--- a/src/bootstack/data/sqlite_source.py
+++ b/src/bootstack/data/sqlite_source.py
@@ -82,6 +82,7 @@ class SqliteDataSource(BaseDataSource):
         - Schema is inferred from first record's data types
         - An internal row-identity column (_bs_row_id) is added automatically as PRIMARY KEY
         - An internal selection column (_bs_selected) is added automatically for selection tracking
+        - An internal JSON column (_bs_data) carries non-scalar record fields (the data bag)
         - These internal columns are filtered out of the display column list automatically
     """
 

--- a/src/bootstack/data/sqlite_source.py
+++ b/src/bootstack/data/sqlite_source.py
@@ -31,7 +31,7 @@ from __future__ import annotations
 import csv
 import json
 import sqlite3
-from typing import Any, Dict, List, Optional, Tuple, Union, Sequence
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union, Sequence
 
 from bootstack.data.base import BaseDataSource
 from bootstack.data.query import Condition, SortKey, normalize_sort_keys
@@ -228,20 +228,37 @@ class SqliteDataSource(BaseDataSource):
 
     def load(
         self,
-        records: Union[Sequence[Primitive], Sequence[dict[str, Any]], Sequence[Sequence[Any]]],
+        records: "Iterable[Primitive] | Iterable[dict[str, Any]] | Iterable[Sequence[Any]]",
         column_keys: Optional[Sequence[str]] = None,
+        *,
+        chunk_size: int = 10_000,
+        on_progress: Optional[Callable[[int], None]] = None,
     ) -> "SqliteDataSource":
-        """Load records into database, creating table with inferred schema.
+        """Load records into the database, creating the table with an inferred schema.
+
+        Records are consumed as a stream and inserted in chunks within a single
+        transaction, so a lazy iterator of millions of rows loads with bounded
+        memory — only `chunk_size` rows are held at a time. The whole load is
+        atomic: if any row fails (for example a duplicate id), the table is rolled
+        back to its prior state.
 
         Args:
-            records: Sequence of dicts, primitives, or row sequences.
-            column_keys: Optional column names when supplying row sequences (lists/tuples).
+            records: An iterable of dicts, primitives, or row sequences — a list,
+                a generator, or any other iterable.
+            column_keys: Optional column names when supplying row sequences
+                (lists/tuples).
+            chunk_size: Number of rows buffered per `executemany` batch.
+            on_progress: Optional callback invoked after each chunk with the
+                running count of rows inserted so far.
 
         Returns:
             Self for method chaining
         """
-        if not records:
-            return self
+        it = iter(records)
+        try:
+            first = next(it)
+        except StopIteration:
+            return self  # empty input — leave any existing data untouched
 
         # Apply fast, in-memory friendly pragmas when using ":memory:" to speed up bulk loads
         try:
@@ -252,26 +269,27 @@ class SqliteDataSource(BaseDataSource):
         except Exception:
             pass
 
-        # Normalize every input shape into a list of dicts (copies — we never
-        # mutate the caller's records).
-        first = records[0]
+        # Build a per-item normalizer to a dict from the first item's shape (the
+        # input is assumed homogeneous). We never mutate the caller's records.
         if isinstance(first, dict):
-            dict_records = [dict(r) for r in records]
+            def to_dict(item: Any) -> Dict[str, Any]:
+                return dict(item)
         elif isinstance(first, (list, tuple)):
             keys = list(column_keys or [str(i) for i in range(len(first))])
-            dict_records = []
-            for row in records:
-                values = list(row)
+
+            def to_dict(item: Any) -> Dict[str, Any]:
+                values = list(item)
                 if len(values) < len(keys):
                     values += [None] * (len(keys) - len(values))
-                dict_records.append(dict(zip(keys, values)))
+                return dict(zip(keys, values))
         else:
-            dict_records = [dict(text=str(x)) for x in records]
+            def to_dict(item: Any) -> Dict[str, Any]:
+                return {"text": str(item)}
 
         # Real (scalar) columns come from the first record; every other field —
         # non-scalar values, and keys absent from the first record — rides the
         # hidden JSON data column instead.
-        first_rec = dict_records[0]
+        first_rec = to_dict(first)
         column_fields = [
             k for k, v in first_rec.items()
             if k not in _INTERNAL_COLUMNS and self._is_scalar(v)
@@ -287,38 +305,77 @@ class SqliteDataSource(BaseDataSource):
         col_types[_ROW_SEL] = "INTEGER"
         col_types[_ROW_DATA] = "TEXT"
 
-        rows_to_insert = []
-        for i, record in enumerate(dict_records):
-            col_vals, bag, row_id = self._split_for_write(record, column_fields, default_id=i)
-            values = [col_vals.get(col) for col in column_fields]
-            values.append(row_id)
-            values.append(0)
-            values.append(self._dumps_bag(bag))
-            rows_to_insert.append(tuple(values))
-
         col_definitions = ", ".join(
             f"{self._quote_identifier(col)} {col_types[col]}" + (" PRIMARY KEY" if col == _ROW_ID else "")
             for col in self._columns
         )
         placeholders = ", ".join("?" for _ in self._columns)
+        insert_sql = f"INSERT INTO {self._table} VALUES ({placeholders})"
 
-        # Recreate table and bulk insert in a single transaction for speed
+        def row_for(record: Dict[str, Any], index: int) -> tuple:
+            col_vals, bag, row_id = self._split_for_write(record, column_fields, default_id=index)
+            values = [col_vals.get(col) for col in column_fields]
+            values.append(row_id)
+            values.append(0)
+            values.append(self._dumps_bag(bag))
+            return tuple(values)
+
+        # Recreate the table and stream-insert in chunks within one transaction:
+        # bounded Python memory (one chunk at a time) and atomic (rolls back on
+        # any error). SQLite buffers the pending rows itself, not Python. We drive
+        # the transaction explicitly (autocommit off) so the DROP/CREATE are part
+        # of it too — Python's sqlite3 otherwise auto-commits DDL, which would
+        # leave the table dropped if a later row failed.
         original_row_factory = self.conn.row_factory
+        original_isolation = self.conn.isolation_level
+        inserted = 0
         try:
             self.conn.row_factory = None  # avoid row wrapping overhead during inserts
-            with self.conn:
-                self.conn.execute(f"DROP TABLE IF EXISTS {self._table}")
-                self.conn.execute(f"CREATE TABLE {self._table} ({col_definitions})")
-                self.conn.executemany(f"INSERT INTO {self._table} VALUES ({placeholders})", rows_to_insert)
+            self.conn.isolation_level = None  # manual transaction control
+            self.conn.execute("BEGIN")
+            self.conn.execute(f"DROP TABLE IF EXISTS {self._table}")
+            self.conn.execute(f"CREATE TABLE {self._table} ({col_definitions})")
+
+            buffer = [row_for(first_rec, 0)]
+            index = 1
+            for raw in it:
+                buffer.append(row_for(to_dict(raw), index))
+                index += 1
+                if len(buffer) >= chunk_size:
+                    self.conn.executemany(insert_sql, buffer)
+                    inserted += len(buffer)
+                    buffer = []
+                    if on_progress is not None:
+                        on_progress(inserted)
+            if buffer:
+                self.conn.executemany(insert_sql, buffer)
+                inserted += len(buffer)
+                if on_progress is not None:
+                    on_progress(inserted)
+            self.conn.execute("COMMIT")
         except sqlite3.IntegrityError as exc:
+            self._safe_rollback()
             raise DuplicateIdError(
                 f"Duplicate value in id field {self._id_field!r} — record ids must be "
                 f"unique. ({exc})"
             ) from exc
+        except BaseException:
+            # Any other failure (serialization error, a raising progress callback,
+            # cancellation) must roll the whole load back too.
+            self._safe_rollback()
+            raise
         finally:
             self.conn.row_factory = original_row_factory
+            self.conn.isolation_level = original_isolation
         self._hub.emit(DataChangeEvent(kind="load"))
         return self
+
+    def _safe_rollback(self) -> None:
+        """Roll back the active transaction, swallowing any rollback error."""
+        try:
+            self.conn.execute("ROLLBACK")
+        except sqlite3.Error:
+            pass
 
     def where(self, condition: Optional[Condition] = None) -> "SqliteDataSource":
         """Filter rows by a condition built with `col` (None clears the filter).

--- a/tests/data/test_readers.py
+++ b/tests/data/test_readers.py
@@ -1,0 +1,206 @@
+"""Tests for the streaming file-reader registry.
+
+Readers turn a file into a lazy iterator of record dicts, keyed by extension.
+Stdlib formats (CSV/TSV/JSON/JSONL/XML) are always available and fully tested
+here; the optional columnar/scientific formats are tested only when their
+dependency is installed, and their "install the extra" error is always checked.
+These are headless (no App).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+
+import pytest
+
+from bootstack.data import (
+    FileSourceConfig,
+    SqliteDataSource,
+    get_reader,
+    read_records,
+    register_reader,
+    supported_extensions,
+)
+
+
+def _has(module: str) -> bool:
+    return importlib.util.find_spec(module) is not None
+
+
+# --------------------------------------------------------------------------- registry
+
+
+def test_supported_extensions_includes_stdlib_and_optional():
+    exts = supported_extensions()
+    for e in (".csv", ".tsv", ".txt", ".json", ".jsonl", ".ndjson", ".xml",
+              ".parquet", ".feather", ".h5"):
+        assert e in exts
+
+
+def test_get_reader_resolves_by_path_and_bare_ext():
+    assert get_reader("data.csv") is get_reader(".csv") is get_reader("csv")
+
+
+def test_unknown_extension_raises():
+    with pytest.raises(ValueError, match="No reader registered"):
+        get_reader("data.nope")
+
+
+def test_register_custom_reader(tmp_path):
+    @register_reader(".demo")
+    def _read_demo(path, config):
+        yield {"from": "demo"}
+
+    p = tmp_path / "x.demo"
+    p.write_text("ignored", encoding="utf-8")
+    assert list(read_records(p)) == [{"from": "demo"}]
+
+
+# --------------------------------------------------------------------------- csv / tsv
+
+
+def test_csv(tmp_path):
+    p = tmp_path / "p.csv"
+    p.write_text("id,name\n1,Alice\n2,Bob\n", encoding="utf-8")
+    assert list(read_records(p)) == [
+        {"id": "1", "name": "Alice"},
+        {"id": "2", "name": "Bob"},
+    ]
+
+
+def test_tsv_uses_tab_by_default(tmp_path):
+    p = tmp_path / "p.tsv"
+    p.write_text("id\tname\n1\tAlice\n", encoding="utf-8")
+    assert list(read_records(p))[0] == {"id": "1", "name": "Alice"}
+
+
+def test_csv_skip_rows(tmp_path):
+    p = tmp_path / "p.csv"
+    p.write_text("# preamble\nid,name\n1,Alice\n", encoding="utf-8")
+    rows = list(read_records(p, FileSourceConfig(skip_rows=1)))
+    assert rows == [{"id": "1", "name": "Alice"}]
+
+
+# --------------------------------------------------------------------------- json
+
+
+def test_jsonl(tmp_path):
+    p = tmp_path / "p.jsonl"
+    p.write_text('{"id":1,"tags":["a"]}\n\n{"id":2}\n', encoding="utf-8")
+    rows = list(read_records(p))
+    assert rows == [{"id": 1, "tags": ["a"]}, {"id": 2}]
+
+
+def test_json_array(tmp_path):
+    p = tmp_path / "p.json"
+    p.write_text(json.dumps([{"id": 1, "name": "A"}, {"id": 2, "name": "B"}]), encoding="utf-8")
+    assert [r["name"] for r in read_records(p)] == ["A", "B"]
+
+
+def test_json_records_key(tmp_path):
+    p = tmp_path / "p.json"
+    p.write_text(json.dumps({"records": [{"id": 9}]}), encoding="utf-8")
+    assert list(read_records(p)) == [{"id": 9}]
+
+
+def test_json_single_object(tmp_path):
+    p = tmp_path / "p.json"
+    p.write_text(json.dumps({"id": 1, "name": "solo"}), encoding="utf-8")
+    assert list(read_records(p)) == [{"id": 1, "name": "solo"}]
+
+
+# --------------------------------------------------------------------------- xml
+
+
+def test_xml_default_record_is_root_child(tmp_path):
+    p = tmp_path / "p.xml"
+    p.write_text(
+        '<rows><row id="1"><name>Alice</name></row>'
+        '<row id="2"><name>Bob</name></row></rows>',
+        encoding="utf-8",
+    )
+    assert list(read_records(p)) == [
+        {"id": "1", "name": "Alice"},
+        {"id": "2", "name": "Bob"},
+    ]
+
+
+def test_xml_explicit_record_tag(tmp_path):
+    p = tmp_path / "p.xml"
+    p.write_text(
+        "<doc><group><item><k>v1</k></item><item><k>v2</k></item></group></doc>",
+        encoding="utf-8",
+    )
+    rows = list(read_records(p, FileSourceConfig(xml_record_tag="item")))
+    assert rows == [{"k": "v1"}, {"k": "v2"}]
+
+
+# --------------------------------------------------------------------------- format override / integration
+
+
+def test_file_format_overrides_extension(tmp_path):
+    p = tmp_path / "data.dat"
+    p.write_text("a,b\n1,2\n", encoding="utf-8")
+    rows = list(read_records(p, FileSourceConfig(file_format="csv")))
+    assert rows == [{"a": "1", "b": "2"}]
+
+
+def test_reader_streams_into_sqlite_load(tmp_path):
+    p = tmp_path / "p.jsonl"
+    p.write_text('{"id":1,"tags":["a"]}\n{"id":2,"tags":["b"]}\n', encoding="utf-8")
+    ds = SqliteDataSource().load(read_records(p), chunk_size=1)
+    assert ds.count == 2
+    assert ds.get(1)["tags"] == ["a"]  # bag survives the file → source path
+
+
+# --------------------------------------------------------------------------- optional formats
+
+
+def test_parquet_without_dep_raises_install_hint(tmp_path):
+    if _has("pyarrow"):
+        pytest.skip("pyarrow installed — gating path not exercised")
+    p = tmp_path / "x.parquet"
+    p.write_text("", encoding="utf-8")
+    with pytest.raises(ImportError, match=r"bootstack\[parquet\]"):
+        list(read_records(p))
+
+
+def test_hdf5_without_dep_raises_install_hint(tmp_path):
+    if _has("pandas"):
+        pytest.skip("pandas installed — gating path not exercised")
+    p = tmp_path / "x.h5"
+    p.write_text("", encoding="utf-8")
+    with pytest.raises(ImportError, match=r"bootstack\[hdf5\]"):
+        list(read_records(p))
+
+
+@pytest.mark.skipif(not _has("pyarrow"), reason="needs pyarrow")
+def test_parquet_roundtrip(tmp_path):
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+
+    p = tmp_path / "p.parquet"
+    pq.write_table(pa.table({"id": [1, 2], "name": ["A", "B"]}), str(p))
+    rows = list(read_records(p))
+    assert [r["name"] for r in rows] == ["A", "B"]
+
+
+@pytest.mark.skipif(not _has("pyarrow"), reason="needs pyarrow")
+def test_feather_roundtrip(tmp_path):
+    import pyarrow as pa
+    import pyarrow.feather as feather
+
+    p = tmp_path / "p.feather"
+    feather.write_feather(pa.table({"id": [1, 2], "name": ["A", "B"]}), str(p))
+    rows = list(read_records(p))
+    assert [r["name"] for r in rows] == ["A", "B"]
+
+
+@pytest.mark.skipif(not (_has("pandas") and _has("tables")), reason="needs pandas + tables")
+def test_hdf5_roundtrip(tmp_path):
+    import pandas as pd
+
+    p = tmp_path / "p.h5"
+    pd.DataFrame({"id": [1, 2], "name": ["A", "B"]}).to_hdf(str(p), key="data", format="table")
+    rows = list(read_records(p, FileSourceConfig(hdf5_key="data")))
+    assert [r["name"] for r in rows] == ["A", "B"]

--- a/tests/data/test_streaming_load.py
+++ b/tests/data/test_streaming_load.py
@@ -1,0 +1,108 @@
+"""Tests for SqliteDataSource streaming chunked load.
+
+`load()` consumes its input as a stream and inserts in chunks within a single
+transaction, so a lazy iterator of many rows loads with bounded memory, and the
+whole load is atomic — a mid-stream failure rolls the table back to its prior
+state. These are headless (no App).
+"""
+from __future__ import annotations
+
+import pytest
+
+from bootstack.data import SqliteDataSource
+from bootstack.errors import DuplicateIdError, SerializationError
+
+
+def _gen(n, *, start=0):
+    for i in range(start, start + n):
+        yield {"id": i, "name": f"p{i}", "tags": [i]}
+
+
+def test_loads_from_a_generator():
+    ds = SqliteDataSource().load(_gen(2500), chunk_size=1000)
+    assert ds.count == 2500
+    assert ds.get(7)["name"] == "p7"
+
+
+def test_progress_callback_reports_running_total():
+    seen = []
+    SqliteDataSource().load(_gen(2500), chunk_size=1000, on_progress=seen.append)
+    assert seen == [1000, 2000, 2500]
+
+
+def test_final_progress_equals_count():
+    seen = []
+    ds = SqliteDataSource().load(_gen(1234), chunk_size=500, on_progress=seen.append)
+    assert seen[-1] == ds.count == 1234
+
+
+def test_chunk_size_does_not_change_result():
+    a = SqliteDataSource().load(_gen(300), chunk_size=7)
+    b = SqliteDataSource().load(_gen(300), chunk_size=10_000)
+    assert a.count == b.count == 300
+    assert a.get(150)["name"] == b.get(150)["name"] == "p150"
+
+
+def test_data_bag_survives_streaming_load():
+    ds = SqliteDataSource().load(
+        iter([{"id": 1, "name": "Alice", "tags": ["x", "y"], "meta": {"k": 1}}])
+    )
+    rec = ds.get(1)
+    assert rec["tags"] == ["x", "y"]
+    assert rec["meta"] == {"k": 1}
+
+
+def test_sequence_rows_stream_with_column_keys():
+    rows = ((i, f"p{i}") for i in range(50))
+    ds = SqliteDataSource().load(rows, column_keys=["id", "name"], chunk_size=10)
+    assert ds.count == 50
+    assert ds.get(3)["name"] == "p3"
+
+
+def test_empty_iterator_is_a_noop():
+    ds = SqliteDataSource().load([{"id": 1, "name": "A"}])
+    ds.load(iter([]))
+    assert ds.count == 1  # existing data untouched
+
+
+def test_duplicate_id_mid_stream_rolls_back():
+    ds = SqliteDataSource().load([{"id": 100, "name": "keep"}])
+
+    def bad():
+        yield {"id": 1, "name": "a"}
+        yield {"id": 1, "name": "dup"}
+
+    with pytest.raises(DuplicateIdError):
+        ds.load(bad(), chunk_size=1)
+
+    # The failed load is atomic — the prior table is restored intact.
+    assert ds.count == 1
+    assert ds.get(100)["name"] == "keep"
+
+
+def test_serialization_error_mid_stream_rolls_back():
+    ds = SqliteDataSource().load([{"id": 100, "name": "keep"}])
+
+    def bad():
+        yield {"id": 1, "name": "a"}
+        yield {"id": 2, "name": "b", "obj": object()}  # not JSON-serializable
+
+    with pytest.raises(SerializationError):
+        ds.load(bad(), chunk_size=10)
+
+    assert ds.count == 1
+    assert ds.get(100)["name"] == "keep"
+
+
+def test_connection_usable_after_rolled_back_load():
+    ds = SqliteDataSource().load([{"id": 1, "name": "A"}])
+
+    def bad():
+        yield {"id": 2, "name": "b", "obj": object()}
+
+    with pytest.raises(SerializationError):
+        ds.load(bad())
+
+    # Isolation level was restored, so normal writes still work.
+    ds.insert({"id": 2, "name": "B"})
+    assert ds.count == 2

--- a/tests/data/test_streaming_load.py
+++ b/tests/data/test_streaming_load.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import pytest
 
-from bootstack.data import SqliteDataSource
+from bootstack.data import MemoryDataSource, SqliteDataSource
 from bootstack.errors import DuplicateIdError, SerializationError
 
 
@@ -92,6 +92,15 @@ def test_serialization_error_mid_stream_rolls_back():
 
     assert ds.count == 1
     assert ds.get(100)["name"] == "keep"
+
+
+def test_memory_load_accepts_a_generator():
+    # Consistency with SqliteDataSource: both load() methods accept any iterable,
+    # so a streaming reader generator works with either source.
+    ds = MemoryDataSource().load(_gen(50))
+    assert ds.count == 50
+    assert ds.get(7)["name"] == "p7"
+    assert ds.get(7)["tags"] == [7]
 
 
 def test_connection_usable_after_rolled_back_load():


### PR DESCRIPTION
First two checkpoints of the large-file streaming initiative (see CLAUDE.md "Next initiative — Large-file streaming + pluggable formats"). Lets data-science-scale files (100k–millions of rows) load with bounded memory instead of materializing everything.

## Checkpoint 1 — streaming chunked `load()` on `SqliteDataSource`
- `load()` consumes its input as a **stream** and inserts in chunks within a single transaction, so a lazy iterator of millions of rows loads with bounded memory (only `chunk_size` rows held at a time).
- Accepts any `Iterable` (list, generator, …) of dicts / sequence-rows / primitives; schema inferred by peeking the first item.
- New keyword-only `chunk_size` and `on_progress(count)` callback.
- **Genuinely atomic** — drives the transaction explicitly (autocommit off) so `DROP`/`CREATE` are inside it too (Python `sqlite3` otherwise auto-commits DDL). A mid-stream duplicate id or serialization error rolls the table back to its prior state; the connection stays usable.

## Checkpoint 2 — pluggable streaming reader registry (`data/readers.py`)
- Extension-keyed registry: `register_reader` / `read_records` / `get_reader` / `supported_extensions` (exported from `bootstack.data`).
- **Stdlib readers (always available):** CSV/TSV/`.txt`, JSONL/NDJSON, JSON (array / `records`-key / single object), XML (incremental `iterparse`, clears elements to stay bounded; record tag configurable).
- **Optional readers (gated):** Parquet + Feather/Arrow (pyarrow), HDF5 (pandas + tables) — registered but raising a clear `pip install bootstack[...]` error when the dep is absent.
- Each reader is a lazy `(path, config) -> Iterator[Record]`, composing directly with CP1's chunked `load()` for file → SQLite streaming ingest.
- Added `xml_record_tag` / `hdf5_key` to `FileSourceConfig`; added `[parquet]` / `[hdf5]` pyproject extras.

## Review fixes
- `MemoryDataSource.load` now accepts any iterable (was sequence-only — a reader generator crashed it), restoring parity with `SqliteDataSource.load`.
- Documented the hidden `_bs_data` data-bag column in the `SqliteDataSource` class docstring.

## Docs
- Data-sources intro generalized (record/dataset language; `:doc:` links; Tree mentioned accurately as not source-backed but sharing the data-bag model).
- "Honoring the data bag" note for custom-source authors; planned-formats note (Parquet/Feather/HDF5/XML).
- Planned follow-ups captured in CLAUDE.md: Checkpoint 3–5, the data-layer review findings folded into CP3, and Tree data-source backing.

## Tests
- `tests/data/test_streaming_load.py` (11) — generator load, chunking, progress, atomic rollback (dup id + serialization error), connection reuse, Memory iterable parity.
- `tests/data/test_readers.py` (17 passed, 3 skipped without optional deps) — every stdlib reader, format override, unknown-extension + gated-dependency errors, reader→load integration.

Not yet done: CP3 (rebuild `FileDataSource` on a SQLite working store), CP4 (streaming export + writers), CP5 (docs/examples).

🤖 Generated with [Claude Code](https://claude.com/claude-code)