### PR TITLE
refactor(signals): remove .get() and the tk.Variable proxy; widen int->float

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,13 +65,21 @@ memories (see them for rationale and gotchas).
   normalized key compare as defense-in-depth (all-NULL-in-sample columns can
   still be TEXT). NOTE: `_ensure_table` (single-record `insert()` into an empty
   source) still infers from one record — inherent, can't sample.
+- **Signal runtime cleanup** (branch `feat/signal-cleanup`) — removed the
+  deprecated `Signal.get()` (call syntax `signal()` is the single getter) and the
+  `__getattr__` tk.Variable proxy (no more silent Tk-method leak); `set()` now
+  widens an `int` into a `float`-typed signal; `subscribe(immediate=)` no longer
+  swallows callback errors. Rewrote ~19 internal `.get()` callers (entry parts,
+  textarea, localization) to call syntax. **Gotcha fixed:** `is_signal()` duck-
+  typed on `hasattr(obj,'get')`; removing `.get()` made it reject real signals so
+  widgets created fresh empty ones — now checks `var`/`subscribe`/`set`/callable.
+  Tests: `tests/signals/test_signal.py`.
 
 ## Next up — candidates (pick one)
 
 - **Persistent KV / prefs store** (`bs.Store`) — memory `project_persistent_kv_store`.
 - **Deferred file-streaming items** — background/progressive ingest, keyset
   pagination, auto-index (memory `project_file_source_streaming`).
-- **Signal runtime-cleanup pass** — memory `project_signal_api_audit_findings`.
 
 ---
 
@@ -295,17 +303,15 @@ rename + filtering DSL were already DONE.
    record-oriented, `AppSettings`=window-geometry-only despite its name). Propose
    `bs.Store` (dict-like, file-backed). Ties into theme persistence.
 
-**Signal API — DECIDED (prior session):** `signal()` is the single getter,
-`.set()` writes, `.get()` deprecated (doc-excluded). Do NOT adopt callable-setter
-`signal(x)`.
+**Signal API — DONE (branch `feat/signal-cleanup`):** `signal()` is the single
+getter; `.get()` and the `__getattr__` proxy are REMOVED; `.set()` writes (with
+int→float widening); `subscribe(immediate=)` propagates callback errors. Do NOT
+adopt callable-setter `signal(x)`.
 
 **Carryover (lower priority):**
 1. **Index/landing pages** — root `index.rst`, `widgets/index.rst`,
    `reference/index.rst`, section indexes are bare; add orientation/gallery.
-2. **Signal runtime-cleanup pass** — memory `project_signal_api_audit_findings`
-   (remove `.get()` + `__getattr__` proxy; `set()` numeric widening; silent
-   swallow in `subscribe(immediate=)`).
-3. **Tree/Table doc pages** (deferred — complex). DataSource rename should land first.
+2. **Tree/Table doc pages** (deferred — complex). DataSource rename should land first.
 4. **localization / windowing** `tasks/` how-tos.
 5. **Screenshots pending:** Tooltip/Toast, 7 Dialog pages.
 6. **AppShell deferred improvements:** `nav_pane_width=` not wired to

--- a/docs/examples/button.py
+++ b/docs/examples/button.py
@@ -64,7 +64,7 @@ with bs.App(title="Button Demo", padding=20, gap=16) as app:
         bs.Button(
             textsignal=btn_text,
             accent="success",
-            on_click=lambda: running.set(not running.get()),
+            on_click=lambda: running.set(not running()),
         )
         bs.Label(textsignal=btn_text, accent="secondary")
 

--- a/docs/examples/label.py
+++ b/docs/examples/label.py
@@ -57,6 +57,6 @@ with bs.App(title="Label Demo", padding=20, gap=16) as app:
         count.subscribe(lambda v: count_text.set(f"Count: {v}"))
         bs.Label(textsignal=count_text, font="heading-md", accent="primary")
         bs.Button("+1", accent="primary",
-                  on_click=lambda: count.set(count.get() + 1))
+                  on_click=lambda: count.set(count() + 1))
 
 app.run()

--- a/docs/reference/signals.rst
+++ b/docs/reference/signals.rst
@@ -39,10 +39,11 @@ Call the signal to read its current value. Use ``set()`` to update it:
    name()              # "World"  — call to read
    name.set("Universe")
 
-``set()`` enforces the original type. Assigning a value of a different type
+``set()`` enforces the signal's type. Assigning a value of a different type
 raises ``TypeError`` — a ``Signal(0)`` accepts ``set(5)`` but rejects
-``set(1.5)``. Setting the same value the signal already holds is a no-op and
-does not notify subscribers.
+``set(1.5)``. The one exception is numeric widening: a ``float`` signal also
+accepts an ``int`` (``bs.Signal(0.0).set(5)`` stores ``5.0``). Setting the same
+value the signal already holds is a no-op and does not notify subscribers.
 
 Binding to widgets
 ------------------
@@ -130,4 +131,4 @@ API reference
    :members:
    :undoc-members:
    :special-members: __call__
-   :exclude-members: tk, var, name, get, from_variable
+   :exclude-members: tk, var, name, from_variable

--- a/docs/widgets/button.rst
+++ b/docs/widgets/button.rst
@@ -195,7 +195,7 @@ automatically.
    running.subscribe(lambda v: btn_text.set("Stop" if v else "Start"))
 
    bs.Button(textsignal=btn_text, accent="primary",
-             on_click=lambda: running.set(not running.get()))
+             on_click=lambda: running.set(not running()))
 
    # Or set directly via the .text property
    btn = bs.Button("Start", accent="primary")

--- a/docs/widgets/label.rst
+++ b/docs/widgets/label.rst
@@ -110,7 +110,7 @@ Bind a ``Signal[str]`` to ``textsignal=`` so the label updates automatically.
    count.subscribe(lambda v: count_text.set(f"Count: {v}"))
 
    bs.Label(textsignal=count_text, font="heading-md", accent="primary")
-   bs.Button("+1", on_click=lambda: count.set(count.get() + 1))
+   bs.Button("+1", on_click=lambda: count.set(count() + 1))
 
 Widget sizing
 ~~~~~~~~~~~~~

--- a/src/bootstack/_core/capabilities/localization.py
+++ b/src/bootstack/_core/capabilities/localization.py
@@ -203,7 +203,7 @@ def create_formatted_signal(
         >>> from bootstack.signals import Signal
         >>> price = Signal(1234.56)
         >>> formatted, formatter = create_formatted_signal(price, "currency")
-        >>> # formatted.get() returns locale-formatted currency string
+        >>> # formatted() returns locale-formatted currency string
     """
     from bootstack.signals import Signal
 

--- a/src/bootstack/_core/capabilities/signals.py
+++ b/src/bootstack/_core/capabilities/signals.py
@@ -29,13 +29,15 @@ def is_signal(obj: Any) -> bool:
         obj: Object to check.
 
     Returns:
-        True if object has Signal-like interface (var, subscribe, get, set).
+        True if object has a Signal-like interface (var, subscribe, set, and is
+        callable for reading). `subscribe`/`var` distinguish it from a plain
+        `tk.Variable`.
     """
     return (
         hasattr(obj, 'var')
         and hasattr(obj, 'subscribe')
-        and hasattr(obj, 'get')
         and hasattr(obj, 'set')
+        and callable(obj)
     )
 
 
@@ -109,7 +111,7 @@ def normalize_signal(
         >>> binding = normalize_signal(var)
         >>> binding.variable is var
         True
-        >>> binding.signal.get()
+        >>> binding.signal()
         'world'
     """
     if value is None:
@@ -148,10 +150,10 @@ def create_signal(default_value: Any) -> SignalBinding:
 
     Examples:
         >>> binding = create_signal("")
-        >>> binding.signal.get()
+        >>> binding.signal()
         ''
         >>> binding = create_signal(0.0)
-        >>> binding.signal.get()
+        >>> binding.signal()
         0.0
     """
     from bootstack.signals import Signal

--- a/src/bootstack/signals/README.md
+++ b/src/bootstack/signals/README.md
@@ -14,9 +14,9 @@ Architecture
   ("array", "read", "write", "unset").
 
 Key behaviors
-- Value access: ``signal()`` or ``signal.get()`` returns the current value;
-  ``signal.set(v)`` updates it. Signals can be passed directly to widget
-  options like ``textsignal``; bootstack uses the underlying Tcl variable name.
+- Value access: ``signal()`` returns the current value; ``signal.set(v)``
+  updates it. Signals can be passed directly to widget options like
+  ``textsignal``; bootstack uses the underlying Tcl variable name.
 - Subscriptions: ``subscribe(cb, immediate=False)`` registers a callback and
   returns a trace id. Multiple subscriptions of the same callback are supported.
   Use ``unsubscribe(cb)`` to remove all subscriptions for that callback or
@@ -26,7 +26,8 @@ Key behaviors
   keeping derived signals alive unnecessarily.
 - Robustness: The last known value is cached and returned if the underlying
   Tcl variable is destroyed. Redundant updates are skipped when the new value
-  equals the current one. Exact type matching is enforced in ``set()``.
+  equals the current one. ``set()`` enforces the signal's type, except that an
+  ``int`` is widened to a ``float``-typed signal.
 
 Usage
 1) Quick start
@@ -34,9 +35,9 @@ Usage
 from bootstack.signals import Signal
 
 count = Signal(0)
-print(count.get())    # -> 0
+print(count())        # -> 0
 count.set(1)
-print(count())        # -> 1 (callable alias of get)
+print(count())        # -> 1
 ```
 
 2) With widgets

--- a/src/bootstack/signals/signal.py
+++ b/src/bootstack/signals/signal.py
@@ -125,14 +125,6 @@ class Signal(Generic[T]):
             # Return last known value when underlying var is destroyed/unset
             return self._last
 
-    def get(self) -> T:
-        """Return the current value of the signal.
-
-        Alias for calling the signal directly (`signal()`), provided for
-        readability when an explicit method call reads better.
-        """
-        return self()
-
     @classmethod
     def from_variable(
             cls,
@@ -200,14 +192,23 @@ class Signal(Generic[T]):
         Set the signal to a new value and notify subscribers.
 
         Args:
-            value: The new value. Must match the original type.
+            value: The new value. Must match the signal's type, except that an
+                `int` may be set on a `float`-typed signal (it is widened).
 
         Raises:
-            TypeError: If the value type does not match the original.
+            TypeError: If the value type does not match the signal's type (and is
+                not an `int` widened to a `float`).
         """
-        # Enforce exact type to avoid bool being accepted for int, etc.
+        # Enforce the type to avoid surprises (e.g. a bool accepted for an int),
+        # but widen an int into a float-typed signal — a Slider seeded at 0 and
+        # later set to 0.5 is the common case. `type(value) is int` excludes bool.
         if type(value) is not self._type:
-            raise TypeError(f"Expected {self._type.__name__}, got {type(value).__name__}")
+            if self._type is float and type(value) is int:
+                value = float(value)  # type: ignore[assignment]
+            else:
+                raise TypeError(
+                    f"Expected {self._type.__name__}, got {type(value).__name__}"
+                )
         # Reduce redundant updates if value unchanged
         try:
             current = self._var.get()
@@ -264,11 +265,9 @@ class Signal(Generic[T]):
         self._subscribers[fid] = callback
         self._callback_index.setdefault(callback, set()).add(fid)
         if immediate:
-            try:
-                callback(self())
-            except Exception:
-                # Do not fail subscription due to callback error
-                pass
+            # Call synchronously at subscription time; let any error surface to
+            # the caller rather than swallowing a real bug in the callback.
+            callback(self())
         return fid
 
     def unsubscribe(self, funcid: str) -> None:
@@ -290,12 +289,6 @@ class Signal(Generic[T]):
             self._trace.remove(fid)
         self._subscribers.clear()
         self._callback_index.clear()
-
-    def __getattr__(self, name: str) -> Any:
-        """
-        Proxy access to the underlying tk.Variable instance.
-        """
-        return getattr(self._var, name)
 
     @property
     def name(self) -> str:

--- a/src/bootstack/widgets/_impl/_parts/numberentry_part.py
+++ b/src/bootstack/widgets/_impl/_parts/numberentry_part.py
@@ -238,7 +238,7 @@ class NumberEntryPart(TextEntryPart):
                 '<<Change>>', data=ChangeEvent(
                     value=self._value,
                     prev_value=prev_value,
-                    text=self.textsignal.get(),
+                    text=self.textsignal(),
                 ))
 
         return self
@@ -249,7 +249,7 @@ class NumberEntryPart(TextEntryPart):
         new_text = self._format_value(self._value)
 
         # Only update if text changed
-        if new_text != self.textsignal.get():
+        if new_text != self.textsignal():
             # Temporarily unsubscribe from input signal to avoid spurious events
             fid = getattr(self, '_on_input_fid', None)
             if fid:

--- a/src/bootstack/widgets/_impl/_parts/spinnerentry_part.py
+++ b/src/bootstack/widgets/_impl/_parts/spinnerentry_part.py
@@ -102,7 +102,7 @@ class SpinnerEntryPart(ValidationMixin, Spinbox):
         if isinstance(value, (int, float)):
             initial_display = str(value)
         else:
-            initial_display = value or self.textsignal.get() or ''
+            initial_display = value or self.textsignal() or ''
 
         # Parse initial value if format is specified
         if value_format is not None:
@@ -121,7 +121,7 @@ class SpinnerEntryPart(ValidationMixin, Spinbox):
             self.textsignal.set('')
 
         # Track last text emitted for input events
-        self._prev_change_text = self.textsignal.get()
+        self._prev_change_text = self.textsignal()
 
         # Subscribe to text changes
         self._on_input_fid = self.textsignal.subscribe(self._handle_change)
@@ -152,7 +152,7 @@ class SpinnerEntryPart(ValidationMixin, Spinbox):
 
     def _handle_change(self, event):
         """Emit <<Input>> event on every text change without parsing."""
-        text = self.textsignal.get()
+        text = self.textsignal()
         if text == self._prev_change_text:
             return
 
@@ -165,7 +165,7 @@ class SpinnerEntryPart(ValidationMixin, Spinbox):
             data = ChangeEvent(
                 value=self._value,
                 prev_value=self._prev_changed_value,
-                text=self.textsignal.get(),
+                text=self.textsignal(),
             )
             self.event_generate('<<Change>>', data=data)
             self._prev_changed_value = self._value
@@ -233,7 +233,7 @@ class SpinnerEntryPart(ValidationMixin, Spinbox):
             Binding identifier for use with off_enter()
         """
         def enrich_callback(event: Event) -> None:
-            data = {"value": self._value, "text": self.textsignal.get()}
+            data = {"value": self._value, "text": self.textsignal()}
             event.data = data
             return callback(event)
 
@@ -297,7 +297,7 @@ class SpinnerEntryPart(ValidationMixin, Spinbox):
             Current display text if no argument provided, None otherwise
         """
         if value is None:
-            return self.textsignal.get()
+            return self.textsignal()
         else:
             self.textsignal.set(value)
             return None
@@ -319,7 +319,7 @@ class SpinnerEntryPart(ValidationMixin, Spinbox):
         # Format the value for display
         new_text = self._format_value(self._value)
 
-        if new_text != self.textsignal.get():
+        if new_text != self.textsignal():
             # Temporarily silence input events while normalizing text
             fid = getattr(self, '_on_input_fid', None)
             if fid:

--- a/src/bootstack/widgets/_impl/_parts/textentry_part.py
+++ b/src/bootstack/widgets/_impl/_parts/textentry_part.py
@@ -69,7 +69,7 @@ class TextEntryPart(ValidationMixin, Entry):
         if isinstance(value, (int, float)):
             initial_display = str(value)
         else:
-            initial_display = value or self.textsignal.get() or ''
+            initial_display = value or self.textsignal() or ''
 
         # Parse initial value if format is specified
         if value_format is not None:
@@ -88,7 +88,7 @@ class TextEntryPart(ValidationMixin, Entry):
             self.textsignal.set('')
 
         # track last text emitted for CHANGE
-        self._prev_change_text = self.textsignal.get()
+        self._prev_change_text = self.textsignal()
 
         # subscribe to text changes
         self._on_input_fid = self.textsignal.subscribe(self._handle_change)
@@ -107,7 +107,7 @@ class TextEntryPart(ValidationMixin, Entry):
         # so the Signal is never set to the placeholder text
         if placeholder:
             self._default_fg = self.cget("foreground")
-            if not self.textsignal.get():
+            if not self.textsignal():
                 self._show_placeholder()
             self.bind('<FocusIn>', self._on_focus_in_placeholder, add=True)
             self.bind('<FocusOut>', self._on_focus_out_placeholder, add=True)
@@ -129,7 +129,7 @@ class TextEntryPart(ValidationMixin, Entry):
             self._hide_placeholder()
 
     def _on_focus_out_placeholder(self, _event) -> None:
-        if self._placeholder_text and not self.textsignal.get():
+        if self._placeholder_text and not self.textsignal():
             self._show_placeholder()
 
     def _store_prev_value(self, _: Any):
@@ -150,7 +150,7 @@ class TextEntryPart(ValidationMixin, Entry):
 
     def _handle_change(self, event):
         """Emit <<Input>> event on every text change without parsing."""
-        text = self.textsignal.get()
+        text = self.textsignal()
         if text == self._prev_change_text:
             return
         if self._showing_placeholder:
@@ -167,7 +167,7 @@ class TextEntryPart(ValidationMixin, Entry):
             data = ChangeEvent(
                 value=self._value,
                 prev_value=self._prev_changed_value,
-                text=self.textsignal.get(),
+                text=self.textsignal(),
             )
             self.event_generate('<<Change>>', data=data)
             self._prev_changed_value = self._value
@@ -223,7 +223,7 @@ class TextEntryPart(ValidationMixin, Entry):
         """Bind to `<Return>`. Callback receives `event.data = {'value': Any, 'text': str}`."""
 
         def enrich_callback(event: Event) -> None:
-            data = {"value": self._value, "text": self.textsignal.get()}
+            data = {"value": self._value, "text": self.textsignal()}
             event.data = data
             return callback(event)
 
@@ -280,7 +280,7 @@ class TextEntryPart(ValidationMixin, Entry):
             Current display text if no argument provided, None otherwise
         """
         if value is None:
-            return self.textsignal.get()
+            return self.textsignal()
         else:
             self.textsignal.set(value)
             return None
@@ -304,7 +304,7 @@ class TextEntryPart(ValidationMixin, Entry):
         # Format the value for display
         new_text = self._format_value(self._value)
 
-        if new_text != self.textsignal.get():
+        if new_text != self.textsignal():
             # temporarily silence CHANGE while normalizing text
             fid = getattr(self, '_on_input_fid', None)
             if fid:

--- a/src/bootstack/widgets/_impl/composites/textarea/core.py
+++ b/src/bootstack/widgets/_impl/composites/textarea/core.py
@@ -253,7 +253,7 @@ class _MultilineCore(tk.Frame):
         self._signal = signal
         self._signal_trace_id = signal.subscribe(self._on_signal_change)
         # Set initial value from signal
-        v = signal.get()
+        v = signal()
         if v is not None:
             self.value = str(v)
 

--- a/src/bootstack/widgets/_impl/composites/textarea/search_overlay.py
+++ b/src/bootstack/widgets/_impl/composites/textarea/search_overlay.py
@@ -236,10 +236,10 @@ class SearchOverlay(PackFrame):
     def _expand_replacement(self, matched_text: str) -> str:
         """Return the replacement string, expanding regex back-references."""
         replacement = self._replace_entry.value or ""
-        if self._regex_sig.get():
+        if self._regex_sig():
             try:
                 query = self._find_entry.value or ""
-                flags = 0 if self._case_sig.get() else re.IGNORECASE
+                flags = 0 if self._case_sig() else re.IGNORECASE
                 m = re.fullmatch(query, matched_text, flags)
                 if m:
                     return m.expand(replacement)
@@ -261,11 +261,11 @@ class SearchOverlay(PackFrame):
             return
 
         text = self._core.value
-        flags = 0 if self._case_sig.get() else re.IGNORECASE
+        flags = 0 if self._case_sig() else re.IGNORECASE
 
         try:
             pattern = re.compile(
-                query if self._regex_sig.get() else re.escape(query),
+                query if self._regex_sig() else re.escape(query),
                 flags,
             )
         except re.error:

--- a/src/bootstack/widgets/_impl/mixins/localization_mixin.py
+++ b/src/bootstack/widgets/_impl/mixins/localization_mixin.py
@@ -162,7 +162,7 @@ class LocalizationMixin(Misc):
         if hasattr(self, '_signal_formatter'):
             value_format, formatter, source_signal = self._signal_formatter
             # Re-format current value from source signal with new locale
-            formatter(source_signal.get())
+            formatter(source_signal())
 
     def _refresh_localized_fields(self) -> None:
         """Refresh all registered localized fields with the current locale."""

--- a/tests/features/boolean_controls.py
+++ b/tests/features/boolean_controls.py
@@ -43,8 +43,8 @@ with App(title="Boolean controls — visual test", minsize=(480, 100), padding=2
     sig = Signal(False)
     state_label_sig = Signal("off")
     def _flip():
-        sig.set(not sig.get())
-        state_label_sig.set("ON" if sig.get() else "off")
+        sig.set(not sig())
+        state_label_sig.set("ON" if sig() else "off")
     with HStack(gap=12, anchor_items="center"):
         Checkbox("Controlled", signal=sig)
         Button("Flip", on_click=_flip, variant="outline")

--- a/tests/features/label_badge.py
+++ b/tests/features/label_badge.py
@@ -10,11 +10,11 @@ with App(title="Label + Badge — visual test", minsize=(480, 200), padding=24, 
     counter_label_signal = Signal("0")
 
     def increment():
-        counter.set(counter.get() + 1)
-        counter_label_signal.set(str(counter.get()))
+        counter.set(counter() + 1)
+        counter_label_signal.set(str(counter()))
 
     def toggle_status():
-        status.set("running" if status.get() == "idle" else "idle")
+        status.set("running" if status() == "idle" else "idle")
 
     # Plain text labels
     with VStack(gap=6):

--- a/tests/features/radio_variants.py
+++ b/tests/features/radio_variants.py
@@ -33,7 +33,7 @@ with App(title="Radio + RadioToggleButton", minsize=(520, 540), padding=20, gap=
             cb_lbl = Label("selected: one")
 
             def _update(e):
-                cb_lbl.value = f"selected: {sig_c.get()}"
+                cb_lbl.value = f"selected: {sig_c()}"
 
             r1 = Radio("One", "one", signal=sig_c)
             r2 = Radio("Two", "two", signal=sig_c)

--- a/tests/features/stream_schedule.py
+++ b/tests/features/stream_schedule.py
@@ -21,7 +21,7 @@ with bs.App(title="Stream + Schedule — visual test", minsize=(600, 500), paddi
                 sched = bs.Schedule(app.tk)
 
                 def _tick():
-                    counter.set(counter.get() + 1)
+                    counter.set(counter() + 1)
 
                 with bs.HStack(gap=8, anchor_items="center"):
                     bs.Label("Tick count:")

--- a/tests/signals/test_signal.py
+++ b/tests/signals/test_signal.py
@@ -1,0 +1,130 @@
+"""Tests for the public Signal API.
+
+Covers reading via call syntax, writing with `set()` (including int->float
+widening), `subscribe(immediate=)` error propagation, and the duck-typed
+`is_signal` detection that widget binding relies on. A signal is backed by the
+App's variable system, so these need a running App; the module shares one
+(creating multiple Apps in one process crashes the Tk runtime).
+"""
+from __future__ import annotations
+
+import pytest
+
+import bootstack as bs
+from bootstack.signals.signal import Signal
+from bootstack._core.capabilities.signals import is_signal
+
+
+@pytest.fixture(scope="module")
+def app():
+    a = bs.App()
+    a.__enter__()
+    root = a._tk_root
+    root.withdraw()
+    try:
+        yield a
+    finally:
+        try:
+            a.__exit__(None, None, None)
+        except Exception:
+            pass
+        try:
+            root.destroy()
+        except Exception:
+            pass
+
+
+@pytest.mark.gui
+def test_call_reads_and_set_writes(app):
+    s = bs.Signal("hello")
+    assert s() == "hello"
+    s.set("world")
+    assert s() == "world"
+
+
+@pytest.mark.gui
+def test_get_method_is_removed(app):
+    # `.get()` was removed; call syntax is the single getter.
+    assert not hasattr(bs.Signal(0), "get")
+
+
+@pytest.mark.gui
+def test_tk_variable_methods_no_longer_leak(app):
+    # The __getattr__ proxy onto the tk.Variable is gone.
+    s = bs.Signal("x")
+    assert not hasattr(s, "trace_add")
+    assert not hasattr(s, "trace_remove")
+    # The explicit escape hatches still exist.
+    assert s.var is not None
+    assert s.tk is s.var
+
+
+@pytest.mark.gui
+def test_set_rejects_wrong_type(app):
+    s = bs.Signal(0)
+    with pytest.raises(TypeError):
+        s.set("nope")
+    with pytest.raises(TypeError):
+        s.set(1.5)          # float into an int signal: narrowing, rejected
+    with pytest.raises(TypeError):
+        s.set(True)         # bool is not an int here
+
+
+@pytest.mark.gui
+def test_set_widens_int_to_float(app):
+    s = bs.Signal(0.0)
+    s.set(5)
+    assert s() == 5.0
+    assert isinstance(s(), float)
+
+
+@pytest.mark.gui
+def test_subscribe_immediate_fires_with_current_value(app):
+    s = bs.Signal(1)
+    seen = []
+    s.subscribe(seen.append, immediate=True)
+    assert seen == [1]
+    s.set(2)
+    assert seen == [1, 2]
+
+
+@pytest.mark.gui
+def test_subscribe_immediate_propagates_callback_error(app):
+    # A failing immediate callback must surface, not be swallowed.
+    s = bs.Signal(0)
+
+    def boom(_value):
+        raise ValueError("boom")
+
+    with pytest.raises(ValueError):
+        s.subscribe(boom, immediate=True)
+
+
+@pytest.mark.gui
+def test_map_tracks_source(app):
+    name = bs.Signal("world")
+    shout = name.map(str.upper)
+    assert shout() == "WORLD"
+    name.set("hello")
+    assert shout() == "HELLO"
+
+
+@pytest.mark.gui
+def test_is_signal_recognizes_signal_without_get(app):
+    # Regression guard: is_signal must not depend on a `.get` method.
+    assert is_signal(bs.Signal(0)) is True
+    assert is_signal("not a signal") is False
+    import tkinter as tk
+    assert is_signal(tk.StringVar(value="x")) is False
+
+
+@pytest.mark.gui
+def test_widget_binding_recognizes_signal(app):
+    # Integration guard: a Signal passed to a widget must be adopted, not
+    # replaced by a fresh empty one (broke when is_signal checked for `.get`).
+    # If the signal were not recognized, the field would create a fresh empty
+    # signal and seed itself with "" instead of the signal's value.
+    s = bs.Signal("seed")
+    field = bs.TextField(textsignal=s)
+    app._tk_root.update_idletasks()
+    assert field.value == "seed"


### PR DESCRIPTION
## Signal runtime cleanup

Tightens the `Signal` public surface (the carryover signal-cleanup pass).

### Changes

- **Removed `Signal.get()`** — calling the signal (`signal()`) is the single getter. Rewrote ~19 internal callers (entry parts, textarea, the localization mixin) to call syntax. (Pre-release, no shim.)
- **Removed the `__getattr__` proxy** that silently forwarded attribute access to the underlying `tk.Variable` — a Tk leak (`signal.trace_add` etc. no longer resolve). The explicit `.var` / `.tk` escape hatches remain for internal plumbing.
- **`set()` numeric widening** — an `int` may now be set on a `float`-typed signal (e.g. a `Slider` seeded at `0` then set to `0.5`). Every other type mismatch still raises `TypeError`, and `bool` is still rejected for an `int` signal (narrowing like `float → int` is also still rejected).
- **`subscribe(immediate=True)` no longer swallows callback errors** — a failing immediate call surfaces to the caller instead of being silently dropped.

### Gotcha found & fixed

`is_signal()` duck-typed on `hasattr(obj, 'get')`. Removing `.get()` made it **reject real Signals**, so widgets fell back to creating a fresh empty signal and a bound `textsignal=`/`signal=` was silently ignored (e.g. `TextField(textsignal=Signal("hi"))` rendered empty). `is_signal` now checks `var` / `subscribe` / `set` + callability. This is exactly the kind of breakage the `__getattr__` proxy used to mask. (Captured in a reference note for future Signal API changes.)

### Docs

`docs/reference/signals.rst` (drops `get` from the autoclass exclude; documents widening), the signals `README`, and the `label` / `button` examples + widget pages updated to call syntax.

## Testing

New `tests/signals/test_signal.py` (10 tests): call-reads / set-writes, `.get()` gone, tk-method proxy gone, type rejection, int→float widening, immediate fires + propagates errors, `map()`, and two regression guards — `is_signal` recognizes a signal without `.get`, and a widget adopts a bound signal. Verified the signal-consuming widgets (TextField, NumberField, SpinnerField, TextArea, Slider, Checkbox) construct and read correctly; existing slider/tree/datatable/listview/data/cli suites pass. (The `test_base_layer` / `test_label_badge` GUI files hit a pre-existing multi-App Tk crash in this environment — confirmed identical on `main`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
