### PR TITLE
feat(data): file streaming cp4 — streaming writers + export_formats

### DIFF
--- a/docs/widgets/datatable.rst
+++ b/docs/widgets/datatable.rst
@@ -399,9 +399,22 @@ Exporting
 ~~~~~~~~~
 
 ``allow_export=True`` adds an export menu with **Copy to clipboard** and **Save to
-file** (CSV, plus Excel when the optional ``bootstack[excel]`` extra is installed).
-The actions export the selected rows if any are selected, otherwise the whole
-filtered set.
+file**. The actions export the selected rows if any are selected, otherwise the
+whole filtered set.
+
+``export_formats=`` chooses which formats the menu offers (default ``('csv',)``):
+
+.. code-block:: python
+
+   bs.DataTable(rows=rows, allow_export=True,
+                export_formats=["csv", "xlsx", "json", "parquet"])
+
+Choose from ``csv``, ``tsv``, ``xlsx``, ``json``, ``jsonl``, ``xml``, ``parquet``,
+``feather``, ``hdf5``. Formats needing an optional dependency
+(``xlsx``→``bootstack[excel]``, ``parquet``/``feather``→``bootstack[parquet]``,
+``hdf5``→``bootstack[hdf5]``) appear in the menu only once it is installed. The
+export carries the **displayed columns**; for the full record set (every field,
+including undisplayed ones) use ``table.data_source.save(path)``.
 
 .. image:: /_static/examples/datatable-export-light.png
    :class: bs-screenshot-light

--- a/src/bootstack/data/__init__.py
+++ b/src/bootstack/data/__init__.py
@@ -46,6 +46,12 @@ from bootstack.data.readers import (
     get_reader,
     supported_extensions,
 )
+from bootstack.data.writers import (
+    register_writer,
+    write_records,
+    get_writer,
+    supported_write_extensions,
+)
 
 __all__ = [
     'BaseDataSource',
@@ -66,4 +72,8 @@ __all__ = [
     'read_records',
     'get_reader',
     'supported_extensions',
+    'register_writer',
+    'write_records',
+    'get_writer',
+    'supported_write_extensions',
 ]

--- a/src/bootstack/data/base.py
+++ b/src/bootstack/data/base.py
@@ -287,15 +287,57 @@ class BaseDataSource(ABC):
         ...
 
     # Export
-    @abstractmethod
+    def save(
+        self,
+        path: str,
+        *,
+        selected_only: bool = False,
+        format: Optional[str] = None,
+        config: Any = None,
+    ) -> None:
+        """Export records to a file, choosing the format by extension.
+
+        Records are streamed into the writer, so a large export does not
+        materialize the whole dataset. The active `where`/`order` view is
+        respected — what you export is what the source currently shows.
+
+        Args:
+            path: Destination file path; its extension selects the format (CSV,
+                TSV, JSON, JSONL, XML, and — with the extras — Parquet, Feather,
+                HDF5).
+            selected_only: Export only selected records instead of all.
+            format: Explicit format name overriding the path extension.
+            config: Optional `FileSourceConfig` controlling encoding/delimiter/etc.
+        """
+        from bootstack.data.writers import write_records
+
+        write_records(
+            path, self._export_records(selected_only=selected_only), config, format=format
+        )
+
     def export_csv(self, filepath: str, include_all: bool = True) -> None:
-        """Export records to CSV file.
+        """Export records to a CSV file (streamed).
 
         Args:
             filepath: Path to output CSV file
             include_all: If True, export all records; if False, export only selected
         """
-        ...
+        self.save(filepath, selected_only=not include_all, format="csv")
+
+    def _export_records(self, *, selected_only: bool = False, chunk_size: int = 1000):
+        """Yield user-facing records for export, paging in chunks (bounded memory)."""
+        if selected_only:
+            for record in self.selected():
+                yield self._public_record(record)
+            return
+        offset = 0
+        while True:
+            chunk = self.page_slice(offset, chunk_size)
+            if not chunk:
+                break
+            for record in chunk:
+                yield self._public_record(record)
+            offset += len(chunk)
 
     # Index-based Access
     @abstractmethod

--- a/src/bootstack/data/memory_source.py
+++ b/src/bootstack/data/memory_source.py
@@ -33,7 +33,6 @@ Data Format:
 
 from __future__ import annotations
 
-import csv
 from collections.abc import Sequence
 from typing import Any, Dict, List, Optional, Union, Mapping, Iterable
 
@@ -422,18 +421,6 @@ class MemoryDataSource(BaseDataSource):
         """Number of selected records."""
         self._ensure_selected_column()
         return sum(1 for r in self._data if r.get("selected") == 1)
-
-    def export_csv(self, filepath: str, include_all: bool = True) -> None:
-        """Export records to CSV file."""
-        rows = self._data if include_all else [r for r in self._data if r.get("selected") == 1]
-        if not rows:
-            return
-        fieldnames = list(self._columns) if self._columns else list(rows[0].keys())
-        with open(filepath, mode="w", newline="", encoding="utf-8") as f:
-            writer = csv.DictWriter(f, fieldnames=fieldnames)
-            writer.writeheader()
-            for r in rows:
-                writer.writerow({k: r.get(k) for k in fieldnames})
 
     def page_slice(self, start_index: int, count: int) -> List[Dict[str, Any]]:
         """Get records by start index and count (respects filter/sort)."""

--- a/src/bootstack/data/sqlite_source.py
+++ b/src/bootstack/data/sqlite_source.py
@@ -28,7 +28,6 @@ Example:
 
 from __future__ import annotations
 
-import csv
 import json
 import sqlite3
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union, Sequence
@@ -775,40 +774,6 @@ class SqliteDataSource(BaseDataSource):
                 (flag, record_id),
             )
             return cur.rowcount > 0
-
-    # === DATA EXPORT ===
-
-    def export_csv(self, filepath: str, include_all: bool = True):
-        """Export records to CSV file."""
-        if not self._table_exists():
-            return
-        self._ensure_selected_column()
-        query = f"SELECT * FROM {self._table}"
-        if not include_all:
-            query += f" WHERE {_ROW_SEL} = 1"
-
-        cursor = self.conn.execute(query)
-        rows = cursor.fetchall()
-
-        if not rows:
-            return
-
-        # Emit public records — internal columns stripped, the JSON bag merged
-        # back into flat fields — over the union of all keys.
-        records = [self._public_record(self._row_to_record(row)) for row in rows]
-        fieldnames: List[str] = []
-        seen: set = set()
-        for rec in records:
-            for key in rec.keys():
-                if key not in seen:
-                    seen.add(key)
-                    fieldnames.append(key)
-
-        with open(filepath, mode='w', newline='', encoding='utf-8') as f:
-            writer = csv.DictWriter(f, fieldnames=fieldnames)
-            writer.writeheader()
-            for rec in records:
-                writer.writerow({k: rec.get(k) for k in fieldnames})
 
     def page_slice(self, start_index: int, count: int) -> List[Dict[str, Any]]:
         """Get records by start index and count (respects filter/sort)."""

--- a/src/bootstack/data/types.py
+++ b/src/bootstack/data/types.py
@@ -286,6 +286,15 @@ class DataSourceProtocol(Protocol):
         ...
 
     # ---------- export ----------
+    def save(self, path: str, *, selected_only: bool = False, format: Optional[str] = None, config: Any = None) -> None:
+        """Export records to a file, format chosen by the path extension (or `format`).
+
+        Records are streamed into the writer; the active `where`/`order` view is
+        respected. Built-in formats: CSV, TSV, JSON, JSONL, XML — plus Parquet,
+        Feather, and HDF5 with the matching extra installed.
+        """
+        ...
+
     def export_csv(self, filepath: str, include_all: bool = True) -> None:
         """Export records to CSV file.
 

--- a/src/bootstack/data/writers.py
+++ b/src/bootstack/data/writers.py
@@ -1,0 +1,232 @@
+"""Streaming record writers — the export counterpart of `readers`.
+
+A *writer* consumes a lazy iterable of record dicts and writes them to a file,
+streaming where the format allows so a large export does not materialize the
+whole dataset. Writers are keyed by file extension in a registry: the stdlib
+formats (CSV / TSV / JSON / JSONL / XML) are always available, and the optional
+columnar/scientific formats (Parquet / Feather / HDF5) register too but raise a
+clear "install the extra" error when used without their dependency.
+
+The contract mirrors the readers — `writer(path, records, config) -> None` — so
+it pairs with `read_records` for round-trips, and backs the source-level
+`save()` / `export_csv()`.
+
+Register a custom writer for your own extension::
+
+    from bootstack.data.writers import register_writer
+
+    @register_writer(".myfmt")
+    def write_myfmt(path, records, config=None):
+        with open(path, "w") as f:
+            for record in records:
+                f.write(serialize(record))
+"""
+
+from __future__ import annotations
+
+import csv
+import importlib
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING, Callable, Dict, Iterable, List, Optional
+from xml.sax.saxutils import escape as _xml_escape
+
+from bootstack.data.types import Record
+
+if TYPE_CHECKING:
+    from bootstack.data.file_source import FileSourceConfig
+
+# A writer consumes record dicts: (path, records, config) -> None.
+Writer = Callable[..., None]
+
+_WRITERS: Dict[str, Writer] = {}
+
+# Format-name aliases (FileSourceConfig.file_format) → canonical extension.
+_FORMAT_ALIASES: Dict[str, str] = {
+    "csv": ".csv",
+    "tsv": ".tsv",
+    "json": ".json",
+    "jsonl": ".jsonl",
+    "ndjson": ".jsonl",
+    "xml": ".xml",
+    "parquet": ".parquet",
+    "feather": ".feather",
+    "hdf5": ".h5",
+}
+
+
+def _norm_ext(ext: str) -> str:
+    ext = ext.lower()
+    return ext if ext.startswith(".") else "." + ext
+
+
+def register_writer(*extensions: str, writer: Optional[Writer] = None):
+    """Register a writer for one or more file extensions (decorator or direct)."""
+
+    def _apply(fn: Writer) -> Writer:
+        for ext in extensions:
+            _WRITERS[_norm_ext(ext)] = fn
+        return fn
+
+    return _apply(writer) if writer is not None else _apply
+
+
+def supported_write_extensions() -> List[str]:
+    """Return the sorted list of registered writer extensions."""
+    return sorted(_WRITERS)
+
+
+def get_writer(path_or_ext: "str | Path") -> Writer:
+    """Resolve the writer for a path or extension.
+
+    Raises:
+        ValueError: If no writer is registered for the extension.
+    """
+    suffix = Path(str(path_or_ext)).suffix or str(path_or_ext)
+    ext = _norm_ext(suffix)
+    try:
+        return _WRITERS[ext]
+    except KeyError:
+        raise ValueError(
+            f"No writer registered for {ext!r}. Supported formats: "
+            f"{', '.join(supported_write_extensions())}."
+        ) from None
+
+
+def write_records(
+    path: "str | Path",
+    records: "Iterable[Record]",
+    config: "Optional[FileSourceConfig]" = None,
+    *,
+    format: Optional[str] = None,
+) -> None:
+    """Write records to a file, choosing the writer by `format` or extension.
+
+    Args:
+        path: Destination file path.
+        records: An iterable of record dicts (consumed lazily).
+        config: Optional formatting configuration (encoding, delimiter, …).
+        format: Explicit format name overriding the path extension.
+    """
+    if format:
+        writer = get_writer(_FORMAT_ALIASES.get(format, format))
+    else:
+        writer = get_writer(path)
+    writer(path, records, config)
+
+
+def _require(module: str, extra: str):
+    """Import an optional dependency or raise a clear install hint."""
+    try:
+        return importlib.import_module(module)
+    except ImportError as exc:
+        raise ImportError(
+            f"Writing this format needs the optional {module!r} dependency. "
+            f"Install it with:  pip install bootstack[{extra}]"
+        ) from exc
+
+
+def _encoding(config: "Optional[FileSourceConfig]") -> str:
+    return getattr(config, "encoding", "utf-8") or "utf-8"
+
+
+# --------------------------------------------------------------------------- stdlib
+
+
+@register_writer(".csv", ".tsv", ".txt")
+def write_csv(path: "str | Path", records: "Iterable[Record]", config: "Optional[FileSourceConfig]" = None) -> None:
+    """Write records to CSV/TSV, streaming a row at a time.
+
+    Column headers are taken from the first record; later records are written with
+    those columns (missing fields blank, extra fields ignored).
+    """
+    delimiter = getattr(config, "delimiter", None)
+    if not delimiter:
+        delimiter = "\t" if _norm_ext(Path(path).suffix) == ".tsv" else ","
+
+    it = iter(records)
+    try:
+        first = next(it)
+    except StopIteration:
+        open(path, "w", encoding=_encoding(config)).close()  # empty export
+        return
+
+    fieldnames = list(first.keys())
+    with open(path, "w", newline="", encoding=_encoding(config)) as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames, delimiter=delimiter, extrasaction="ignore")
+        writer.writeheader()
+        writer.writerow(first)
+        for record in it:
+            writer.writerow(record)
+
+
+@register_writer(".jsonl", ".ndjson")
+def write_jsonl(path: "str | Path", records: "Iterable[Record]", config: "Optional[FileSourceConfig]" = None) -> None:
+    """Write records as line-delimited JSON (one object per line) — fully streamed."""
+    with open(path, "w", encoding=_encoding(config)) as f:
+        for record in records:
+            f.write(json.dumps(record))
+            f.write("\n")
+
+
+@register_writer(".json")
+def write_json(path: "str | Path", records: "Iterable[Record]", config: "Optional[FileSourceConfig]" = None) -> None:
+    """Write records as a JSON array, streamed element by element."""
+    with open(path, "w", encoding=_encoding(config)) as f:
+        f.write("[")
+        first = True
+        for record in records:
+            if not first:
+                f.write(", ")
+            f.write(json.dumps(record))
+            first = False
+        f.write("]")
+
+
+@register_writer(".xml")
+def write_xml(path: "str | Path", records: "Iterable[Record]", config: "Optional[FileSourceConfig]" = None) -> None:
+    """Write records as XML, streaming one record element at a time.
+
+    Each record becomes a ``<record>`` element (or ``config.xml_record_tag``) whose
+    child elements are the record's fields.
+    """
+    record_tag = getattr(config, "xml_record_tag", None) or "record"
+    root_tag = "records"
+    with open(path, "w", encoding=_encoding(config)) as f:
+        f.write(f"<{root_tag}>")
+        for record in records:
+            f.write(f"<{record_tag}>")
+            for key, value in record.items():
+                text = "" if value is None else _xml_escape(str(value))
+                f.write(f"<{key}>{text}</{key}>")
+            f.write(f"</{record_tag}>")
+        f.write(f"</{root_tag}>")
+
+
+# --------------------------------------------------------------------------- optional
+
+
+@register_writer(".parquet")
+def write_parquet(path: "str | Path", records: "Iterable[Record]", config: "Optional[FileSourceConfig]" = None) -> None:
+    """Write records to a Parquet file (needs pyarrow)."""
+    pa = _require("pyarrow", "parquet")
+    import pyarrow.parquet as pq
+
+    pq.write_table(pa.Table.from_pylist(list(records)), str(path))
+
+
+@register_writer(".feather", ".arrow")
+def write_feather(path: "str | Path", records: "Iterable[Record]", config: "Optional[FileSourceConfig]" = None) -> None:
+    """Write records to a Feather/Arrow IPC file (needs pyarrow)."""
+    pa = _require("pyarrow", "parquet")
+    import pyarrow.feather as feather
+
+    feather.write_feather(pa.Table.from_pylist(list(records)), str(path))
+
+
+@register_writer(".h5", ".hdf5", ".hdf")
+def write_hdf5(path: "str | Path", records: "Iterable[Record]", config: "Optional[FileSourceConfig]" = None) -> None:
+    """Write records to a tabular HDF5 file (needs pandas + tables)."""
+    pd = _require("pandas", "hdf5")
+    key = getattr(config, "hdf5_key", None) or "data"
+    pd.DataFrame(list(records)).to_hdf(str(path), key=key, format="table")

--- a/src/bootstack/widgets/_impl/composites/tableview/tableview.py
+++ b/src/bootstack/widgets/_impl/composites/tableview/tableview.py
@@ -177,11 +177,43 @@ class _ExportJob:
 
 def _has_xlsxwriter() -> bool:
     """Whether the optional XlsxWriter dependency (bootstack[excel]) is installed."""
+    return _module_available("xlsxwriter")
+
+
+def _module_available(module: str) -> bool:
+    """Whether an optional dependency can be imported."""
     import importlib.util
     try:
-        return importlib.util.find_spec("xlsxwriter") is not None
+        return importlib.util.find_spec(module) is not None
     except Exception:
         return False
+
+
+# Export formats the DataTable can offer. `kind` picks the engine: 'cooperative'
+# uses the column-aware, cancelable, chunk-by-chunk exporter (good for huge CSVs);
+# 'registry' streams through bootstack.data.writers (synchronous). `extra` names
+# the pip extra to install when `available` is False.
+_EXPORT_FORMATS: dict = {
+    "csv":     {"ext": ".csv",     "label": "CSV file",        "kind": "cooperative", "extra": None,      "available": lambda: True},
+    "tsv":     {"ext": ".tsv",     "label": "TSV file",        "kind": "cooperative", "extra": None,      "available": lambda: True},
+    "xlsx":    {"ext": ".xlsx",    "label": "Excel file",      "kind": "cooperative", "extra": "excel",   "available": _has_xlsxwriter},
+    "json":    {"ext": ".json",    "label": "JSON file",       "kind": "registry",    "extra": None,      "available": lambda: True},
+    "jsonl":   {"ext": ".jsonl",   "label": "JSON Lines file", "kind": "registry",    "extra": None,      "available": lambda: True},
+    "xml":     {"ext": ".xml",     "label": "XML file",        "kind": "registry",    "extra": None,      "available": lambda: True},
+    "parquet": {"ext": ".parquet", "label": "Parquet file",    "kind": "registry",    "extra": "parquet", "available": lambda: _module_available("pyarrow")},
+    "feather": {"ext": ".feather", "label": "Feather file",    "kind": "registry",    "extra": "parquet", "available": lambda: _module_available("pyarrow")},
+    "hdf5":    {"ext": ".h5",      "label": "HDF5 file",       "kind": "registry",    "extra": "hdf5",    "available": lambda: _module_available("tables")},
+}
+
+# Map a file extension to a canonical export format name (including aliases).
+_EXT_TO_EXPORT_FORMAT: dict = {spec["ext"]: name for name, spec in _EXPORT_FORMATS.items()}
+_EXT_TO_EXPORT_FORMAT.update({
+    ".ndjson": "jsonl",
+    ".hdf5": "hdf5",
+    ".hdf": "hdf5",
+    ".arrow": "feather",
+    ".txt": "csv",
+})
 
 _TABLE_SEARCH_MODE_OPTIONS = [
     ("table.search_mode_equals", "EQUALS"),
@@ -331,6 +363,7 @@ class TableView(Frame):
             export_scope=export_scope,
             export_formats=export_formats,
         )
+        self._warn_unavailable_export_formats()
         self._filtering = _build_filtering_options(
             enable_filtering=enable_filtering,
             enable_header_filtering=enable_header_filtering,
@@ -2327,19 +2360,50 @@ class TableView(Frame):
                 yield self._public_record(rec)
 
     # ------------------------------------------------------------------ Export — file/clipboard
+    def _configured_export_formats(self) -> list[str]:
+        """The export formats this table offers (the `export_formats` config)."""
+        configured = self._exporting.get('formats') or ('csv',)
+        return [f for f in configured if f in _EXPORT_FORMATS]
+
+    def _available_export_formats(self) -> list[str]:
+        """Configured formats whose optional dependency (if any) is installed."""
+        return [f for f in self._configured_export_formats() if _EXPORT_FORMATS[f]["available"]()]
+
+    def _warn_unavailable_export_formats(self) -> None:
+        """Warn (developer-facing) about configured formats missing their dependency."""
+        for fmt in self._configured_export_formats():
+            spec = _EXPORT_FORMATS[fmt]
+            if not spec["available"]():
+                logger.warning(
+                    "DataTable export_formats includes %r, but its dependency is not "
+                    "installed (pip install bootstack[%s]); it is hidden from the export "
+                    "menu until then.", fmt, spec["extra"],
+                )
+
     def _resolve_format(self, path: str, fmt: str | None) -> str:
-        """Resolve the export format from an explicit `fmt` or the path extension."""
-        resolved = (fmt or os.path.splitext(path)[1]).lower().lstrip(".")
-        if resolved not in ("csv", "tsv", "xlsx"):
+        """Resolve the export format from an explicit `fmt` or the path extension.
+
+        Validates against the configured `export_formats` and that the format's
+        optional dependency (if any) is installed.
+        """
+        if fmt:
+            name = fmt.lower()
+        else:
+            ext = os.path.splitext(path)[1].lower()
+            name = _EXT_TO_EXPORT_FORMAT.get(ext)
+        configured = self._configured_export_formats()
+        if name not in _EXPORT_FORMATS or name not in configured:
             raise ValueError(
-                f"Unsupported export format {resolved!r}; expected csv, tsv, or xlsx."
+                f"Export format {name!r} is not enabled. Configured formats: "
+                f"{', '.join(configured)}. Add it via export_formats=."
             )
-        if resolved == "xlsx" and not _has_xlsxwriter():
+        spec = _EXPORT_FORMATS[name]
+        if not spec["available"]():
             raise RuntimeError(
-                "Excel (.xlsx) export requires the optional dependency: "
-                "pip install bootstack[excel]."
+                f"{name} export requires an optional dependency: "
+                f"pip install bootstack[{spec['extra']}]."
             )
-        return resolved
+        return name
 
     def _make_writer(self, path: str, fmt: str, headers: list[str], keys: list[str]):
         """Open a streaming writer for `fmt`; return `(write_chunk, close)`.
@@ -2384,7 +2448,7 @@ class TableView(Frame):
         path: str,
         scope: Literal["all", "page", "selection"] = "all",
         *,
-        format: Literal["csv", "tsv", "xlsx"] | None = None,
+        format: str | None = None,
         chunk_size: int = _EXPORT_CHUNK_SIZE,
         on_progress=None,
     ) -> int:
@@ -2395,6 +2459,8 @@ class TableView(Frame):
         Returns the number of rows written.
         """
         fmt = self._resolve_format(path, format)
+        if _EXPORT_FORMATS[fmt]["kind"] == "registry":
+            return self._export_file_registry(path, scope, fmt, chunk_size, on_progress)
         headers, keys = self._export_columns()
         total = self._scope_count(scope)
         write_chunk, close = self._make_writer(path, fmt, headers, keys)
@@ -2409,6 +2475,33 @@ class TableView(Frame):
             close()
         self._emit_export(target="file", fmt=fmt, path=path, count=written)
         return written
+
+    def _export_file_registry(self, path, scope, fmt, chunk_size, on_progress) -> int:
+        """Synchronously stream a registry-format export over the displayed columns.
+
+        Records are projected to the exported columns (what the table shows) and
+        streamed through `bootstack.data.writers`, so the export carries the same
+        columns as CSV/XLSX. (For the full record set, use
+        ``table.data_source.save(path)``.)
+        """
+        from bootstack.data.writers import write_records
+
+        _headers, keys = self._export_columns()
+        total = self._scope_count(scope)
+        counter = {"n": 0}
+
+        def _records():
+            for chunk in self._iter_raw_chunks(scope, chunk_size):
+                for raw in chunk:
+                    pub = self._public_record(raw)
+                    yield {k: pub.get(k) for k in keys}
+                counter["n"] += len(chunk)
+                if on_progress is not None:
+                    on_progress(counter["n"], total)
+
+        write_records(path, _records(), format=fmt)
+        self._emit_export(target="file", fmt=fmt, path=path, count=counter["n"])
+        return counter["n"]
 
     def export_file_async(
         self,
@@ -2428,6 +2521,11 @@ class TableView(Frame):
         removes the partial file. Call `job.cancel()` to stop.
         """
         fmt = self._resolve_format(path, format)
+        if _EXPORT_FORMATS[fmt]["kind"] == "registry":
+            raise ValueError(
+                f"Async export supports csv/tsv/xlsx; {fmt!r} writes synchronously — "
+                f"use export_file()."
+            )
         headers, keys = self._export_columns()
         total = self._scope_count(scope)
         write_chunk, close = self._make_writer(path, fmt, headers, keys)
@@ -2510,23 +2608,32 @@ class TableView(Frame):
         """
         from tkinter import filedialog
 
-        filetypes = [("CSV file", "*.csv")]
-        if _has_xlsxwriter():
-            filetypes.append(("Excel file", "*.xlsx"))
+        available = self._available_export_formats() or ["csv"]
+        filetypes = [(_EXPORT_FORMATS[f]["label"], "*" + _EXPORT_FORMATS[f]["ext"]) for f in available]
         filetypes.append(("All files", "*.*"))
+        default_fmt = available[0]
+        default_ext = _EXPORT_FORMATS[default_fmt]["ext"]
 
         scope = self._default_scope()
         path = filedialog.asksaveasfilename(
             parent=self.winfo_toplevel(),
             title=MessageCatalog.translate("table.export"),
-            defaultextension=".csv",
-            initialfile="table_export.csv",
+            defaultextension=default_ext,
+            initialfile="table_export" + default_ext,
             filetypes=filetypes,
         )
         if not path:
             return
 
-        if self._scope_count(scope) <= _EXPORT_ASYNC_THRESHOLD:
+        # Registry formats write synchronously; only the cooperative formats
+        # (csv/tsv/xlsx) use the async progress path for very large exports.
+        try:
+            fmt = self._resolve_format(path, None)
+        except Exception:
+            logger.exception("Failed to resolve export format for %s", path)
+            return
+        cooperative = _EXPORT_FORMATS[fmt]["kind"] == "cooperative"
+        if not cooperative or self._scope_count(scope) <= _EXPORT_ASYNC_THRESHOLD:
             try:
                 self.export_file(path, scope=scope)
             except Exception:

--- a/src/bootstack/widgets/datatable.py
+++ b/src/bootstack/widgets/datatable.py
@@ -102,6 +102,13 @@ class DataTable(PublicWidgetBase):
             also offered when the optional `bootstack[excel]` dependency is
             installed. For explicit control use `export_file()` / `to_csv()`
             with `scope=`. Default `False`.
+        export_formats: Which formats the export menu offers. Choose from
+            `'csv'`, `'tsv'`, `'xlsx'`, `'json'`, `'jsonl'`, `'xml'`, `'parquet'`,
+            `'feather'`, `'hdf5'`. Default `('csv',)`. Formats needing an optional
+            dependency (`xlsx`→`bootstack[excel]`, `parquet`/`feather`→
+            `bootstack[parquet]`, `hdf5`→`bootstack[hdf5]`) appear only when it is
+            installed. Registry formats export the displayed columns; for the full
+            record set use `data_source.save(path)`.
         striped: Alternate row background colors. Default `True`.
         density: Row compactness — `'default'` or `'compact'` (tighter row
             height, smaller body font and padding). Default `'default'`.
@@ -143,6 +150,7 @@ class DataTable(PublicWidgetBase):
         allow_edit: bool = False,
         allow_delete: bool = False,
         allow_export: bool = False,
+        export_formats: list[str] | None = None,
         striped: bool = True,
         density: WidgetDensity = "default",
         allow_group: bool = False,
@@ -185,6 +193,8 @@ class DataTable(PublicWidgetBase):
             internal_kwargs["datasource"] = data_source
         if form is not None:
             internal_kwargs["form_options"] = form
+        if export_formats is not None:
+            internal_kwargs["export_formats"] = tuple(export_formats)
         internal_kwargs.update(kwargs)
 
         self._internal = _InternalTableView(tk_master, **internal_kwargs)

--- a/tests/data/test_writers.py
+++ b/tests/data/test_writers.py
@@ -1,0 +1,180 @@
+"""Tests for the streaming writer registry and source-level save()/export.
+
+Writers consume a lazy iterable of records and write them out; they mirror the
+readers, so write→read round-trips. `save()` streams a source's records (public
+records, active view respected) into the writer chosen by extension. Headless.
+"""
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+from bootstack.data import (
+    MemoryDataSource,
+    SqliteDataSource,
+    get_writer,
+    read_records,
+    register_writer,
+    supported_write_extensions,
+    write_records,
+)
+
+ROWS = [{"id": 1, "name": "Ada", "tags": ["x"]}, {"id": 2, "name": "Bob", "tags": ["y", "z"]}]
+
+
+def _has(module: str) -> bool:
+    return importlib.util.find_spec(module) is not None
+
+
+# --------------------------------------------------------------------------- registry
+
+
+def test_supported_write_extensions():
+    exts = supported_write_extensions()
+    for e in (".csv", ".tsv", ".json", ".jsonl", ".xml", ".parquet", ".feather", ".h5"):
+        assert e in exts
+
+
+def test_unknown_extension_raises():
+    with pytest.raises(ValueError, match="No writer registered"):
+        get_writer("out.zzz")
+
+
+def test_register_custom_writer(tmp_path):
+    @register_writer(".upper")
+    def _w(path, records, config=None):
+        with open(path, "w", encoding="utf-8") as f:
+            for r in records:
+                f.write(str(r.get("name", "")).upper())
+
+    p = tmp_path / "x.upper"
+    write_records(p, iter([{"name": "ada"}]))
+    assert p.read_text(encoding="utf-8") == "ADA"
+
+
+# --------------------------------------------------------------------------- round-trips
+
+
+@pytest.mark.parametrize("ext", [".csv", ".tsv", ".jsonl", ".json", ".xml"])
+def test_roundtrip_count_and_names(tmp_path, ext):
+    p = tmp_path / f"out{ext}"
+    write_records(p, iter(ROWS))
+    back = list(read_records(p))
+    assert [r["name"] for r in back] == ["Ada", "Bob"]
+
+
+@pytest.mark.parametrize("ext", [".jsonl", ".json"])
+def test_json_formats_preserve_structure(tmp_path, ext):
+    p = tmp_path / f"out{ext}"
+    write_records(p, iter(ROWS))
+    back = list(read_records(p))
+    assert back[1]["tags"] == ["y", "z"]  # lists survive in JSON
+
+
+def test_csv_stringifies_non_scalar(tmp_path):
+    p = tmp_path / "out.csv"
+    write_records(p, iter(ROWS))
+    back = list(read_records(p))
+    assert back[0]["tags"] == "['x']"  # flat text format → str
+
+
+def test_empty_export_writes_a_file(tmp_path):
+    p = tmp_path / "empty.csv"
+    write_records(p, iter([]))
+    assert p.exists()
+
+
+def test_format_override(tmp_path):
+    from bootstack.data import FileSourceConfig
+
+    p = tmp_path / "data.dat"  # extension the registry doesn't know
+    write_records(p, iter(ROWS), format="csv")  # forced CSV
+    assert [r["name"] for r in read_records(p, FileSourceConfig(file_format="csv"))] == ["Ada", "Bob"]
+
+
+# --------------------------------------------------------------------------- save() from a source
+
+
+def test_save_streams_public_records(tmp_path):
+    ds = SqliteDataSource().load(ROWS)
+    p = tmp_path / "src.jsonl"
+    ds.save(p)
+    back = list(read_records(p))
+    assert back[1]["tags"] == ["y", "z"]
+    # internal bookkeeping never leaks into the export
+    assert "_bs_row_id" not in back[0] and "selected" not in back[0]
+    assert "id" in back[0]
+
+
+def test_export_csv_strips_internal_fields(tmp_path):
+    ds = SqliteDataSource().load(ROWS)
+    p = tmp_path / "src.csv"
+    ds.export_csv(str(p))
+    header = p.read_text(encoding="utf-8").splitlines()[0]
+    assert "_bs" not in header and "selected" not in header
+    assert header.split(",")[:2] == ["id", "name"]
+
+
+def test_save_selected_only(tmp_path):
+    ds = SqliteDataSource().load(ROWS)
+    ds.select(2)
+    p = tmp_path / "sel.json"
+    ds.save(p, selected_only=True)
+    back = list(read_records(p))
+    assert [r["id"] for r in back] == [2]
+
+
+def test_save_respects_active_filter(tmp_path):
+    from bootstack import col
+
+    ds = SqliteDataSource().load(ROWS)
+    ds.where(col("name") == "Bob")
+    p = tmp_path / "filtered.jsonl"
+    ds.save(p)
+    back = list(read_records(p))
+    assert [r["name"] for r in back] == ["Bob"]
+
+
+def test_memory_source_save(tmp_path):
+    ds = MemoryDataSource().load(ROWS)
+    p = tmp_path / "mem.jsonl"
+    ds.save(p)
+    assert len(list(read_records(p))) == 2
+
+
+def test_save_roundtrips_through_a_file_source(tmp_path):
+    from bootstack.data import FileDataSource
+
+    src = SqliteDataSource().load(ROWS)
+    p = tmp_path / "dump.jsonl"
+    src.save(p)
+    fds = FileDataSource(p)
+    fds.load()
+    assert fds.count == 2
+    assert fds.get(2)["tags"] == ["y", "z"]
+    fds.close()
+
+
+# --------------------------------------------------------------------------- optional formats
+
+
+def test_parquet_without_dep_raises_install_hint(tmp_path):
+    if _has("pyarrow"):
+        pytest.skip("pyarrow installed — gating path not exercised")
+    with pytest.raises(ImportError, match=r"bootstack\[parquet\]"):
+        write_records(tmp_path / "x.parquet", iter(ROWS))
+
+
+def test_hdf5_without_dep_raises_install_hint(tmp_path):
+    if _has("pandas"):
+        pytest.skip("pandas installed — gating path not exercised")
+    with pytest.raises(ImportError, match=r"bootstack\[hdf5\]"):
+        write_records(tmp_path / "x.h5", iter(ROWS))
+
+
+@pytest.mark.skipif(not _has("pyarrow"), reason="needs pyarrow")
+def test_parquet_roundtrip(tmp_path):
+    p = tmp_path / "out.parquet"
+    write_records(p, iter([{"id": 1, "name": "A"}, {"id": 2, "name": "B"}]))
+    assert [r["name"] for r in read_records(p)] == ["A", "B"]

--- a/tests/widgets/public/test_datatable.py
+++ b/tests/widgets/public/test_datatable.py
@@ -153,6 +153,51 @@ def test_nonscalar_fields_survive_default_source(shown_app):
         assert "_bs_data" not in r and "_bs_row_id" not in r
 
 
+# --------------------------------------------------------------------------- export formats
+
+
+@pytest.mark.gui
+def test_export_formats_drive_available_and_resolution(shown_app):
+    table = bs.DataTable(
+        rows=[dict(r) for r in ROWS], columns=["name", "role"],
+        allow_export=True, export_formats=["csv", "json", "jsonl"],
+    )
+    _pump(shown_app)
+    internal = table._internal
+
+    assert internal._available_export_formats() == ["csv", "json", "jsonl"]
+    # A format not in export_formats is rejected.
+    import pytest as _pytest
+    with _pytest.raises(ValueError):
+        internal._resolve_format("out.xlsx", None)
+
+
+@pytest.mark.gui
+def test_export_file_writes_registry_formats(shown_app, tmp_path):
+    from bootstack.data import read_records, FileSourceConfig
+
+    table = bs.DataTable(
+        rows=[dict(r) for r in ROWS], columns=["name", "role"],
+        allow_export=True, export_formats=["csv", "json", "jsonl"],
+    )
+    _pump(shown_app)
+    internal = table._internal
+
+    # JSON (registry) export — projected to the displayed columns.
+    p = tmp_path / "out.json"
+    n = internal.export_file(str(p), scope="all")
+    assert n == 3
+    back = list(read_records(p))
+    assert [r["name"] for r in back] == ["Ada", "Boole", "Church"]
+    assert set(back[0].keys()) == {"name", "role"}  # only displayed columns
+
+    # CSV (cooperative) still works.
+    c = tmp_path / "out.csv"
+    internal.export_file(str(c), scope="all")
+    rows = list(read_records(c, FileSourceConfig(file_format="csv")))
+    assert [r["name"] for r in rows] == ["Ada", "Boole", "Church"]
+
+
 # --------------------------------------------------------------------------- appearance
 
 


### PR DESCRIPTION
Checkpoint 4 of the large-file streaming initiative: the export counterpart of the reader registry, plus wiring the DataTable export menu to declared formats.

## Streaming writer registry + source `save()`
- `data/writers.py`: `register_writer` / `write_records` / `get_writer` / `supported_write_extensions`. Stdlib writers stream a record at a time — CSV/TSV, JSONL/NDJSON, JSON (array, element by element), XML. Optional behind import guards: Parquet + Feather (pyarrow), HDF5 (pandas + tables). JSON/JSONL preserve structure; flat formats stringify non-scalars.
- `BaseDataSource.save(path, *, selected_only, format, config)` streams the source's **public** records (internal fields stripped, active `where`/`order` respected) into the writer chosen by extension; pages via `page_slice` so memory stays flat.
- `export_csv` is now concrete on `BaseDataSource` (delegates to `save`, streamed); the `fetchall()`-materializing Memory/Sqlite overrides are removed. Export now respects the active filter (was: ignored it).
- `save()` added to `DataSourceProtocol`; registry exported from `bootstack.data`.

## DataTable `export_formats`
- `export_formats=[...]` (default `('csv',)`) is the single source of truth: it builds the Save-to-file dialog filetypes and validates `export_file()`. Choose from csv/tsv/xlsx/json/jsonl/xml/parquet/feather/hdf5. (The config existed but was never consulted — now it is.)
- Dispatch by engine: csv/tsv/xlsx keep the cooperative, cancelable, column-aware async exporter (big-CSV path); the rest stream through the writer registry (synchronous), projected to the displayed columns. `export_file_async` stays cooperative-only.
- Optional-dep formats appear in the menu only when installed; a configured-but-missing format logs a developer warning and is hidden (programmatic `export_file()` still raises the clear `pip install bootstack[...]`).
- Exposed on the public `DataTable` (+ docstring, `datatable.rst`). For the full record set, `data_source.save(path)`.

## Tests
`tests/data/test_writers.py` (round-trips per format, save/export strips internals, selected_only, filter-respect, file round-trip, gated optionals); DataTable GUI tests for format availability/resolution + registry-format export. Full data suite 114 passed / 4 skipped; docs build clean.

Remaining: CP5 (docs/examples polish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)