### PR TITLE
feat(tree): data-source backing via flat adjacency-list projection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,19 +42,33 @@ memories (see them for rationale and gotchas).
 - **Docs + public API audit, typed events, theming/font tracks, DataSource
   observable query + verb rename** — see "Prior initiative" below and the
   `project_*` memories.
+- **Tree data-source backing** (branch `feat/tree-datasource`, awaiting merge) —
+  `Tree(
+  data_source=src, parent_field="parent_id", root_value=None, label_field=,
+  icon_field=, node_builder=, order=)` projects a FLAT adjacency-list source as a
+  lazy hierarchy: auto-generated per-node `loader`s issue
+  `src._query(col(parent_field)==id, ...)` on expand (uses `_query`, not
+  `where()`, so view state is undisturbed). Record→node = fields + optional
+  `node_builder`; chevrons via a batched has-children `IN(...)` query per expand;
+  `data_source` property + `refresh()`. Impl in
+  `widgets/_impl/composites/tree/source_binding.py`. Mutually exclusive with
+  `nodes=`. Memory `project_tree_datasource_backing`. **Deferred:** per-node child
+  pagination, tree filtering, auto-refresh on `on_change`, native
+  `TreeDataSourceProtocol`, Tree widget doc page. **Found (not fixed):** latent
+  `SqliteDataSource` TEXT-affinity bug — a column whose FIRST row value is NULL
+  gets TEXT affinity, so int values store as strings (worked around in the binding
+  by string-normalizing the has-children key comparison).
 
-## Next up — Tree data-source backing (designed, not started)
+## Next up — candidates (pick one)
 
-Full design in memory `project_tree_datasource_backing`. The hierarchical sibling
-of the file-streaming work ("fetch on demand") — lets a huge hierarchical dataset
-load branch-by-branch. **Decision:** hierarchy is a *projection* over a FLAT
-adjacency-list source (every row has `parent_id`), NOT a storage mode or runtime
-flag. Reuse Tree's existing per-node `loader` seam: `Tree(data_source=src,
-parent_field="parent_id")` issues `src.where(col(parent_field)==node.id).page(...)`
-per expand. No flat-protocol change; any `DataSourceProtocol` can back a tree.
-Optional later: a native `TreeDataSourceProtocol` (`roots`/`children`/
-`has_children`) for genuinely tree-shaped stores; the flat adapter builds on it.
-Defaults: adjacency list (not materialized path); filtering-a-tree scoped out of v1.
+- **SqliteDataSource schema inference** — fix the TEXT-affinity-from-leading-NULL
+  bug surfaced by Tree backing (infer a column's type by scanning more than the
+  first row, or accept explicit dtypes). General correctness win for the
+  data-science/engineering audience; see `project_tree_datasource_backing`.
+- **Persistent KV / prefs store** (`bs.Store`) — memory `project_persistent_kv_store`.
+- **Deferred file-streaming items** — background/progressive ingest, keyset
+  pagination, auto-index (memory `project_file_source_streaming`).
+- **Signal runtime-cleanup pass** — memory `project_signal_api_audit_findings`.
 
 ---
 

--- a/docs/examples/tree_datasource.py
+++ b/docs/examples/tree_datasource.py
@@ -1,0 +1,66 @@
+"""Tree — data-source backing (flat adjacency list projected as a hierarchy).
+
+A data-source-backed tree stores flat records that each point at their parent
+via a `parent_field` (an adjacency list). The tree loads one branch at a time —
+a node's children are queried only when it is expanded — so even a very large
+hierarchy shows instantly. Any data source works; this demo uses an in-memory
+source and a SQLite source side by side.
+
+Run with:
+    python docs/examples/tree_datasource.py
+"""
+
+import bootstack as bs
+
+# A flat org chart: every row carries its own id and its parent's id.
+# parent_id is None for the roots.
+ORG = [
+    {"id": 1, "parent_id": None, "name": "Engineering", "kind": "team"},
+    {"id": 2, "parent_id": 1, "name": "Platform", "kind": "team"},
+    {"id": 3, "parent_id": 1, "name": "Product", "kind": "team"},
+    {"id": 4, "parent_id": 2, "name": "Ada Lovelace", "kind": "person"},
+    {"id": 5, "parent_id": 2, "name": "Alan Turing", "kind": "person"},
+    {"id": 6, "parent_id": 3, "name": "Grace Hopper", "kind": "person"},
+    {"id": 7, "parent_id": None, "name": "Design", "kind": "team"},
+    {"id": 8, "parent_id": 7, "name": "Don Norman", "kind": "person"},
+]
+
+ICONS = {"team": "people-fill", "person": "person-fill"}
+
+
+with bs.App(title="Tree — data source", padding=20, gap=16, minsize=(760, 520)) as app:
+    with bs.Grid(columns=2, gap=20, fill="both", expand=True, sticky_items="nsew"):
+
+        # In-memory source, simple field mapping. Folders (teams) get a chevron;
+        # leaf people do not — decided by a batched has-children check per expand.
+        with bs.VStack(gap=6):
+            bs.Label("MemoryDataSource", font="heading-sm")
+            mem = bs.MemoryDataSource()
+            mem.load([dict(r) for r in ORG])
+            bs.Tree(
+                data_source=mem,
+                parent_field="parent_id",
+                label_field="name",
+                order="name",
+                fill="both", expand=True,
+            )
+
+        # SQLite source with a node_builder for computed labels + icons.
+        with bs.VStack(gap=6):
+            bs.Label("SqliteDataSource + node_builder", font="heading-sm")
+            db = bs.SqliteDataSource()
+            db.load([dict(r) for r in ORG])
+            tree = bs.Tree(
+                data_source=db,
+                parent_field="parent_id",
+                node_builder=lambda r: {
+                    "label": r["name"],
+                    "icon": ICONS.get(r["kind"], "dot"),
+                },
+                order="name",
+                accent="primary",
+                fill="both", expand=True,
+            )
+            tree.on_activate(lambda n: print("activated:", n.data.get("name")))
+
+app.run()

--- a/docs/examples/tree_datasource_demo.py
+++ b/docs/examples/tree_datasource_demo.py
@@ -1,0 +1,106 @@
+"""Tree — data-source backing, lazy loading at scale (interactive demo).
+
+Generates a ~5,000-node org chart as a FLAT adjacency list (every row carries
+its own id and its parent's id), loads it into a SqliteDataSource, and projects
+it as a hierarchy with `bs.Tree(data_source=...)`.
+
+The whole tree is in the source, but only the children of nodes you actually
+expand are ever queried — so the window appears instantly and the live counter
+at the top shows how few nodes are materialized vs. how many exist. Expand a few
+branches and watch "queries run" tick up one-per-expand while "nodes shown"
+stays tiny relative to the 5,000 in the source.
+
+Run with:
+    python docs/examples/tree_datasource_demo.py
+"""
+
+import bootstack as bs
+
+# --------------------------------------------------------------------------- data
+
+DIVISIONS = ["Engineering", "Design", "Sales", "Marketing",
+             "Finance", "Legal", "Support", "Operations"]
+FIRST = ["Ada", "Alan", "Grace", "Linus", "Margaret", "Dennis",
+         "Barbara", "Ken", "Katherine", "Edsger", "Donald", "Radia"]
+LAST = ["Lovelace", "Turing", "Hopper", "Torvalds", "Hamilton", "Ritchie",
+        "Liskov", "Thompson", "Johnson", "Dijkstra", "Knuth", "Perlman"]
+
+
+def build_org():
+    """Build a flat adjacency list: division -> department -> team -> person."""
+    rows = []
+    nid = 0
+
+    def add(parent_id, name, kind):
+        nonlocal nid
+        nid += 1
+        rows.append({"id": nid, "parent_id": parent_id, "name": name, "kind": kind})
+        return nid
+
+    for d, div in enumerate(DIVISIONS):
+        div_id = add(None, div, "division")
+        for dep in range(6):
+            dep_id = add(div_id, f"{div} Dept {dep + 1}", "department")
+            for team in range(8):
+                team_id = add(dep_id, f"Team {chr(65 + team)}", "team")
+                for p in range(12):
+                    person = f"{FIRST[(d + p) % len(FIRST)]} {LAST[(team + p) % len(LAST)]}"
+                    add(team_id, person, "person")
+    return rows
+
+
+ICONS = {
+    "division": "building",
+    "department": "diagram-3",
+    "team": "people-fill",
+    "person": "person",
+}
+
+ROWS = build_org()
+
+# --------------------------------------------------------------------------- ui
+
+with bs.App(title="Tree — lazy loading at scale", padding=16, gap=12,
+            size=(560, 720)) as app:
+
+    # A SqliteDataSource holds the whole flat dataset. Wrap _query so the demo
+    # can show that one query runs per expand (the framework does not need this).
+    src = bs.SqliteDataSource()
+    src.load([dict(r) for r in ROWS])
+
+    stats = {"queries": 0}
+    _real_query = src._query
+
+    def _counted_query(condition, sort_keys):
+        stats["queries"] += 1
+        return _real_query(condition, sort_keys)
+
+    src._query = _counted_query
+
+    status = bs.Signal("")
+    bs.Label(textsignal=status, font="body")
+
+    tree = bs.Tree(
+        data_source=src,
+        parent_field="parent_id",
+        node_builder=lambda r: {"label": r["name"], "icon": ICONS.get(r["kind"], "dot")},
+        order="name",
+        accent="primary",
+        fill="both", expand=True,
+    )
+
+    def refresh_status(*_):
+        materialized = sum(1 for _ in tree.walk())
+        status.set(
+            f"source: {len(ROWS):,} records   ·   "
+            f"queries run: {stats['queries']}   ·   "
+            f"nodes materialized: {materialized}"
+        )
+
+    tree.on_expand(refresh_status)
+    tree.on_collapse(refresh_status)
+    tree.on_activate(lambda n: print("activated:", n.data.get("name")))
+
+    refresh_status()  # initial: only the 8 divisions are loaded
+
+app.run()

--- a/src/bootstack/widgets/_impl/composites/tree/source_binding.py
+++ b/src/bootstack/widgets/_impl/composites/tree/source_binding.py
@@ -1,0 +1,136 @@
+"""Project a flat adjacency-list data source as a lazy Tree hierarchy.
+
+A data-source-backed tree is "auto-generate the loader from a source": the
+source stores flat records that each carry a `parent_field` pointing at their
+parent's id (an adjacency list), and the binding projects that flat shape as a
+hierarchy by issuing one indexed query per expanded node. Nothing about the flat
+`DataSourceProtocol` changes — the hierarchy lives entirely in this binding, so
+any source (SQLite, memory, a custom adapter) can back a tree.
+
+Scale comes for free: only the children of *expanded* nodes are ever queried
+(one `WHERE parent_field = ?` each), and a single batched existence query per
+expand decides which of those children get a chevron.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, List, Sequence
+
+from bootstack.data.query import Condition, SortKey, col, normalize_sort_keys
+
+__all__ = ["SourceBinding"]
+
+
+def _key(value: Any) -> Any:
+    """Normalize an identifier for cross-column comparison.
+
+    A record's id and another record's `parent_field` may be stored with
+    different types — for example SQLite gives an all-integer column TEXT
+    affinity if its first value is NULL, so parent ids come back as `'1'` while
+    ids come back as `1`. They are the same logical key, so compare them as
+    strings (NULL stays distinct).
+    """
+    return None if value is None else str(value)
+
+
+def _child_condition(parent_field: str, value: Any) -> Condition:
+    """Match the rows whose `parent_field` equals `value`.
+
+    A `value` of `None` means "the roots" and matches a NULL/absent parent.
+    """
+    column = col(parent_field)
+    if value is None:
+        return column.is_null()
+    return column == value
+
+
+class SourceBinding:
+    """Binds a flat adjacency-list data source to a `Tree`.
+
+    Holds the projection config and turns records into node specs, wiring each
+    node that has children with a `loader` closure that re-queries on expand.
+    """
+
+    def __init__(
+        self,
+        source: Any,
+        *,
+        parent_field: str,
+        root_value: Any,
+        label_field: str,
+        icon_field: str | None,
+        node_builder: Callable[[dict], dict] | None,
+        order: Any = None,
+    ) -> None:
+        self.source = source
+        self.parent_field = parent_field
+        self.root_value = root_value
+        self.label_field = label_field
+        self.icon_field = icon_field
+        self.node_builder = node_builder
+        self.sort_keys: List[SortKey] = self._normalize_order(order)
+
+    @staticmethod
+    def _normalize_order(order: Any) -> List[SortKey]:
+        if order is None:
+            return []
+        keys: Sequence[Any]
+        if isinstance(order, (list, tuple)):
+            keys = order
+        else:
+            keys = (order,)
+        return normalize_sort_keys(keys)
+
+    # ----- spec building -----
+
+    def _spec(self, record: Any, has_children: bool) -> dict:
+        """Turn one raw record into a node spec dict."""
+        public = self.source._public_record(record)
+        if self.node_builder is not None:
+            spec = dict(self.node_builder(public))
+        else:
+            if self.label_field not in public:
+                raise KeyError(
+                    f"Tree(data_source=...): no field {self.label_field!r} in the "
+                    f"record {dict(public)!r}. Set label_field= to the column that "
+                    f"holds the node label, or pass node_builder=."
+                )
+            spec = {"label": str(public.get(self.label_field, ""))}
+            if self.icon_field and public.get(self.icon_field):
+                spec["icon"] = public[self.icon_field]
+        spec.setdefault("data", dict(public))
+        if has_children:
+            record_id = self.source._record_id(record)
+            spec["loader"] = lambda _node, _pid=record_id: self._fetch(_pid)
+        return spec
+
+    def _fetch(self, parent_value: Any) -> List[dict]:
+        """Fetch and build the child specs for one parent value."""
+        records = self.source._query(
+            _child_condition(self.parent_field, parent_value), self.sort_keys
+        )
+        if not records:
+            return []
+        ids = [self.source._record_id(r) for r in records]
+        with_children = self._records_with_children(ids)
+        return [
+            self._spec(r, _key(self.source._record_id(r)) in with_children)
+            for r in records
+        ]
+
+    def _records_with_children(self, ids: Sequence[Any]) -> set:
+        """Return the subset of `ids` that are some row's `parent_field` value.
+
+        One batched existence query decides chevrons for a whole sibling group,
+        so the cost is O(1 query) per expand regardless of how many children the
+        expanded node has.
+        """
+        ids = [i for i in ids if i is not None]
+        if not ids:
+            return set()
+        rows = self.source._query(col(self.parent_field).is_in(ids), [])
+        return {_key(r.get(self.parent_field)) for r in rows}
+
+    def roots(self) -> List[dict]:
+        """Build the specs for the top-level (root) nodes."""
+        return self._fetch(self.root_value)

--- a/src/bootstack/widgets/tree.py
+++ b/src/bootstack/widgets/tree.py
@@ -31,7 +31,29 @@ class Tree(PublicWidgetBase):
         nodes: Declarative initial tree — a list of node specs, where each spec
             is a label string or a dict like
             ``{"label": "src", "icon": "folder", "children": [...]}``. Anything
-            not a recognized display key becomes that node's `data`.
+            not a recognized display key becomes that node's `data`. Mutually
+            exclusive with `data_source`.
+        data_source: A flat data source to project as a hierarchy. Each record
+            carries a `parent_field` pointing at its parent's id (an adjacency
+            list); the tree loads one branch at a time, querying a node's
+            children only when it is expanded — so a huge hierarchy shows
+            instantly. Any `DataSourceProtocol` source works. Mutually exclusive
+            with `nodes`.
+        parent_field: With `data_source`, the record field that holds each row's
+            parent id. Defaults to ``'parent_id'``.
+        root_value: With `data_source`, the `parent_field` value that marks a
+            root node. Defaults to ``None`` (a NULL/absent parent).
+        label_field: With `data_source`, the record field used as the node label.
+            Defaults to ``'name'``. Ignored when `node_builder` is given.
+        icon_field: With `data_source`, an optional record field whose value is
+            used as the node icon.
+        node_builder: With `data_source`, an optional callable taking a record
+            and returning a node spec dict (``{'label': ..., 'icon': ...}``) for
+            full control over how a record renders. Overrides
+            `label_field`/`icon_field`.
+        order: With `data_source`, the ordering applied to each sibling group —
+            a sort key or sequence of keys (``'name'``, ``'-created'``, a `col`,
+            or a `SortKey`). Defaults to the source's natural order.
         selection_mode: ``'single'`` (default) — one highlighted node;
             ``'multi'`` — click-to-toggle a set; ``'none'`` — no highlight
             selection (navigation/display only).
@@ -61,6 +83,13 @@ class Tree(PublicWidgetBase):
         self,
         *,
         nodes: list | None = None,
+        data_source: Any = None,
+        parent_field: str = "parent_id",
+        root_value: Any = None,
+        label_field: str = "name",
+        icon_field: str | None = None,
+        node_builder: Callable[[dict], dict] | None = None,
+        order: Any = None,
         selection_mode: Literal["none", "single", "multi"] = "single",
         show_selection_controls: bool = False,
         select_on_click: bool = True,
@@ -100,7 +129,30 @@ class Tree(PublicWidgetBase):
 
         if height is not None:
             self._internal.configure(height=height)
-        if nodes:
+
+        # Data-source backing: project a flat adjacency-list source as a lazy
+        # hierarchy. Mutually exclusive with declarative `nodes=`.
+        self._binding: Any = None
+        if data_source is not None:
+            if nodes:
+                raise ValueError(
+                    "Tree: pass either nodes= or data_source=, not both."
+                )
+            from bootstack.widgets._impl.composites.tree.source_binding import (
+                SourceBinding,
+            )
+
+            self._binding = SourceBinding(
+                data_source,
+                parent_field=parent_field,
+                root_value=root_value,
+                label_field=label_field,
+                icon_field=icon_field,
+                node_builder=node_builder,
+                order=order,
+            )
+            self._internal.load(self._binding.roots())
+        elif nodes:
             self._internal.load(nodes)
 
         # Per-node context menu (set via set_context_menu).
@@ -179,6 +231,22 @@ class Tree(PublicWidgetBase):
     def clear(self) -> None:
         """Remove all nodes."""
         self._internal.clear()
+
+    @property
+    def data_source(self) -> Any:
+        """The backing data source, or ``None`` for a declarative tree."""
+        return self._binding.source if self._binding is not None else None
+
+    def refresh(self) -> None:
+        """Reload a data-source-backed tree from its source.
+
+        Re-queries the roots and discards loaded branches, so the tree reflects
+        records that were inserted, updated, or deleted in the source. Selection
+        and expansion state are reset. A no-op for a declarative tree.
+        """
+        if self._binding is None:
+            return
+        self._internal.load(self._binding.roots())
 
     # ----- navigation / lookup -----
 

--- a/tests/widgets/public/test_tree.py
+++ b/tests/widgets/public/test_tree.py
@@ -460,3 +460,154 @@ def test_set_context_menu_builder_invoked_per_right_click(shown_app):
     # Detaching removes the subscription.
     tree.set_context_menu(None)
     assert tree._ctx_sub is None
+
+
+# --------------------------------------------------------------------------- data-source backing
+
+
+# Flat adjacency list: src/ (1) -> app.py (2) -> deep (5); src/ -> util.py (3);
+# README.md (4) is a root leaf.
+FLAT_ROWS = [
+    {"id": 1, "parent_id": None, "name": "src", "kind": "folder"},
+    {"id": 2, "parent_id": 1, "name": "app.py", "kind": "file"},
+    {"id": 3, "parent_id": 1, "name": "util.py", "kind": "file"},
+    {"id": 4, "parent_id": None, "name": "README.md", "kind": "file"},
+    {"id": 5, "parent_id": 2, "name": "deep", "kind": "file"},
+]
+
+
+def _counting_source(rows):
+    """A MemoryDataSource that records how many times _query is called."""
+    src = bs.MemoryDataSource()
+    src.load([dict(r) for r in rows])
+    calls = {"n": 0}
+    real_query = src._query
+
+    def counted(condition, sort_keys):
+        calls["n"] += 1
+        return real_query(condition, sort_keys)
+
+    src._query = counted
+    return src, calls
+
+
+@pytest.mark.gui
+def test_datasource_loads_only_roots_initially(shown_app):
+    src, _ = _counting_source(FLAT_ROWS)
+    tree = bs.Tree(data_source=src, parent_field="parent_id")
+    _pump(shown_app)
+
+    roots = _roots(tree)
+    assert [n.label for n in roots] == ["src", "README.md"]
+    # No child branch loaded yet.
+    assert all(not n.children for n in roots)
+
+
+@pytest.mark.gui
+def test_datasource_chevrons_reflect_has_children(shown_app):
+    src, _ = _counting_source(FLAT_ROWS)
+    tree = bs.Tree(data_source=src, parent_field="parent_id")
+    _pump(shown_app)
+
+    src_node, readme = _roots(tree)
+    # The parent gets a loader (chevron); the leaf root does not.
+    assert src_node.expandable is True
+    assert readme.expandable is False
+    assert readme.is_leaf is True
+
+
+@pytest.mark.gui
+def test_datasource_lazy_expand_loads_branch(shown_app):
+    src, _ = _counting_source(FLAT_ROWS)
+    tree = bs.Tree(data_source=src, parent_field="parent_id", order="name")
+    _pump(shown_app)
+
+    # order="name" sorts roots too: README.md before src.
+    src_node = [n for n in _roots(tree) if n.label == "src"][0]
+    tree.expand(src_node)
+    _pump(shown_app)
+
+    # Children loaded, ordered by name; app.py has its own child, util.py does not.
+    assert [n.label for n in src_node.children] == ["app.py", "util.py"]
+    app_py, util_py = src_node.children
+    assert app_py.expandable is True
+    assert util_py.is_leaf is True
+
+    tree.expand(app_py)
+    _pump(shown_app)
+    assert [n.label for n in app_py.children] == ["deep"]
+    assert app_py.children[0].is_leaf is True
+
+
+@pytest.mark.gui
+def test_datasource_data_bag_carries_record(shown_app):
+    src, _ = _counting_source(FLAT_ROWS)
+    tree = bs.Tree(data_source=src, parent_field="parent_id")
+    _pump(shown_app)
+
+    src_node = _roots(tree)[0]
+    assert src_node.data["id"] == 1
+    assert src_node.data["kind"] == "folder"
+
+
+@pytest.mark.gui
+def test_datasource_icon_field_and_node_builder(shown_app):
+    src, _ = _counting_source(FLAT_ROWS)
+    tree = bs.Tree(
+        data_source=src,
+        parent_field="parent_id",
+        node_builder=lambda r: {"label": f"{r['name']} [{r['kind']}]"},
+    )
+    _pump(shown_app)
+    assert _roots(tree)[0].label == "src [folder]"
+
+
+@pytest.mark.gui
+def test_datasource_missing_label_field_raises(shown_app):
+    src = bs.MemoryDataSource()
+    src.load([{"id": 1, "parent_id": None, "title": "x"}])
+    with pytest.raises(KeyError):
+        bs.Tree(data_source=src, parent_field="parent_id")  # default label_field="name"
+
+
+@pytest.mark.gui
+def test_datasource_and_nodes_mutually_exclusive(shown_app):
+    src, _ = _counting_source(FLAT_ROWS)
+    with pytest.raises(ValueError):
+        bs.Tree(data_source=src, nodes=["a", "b"])
+
+
+@pytest.mark.gui
+def test_datasource_refresh_requeries(shown_app):
+    src, _ = _counting_source(FLAT_ROWS)
+    tree = bs.Tree(data_source=src, parent_field="parent_id")
+    _pump(shown_app)
+    assert [n.label for n in _roots(tree)] == ["src", "README.md"]
+
+    src.insert({"id": 6, "parent_id": None, "name": "LICENSE", "kind": "file"})
+    tree.refresh()
+    _pump(shown_app)
+    assert "LICENSE" in [n.label for n in _roots(tree)]
+
+
+@pytest.mark.gui
+def test_datasource_sqlite_backing(shown_app):
+    src = bs.SqliteDataSource()
+    src.load([dict(r) for r in FLAT_ROWS])
+    tree = bs.Tree(data_source=src, parent_field="parent_id", order="name")
+    _pump(shown_app)
+
+    assert [n.label for n in _roots(tree)] == ["README.md", "src"]
+    src_node = [n for n in _roots(tree) if n.label == "src"][0]
+    tree.expand(src_node)
+    _pump(shown_app)
+    assert [n.label for n in src_node.children] == ["app.py", "util.py"]
+    src.close()
+
+
+@pytest.mark.gui
+def test_datasource_property(shown_app):
+    src, _ = _counting_source(FLAT_ROWS)
+    tree = bs.Tree(data_source=src, parent_field="parent_id")
+    assert tree.data_source is src
+    assert bs.Tree().data_source is None


### PR DESCRIPTION
## Tree data-source backing

Lets a `Tree` project a **flat adjacency-list data source** as a lazy hierarchy — the hierarchical sibling of the file-streaming work. A huge tree (org chart, taxonomy, filesystem) shows instantly and loads branch-by-branch.

```python
bs.Tree(
    data_source=src,            # any DataSourceProtocol source
    parent_field="parent_id",   # each row links to its parent's id
    root_value=None,            # parent value that marks roots
    label_field="name",         # simple mapping...
    icon_field="kind",
    node_builder=lambda r: {...},  # ...or full control
    order="name",               # per-sibling-group ordering
)
```

### Design

- **Hierarchy is a projection, not a storage mode.** No change to the flat `DataSourceProtocol` — any source (Memory, SQLite, custom) can back a tree. "Tree-ness" lives entirely in the binding.
- **Reuses Tree's existing per-node `loader` seam.** The binding auto-generates loaders that query a node's children only on expand via `source._query(col(parent_field)==id, ...)`. It uses `_query` (not `where()`) so the source's active view state / pagination is undisturbed.
- **Record→node mapping:** `label_field`/`icon_field` for the common case, plus an optional `node_builder(record)->spec` escape hatch for computed labels/icons. A clear `KeyError` fires when `label_field` is absent.
- **Chevrons:** one batched has-children `IN(...)` query per expand decides which siblings are expandable — O(1 query) per expand regardless of sibling count, and no chevron flicker on leaves.
- Public `Tree.data_source` property and `Tree.refresh()`; `data_source` and `nodes=` are mutually exclusive.

### Found (worked around, not fixed)

`SqliteDataSource` infers a column's type from the **first row only**, so a column whose first value is `NULL` (roots have `parent_id=None`) gets TEXT affinity and stores int ids as strings. SQL linking still works (SQLite coerces in `WHERE`), but the Python-side has-children comparison compared `int` vs `str`. The binding normalizes both sides to strings to tolerate it. The underlying schema-inference bug is a general footgun (e.g. a CSV with an empty leading cell in an int column) and is flagged as a good next fix.

### Deferred

Per-node child pagination ("show more" within one node), tree filtering, auto-refresh on source `on_change`, a native `TreeDataSourceProtocol`, and the Tree widget doc page.

## Testing

- 10 new `test_datasource_*` in `tests/widgets/public/test_tree.py` (lazy roots, chevron correctness, deep expand, data bag, `node_builder`, missing-label error, mutual exclusion, `refresh`, SQLite + Memory). Full Tree suite green.
- Examples: `docs/examples/tree_datasource.py` (simple Memory vs. SQLite) and `docs/examples/tree_datasource_demo.py` (interactive ~5,000-node lazy-load demo with a live "queries run / nodes materialized" counter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
