### PR TITLE
docs(data): file streaming cp5 — exporting docs + example

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -322,9 +322,14 @@ chevron is just an icon button.
 
 ## Next initiative — Large-file streaming + pluggable formats (PLANNED 2026-06-07)
 
-Design settled, not started. Full rationale + checkpoints in memory
-`project_file_source_streaming`. Builds on the data bag (`feat/data-bag`,
-unpushed-merge pending) and the change hub (`project_datasource_change_events`).
+**STATUS: COMPLETE (cp1–cp5).** Merged: cp1+cp2 (PR #93), cp3 (#94), cp4 (#95);
+cp5 on `feat/file-streaming-cp5` (PR pending). Full rationale + checkpoints in
+memory `project_file_source_streaming`. Built on the data bag and the change hub
+(`project_datasource_change_events`). The follow-up Tree data-source backing
+(below) remains parked. **Deferred within this initiative:** background/
+progressive ingest (`load()` is synchronous but streamed — SQLite cross-thread
+constraints make threaded ingest a separate effort); keyset pagination; auto-index
+on sorted/filtered columns.
 
 **Problem:** data scientists open CSV/JSON files with 100k–millions of rows.
 `FileDataSource` currently **extends `MemoryDataSource`** and loads the WHOLE file

--- a/docs/examples/file_source.py
+++ b/docs/examples/file_source.py
@@ -1,0 +1,64 @@
+"""File-backed data source — stream a CSV into a table, export to any format.
+
+A CSV is generated on a temp path, then ``FileDataSource`` streams it into a
+SQLite working store (bounded memory, even for large files). The ``DataTable``
+pages, filters, and sorts it as fast SQL, and its export menu offers several
+formats via ``export_formats=``. The original file is read-only input; edits live
+in the working store, and the temp store is cleaned up automatically.
+
+Run with:
+    python docs/examples/file_source.py
+"""
+
+import csv
+import tempfile
+from pathlib import Path
+
+import bootstack as bs
+
+DEPARTMENTS = ["Engineering", "Design", "Sales", "Support"]
+
+
+def make_csv() -> Path:
+    """Write a sample CSV to a temp file and return its path."""
+    path = Path(tempfile.gettempdir()) / "bootstack_people.csv"
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(["id", "name", "department", "score"])
+        for i in range(1, 501):
+            writer.writerow([i, f"Person {i:03d}", DEPARTMENTS[i % 4], (i * 7) % 100])
+    return path
+
+
+def main() -> None:
+    csv_path = make_csv()
+
+    # Stream the file into a SQLite working store (temporary, auto-cleaned).
+    source = bs.FileDataSource(csv_path)
+    source.load()
+
+    with bs.App(title="FileDataSource", size=(720, 480), padding=12, gap=8) as app:
+        bs.Label("500 rows streamed from a CSV — sort, filter, and export.",
+                 font="heading-sm")
+
+        bs.DataTable(
+            data_source=source,
+            columns=[
+                {"text": "ID", "key": "id", "width": 60},
+                {"text": "Name", "key": "name", "width": 160},
+                {"text": "Department", "key": "department", "width": 140},
+                {"text": "Score", "key": "score", "width": 80},
+            ],
+            page_size=25,
+            allow_export=True,
+            export_formats=["csv", "json", "jsonl", "xml"],
+            fill="both",
+            expand=True,
+        )
+
+    app.run()
+    source.close()  # remove the temp working store
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/reference/data-sources.rst
+++ b/docs/reference/data-sources.rst
@@ -250,6 +250,42 @@ derived view or a metric:
    bind to the source directly instead; they already listen via ``on_change``
    and refetch only their visible window.
 
+Exporting
+---------
+
+Write a source's records to a file with ``save()`` — the format is chosen by the
+path extension, and records stream out so a large export stays at flat memory.
+The active ``where`` / ``order`` view is respected, so you export what the source
+currently shows:
+
+.. code-block:: python
+
+   ds.save("people.csv")                      # CSV
+   ds.save("people.jsonl")                    # JSON Lines — a record per line
+   ds.save("active.json", selected_only=True) # only the selected rows
+
+Built-in formats are CSV, TSV, JSON, JSONL, and XML; Parquet, Feather, and HDF5
+come with the optional extras (``pip install bootstack[parquet]`` /
+``bootstack[hdf5]``). JSON and JSONL preserve nested structure (lists, dicts);
+the flat text formats stringify non-scalar fields.
+
+Reading and writing go through symmetric registries, so ``read_records`` and
+``save`` round-trip, and you can teach both a new format:
+
+.. code-block:: python
+
+   from bootstack.data import read_records, register_writer
+
+   ds.save("dump.jsonl")
+   rows = list(read_records("dump.jsonl"))    # same records back
+
+   @register_writer(".ndjson.gz")             # add your own format
+   def write_gzipped_jsonl(path, records, config=None):
+       ...
+
+The :class:`DataTable <bootstack.widgets.datatable.DataTable>` export menu is
+built on these same writers — see its ``export_formats`` option.
+
 Writing your own source
 -----------------------
 
@@ -321,3 +357,18 @@ The interface and base class for writing your own:
 
 .. autoclass:: bootstack.data.BaseDataSource
    :members:
+
+Reading and writing files directly (the format registries behind
+``FileDataSource`` and ``save()``):
+
+.. autofunction:: bootstack.data.read_records
+
+.. autofunction:: bootstack.data.write_records
+
+.. autofunction:: bootstack.data.register_reader
+
+.. autofunction:: bootstack.data.register_writer
+
+.. autofunction:: bootstack.data.supported_extensions
+
+.. autofunction:: bootstack.data.supported_write_extensions


### PR DESCRIPTION
Final checkpoint of the large-file streaming initiative — documentation and a runnable example.

## Docs
- **data-sources.rst** gains an **Exporting** section: `save()` chooses the format by extension, streams records (bounded memory), respects the active `where`/`order` view, and supports `selected_only`. Covers the built-in formats (CSV/TSV/JSON/JSONL/XML) and the optional extras (Parquet/Feather via `bootstack[parquet]`, HDF5 via `bootstack[hdf5]`), the symmetric read/write registries, and `register_writer` for custom formats.
- API reference now documents the public registry functions: `read_records`, `write_records`, `register_reader`, `register_writer`, `supported_extensions`, `supported_write_extensions`.

## Example
- `docs/examples/file_source.py` — a runnable demo: stream a 500-row CSV through `FileDataSource` into a `DataTable` with a multi-format export menu (`export_formats=["csv","json","jsonl","xml"]`). Verified it constructs/loads/exports without error.

## Handoff
- CLAUDE.md + memory mark the initiative **complete (cp1–cp5)**, with the deferred items noted (background/progressive ingest, keyset pagination, auto-index) and the Tree data-source backing follow-up still parked.

Docs build is clean (no new warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)