### PR TITLE
feat(data): file streaming cp3 — FileDataSource on a SQLite working store

### DIFF
--- a/docs/reference/data-sources.rst
+++ b/docs/reference/data-sources.rst
@@ -45,19 +45,44 @@ supply your own to back the table with a database file:
 File-backed data
 ----------------
 
-``FileDataSource`` loads records from CSV, TSV, JSON, and JSONL files, configured
-with a ``FileSourceConfig``. It reads the file into memory and treats the original
-as **read-only input** — edits live in memory only and are not written back, and
-``reload()`` re-reads the file. To save changes, export them to a new file
-(:meth:`export_csv <bootstack.data.SqliteDataSource.export_csv>` or the
-:class:`DataTable <bootstack.widgets.datatable.DataTable>` export menu). Only
-``SqliteDataSource`` (file-backed) persists changes in place:
+``FileDataSource`` reads a file and **streams it — a chunk at a time — into a
+SQLite working store**, so even a multi-million-row file loads with bounded
+memory. After ``load()`` it *is* a ``SqliteDataSource``: paging, filtering,
+sorting, and CRUD are all fast SQL. Configure parsing and transforms with a
+``FileSourceConfig``:
 
 .. code-block:: python
 
-   config = bs.FileSourceConfig(file_format="csv", has_header=True)
-   ds = bs.FileDataSource("people.csv", config=config)
+   ds = bs.FileDataSource("people.csv")
+   ds.load()
    bs.DataTable(data_source=ds)
+
+The original file is **read-only input** — edits live in the working store and
+are never written back. To save changes, export to a new file
+(:meth:`export_csv <bootstack.data.SqliteDataSource.export_csv>` or the
+:class:`DataTable <bootstack.widgets.datatable.DataTable>` export menu);
+``reload()`` re-ingests from the file.
+
+The working store is, by choice:
+
+- **temporary on disk** (default) — bounded memory, removed on ``close()``.
+- ``cache="people.db"`` — a **persistent** store: edits survive restarts, and
+  re-opening skips re-ingest while the cache is newer than the source file.
+- ``cache=":memory:"`` — in-memory: compact, but RAM-bound.
+
+Close the store when done — explicitly or with a ``with`` block:
+
+.. code-block:: python
+
+   with bs.FileDataSource("people.csv", cache="people.db") as ds:
+       ds.load()
+       first = ds.page(0)
+
+**Formats.** CSV, TSV, JSON, JSONL/NDJSON, and XML are built in. Columnar and
+scientific formats are available through optional extras — Parquet and Feather
+(``pip install bootstack[parquet]``) and HDF5 (``pip install bootstack[hdf5]``);
+each is a streaming reader, and a clear error tells you to install the extra if
+it is missing.
 
 JSON comes in two shapes: a top-level **array of objects** (``.json``), or
 **JSONL/NDJSON** — one object per line (``.jsonl`` / ``.ndjson``), which streams a
@@ -69,13 +94,6 @@ nested under a key (an API response like ``{"data": [...]}``), point at it with
 
    bs.FileDataSource("export.ndjson")                                  # streamed
    bs.FileDataSource("api.json", bs.FileSourceConfig(json_records_key="data"))
-
-.. note::
-
-   **Planned:** support for columnar and scientific formats — Parquet, Feather,
-   and HDF5 (plus XML) — via optional extras (``pip install bootstack[parquet]``,
-   ``bootstack[hdf5]``). Each will be a streaming reader that ingests large files
-   in chunks with bounded memory, rather than loading the whole file at once.
 
 .. _carrying-extra-data:
 
@@ -100,18 +118,19 @@ not a stripped-down shadow:
 This works the same on every source, but *what* a field may hold depends on
 where the records live:
 
-- **In-memory** (``MemoryDataSource``, ``FileDataSource``, and the default
-  ``ListView`` source) holds **anything**, including live Python objects, by
-  reference. The field you put in is the object you get back.
-- **SQLite** (``SqliteDataSource``) is persistent. Scalar fields (text, numbers,
-  booleans) become real columns you can filter and sort on. Non-scalar fields
-  (lists, dicts) are carried as JSON automatically and merged back transparently
-  on read — so records still read flat and complete. Because they ride a JSON
-  blob, **bagged fields are preserved but not queryable** via ``where`` / ``order``
-  (keep anything you need to filter on as a scalar field). Values must be
-  JSON-serializable; handing a live object to a SQLite-backed source raises
-  :class:`SerializationError <bootstack.errors.SerializationError>` — use an in-memory
-  source for those.
+- **In-memory** (``MemoryDataSource`` and the default ``ListView`` source) holds
+  **anything**, including live Python objects, by reference. The field you put in
+  is the object you get back.
+- **SQLite-backed** (``SqliteDataSource``, and ``FileDataSource`` — which ingests
+  the file into a SQLite store). Scalar fields (text, numbers, booleans) become
+  real columns you can filter and sort on. Non-scalar fields (lists, dicts) are
+  carried as JSON automatically and merged back transparently on read — so records
+  still read flat and complete. Because they ride a JSON blob, **bagged fields are
+  preserved but not queryable** via ``where`` / ``order`` (keep anything you need
+  to filter on as a scalar field). Values must be JSON-serializable; handing a
+  live object to a SQLite-backed source raises
+  :class:`SerializationError <bootstack.errors.SerializationError>` — use an
+  in-memory source for those.
 
 Filtering and sorting
 ---------------------

--- a/docs/reference/data-sources.rst
+++ b/docs/reference/data-sources.rst
@@ -65,7 +65,8 @@ are never written back. To save changes, export to a new file
 
 The working store is, by choice:
 
-- **temporary on disk** (default) — bounded memory, removed on ``close()``.
+- **temporary on disk** (default) — bounded memory, removed on ``close()`` (and
+  automatically, as a safety net, when the source is dropped or at exit).
 - ``cache="people.db"`` — a **persistent** store: edits survive restarts, and
   re-opening skips re-ingest while the cache is newer than the source file.
 - ``cache=":memory:"`` — in-memory: compact, but RAM-bound.

--- a/docs/reference/data-sources.rst
+++ b/docs/reference/data-sources.rst
@@ -59,6 +59,17 @@ as **read-only input** — edits live in memory only and are not written back, a
    ds = bs.FileDataSource("people.csv", config=config)
    bs.DataTable(data_source=ds)
 
+JSON comes in two shapes: a top-level **array of objects** (``.json``), or
+**JSONL/NDJSON** — one object per line (``.jsonl`` / ``.ndjson``), which streams a
+record at a time and is the right choice for large data. When the records are
+nested under a key (an API response like ``{"data": [...]}``), point at it with
+``json_records_key="data"``.
+
+.. code-block:: python
+
+   bs.FileDataSource("export.ndjson")                                  # streamed
+   bs.FileDataSource("api.json", bs.FileSourceConfig(json_records_key="data"))
+
 .. note::
 
    **Planned:** support for columnar and scientific formats — Parquet, Feather,

--- a/src/bootstack/data/base.py
+++ b/src/bootstack/data/base.py
@@ -353,6 +353,29 @@ class BaseDataSource(ABC):
         """
         return False
 
+    # ========== RESOURCE LIFECYCLE (close / context manager) ==========
+
+    def close(self) -> None:
+        """Release any resources held by this data source.
+
+        The default is a no-op — in-memory sources hold none. Sources backed by
+        a database connection or file handle override this to release it. Safe to
+        call more than once.
+        """
+        return None
+
+    def __enter__(self) -> "BaseDataSource":
+        """Enter a `with` block, returning the data source itself."""
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        """Exit a `with` block, releasing resources via `close()`.
+
+        Returns False so any exception raised inside the block propagates.
+        """
+        self.close()
+        return False
+
     # ========== ROW IDENTITY (for datasource-aware widgets) ==========
 
     @property

--- a/src/bootstack/data/file_source.py
+++ b/src/bootstack/data/file_source.py
@@ -35,12 +35,32 @@ from __future__ import annotations
 import os
 import sqlite3
 import tempfile
+import weakref
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterator, List, Literal, Optional
 
 from bootstack.data.sqlite_source import SqliteDataSource
 from bootstack.data.types import Record
+
+
+def _cleanup_temp_store(conn: "sqlite3.Connection", path: str) -> None:
+    """Close the connection and remove a temporary working-store file.
+
+    Registered as a `weakref.finalize` callback so a `FileDataSource` whose
+    `close()` was never called still cleans up its temp file when garbage
+    collected or at interpreter exit — no orphaned files left behind. Takes the
+    connection and path directly (never the source) so it holds no strong
+    reference that would keep the source alive.
+    """
+    try:
+        conn.close()
+    except Exception:
+        pass
+    try:
+        os.remove(path)
+    except OSError:
+        pass
 
 
 @dataclass
@@ -182,6 +202,15 @@ class FileDataSource(SqliteDataSource):
 
         super().__init__(name=store_name, page_size=page_size, id_field=id_field)
 
+        # Safety net: a temp store is removed even if close() is never called —
+        # the finalizer runs on garbage collection and at interpreter exit, so no
+        # orphaned temp files accumulate.
+        self._finalizer: Optional[weakref.finalize] = None
+        if self._is_temp:
+            self._finalizer = weakref.finalize(
+                self, _cleanup_temp_store, self.conn, store_name
+            )
+
         # Reuse a fresh persistent cache without re-ingesting.
         self.is_loaded = False
         if self._cache_is_fresh():
@@ -259,13 +288,15 @@ class FileDataSource(SqliteDataSource):
     # ------------------------------------------------------------------ lifecycle
 
     def close(self) -> None:
-        """Close the working store, removing the temporary file if one was used."""
-        super().close()
-        if self._is_temp:
-            try:
-                os.remove(self._store_name)
-            except OSError:
-                pass
+        """Close the working store, removing the temporary file if one was used.
+
+        Idempotent. A temporary store is also cleaned automatically if this is
+        never called (see the finalizer registered in `__init__`).
+        """
+        if self._finalizer is not None:
+            self._finalizer()  # closes the connection and removes the temp file (once)
+        else:
+            super().close()
 
     # ------------------------------------------------------------------ transforms
 

--- a/src/bootstack/data/file_source.py
+++ b/src/bootstack/data/file_source.py
@@ -43,7 +43,6 @@ Example:
 from __future__ import annotations
 
 import csv
-import json
 import threading
 from dataclasses import dataclass
 from pathlib import Path
@@ -72,7 +71,9 @@ class FileSourceConfig:
         header_row: Row index containing column names (None = no header).
         has_header: Whether the first row contains column names.
         json_lines: True for line-delimited JSON (JSONL/NDJSON format).
-        json_orient: Pandas-like orientation for JSON arrays.
+        json_records_key: Key whose value is the records list in a JSON object
+            (e.g. "data" for {"data": [...]}); None = a top-level array, or the
+            object itself as one record.
         xml_record_tag: Element tag that marks one record (None = direct children of the root).
         hdf5_key: Dataset/table key to read from an HDF5 file (None = the first key).
         column_renames: Map {old_name: new_name} for renaming columns.
@@ -108,7 +109,7 @@ class FileSourceConfig:
     header_row: Optional[int] = 0
     has_header: bool = True
     json_lines: bool = False
-    json_orient: Literal['records', 'index', 'columns', 'values'] = 'records'
+    json_records_key: Optional[str] = None
     xml_record_tag: Optional[str] = None
     hdf5_key: Optional[str] = None
     column_renames: Optional[Dict[str, str]] = None
@@ -299,35 +300,17 @@ class FileDataSource(MemoryDataSource):
                 yield dict(row)
 
     def _parse_json_records(self) -> Iterator[Record]:
-        """Parse JSON file and yield records."""
-        with open(self.filepath, 'r', encoding=self.config.encoding) as f:
-            if self.config.json_lines:
-                # JSONL format - one JSON object per line
-                for line in f:
-                    line = line.strip()
-                    if line:
-                        yield json.loads(line)
-            else:
-                # Standard JSON
-                data = json.load(f)
+        """Parse JSON file and yield records.
 
-                # Handle different JSON structures
-                if isinstance(data, list):
-                    for item in data:
-                        if isinstance(item, dict):
-                            yield item
-                        else:
-                            yield {'value': item}
-                elif isinstance(data, dict):
-                    # Could be records, columns, etc.
-                    if self.config.json_orient == 'records':
-                        # Assume it's a dict of lists
-                        for item in data.get('records', data.values()):
-                            if isinstance(item, dict):
-                                yield item
-                    else:
-                        # Single record
-                        yield data
+        Delegates to the shared streaming reader so JSON parsing has a single
+        source of truth (see `bootstack.data.readers.read_json`).
+        """
+        from bootstack.data.readers import read_json, read_jsonl
+
+        if self._detected_format == 'jsonl':
+            yield from read_jsonl(self.filepath, self.config)
+        else:
+            yield from read_json(self.filepath, self.config)
 
     def _parse_records(self) -> Iterator[Record]:
         """Parse file and yield records based on format."""

--- a/src/bootstack/data/file_source.py
+++ b/src/bootstack/data/file_source.py
@@ -1,76 +1,61 @@
-"""File-based datasource with support for CSV, JSON, and lazy loading strategies.
+"""File-backed data source — streams a file into a SQLite working store.
 
-Provides file-backed data storage with multiple loading strategies optimized for
-different file sizes. Supports extensive transformation pipelines for data cleaning
-and preprocessing.
+`FileDataSource` reads CSV / TSV / JSON / JSONL (and, with the optional extras,
+Parquet / Feather / HDF5) and ingests it — a chunk at a time, with bounded
+memory — into a SQLite working store. After loading it *is* a
+`SqliteDataSource`, so paging, filtering, sorting, and CRUD are all fast SQL at
+flat memory, no matter how large the file.
 
-Supported Formats (Built-in):
-    - CSV: Comma-separated values
-    - TSV: Tab-separated values
-    - JSON: Standard JSON arrays or objects
-    - JSONL/NDJSON: Line-delimited JSON (one record per line)
+The original file is treated as **read-only input**: edits live in the working
+store, never written back. Save changes by exporting to a new file.
 
-Loading Strategies:
-    - Eager: Load all data into memory at once (fast access, high memory)
-    - Lazy: Load data on-demand per page (slow access, low memory)
-    - Chunked: Load in configurable batches (balanced approach)
-    - Hybrid: Index in memory, lazy-load records (optimized balance)
-    - Auto: Automatically select strategy based on file size
+Working store (where the ingested data lives):
+    - default: a temporary on-disk SQLite file, removed on `close()` — bounded
+      memory even for millions of rows.
+    - ``cache="path.db"``: a named, persistent store. Edits survive restarts, and
+      re-opening skips re-ingest while the cache is newer than the source file.
+    - ``cache=":memory:"``: an in-memory store — compact, but RAM-bound.
 
-Transformation Pipeline:
-    - Column renaming
-    - Type conversions
-    - Custom transformation functions per column
-    - Row-level filtering during load
-    - Row-level transformations
-    - Default values for missing data
-
-Large File Optimization:
-    - Streaming parsing for minimal memory usage
-    - Threading for non-blocking loads
-    - Progress callbacks for UI updates
-    - Automatic strategy selection based on file size
+Transformation pipeline (applied per record during ingest):
+    column selection / renames / default values / type conversions / per-column
+    transforms / row filter / row transform.
 
 Example:
     .. code-block:: python
 
         ds = FileDataSource("data.csv")
         ds.load()
+        ds.where(col("age") > 25)
         first = ds.page(0)
-
+        ds.close()          # or use `with FileDataSource(...) as ds:`
 """
 
 from __future__ import annotations
 
-import csv
-import threading
+import os
+import sqlite3
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import (
-    Any, Callable, Dict, Iterator, List, Literal, Optional
-)
+from typing import Any, Callable, Dict, Iterator, List, Literal, Optional
 
-from bootstack.data.memory_source import MemoryDataSource
+from bootstack.data.sqlite_source import SqliteDataSource
 from bootstack.data.types import Record
-from bootstack.events import DataChangeEvent
 
 
 @dataclass
 class FileSourceConfig:
-    """Configuration for file datasource loading and transformations.
-
-    Controls how files are parsed, loaded, and transformed. Provides extensive
-    customization for handling various data formats and scenarios.
+    """Configuration for file parsing and the per-record transformation pipeline.
 
     Attributes:
-        file_format: Format type - auto-detected from extension if 'auto'.
+        file_format: Format override; auto-detected from the extension if 'auto'.
         encoding: Character encoding for reading the file.
-        delimiter: Field separator (None = auto-detect: ',' for CSV, tab for TSV).
+        delimiter: Field separator (None = auto: ',' for CSV, tab for TSV).
         quotechar: Quote character for fields containing the delimiter.
-        skip_rows: Number of header rows to skip.
+        skip_rows: Number of leading rows to skip before the header (CSV/TSV).
         header_row: Row index containing column names (None = no header).
         has_header: Whether the first row contains column names.
-        json_lines: True for line-delimited JSON (JSONL/NDJSON format).
+        json_lines: True for line-delimited JSON (JSONL/NDJSON).
         json_records_key: Key whose value is the records list in a JSON object
             (e.g. "data" for {"data": [...]}); None = a top-level array, or the
             object itself as one record.
@@ -79,17 +64,13 @@ class FileSourceConfig:
         column_renames: Map {old_name: new_name} for renaming columns.
         column_types: Map {column: type} for type conversions.
         column_transforms: Map {column: func} for custom transformations.
-        columns_to_load: List of columns to load (None = all columns).
+        columns_to_load: List of columns to keep (None = all columns).
         default_values: Map {column: value} for missing/null values.
         row_filter: Function(row_dict) -> bool to filter rows during load.
         row_transform: Function(row_dict) -> row_dict for row-level transforms.
-        loading_strategy: How to load file ('eager', 'lazy', 'chunked', 'hybrid', 'auto').
-        chunk_size: Rows per chunk for chunked/lazy loading.
-        max_memory_rows: Threshold for auto-switching loading strategies.
-        use_threading: Load file in background thread (non-blocking).
-        progress_callback: Function(current, total) called during load.
-        on_complete: Function() called when loading completes.
-        on_error: Function(exception) called if loading fails.
+        chunk_size: Rows ingested per batch (bounds memory during load).
+        progress_callback: Function(count) called after each ingested chunk with
+            the running total of rows loaded so far.
 
     Example:
         .. code-block:: python
@@ -101,7 +82,9 @@ class FileSourceConfig:
 
     """
 
-    file_format: Literal['auto', 'csv', 'tsv', 'json', 'jsonl'] = 'auto'
+    file_format: Literal[
+        'auto', 'csv', 'tsv', 'json', 'jsonl', 'ndjson', 'xml', 'parquet', 'feather', 'hdf5'
+    ] = 'auto'
     encoding: str = 'utf-8'
     delimiter: Optional[str] = None
     quotechar: str = '"'
@@ -119,247 +102,209 @@ class FileSourceConfig:
     default_values: Optional[Dict[str, Any]] = None
     row_filter: Optional[Callable[[Dict[str, Any]], bool]] = None
     row_transform: Optional[Callable[[Dict[str, Any]], Dict[str, Any]]] = None
-    loading_strategy: Literal['eager', 'lazy', 'chunked', 'hybrid', 'auto'] = 'auto'
-    chunk_size: int = 10000
-    max_memory_rows: int = 100000
-    use_threading: bool = False
-    progress_callback: Optional[Callable[[int, int], None]] = None
-    on_complete: Optional[Callable[[], None]] = None
-    on_error: Optional[Callable[[Exception], None]] = None
+    chunk_size: int = 10_000
+    progress_callback: Optional[Callable[[int], None]] = None
 
 
-class FileDataSource(MemoryDataSource):
-    """File-based datasource with MemoryDataSource API and advanced loading strategies.
+class FileDataSource(SqliteDataSource):
+    """A `SqliteDataSource` whose data is streamed in from a file.
 
-    Extends MemoryDataSource to load data from files (CSV, JSON, JSONL) with support
-    for large files via multiple loading strategies. Provides extensive transformation
-    pipeline for data preprocessing.
+    Reads a CSV / TSV / JSON / JSONL file (or an optional Parquet / Feather /
+    HDF5 file) and ingests it chunk-by-chunk into a SQLite working store, so even
+    a multi-million-row file loads with bounded memory. Once loaded it behaves
+    exactly like a `SqliteDataSource` — fast SQL paging, filtering, sorting, CRUD.
 
-    The datasource automatically selects optimal loading strategy based on file size
-    and configuration. Supports background loading with progress callbacks for UI
-    integration.
+    The original file is read-only input; edits live in the working store and are
+    never written back. Export to save changes.
 
     Args:
-        filepath: Path to data file
-        config: FileSourceConfig object (uses defaults if None)
-        page_size: Records per page for pagination (default: 10)
+        filepath: Path to the data file.
+        config: Optional `FileSourceConfig` for parsing and transforms.
+        page_size: Number of records returned per page.
+        cache: Working store location. None (default) uses a temporary on-disk
+            file removed on `close()`. A path names a persistent store whose data
+            survives restarts (and is reused without re-ingest while it is newer
+            than the source). ``":memory:"`` keeps the store in memory.
+        id_field: Record field used as the stable row identity.
 
     Attributes:
-        filepath: Path object for the data file
-        config: Active configuration
-        is_loaded: Whether file has been loaded
-
-    Loading Strategies:
-        Eager: Load entire file into memory
-            - Fastest access after initial load
-            - High memory usage
-            - Best for: Small files (< 100k rows)
-
-        Lazy: Load data on-demand per page
-            - Slowest access (re-parses on each request)
-            - Minimal memory usage
-            - Best for: Very large files (> 1M rows)
-
-        Chunked: Load file in batches
-            - Balanced performance and memory
-            - Shows progress during load
-            - Best for: Medium files (100k-500k rows)
-
-        Hybrid: Index in memory, lazy-load records
-            - Fast filtering/sorting
-            - Moderate memory usage
-            - Best for: Large files (500k-1M rows)
-
-        Auto: Automatically select based on file size
-            - < 100k rows: Eager
-            - 100k-500k: Chunked
-            - > 500k: Hybrid
+        filepath: Path to the data file.
+        config: Active configuration.
+        is_loaded: Whether the file has been ingested (or a fresh cache adopted).
 
     Example:
         .. code-block:: python
 
-            ds = FileDataSource("data.csv")
-            ds.load()
-            ds.where(col("age") > 25)
-            first = ds.page(0)
-
+            with FileDataSource("people.csv") as ds:
+                ds.load()
+                ds.where(col("age") > 25)
+                first = ds.page(0)
 
     Note:
-        - File is re-parsed on reload()
-        - Threading uses daemon threads (auto-cleanup)
-        - All MemoryDataSource methods available after load
-        - Lazy strategy re-parses file on filter/sort changes
+        - `reload()` re-ingests from the file.
+        - Background-thread ingest and progressive display are a planned follow-up;
+          `load()` is currently synchronous (but streamed, so memory stays bounded).
     """
 
     def __init__(
         self,
         filepath: str | Path,
         config: Optional[FileSourceConfig] = None,
-        page_size: int = 10
+        page_size: int = 10,
+        *,
+        cache: Optional[str] = None,
+        id_field: str = "id",
     ):
-        """Configure a file-backed datasource and detect file format.
-
-        Args:
-            filepath: Location of the data file to be read.
-            config: Optional overrides for parsing, transforms, and threading.
-            page_size: Number of records returned per page after loading.
+        """Configure a file-backed source and open its SQLite working store.
 
         Raises:
             FileNotFoundError: If the supplied file path cannot be found.
         """
-        super().__init__(page_size=page_size)
-
         self.filepath = Path(filepath)
         self.config = config or FileSourceConfig()
-
-        # Loading state
-        self.is_loaded = False
-        self._loading = False
-        self._load_progress = (0, 0)
-        self._load_thread = None
-
-        # Detect file format
-        self._detected_format = self._detect_format()
-
-        # Validate file exists
         if not self.filepath.exists():
             raise FileNotFoundError(f"File not found: {self.filepath}")
 
-    def _detect_format(self) -> str:
-        """Detect file format from extension or config."""
-        if self.config.file_format != 'auto':
-            return self.config.file_format
-
-        ext = self.filepath.suffix.lower()
-        format_map = {
-            '.csv': 'csv',
-            '.tsv': 'tsv',
-            '.txt': 'csv',  # Assume CSV for .txt
-            '.json': 'json',
-            '.jsonl': 'jsonl',
-            '.ndjson': 'jsonl',
-        }
-
-        return format_map.get(ext, 'csv')  # Default to CSV
-
-    def _estimate_row_count(self) -> int:
-        """Estimate total row count for progress tracking."""
-        file_size = self.filepath.stat().st_size
-
-        # Estimate based on file format
-        if self._detected_format in ('csv', 'tsv'):
-            # Sample first few lines to estimate average row size
-            with open(self.filepath, 'r', encoding=self.config.encoding) as f:
-                sample_lines = []
-                for i, line in enumerate(f):
-                    if i >= 100:  # Sample first 100 lines
-                        break
-                    sample_lines.append(len(line.encode('utf-8')))
-
-                if sample_lines:
-                    avg_line_size = sum(sample_lines) / len(sample_lines)
-                    estimated = int(file_size / avg_line_size)
-                    return max(estimated - self.config.skip_rows - 1, 0)
-
-        # For JSON, harder to estimate - use file size as proxy
-        return file_size // 100  # Very rough estimate
-
-    def _determine_strategy(self) -> str:
-        """Determine optimal loading strategy."""
-        if self.config.loading_strategy != 'auto':
-            return self.config.loading_strategy
-
-        # Auto-select based on estimated row count
-        estimated_rows = self._estimate_row_count()
-
-        if estimated_rows < self.config.max_memory_rows:
-            return 'eager'
-        elif estimated_rows < self.config.max_memory_rows * 5:
-            return 'chunked'
+        # Choose the working store.
+        self._is_temp = False
+        self._cache_path: Optional[Path] = None
+        if cache is None:
+            fd, tmp = tempfile.mkstemp(suffix=".bsdb")
+            os.close(fd)
+            store_name = tmp
+            self._is_temp = True
+        elif cache == ":memory:":
+            store_name = ":memory:"
         else:
-            return 'hybrid'
+            store_name = str(cache)
+            self._cache_path = Path(cache)
+        self._store_name = store_name
 
-    def _parse_csv_records(self) -> Iterator[Record]:
-        """Parse CSV/TSV file and yield records."""
-        delimiter = self.config.delimiter
-        if delimiter is None:
-            delimiter = '\t' if self._detected_format == 'tsv' else ','
+        super().__init__(name=store_name, page_size=page_size, id_field=id_field)
 
-        with open(self.filepath, 'r', encoding=self.config.encoding, newline='') as f:
-            # Skip initial rows if configured
-            for _ in range(self.config.skip_rows):
-                next(f, None)
+        # Reuse a fresh persistent cache without re-ingesting.
+        self.is_loaded = False
+        if self._cache_is_fresh():
+            self._adopt_existing_schema()
+            self.is_loaded = True
 
-            reader = csv.DictReader(
-                f,
-                delimiter=delimiter,
-                quotechar=self.config.quotechar
-            )
+    # ------------------------------------------------------------------ loading
 
-            for row in reader:
-                yield dict(row)
+    def load(self, *, force: bool = False) -> "FileDataSource":
+        """Ingest the file into the working store (streamed, in chunks).
 
-    def _parse_json_records(self) -> Iterator[Record]:
-        """Parse JSON file and yield records.
+        Unlike other sources, a `FileDataSource` draws its records from the file
+        given at construction, so `load()` takes no records. It is a no-op when a
+        fresh persistent cache was adopted, unless `force=True`.
 
-        Delegates to the shared streaming reader so JSON parsing has a single
-        source of truth (see `bootstack.data.readers.read_json`).
-        """
-        from bootstack.data.readers import read_json, read_jsonl
-
-        if self._detected_format == 'jsonl':
-            yield from read_jsonl(self.filepath, self.config)
-        else:
-            yield from read_json(self.filepath, self.config)
-
-    def _parse_records(self) -> Iterator[Record]:
-        """Parse file and yield records based on format."""
-        if self._detected_format in ('csv', 'tsv'):
-            yield from self._parse_csv_records()
-        elif self._detected_format in ('json', 'jsonl'):
-            yield from self._parse_json_records()
-        else:
-            raise ValueError(f"Unsupported format: {self._detected_format}")
-
-    def _apply_transformations(self, record: Record) -> Optional[Record]:
-        """Apply transformation pipeline to a single record.
+        Args:
+            force: Re-ingest even if data is already present (used by `reload`).
 
         Returns:
-            Transformed record or None if filtered out
+            Self for method chaining.
         """
-        # Apply row filter first
+        if self.is_loaded and not force:
+            return self
+        super().load(
+            self._iter_records(),
+            chunk_size=self.config.chunk_size,
+            on_progress=self._on_progress,
+        )
+        self.is_loaded = True
+        return self
+
+    def reload(self) -> None:
+        """Re-ingest the file from disk, replacing the working store's contents."""
+        self.load(force=True)
+
+    def _iter_records(self) -> Iterator[Record]:
+        """Stream parsed, transformed records from the file."""
+        from bootstack.data.readers import read_records
+
+        for raw in read_records(self.filepath, self.config):
+            record = self._apply_transformations(raw)
+            if record is not None:
+                yield record
+
+    def _on_progress(self, count: int) -> None:
+        if self.config.progress_callback:
+            self.config.progress_callback(count)
+
+    # ------------------------------------------------------------------ cache
+
+    def _cache_is_fresh(self) -> bool:
+        """Whether a named cache already holds up-to-date data for the source."""
+        if self._cache_path is None:
+            return False
+        try:
+            if not self._cache_path.exists() or self._cache_path.stat().st_size == 0:
+                return False
+            if self._cache_path.stat().st_mtime < self.filepath.stat().st_mtime:
+                return False
+            count = self.conn.execute(f"SELECT COUNT(*) FROM {self._table}").fetchone()[0]
+            return count > 0
+        except sqlite3.Error:
+            return False
+        except OSError:
+            return False
+
+    def _adopt_existing_schema(self) -> None:
+        """Populate the column list from an existing cache table (no re-ingest)."""
+        try:
+            cur = self.conn.execute(f"PRAGMA table_info({self._table})")
+            self._columns = [row["name"] for row in cur.fetchall()]
+        except sqlite3.Error:
+            self._columns = []
+
+    # ------------------------------------------------------------------ lifecycle
+
+    def close(self) -> None:
+        """Close the working store, removing the temporary file if one was used."""
+        super().close()
+        if self._is_temp:
+            try:
+                os.remove(self._store_name)
+            except OSError:
+                pass
+
+    # ------------------------------------------------------------------ transforms
+
+    def _apply_transformations(self, record: Record) -> Optional[Record]:
+        """Apply the configured transformation pipeline to a single record.
+
+        Returns:
+            The transformed record, or None if filtered out.
+        """
+        # Apply row filter first.
         if self.config.row_filter and not self.config.row_filter(record):
             return None
 
-        # Apply column selection
+        # Column selection.
         if self.config.columns_to_load:
             record = {k: v for k, v in record.items() if k in self.config.columns_to_load}
 
-        # Apply column renames
+        # Column renames.
         if self.config.column_renames:
             for old_name, new_name in self.config.column_renames.items():
                 if old_name in record:
                     record[new_name] = record.pop(old_name)
 
-        # Apply default values
+        # Default values.
         if self.config.default_values:
             for col, default in self.config.default_values.items():
                 if col not in record or record[col] is None:
                     record[col] = default
 
-        # Apply type conversions
+        # Type conversions.
         if self.config.column_types:
             for col, col_type in self.config.column_types.items():
                 if col in record and record[col] is not None:
                     try:
-                        if callable(col_type):
-                            record[col] = col_type(record[col])
-                        else:
-                            record[col] = col_type(record[col])
+                        record[col] = col_type(record[col])
                     except (ValueError, TypeError):
                         pass  # Keep original value if conversion fails
 
-        # Apply column transformations
+        # Per-column transforms.
         if self.config.column_transforms:
             for col, transform_func in self.config.column_transforms.items():
                 if col in record:
@@ -368,171 +313,8 @@ class FileDataSource(MemoryDataSource):
                     except Exception:
                         pass  # Keep original value if transform fails
 
-        # Apply row-level transformation
+        # Row-level transform.
         if self.config.row_transform:
             record = self.config.row_transform(record)
 
         return record
-
-    def _load_eager(self) -> None:
-        """Load all records into memory at once."""
-        records = []
-        estimated_total = self._estimate_row_count()
-
-        for i, raw_record in enumerate(self._parse_records()):
-            record = self._apply_transformations(raw_record)
-            if record is not None:
-                records.append(record)
-
-            if self.config.progress_callback and (i + 1) % 1000 == 0:
-                self._load_progress = (i + 1, estimated_total)
-                self.config.progress_callback(i + 1, estimated_total)
-
-        # Set data in parent MemoryDataSource
-        super().load(records)
-        self.is_loaded = True
-        self._load_progress = (len(records), len(records))
-
-        if self.config.progress_callback:
-            self.config.progress_callback(len(records), len(records))
-
-    def _load_chunked(self) -> None:
-        """Load file in chunks."""
-        chunk = []
-        estimated_total = self._estimate_row_count()
-        loaded_count = 0
-
-        for i, raw_record in enumerate(self._parse_records()):
-            record = self._apply_transformations(raw_record)
-            if record is not None:
-                chunk.append(record)
-
-            # Process chunk when it reaches chunk_size
-            if len(chunk) >= self.config.chunk_size:
-                if not self.is_loaded:
-                    super().load(chunk)
-                    self.is_loaded = True
-                else:
-                    # Append to existing data
-                    for rec in chunk:
-                        self.insert(rec)
-
-                loaded_count += len(chunk)
-                self._load_progress = (loaded_count, estimated_total)
-
-                if self.config.progress_callback:
-                    self.config.progress_callback(loaded_count, estimated_total)
-
-                chunk = []
-
-        # Process remaining records
-        if chunk:
-            if not self.is_loaded:
-                super().load(chunk)
-                self.is_loaded = True
-            else:
-                for rec in chunk:
-                    self.insert(rec)
-
-            loaded_count += len(chunk)
-
-        self._load_progress = (loaded_count, loaded_count)
-        if self.config.progress_callback:
-            self.config.progress_callback(loaded_count, loaded_count)
-
-    def _load_impl(self) -> None:
-        """Internal load implementation (runs in thread if use_threading=True)."""
-        try:
-            # Suppress the per-chunk insert/load emits during the bulk read, then
-            # broadcast a single coalesced `load`. When this runs on a background
-            # thread the hub marshals that broadcast to the main thread.
-            with self._hub.silence():
-                strategy = self._determine_strategy()
-
-                if strategy == 'eager':
-                    self._load_eager()
-                elif strategy == 'chunked':
-                    self._load_chunked()
-                elif strategy in ('lazy', 'hybrid'):
-                    # For now, fall back to eager (lazy/hybrid require more complex implementation)
-                    self._load_eager()
-
-            self._loading = False
-            self._hub.emit(DataChangeEvent(kind="load"))
-
-            if self.config.on_complete:
-                self.config.on_complete()
-
-        except Exception as e:
-            self._loading = False
-            self.is_loaded = False
-
-            if self.config.on_error:
-                self.config.on_error(e)
-            else:
-                raise
-
-    def load(self, *, on_complete: Optional[Callable] = None) -> None:
-        """Load records from the configured file.
-
-        Unlike other sources, a `FileDataSource` draws its records from the
-        file given at construction, so `load()` takes no records. For threaded
-        loading it returns immediately and calls `on_complete` when done; for
-        synchronous loading it blocks until complete.
-
-        Args:
-            on_complete: Optional callback when loading finishes (overrides config)
-        """
-        if self._loading:
-            return  # Already loading
-
-        self._loading = True
-        self.is_loaded = False
-        self._load_progress = (0, 0)
-
-        # Override on_complete if provided
-        if on_complete:
-            original_callback = self.config.on_complete
-            self.config.on_complete = on_complete
-
-        if self.config.use_threading:
-            # Load in background thread
-            self._load_thread = threading.Thread(target=self._load_impl, daemon=True)
-            self._load_thread.start()
-        else:
-            # Load synchronously
-            self._load_impl()
-
-        # Restore original callback if overridden
-        if on_complete:
-            self.config.on_complete = original_callback
-
-    def reload(self) -> None:
-        """Reload from file, clearing current data."""
-        self.is_loaded = False
-        self._data.clear()
-        self._columns.clear()
-        self._id_index.clear()
-        self.load()
-
-    def is_loading(self) -> bool:
-        """Check if file is currently loading."""
-        return self._loading
-
-    def get_load_progress(self) -> tuple[int, int]:
-        """Get loading progress as (current, total) rows."""
-        return self._load_progress
-
-    def wait_for_load(self, timeout: Optional[float] = None) -> bool:
-        """Wait for loading to complete (if threaded).
-
-        Args:
-            timeout: Max seconds to wait (None = wait forever)
-
-        Returns:
-            True if load completed, False if timed out
-        """
-        if self._load_thread and self._load_thread.is_alive():
-            self._load_thread.join(timeout=timeout)
-            return not self._load_thread.is_alive()
-        return True

--- a/src/bootstack/data/readers.py
+++ b/src/bootstack/data/readers.py
@@ -178,25 +178,38 @@ def read_jsonl(path: "str | Path", config: "FileSourceConfig") -> Iterator[Recor
 def read_json(path: "str | Path", config: "FileSourceConfig") -> Iterator[Record]:
     """Read records from a JSON file.
 
-    A JSON *array* is parsed in full (the stdlib parser cannot stream an array —
-    prefer JSONL for very large data). An object with a `"records"` key yields
-    that list; any other object is treated as a single record.
+    Supported shapes:
+
+    - a top-level **array of objects** → one record per element;
+    - a top-level **object** with its records under `config.json_records_key`
+      (e.g. an API response like `{"data": [...]}`) → that list;
+    - any other top-level **object** → a single record.
+
+    A JSON array is parsed in full — the stdlib parser cannot stream an array, so
+    prefer JSONL / `.ndjson` (or set `config.json_lines`) for very large data.
     """
     if getattr(config, "json_lines", False):
         yield from read_jsonl(path, config)
         return
     with open(path, "r", encoding=config.encoding) as f:
         data = json.load(f)
+
+    key = getattr(config, "json_records_key", None)
+    if key is not None:
+        items = data.get(key) if isinstance(data, dict) else None
+        if not isinstance(items, list):
+            raise ValueError(
+                f"json_records_key={key!r} did not resolve to a list of records in {path}."
+            )
+        for item in items:
+            yield item if isinstance(item, dict) else {"value": item}
+        return
+
     if isinstance(data, list):
         for item in data:
             yield item if isinstance(item, dict) else {"value": item}
     elif isinstance(data, dict):
-        if isinstance(data.get("records"), list):
-            for item in data["records"]:
-                if isinstance(item, dict):
-                    yield item
-        else:
-            yield data
+        yield data
 
 
 @register_reader(".xml")

--- a/src/bootstack/data/sqlite_source.py
+++ b/src/bootstack/data/sqlite_source.py
@@ -105,6 +105,19 @@ class SqliteDataSource(BaseDataSource):
         self._sort: List[SortKey] = []
         self._columns = []
 
+    def close(self) -> None:
+        """Close the underlying SQLite connection. Idempotent.
+
+        Use a `with` block to close automatically::
+
+            with bs.SqliteDataSource("app.db") as ds:
+                ds.load(rows)
+        """
+        try:
+            self.conn.close()
+        except sqlite3.Error:
+            pass
+
     # ---- internal query-fragment builders -------------------------------
 
     def _where_clause(self) -> tuple[str, list]:

--- a/src/bootstack/data/sqlite_source.py
+++ b/src/bootstack/data/sqlite_source.py
@@ -272,7 +272,14 @@ class SqliteDataSource(BaseDataSource):
         try:
             first = next(it)
         except StopIteration:
-            return self  # empty input — leave any existing data untouched
+            # Empty input clears to an empty source (consistent with MemoryDataSource).
+            try:
+                self.conn.execute(f"DROP TABLE IF EXISTS {self._table}")
+            except sqlite3.Error:
+                pass
+            self._columns = []
+            self._hub.emit(DataChangeEvent(kind="load"))
+            return self
 
         # Apply fast, in-memory friendly pragmas when using ":memory:" to speed up bulk loads
         try:
@@ -391,6 +398,14 @@ class SqliteDataSource(BaseDataSource):
         except sqlite3.Error:
             pass
 
+    def _table_exists(self) -> bool:
+        """Whether the records table exists yet (False before any data is loaded)."""
+        try:
+            self.conn.execute(f"SELECT 1 FROM {self._table} LIMIT 1")
+            return True
+        except sqlite3.OperationalError:
+            return False
+
     def where(self, condition: Optional[Condition] = None) -> "SqliteDataSource":
         """Filter rows by a condition built with `col` (None clears the filter).
 
@@ -411,6 +426,8 @@ class SqliteDataSource(BaseDataSource):
         """Get records for specified page."""
         if page is not None:
             self._page = page
+        if not self._table_exists():
+            return []
         offset = self._page * self.page_size
 
         where, params = self._where_clause()
@@ -438,6 +455,8 @@ class SqliteDataSource(BaseDataSource):
     @property
     def count(self) -> int:
         """Total number of records matching the current filter."""
+        if not self._table_exists():
+            return 0
         where, params = self._where_clause()
         query = f"SELECT COUNT(*) FROM {self._table}{where}"
         return self.conn.execute(query, params).fetchone()[0]
@@ -483,6 +502,8 @@ class SqliteDataSource(BaseDataSource):
 
     def get(self, record_id: Any) -> Optional[Dict[str, Any]]:
         """Retrieve single record by ID."""
+        if not self._table_exists():
+            return None
         cursor = self.conn.execute(f"SELECT * FROM {self._table} WHERE {_ROW_ID} = ?", (record_id,))
         row = cursor.fetchone()
         return self._row_to_record(row) if row else None
@@ -505,7 +526,7 @@ class SqliteDataSource(BaseDataSource):
 
     def update(self, record_id: Any, updates: Dict[str, Any]) -> bool:
         """Update record fields by ID."""
-        if not updates:
+        if not updates or not self._table_exists():
             return False
 
         col_set = set(self._user_column_fields)
@@ -560,6 +581,8 @@ class SqliteDataSource(BaseDataSource):
 
     def delete(self, record_id: Any) -> bool:
         """Delete record by ID."""
+        if not self._table_exists():
+            return False
         with self.conn:
             cur = self.conn.execute(f"DELETE FROM {self._table} WHERE {_ROW_ID} = ?", (record_id,))
             changed = cur.rowcount > 0
@@ -639,7 +662,7 @@ class SqliteDataSource(BaseDataSource):
 
     def is_selected(self, record_id: Any) -> bool:
         """Check whether a record is currently selected."""
-        if _ROW_SEL not in self._columns:
+        if not self._table_exists() or _ROW_SEL not in self._columns:
             return False
         row = self.conn.execute(
             f"SELECT {_ROW_SEL} FROM {self._table} WHERE {_ROW_ID} = ?",
@@ -665,6 +688,8 @@ class SqliteDataSource(BaseDataSource):
 
     def select_all(self, current_page_only: bool = False) -> int:
         """Select all records (optionally only current page)."""
+        if not self._table_exists():
+            return 0
         self._ensure_selected_column()
         if current_page_only:
             ids = [row[_ROW_ID] for row in self.page()]
@@ -685,6 +710,8 @@ class SqliteDataSource(BaseDataSource):
 
     def deselect_all(self, current_page_only: bool = False) -> int:
         """Deselect all records (optionally only current page)."""
+        if not self._table_exists():
+            return 0
         self._ensure_selected_column()
         if current_page_only:
             ids = [row[_ROW_ID] for row in self.page()]
@@ -705,6 +732,8 @@ class SqliteDataSource(BaseDataSource):
 
     def selected(self, page: Optional[int] = None) -> List[Dict[str, Any]]:
         """Get selected records, optionally paginated."""
+        if not self._table_exists():
+            return []
         self._ensure_selected_column()
         query = f"SELECT * FROM {self._table} WHERE {_ROW_SEL} = 1"
 
@@ -725,12 +754,16 @@ class SqliteDataSource(BaseDataSource):
     @property
     def selected_count(self) -> int:
         """Number of selected records."""
+        if not self._table_exists():
+            return 0
         self._ensure_selected_column()
         query = f"SELECT COUNT(*) FROM {self._table} WHERE {_ROW_SEL} = 1"
         return self.conn.execute(query).fetchone()[0]
 
     def _set_selected_flag(self, record_id: Any, flag: int) -> bool:
         """Set selection flag for record by ID."""
+        if not self._table_exists():
+            return False
         if _ROW_SEL not in self._columns:
             with self.conn:
                 self.conn.execute(f"ALTER TABLE {self._table} ADD COLUMN {_ROW_SEL} INTEGER DEFAULT 0")
@@ -747,6 +780,8 @@ class SqliteDataSource(BaseDataSource):
 
     def export_csv(self, filepath: str, include_all: bool = True):
         """Export records to CSV file."""
+        if not self._table_exists():
+            return
         self._ensure_selected_column()
         query = f"SELECT * FROM {self._table}"
         if not include_all:
@@ -777,6 +812,8 @@ class SqliteDataSource(BaseDataSource):
 
     def page_slice(self, start_index: int, count: int) -> List[Dict[str, Any]]:
         """Get records by start index and count (respects filter/sort)."""
+        if not self._table_exists():
+            return []
         where, params = self._where_clause()
         query = (
             f"SELECT * FROM {self._table}{where}{self._order_clause()}"
@@ -795,6 +832,8 @@ class SqliteDataSource(BaseDataSource):
         Returns:
             List of distinct values sorted alphabetically.
         """
+        if not self._table_exists():
+            return []
         quoted_col = self._quote_identifier(column)
         query = f"SELECT DISTINCT {quoted_col} FROM {self._table}"
         query += f" ORDER BY {quoted_col} LIMIT {limit}"

--- a/src/bootstack/data/types.py
+++ b/src/bootstack/data/types.py
@@ -265,6 +265,14 @@ class DataSourceProtocol(Protocol):
         """
         ...
 
+    def close(self) -> None:
+        """Release any resources held by the source (a connection, file handle).
+
+        A no-op for in-memory sources. Sources are also context managers, so a
+        `with` block closes automatically. Safe to call more than once.
+        """
+        ...
+
     def move(self, record_id: Any, target_index: int) -> bool:
         """Reorder a record to a new position.
 

--- a/tests/data/test_data_bag.py
+++ b/tests/data/test_data_bag.py
@@ -3,11 +3,12 @@
 A record should never lose user data: fields the widget does not display are
 still carried through and handed back. Fidelity is tiered by storage:
 
-- In-memory sources (``MemoryDataSource``, ``FileDataSource``) hold *anything*,
-  including live Python objects, by reference.
-- ``SqliteDataSource`` is persistent: SQL columns are scalar-only, so non-scalar
-  fields (lists/dicts) ride a hidden JSON column and round-trip transparently.
-  Values must be JSON-serializable; live objects raise ``SerializationError``.
+- In-memory sources (``MemoryDataSource``) hold *anything*, including live Python
+  objects, by reference.
+- SQLite-backed sources (``SqliteDataSource``, and ``FileDataSource`` which
+  ingests into SQLite) store non-scalar fields (lists/dicts) in a hidden JSON
+  column that round-trips transparently. Values must be JSON-serializable; live
+  objects raise ``SerializationError``.
 
 These are headless (no App) — the data layer is App-independent.
 """

--- a/tests/data/test_file_source.py
+++ b/tests/data/test_file_source.py
@@ -1,0 +1,154 @@
+"""Tests for FileDataSource — streaming file ingest into a SQLite working store.
+
+FileDataSource reads a file and ingests it (a chunk at a time) into a SQLite
+store, so after `load()` it behaves like a `SqliteDataSource`. The original file
+is read-only input; the working store is a temp file by default (removed on
+`close()`), a named persistent cache, or in-memory. Headless (no App).
+"""
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from bootstack import col
+from bootstack.data import FileDataSource, FileSourceConfig
+
+
+def _csv(tmp_path, text="id,name,age\n1,Ada,40\n2,Bob,25\n3,Cy,33\n"):
+    p = tmp_path / "people.csv"
+    p.write_text(text, encoding="utf-8")
+    return p
+
+
+def test_loads_and_queries_via_sql(tmp_path):
+    ds = FileDataSource(_csv(tmp_path))
+    ds.load()
+    assert ds.count == 3
+    ds.where(col("age") >= 33).order("-age")
+    assert [r["name"] for r in ds.page(0)] == ["Ada", "Cy"]
+    ds.close()
+
+
+def test_default_store_is_temp_and_removed_on_close(tmp_path):
+    ds = FileDataSource(_csv(tmp_path))
+    ds.load()
+    store = ds._store_name
+    assert ds._is_temp and os.path.exists(store)
+    ds.close()
+    assert not os.path.exists(store)
+
+
+def test_context_manager_cleans_up(tmp_path):
+    with FileDataSource(_csv(tmp_path)) as ds:
+        ds.load()
+        assert ds.count == 3
+        store = ds._store_name
+    assert not os.path.exists(store)
+
+
+def test_transform_pipeline(tmp_path):
+    cfg = FileSourceConfig(column_renames={"name": "full_name"}, column_types={"age": int})
+    ds = FileDataSource(_csv(tmp_path), cfg)
+    ds.load()
+    rec = ds.get(1)
+    assert rec["full_name"] == "Ada"
+    assert rec["age"] == 40 and isinstance(rec["age"], int)
+    ds.close()
+
+
+def test_row_filter(tmp_path):
+    cfg = FileSourceConfig(row_filter=lambda r: int(r["age"]) >= 30)
+    ds = FileDataSource(_csv(tmp_path), cfg)
+    ds.load()
+    assert sorted(r["name"] for r in ds.page(0)) == ["Ada", "Cy"]
+    ds.close()
+
+
+def test_jsonl_non_scalar_bag_roundtrips(tmp_path):
+    p = tmp_path / "x.jsonl"
+    p.write_text('{"id":1,"name":"A","tags":["x","y"]}\n{"id":2,"name":"B","tags":[]}\n', encoding="utf-8")
+    ds = FileDataSource(p)
+    ds.load()
+    assert ds.get(1)["tags"] == ["x", "y"]
+    ds.close()
+
+
+def test_json_records_key(tmp_path):
+    p = tmp_path / "api.json"
+    p.write_text('{"data": [{"id": 1, "name": "A"}, {"id": 2, "name": "B"}]}', encoding="utf-8")
+    ds = FileDataSource(p, FileSourceConfig(json_records_key="data"))
+    ds.load()
+    assert ds.count == 2 and ds.get(1)["name"] == "A"
+    ds.close()
+
+
+def test_memory_store(tmp_path):
+    ds = FileDataSource(_csv(tmp_path), cache=":memory:")
+    ds.load()
+    assert ds.count == 3 and ds._store_name == ":memory:" and not ds._is_temp
+    ds.close()
+
+
+def test_named_cache_persists_and_skips_reingest(tmp_path):
+    src = _csv(tmp_path)
+    cache = tmp_path / "cache.db"
+
+    first = FileDataSource(src, cache=str(cache))
+    first.load()
+    assert first.count == 3 and not first._is_temp
+    first.close()
+    assert cache.exists()
+
+    # Reopen: a fresh cache is adopted without re-ingest.
+    again = FileDataSource(src, cache=str(cache))
+    assert again.is_loaded is True
+    assert again.count == 3
+    again.load()  # no-op while fresh
+    assert again.count == 3
+    again.close()
+
+
+def test_named_cache_reingests_when_source_is_newer(tmp_path):
+    src = _csv(tmp_path)
+    cache = tmp_path / "cache.db"
+    FileDataSource(src, cache=str(cache)).load()
+
+    time.sleep(0.01)
+    src.write_text("id,name,age\n1,Ada,40\n2,Bob,25\n3,Cy,33\n4,Dee,50\n", encoding="utf-8")
+    os.utime(src, None)
+
+    ds = FileDataSource(src, cache=str(cache))
+    assert ds.is_loaded is False  # stale → not adopted
+    ds.load()
+    assert ds.count == 4
+    ds.close()
+
+
+def test_reload_reingests(tmp_path):
+    ds = FileDataSource(_csv(tmp_path))
+    ds.load()
+    assert ds.count == 3
+    ds.reload()
+    assert ds.count == 3
+    ds.close()
+
+
+def test_progress_callback(tmp_path):
+    rows = "\n".join(f"{i},n{i}" for i in range(2500))
+    p = tmp_path / "big.csv"
+    p.write_text("id,name\n" + rows + "\n", encoding="utf-8")
+    seen = []
+    cfg = FileSourceConfig(chunk_size=1000, progress_callback=seen.append)
+    ds = FileDataSource(p, cfg)
+    ds.load()
+    assert seen == [1000, 2000, 2500]
+    assert ds.count == 2500
+    ds.close()
+
+
+def test_missing_file_raises(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        FileDataSource(tmp_path / "nope.csv")

--- a/tests/data/test_file_source.py
+++ b/tests/data/test_file_source.py
@@ -49,6 +49,29 @@ def test_context_manager_cleans_up(tmp_path):
     assert not os.path.exists(store)
 
 
+def test_temp_store_cleaned_on_gc_without_close(tmp_path):
+    # Safety net: a forgotten FileDataSource (never closed) still removes its temp
+    # file when garbage collected — no orphaned files.
+    import gc
+
+    ds = FileDataSource(_csv(tmp_path))
+    ds.load()
+    store = ds._store_name
+    assert os.path.exists(store)
+    del ds
+    gc.collect()
+    assert not os.path.exists(store)
+
+
+def test_close_is_idempotent_for_temp(tmp_path):
+    ds = FileDataSource(_csv(tmp_path))
+    ds.load()
+    store = ds._store_name
+    ds.close()
+    ds.close()  # no error on a second close
+    assert not os.path.exists(store)
+
+
 def test_transform_pipeline(tmp_path):
     cfg = FileSourceConfig(column_renames={"name": "full_name"}, column_types={"age": int})
     ds = FileDataSource(_csv(tmp_path), cfg)

--- a/tests/data/test_lifecycle.py
+++ b/tests/data/test_lifecycle.py
@@ -1,0 +1,59 @@
+"""Tests for data-source resource lifecycle — close() and context manager.
+
+Sources follow the Python file-object convention: an explicit ``close()`` plus
+``with`` support. In-memory sources have nothing to release (no-op close);
+``SqliteDataSource`` closes its connection. Headless (no App).
+"""
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from bootstack.data import MemoryDataSource, SqliteDataSource
+
+
+def test_sqlite_context_manager_returns_self_and_works():
+    with SqliteDataSource() as ds:
+        ds.load([{"id": 1, "name": "A"}])
+        assert ds.count == 1
+
+
+def test_sqlite_close_releases_connection():
+    ds = SqliteDataSource().load([{"id": 1, "name": "A"}])
+    ds.close()
+    # Using a closed connection raises — the resource really was released.
+    with pytest.raises(sqlite3.ProgrammingError):
+        ds.conn.execute("SELECT 1")
+
+
+def test_sqlite_close_is_idempotent():
+    ds = SqliteDataSource()
+    ds.close()
+    ds.close()  # no error on a second close
+
+
+def test_sqlite_with_block_closes_on_exit():
+    ds = SqliteDataSource().load([{"id": 1, "name": "A"}])
+    with ds:
+        assert ds.count == 1
+    with pytest.raises(sqlite3.ProgrammingError):
+        ds.conn.execute("SELECT 1")
+
+
+def test_sqlite_with_block_closes_even_on_exception():
+    ds = SqliteDataSource()
+    with pytest.raises(ValueError):
+        with ds:
+            raise ValueError("boom")
+    with pytest.raises(sqlite3.ProgrammingError):
+        ds.conn.execute("SELECT 1")
+
+
+def test_memory_context_manager_is_noop_close():
+    with MemoryDataSource() as ds:
+        ds.load([{"id": 1, "name": "A"}])
+        assert ds.count == 1
+    # No resources to release; data remains accessible after the block.
+    assert ds.count == 1
+    ds.close()  # still a no-op, no error

--- a/tests/data/test_readers.py
+++ b/tests/data/test_readers.py
@@ -98,15 +98,32 @@ def test_json_array(tmp_path):
 
 
 def test_json_records_key(tmp_path):
+    # Records nested under a key (e.g. an API response) — opt in explicitly.
     p = tmp_path / "p.json"
-    p.write_text(json.dumps({"records": [{"id": 9}]}), encoding="utf-8")
-    assert list(read_records(p)) == [{"id": 9}]
+    p.write_text(json.dumps({"data": [{"id": 9}, {"id": 10}]}), encoding="utf-8")
+    rows = list(read_records(p, FileSourceConfig(json_records_key="data")))
+    assert rows == [{"id": 9}, {"id": 10}]
+
+
+def test_json_records_key_must_resolve_to_a_list(tmp_path):
+    p = tmp_path / "p.json"
+    p.write_text(json.dumps({"data": "oops"}), encoding="utf-8")
+    with pytest.raises(ValueError, match="json_records_key"):
+        list(read_records(p, FileSourceConfig(json_records_key="data")))
 
 
 def test_json_single_object(tmp_path):
     p = tmp_path / "p.json"
     p.write_text(json.dumps({"id": 1, "name": "solo"}), encoding="utf-8")
     assert list(read_records(p)) == [{"id": 1, "name": "solo"}]
+
+
+def test_json_no_magic_records_key(tmp_path):
+    # Without json_records_key, an object is one record — no implicit "records"
+    # sniffing (explicit beats magic).
+    p = tmp_path / "p.json"
+    p.write_text(json.dumps({"records": [{"id": 9}]}), encoding="utf-8")
+    assert list(read_records(p)) == [{"records": [{"id": 9}]}]
 
 
 # --------------------------------------------------------------------------- xml

--- a/tests/data/test_streaming_load.py
+++ b/tests/data/test_streaming_load.py
@@ -59,12 +59,6 @@ def test_sequence_rows_stream_with_column_keys():
     assert ds.get(3)["name"] == "p3"
 
 
-def test_empty_iterator_is_a_noop():
-    ds = SqliteDataSource().load([{"id": 1, "name": "A"}])
-    ds.load(iter([]))
-    assert ds.count == 1  # existing data untouched
-
-
 def test_duplicate_id_mid_stream_rolls_back():
     ds = SqliteDataSource().load([{"id": 100, "name": "keep"}])
 
@@ -101,6 +95,39 @@ def test_memory_load_accepts_a_generator():
     assert ds.count == 50
     assert ds.get(7)["name"] == "p7"
     assert ds.get(7)["tags"] == [7]
+
+
+def test_fresh_source_reads_empty_not_raise():
+    # A fresh SqliteDataSource (no table yet) reads as empty, like MemoryDataSource —
+    # it must not raise "no such table".
+    ds = SqliteDataSource()
+    assert ds.count == 0
+    assert ds.page(0) == []
+    assert ds.page_slice(0, 10) == []
+    assert ds.selected() == []
+    assert ds.selected_count == 0
+    assert ds.has_next_page() is False
+    assert ds.get(1) is None
+    assert ds.update(1, {"x": 1}) is False
+    assert ds.delete(1) is False
+    assert ds.is_selected(1) is False
+    assert ds.select_all() == 0
+
+
+@pytest.mark.parametrize("cls", [MemoryDataSource, SqliteDataSource])
+def test_empty_load_clears_and_reads_empty(cls):
+    ds = cls().load([{"id": 1, "name": "A"}, {"id": 2, "name": "B"}])
+    assert ds.count == 2
+    ds.load([])  # empty load clears — same contract on both sources
+    assert ds.count == 0
+    assert ds.page(0) == []
+
+
+def test_insert_works_after_empty_load():
+    ds = SqliteDataSource().load([{"id": 1, "name": "A"}])
+    ds.load([])
+    rid = ds.insert({"id": 5, "name": "fresh"})
+    assert ds.count == 1 and ds.get(rid)["name"] == "fresh"
 
 
 def test_connection_usable_after_rolled_back_load():


### PR DESCRIPTION
Checkpoint 3 of the large-file streaming initiative: `FileDataSource` is rebuilt to ingest a file into a SQLite working store, plus the JSON/lifecycle/robustness work that came with it.

## FileDataSource on a SQLite working store
`FileDataSource` now extends `SqliteDataSource` (was `MemoryDataSource`) and streams the file — a chunk at a time, via the CP2 reader registry + CP1 chunked `load()` — into a SQLite store. A multi-million-row file loads with **bounded memory**, and after `load()` it's a full `SqliteDataSource` (fast SQL paging/filter/sort/CRUD).

- **Working store, by choice:** temporary on-disk (default, auto-cleaned), `cache="x.db"` (persistent; skips re-ingest while newer than the source via mtime + schema adopt), or `cache=":memory:"`.
- Original file is **read-only input**; `reload()` re-ingests; transform pipeline preserved; `progress_callback(count)` per chunk.
- Collapsed the dishonest loading-strategy/threading config (eager/lazy/hybrid/auto, `use_threading`, `wait_for_load`, …) — clean break. Background/progressive ingest is a noted follow-up; `load()` is synchronous but streamed.
- Widened `FileSourceConfig.file_format` to include xml/parquet/feather/hdf5.

## Resource lifecycle (close + context manager)
- `BaseDataSource`: no-op `close()` + `__enter__`/`__exit__`; `SqliteDataSource.close()` closes the connection (idempotent); declared on the protocol.
- **Temp-store auto-cleanup:** a `weakref.finalize` removes the temp file even if `close()` is never called (on GC and at interpreter exit) — no orphaned files. Three cleanup paths: `with` → `close()` → finalizer.

## JSON record shapes (dropped `json_orient`)
Pandas pivot layouts can't stream and were never properly implemented. New contract: top-level array of objects, JSONL/NDJSON (streams), or records under an explicit `json_records_key` (e.g. `"data"`), else a top-level object is one record. No implicit `"records"` sniffing. `FileDataSource._parse_json_records` delegates to `readers.read_json` (single source of truth).

## Robustness: empty load + missing table
- A missing records table now reads as empty everywhere (count→0, page/page_slice/selected→[], get→None, update/delete→False, …) instead of raising "no such table" — fixes a latent bug on fresh/empty sources.
- `load([])` clears to an empty source and emits `load`, matching `MemoryDataSource` (was a silent no-op).

## Docs
Rewrote the File-backed section (SQLite working store, formats, cache, close); reclassified `FileDataSource` under the SQLite-backed data-bag tier.

## Tests
`tests/data/test_file_source.py` (15), `test_lifecycle.py` (6), plus streaming/empty-load/missing-table additions. Full data suite: 93 passed, 3 skipped (optional-format roundtrips without the dep).

Remaining in the initiative: CP4 (streaming export + writer registry + DataTable export-menu formats), CP5 (docs/examples).

🤖 Generated with [Claude Code](https://claude.com/claude-code)