### PR TITLE
fix(data): infer SqliteDataSource column types from a row sample

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,17 +54,20 @@ memories (see them for rationale and gotchas).
   `widgets/_impl/composites/tree/source_binding.py`. Mutually exclusive with
   `nodes=`. Memory `project_tree_datasource_backing`. **Deferred:** per-node child
   pagination, tree filtering, auto-refresh on `on_change`, native
-  `TreeDataSourceProtocol`, Tree widget doc page. **Found (not fixed):** latent
-  `SqliteDataSource` TEXT-affinity bug — a column whose FIRST row value is NULL
-  gets TEXT affinity, so int values store as strings (worked around in the binding
-  by string-normalizing the has-children key comparison).
+  `TreeDataSourceProtocol`, Tree widget doc page.
+- **SqliteDataSource schema inference** (branch `feat/sqlite-schema-inference`) —
+  fixed the TEXT-affinity-from-leading-NULL bug surfaced by Tree backing.
+  `load()` now samples the leading rows (`_SCHEMA_SAMPLE_SIZE=1000`) and infers
+  each column's type from the first non-NULL values via `_resolve_column_type`
+  (ignores NULL; INTEGER+REAL → REAL; any other mix → TEXT). Sampled rows are
+  buffered and still inserted; memory stays bounded. Tests:
+  `tests/data/test_schema_inference.py`. The Tree binding keeps its string-
+  normalized key compare as defense-in-depth (all-NULL-in-sample columns can
+  still be TEXT). NOTE: `_ensure_table` (single-record `insert()` into an empty
+  source) still infers from one record — inherent, can't sample.
 
 ## Next up — candidates (pick one)
 
-- **SqliteDataSource schema inference** — fix the TEXT-affinity-from-leading-NULL
-  bug surfaced by Tree backing (infer a column's type by scanning more than the
-  first row, or accept explicit dtypes). General correctness win for the
-  data-science/engineering audience; see `project_tree_datasource_backing`.
 - **Persistent KV / prefs store** (`bs.Store`) — memory `project_persistent_kv_store`.
 - **Deferred file-streaming items** — background/progressive ingest, keyset
   pagination, auto-index (memory `project_file_source_streaming`).

--- a/src/bootstack/data/sqlite_source.py
+++ b/src/bootstack/data/sqlite_source.py
@@ -50,6 +50,10 @@ _INTERNAL_COLUMNS = (_ROW_ID, _ROW_SEL, _ROW_DATA)
 # Values storable directly in a SQL column. Everything else is bagged as JSON.
 _SCALAR_TYPES = (str, bytes, bytearray, bool, int, float, type(None))
 
+# Leading rows scanned by `load()` to infer a column's type. Scanning past a
+# leading NULL keeps an otherwise-numeric column from being typed TEXT.
+_SCHEMA_SAMPLE_SIZE = 1000
+
 
 class SqliteDataSource(BaseDataSource):
     """SQLite-backed data manager with pagination, filtering, sorting, and CRUD operations.
@@ -148,6 +152,38 @@ class SqliteDataSource(BaseDataSource):
     def _is_scalar(value: Any) -> bool:
         """Whether a value can live directly in a SQL column (vs. the JSON bag)."""
         return isinstance(value, _SCALAR_TYPES)
+
+    @classmethod
+    def _resolve_column_type(cls, values: Iterable[Any]) -> str:
+        """Infer a column's SQL type from a sample of its values.
+
+        Unlike inferring from a single value, this scans the sample and ignores
+        `None`, so a leading NULL no longer forces TEXT affinity on an otherwise-
+        numeric column. Mixed integer and real values resolve to REAL (numeric
+        promotion); any other mix of kinds falls back to TEXT.
+
+        Args:
+            values: An iterable of a column's sampled values.
+
+        Returns:
+            One of `'INTEGER'`, `'REAL'`, `'BLOB'`, or `'TEXT'`.
+        """
+        types: set[str] = set()
+        for value in values:
+            if value is None:
+                continue
+            types.add(cls._infer_type(value))
+            # A mix that is not purely numeric can only be stored faithfully as
+            # TEXT — stop early once we know that.
+            if len(types) > 1 and not types <= {"INTEGER", "REAL"}:
+                return "TEXT"
+        if not types:
+            return "TEXT"
+        if types == {"INTEGER"}:
+            return "INTEGER"
+        if types <= {"INTEGER", "REAL"}:
+            return "REAL"
+        return next(iter(types))
 
     @staticmethod
     def _dumps_bag(bag: Dict[str, Any]) -> Optional[str]:
@@ -316,10 +352,26 @@ class SqliteDataSource(BaseDataSource):
         ]
         self._columns = column_fields + list(_INTERNAL_COLUMNS)
 
-        col_types = {col: self._infer_type(first_rec.get(col)) for col in column_fields}
+        # Sample the leading rows to infer column types. Scanning past a leading
+        # NULL keeps an otherwise-numeric column from being typed TEXT (which
+        # would store its ints as strings). The sampled rows are buffered so they
+        # are still inserted below; memory stays bounded by the sample size.
+        sample: List[Dict[str, Any]] = [first_rec]
+        sample_cap = max(1, min(int(chunk_size), _SCHEMA_SAMPLE_SIZE))
+        for raw in it:
+            sample.append(to_dict(raw))
+            if len(sample) >= sample_cap:
+                break
+
+        col_types = {
+            col: self._resolve_column_type(rec.get(col) for rec in sample)
+            for col in column_fields
+        }
         if self._id_field in column_fields:
-            # Type the identity from the adopted id value (e.g. TEXT for UUIDs).
-            col_types[_ROW_ID] = self._infer_type(first_rec.get(self._id_field))
+            # Type the identity from the adopted id values (e.g. TEXT for UUIDs).
+            col_types[_ROW_ID] = self._resolve_column_type(
+                rec.get(self._id_field) for rec in sample
+            )
         else:
             col_types[_ROW_ID] = "INTEGER"
         col_types[_ROW_SEL] = "INTEGER"
@@ -356,22 +408,33 @@ class SqliteDataSource(BaseDataSource):
             self.conn.execute(f"DROP TABLE IF EXISTS {self._table}")
             self.conn.execute(f"CREATE TABLE {self._table} ({col_definitions})")
 
-            buffer = [row_for(first_rec, 0)]
-            index = 1
+            buffer: List[tuple] = []
+
+            def flush() -> None:
+                nonlocal inserted, buffer
+                if not buffer:
+                    return
+                self.conn.executemany(insert_sql, buffer)
+                inserted += len(buffer)
+                buffer = []
+                if on_progress is not None:
+                    on_progress(inserted)
+
+            # Insert the buffered sample first, then the rest of the stream. A
+            # single running index gives rows without an explicit id their
+            # default 0, 1, 2, ... identity.
+            index = 0
+            for rec in sample:
+                buffer.append(row_for(rec, index))
+                index += 1
+                if len(buffer) >= chunk_size:
+                    flush()
             for raw in it:
                 buffer.append(row_for(to_dict(raw), index))
                 index += 1
                 if len(buffer) >= chunk_size:
-                    self.conn.executemany(insert_sql, buffer)
-                    inserted += len(buffer)
-                    buffer = []
-                    if on_progress is not None:
-                        on_progress(inserted)
-            if buffer:
-                self.conn.executemany(insert_sql, buffer)
-                inserted += len(buffer)
-                if on_progress is not None:
-                    on_progress(inserted)
+                    flush()
+            flush()
             self.conn.execute("COMMIT")
         except sqlite3.IntegrityError as exc:
             self._safe_rollback()

--- a/src/bootstack/widgets/_impl/composites/tree/source_binding.py
+++ b/src/bootstack/widgets/_impl/composites/tree/source_binding.py
@@ -25,10 +25,10 @@ def _key(value: Any) -> Any:
     """Normalize an identifier for cross-column comparison.
 
     A record's id and another record's `parent_field` may be stored with
-    different types — for example SQLite gives an all-integer column TEXT
-    affinity if its first value is NULL, so parent ids come back as `'1'` while
-    ids come back as `1`. They are the same logical key, so compare them as
-    strings (NULL stays distinct).
+    different types depending on the source — for instance a column whose sampled
+    values are all NULL gets TEXT affinity, so its ids can come back as `'1'`
+    while a sibling id column returns `1`. They are the same logical key, so
+    compare them as strings (NULL stays distinct).
     """
     return None if value is None else str(value)
 

--- a/tests/data/test_schema_inference.py
+++ b/tests/data/test_schema_inference.py
@@ -1,0 +1,100 @@
+"""Tests for SqliteDataSource column-type (affinity) inference.
+
+`load()` samples the leading rows to pick each column's SQL type, so a leading
+NULL no longer forces TEXT affinity on an otherwise-numeric column (which would
+silently store its integers as strings). These are headless (no App).
+"""
+from __future__ import annotations
+
+from bootstack.data import SqliteDataSource
+from bootstack.data.query import col
+
+
+def _affinity(ds: SqliteDataSource, column: str) -> str:
+    rows = ds.conn.execute(f"PRAGMA table_info({ds._table})").fetchall()
+    for r in rows:
+        # PRAGMA table_info columns: (cid, name, type, notnull, dflt, pk)
+        name, ctype = r[1], r[2]
+        if name == column:
+            return ctype
+    raise AssertionError(f"no column {column!r}")
+
+
+def test_leading_null_does_not_force_text_affinity():
+    # parent_id is None in the first row but integer afterwards.
+    ds = SqliteDataSource().load([
+        {"id": 1, "parent_id": None, "name": "root"},
+        {"id": 2, "parent_id": 1, "name": "child"},
+        {"id": 3, "parent_id": 1, "name": "child2"},
+    ])
+    assert _affinity(ds, "parent_id") == "INTEGER"
+    # Values read back as ints, not strings — this is what broke tree backing.
+    kids = ds._query(col("parent_id") == 1, [])
+    assert [r["parent_id"] for r in kids] == [1, 1]
+    assert all(isinstance(r["parent_id"], int) for r in kids)
+
+
+def test_all_null_column_falls_back_to_text():
+    ds = SqliteDataSource().load([
+        {"id": 1, "note": None},
+        {"id": 2, "note": None},
+    ])
+    assert _affinity(ds, "note") == "TEXT"
+
+
+def test_integer_and_real_promote_to_real():
+    ds = SqliteDataSource().load([
+        {"id": 1, "amount": None},
+        {"id": 2, "amount": 5},
+        {"id": 3, "amount": 2.5},
+    ])
+    assert _affinity(ds, "amount") == "REAL"
+
+
+def test_mixed_numeric_and_text_falls_back_to_text():
+    ds = SqliteDataSource().load([
+        {"id": 1, "code": None},
+        {"id": 2, "code": 10},
+        {"id": 3, "code": "A-12"},
+    ])
+    assert _affinity(ds, "code") == "TEXT"
+
+
+def test_pure_integer_column_stays_integer():
+    ds = SqliteDataSource().load([
+        {"id": 1, "qty": 4},
+        {"id": 2, "qty": 7},
+    ])
+    assert _affinity(ds, "qty") == "INTEGER"
+
+
+def test_string_id_still_typed_text():
+    ds = SqliteDataSource().load([
+        {"id": "a1b2", "name": "x"},
+        {"id": "c3d4", "name": "y"},
+    ])
+    assert _affinity(ds, "_bs_row_id") == "TEXT"
+
+
+def test_sampling_is_bounded_but_covers_leading_run(monkeypatch):
+    # Only the leading sample window is scanned; a column whose values are all
+    # None within the sample types as TEXT. Use a tiny window to assert the bound.
+    import bootstack.data.sqlite_source as mod
+
+    monkeypatch.setattr(mod, "_SCHEMA_SAMPLE_SIZE", 2)
+    rows = [{"id": i, "late": None} for i in range(2)]
+    rows += [{"id": i, "late": i} for i in range(2, 6)]
+    ds = SqliteDataSource().load(rows, chunk_size=10)
+    # All sampled values were None -> TEXT (documented sampling bound).
+    assert _affinity(ds, "late") == "TEXT"
+    # But every row is still inserted and readable.
+    assert ds.count == 6
+
+
+def test_chunk_smaller_than_sample_still_infers_and_inserts_all():
+    # chunk_size below the sample size must not drop rows or mis-type.
+    rows = [{"id": 1, "parent_id": None, "name": "r"}]
+    rows += [{"id": i, "parent_id": 1, "name": f"c{i}"} for i in range(2, 12)]
+    ds = SqliteDataSource().load(rows, chunk_size=3)
+    assert _affinity(ds, "parent_id") == "INTEGER"
+    assert ds.count == 11


### PR DESCRIPTION
## SqliteDataSource column-type inference from a row sample

Fixes a latent schema-inference bug surfaced by the Tree data-source work (#97).

### The bug

`load()` typed each column from the **first row only**, and `_infer_type(None)` returns `TEXT`. So a column whose first value is `NULL` got **TEXT affinity** and silently stored its integers as **strings**:

```python
src = bs.SqliteDataSource().load([
    {"id": 1, "parent_id": None, "name": "root"},   # parent_id NULL first...
    {"id": 2, "parent_id": 1, "name": "child"},      # ...int afterwards
])
# before: parent_id is TEXT; reads back as '1' (string)
```

SQL comparisons still coerced (`WHERE parent_id = 1` matched), but values **read back as strings**, breaking Python-side equality — exactly what the Tree adjacency-list binding hit (an integer `id` would not match a string `parent_id`). It is a general footgun for any tabular/CSV ingest where a numeric column has an empty leading cell.

### The fix

`load()` now **samples the leading rows** (up to `_SCHEMA_SAMPLE_SIZE = 1000`) and infers each column's type from the first non-`NULL` values via a new `_resolve_column_type`:

- `NULL`s are ignored (a leading NULL no longer forces TEXT).
- `INTEGER` + `REAL` together promote to `REAL`.
- Any other mix of kinds falls back to `TEXT`.

The sampled rows are buffered and still inserted (via a `flush` closure), so **memory stays bounded by the sample size** and the load remains streaming + atomic. A single running index preserves the `0, 1, 2, …` default-id behavior for rows without an explicit id.

```python
# after: parent_id is INTEGER; reads back as 1 (int)
```

### Scope / notes

- The Tree binding keeps its string-normalized key comparison as **defense-in-depth** — a column whose sampled values are *all* NULL can still legitimately be TEXT.
- `_ensure_table` (the single-record `insert()`-into-empty-source path) still infers from one record — inherent, it has no sample to scan.

## Testing

New `tests/data/test_schema_inference.py` (8 tests): leading-NULL → INTEGER (with int round-trip), all-NULL → TEXT fallback, int+float → REAL, mixed numeric+text → TEXT, pure-int stays INTEGER, string id stays TEXT, the sampling bound is respected while all rows still insert, and `chunk_size` smaller than the sample. Full streaming/data/tree suites pass (the pre-existing flaky `test_observable` is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
