### PR TITLE
feat(store): add bs.Store, a file-backed preferences store

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,15 +84,25 @@ memories (see them for rationale and gotchas).
   `_core/paths.py` (`user_config_dir`/`app_config_dir`/`app_config_file`), which
   also now backs `App._state_file_path` (window-state) — single config-dir
   convention. Tests `tests/test_store.py`; docs `reference/store.rst` (with a
-  remember-the-theme recipe). **Decided standalone-first** (pre-release): the
-  `App(remember_theme=True)` sugar is a queued fast-follow, NOT built yet; did
-  NOT refactor window-state to route through Store (only shared the path helper).
+  remember-the-theme recipe). `bs.Store` ships standalone; the App-side
+  persistence integration is deferred to the settings-flattening work below (do
+  NOT add a one-off `remember_theme`/`app.store`). Did NOT refactor window-state
+  to route through Store (only shared the path helper).
 
 ## Next up — candidates (pick one)
 
-- **`App(remember_theme=True)`** — promote the store.rst theme-persistence recipe
-  into a built-in flag, mirroring `remember_window_state` (the queued Store
-  fast-follow).
+- **Flatten `AppSettings` into the `App` constructor** (DESIGN DECIDED 2026-06-07,
+  not started; memory `project_app_settings_flattening`) — config is split-brain
+  today (`title`/`size`/`theme` are top-level kwargs but `locale`/`window_style`/
+  `remember_*` only via `settings={...}`). Promote settings fields to direct
+  `App(...)` keyword args as the single config path; keep `AppSettings` as an
+  INTERNAL resolved-config holder (runs the locale derivation) + a read accessor
+  `app.settings`; drop the public `settings=` input (pre-release, no shims — touch
+  `AppShell` + examples). `remember_window_state` and a NEW `remember_theme`
+  become plain flat kwargs here (this is the agreed home for `remember_theme` —
+  NOT a standalone PR). `bs.Store` stays the separate persistence layer. Riskiest
+  change (central constructor) → its own focused PR. Open choices: promote all
+  fields vs common-first; keep `app.settings` read accessor (lean yes).
 - **Deferred file-streaming items** — background/progressive ingest, keyset
   pagination, auto-index (memory `project_file_source_streaming`).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,19 +92,33 @@ memories (see them for rationale and gotchas).
 ## Next up — candidates (pick one)
 
 - **Flatten `AppSettings` into the `App` constructor** (DESIGN DECIDED 2026-06-07,
-  not started; memory `project_app_settings_flattening`) — config is split-brain
-  today (`title`/`size`/`theme` are top-level kwargs but `locale`/`window_style`/
+  not started; full design in memory `project_app_settings_flattening`) — config
+  is split-brain today (`title`/`size`/`theme` top-level but `locale`/`window_style`/
   `remember_*` only via `settings={...}`). Promote settings fields to direct
-  `App(...)` keyword args as the single config path; keep `AppSettings` as an
-  INTERNAL resolved-config holder (runs the locale derivation) + a read accessor
-  `app.settings`; drop the public `settings=` input (pre-release, no shims — touch
-  `AppShell` + examples). `remember_window_state` and a NEW `remember_theme`
-  become plain flat kwargs here (this is the agreed home for `remember_theme` —
-  NOT a standalone PR). `bs.Store` stays the separate persistence layer. Riskiest
-  change (central constructor) → its own focused PR. Open choices: promote all
-  fields vs common-first; keep `app.settings` read accessor (lean yes).
+  `App(...)` kwargs as the single config path. **No public `AppSettings`, no
+  `app.settings`** — config is read/written as **app properties** (`app.theme`,
+  `app.title`, `app.locale`; derived ones like `app.date_format` read-only;
+  cohesive clusters may get a sub-namespace, likely just `app.localization.*`).
+  `AppSettings` survives only as an internal resolved-config holder. Drop public
+  `settings=` (pre-release, no shims — touch `AppShell` + examples). Persistence
+  falls out for free and retires `remember_*`: `bs.App(**store.as_dict())` restore
+  + explicit write-back; keep ONE built-in `remember_window_state` flag for the
+  fiddly geometry string; consider a tolerant `App.from_store()` (version-skew
+  filtering). `bs.Store` stays the separate persistence layer. Riskiest change
+  (central constructor) → its own focused PR.
 - **Deferred file-streaming items** — background/progressive ingest, keyset
   pagination, auto-index (memory `project_file_source_streaming`).
+
+## Carryover (deferred)
+
+- **Reference docs thin on examples** — the `docs/reference/*` pages are light on
+  worked examples/patterns across the board; enrich next docs pass. SPECIFICALLY
+  `reference/store.rst` must document the persistence patterns + caveats:
+  `bs.App(**store.as_dict())` restore + write-back, store hygiene (app-config in
+  its own store, separate from app-state), version skew / `App.from_store`, and
+  the window-geometry-stays-a-flag exception. Land any needed Store ergonomics
+  (`update(**kwargs)`, `to_dict` alias) WITH those examples. Memories
+  `project_docs_initiative`, `project_app_settings_flattening`.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,10 +74,25 @@ memories (see them for rationale and gotchas).
   typed on `hasattr(obj,'get')`; removing `.get()` made it reject real signals so
   widgets created fresh empty ones — now checks `var`/`subscribe`/`set`/callable.
   Tests: `tests/signals/test_signal.py`.
+- **Preferences store `bs.Store`** (branch `feat/store`) — public, dict-like,
+  JSON file-backed key-value store for app prefs (`store.py`). `get`/`set`/
+  `delete`/`setdefault`/`update`/`clear`/`keys`/`values`/`items`/`as_dict`/
+  `reload`/`save` + full mapping protocol; write-through `autosave=True` default
+  with atomic writes (temp + `os.replace`); JSON-only values (`SerializationError`
+  otherwise), string keys; corrupt/missing file starts empty; no App required.
+  Lives at `<config>/<app>/<name>.json` via new shared helper
+  `_core/paths.py` (`user_config_dir`/`app_config_dir`/`app_config_file`), which
+  also now backs `App._state_file_path` (window-state) — single config-dir
+  convention. Tests `tests/test_store.py`; docs `reference/store.rst` (with a
+  remember-the-theme recipe). **Decided standalone-first** (pre-release): the
+  `App(remember_theme=True)` sugar is a queued fast-follow, NOT built yet; did
+  NOT refactor window-state to route through Store (only shared the path helper).
 
 ## Next up — candidates (pick one)
 
-- **Persistent KV / prefs store** (`bs.Store`) — memory `project_persistent_kv_store`.
+- **`App(remember_theme=True)`** — promote the store.rst theme-persistence recipe
+  into a built-in flag, mirroring `remember_window_state` (the queued Store
+  fast-follow).
 - **Deferred file-streaming items** — background/progressive ingest, keyset
   pagination, auto-index (memory `project_file_source_streaming`).
 
@@ -298,10 +313,10 @@ rename + filtering DSL were already DONE.
    Table "SQL" search mode; fixed `FormDialog(master=)`→`parent=`. Also docs-config
    cleanup (removed `viewcode`, `html_show_sourcelink`/`copy_source` off,
    `_templates/sidebar-nav-bs.html` drops the "Section Navigation" header).
-3. **Persistent KV / prefs store** (proposed, memory `project_persistent_kv_store`):
-   no public persistent K-V exists (`MemoryDataSource`=RAM, `SqliteDataSource`=
-   record-oriented, `AppSettings`=window-geometry-only despite its name). Propose
-   `bs.Store` (dict-like, file-backed). Ties into theme persistence.
+3. **Persistent KV / prefs store — DONE** (branch `feat/store`, memory
+   `project_persistent_kv_store`): shipped `bs.Store` (dict-like, JSON file-
+   backed). `AppSettings` is still window-geometry-only (not folded into Store —
+   that was deliberately scoped out).
 
 **Signal API — DONE (branch `feat/signal-cleanup`):** `signal()` is the single
 getter; `.get()` and the `__getattr__` proxy are REMOVED; `.set()` writes (with

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -14,6 +14,7 @@ events, validation, data sources, and app-level utilities.
    streams
    validation
    data-sources
+   store
    shortcuts
    scheduling
    errors

--- a/docs/reference/store.rst
+++ b/docs/reference/store.rst
@@ -1,0 +1,117 @@
+Preferences store
+=================
+
+``Store`` is a small, file-backed key-value store for the bits of state an app
+wants to remember between runs — the chosen theme, a "show tips on startup"
+flag, recent files, the last-opened tab. It behaves like a dictionary, persists
+to a JSON file under the OS configuration directory, and saves on every change.
+
+It is deliberately *not* a data source: there are no rows, ids, pagination, or
+queries. Use :doc:`/reference/data-sources` for record-oriented data, and
+``Store`` for "remember this setting".
+
+Creating a store
+----------------
+
+Give the store a logical name. Its file lives under the per-platform config
+directory (``Library/Application Support`` on macOS, ``%APPDATA%`` on Windows,
+``$XDG_CONFIG_HOME`` on Linux), in a sub-directory named for your app:
+
+.. code-block:: python
+
+   import bootstack as bs
+
+   store = bs.Store("settings")     # <config>/<app>/settings.json
+
+Pass ``path=`` for an explicit location, or ``app_name=`` to override the
+sub-directory. A ``Store`` does not need a running ``App`` — it is plain file
+I/O — so you can create one before constructing the app (handy for restoring the
+startup theme).
+
+Reading and writing
+-------------------
+
+Read with ``get()`` (with an optional default) and write with ``set()``. The
+mapping syntax works too:
+
+.. code-block:: python
+
+   store.set("theme", "bootstrap-dark")
+   store.get("theme", "bootstrap-light")   # default if absent
+
+   store["sidebar_open"] = True
+   store["sidebar_open"]                    # KeyError if absent
+   "theme" in store
+   del store["theme"]                       # KeyError if absent
+   store.delete("theme")                    # no-op if absent
+
+By default every change is written immediately, with an atomic write (a
+temporary file renamed over the target) so a crash mid-write cannot corrupt the
+file. Values must be JSON-serializable — scalars, lists, and dicts; anything
+else raises ``SerializationError``. Keys must be strings.
+
+.. code-block:: python
+
+   store.set("recent_files", ["a.txt", "b.txt"])   # lists/dicts are fine
+   store.set("handle", open("x"))                   # SerializationError
+
+Bulk and dict-like operations
+-----------------------------
+
+``Store`` supports the familiar mapping methods; ``update()`` writes once at the
+end rather than per key:
+
+.. code-block:: python
+
+   store.update({"theme": "dark", "font_scale": 1.2})
+   store.setdefault("locale", "en_US")
+   store.keys(); store.values(); store.items()
+   len(store); list(store)
+   store.as_dict()        # a plain-dict copy
+   store.clear()
+
+Deferring writes
+----------------
+
+Pass ``autosave=False`` to batch changes in memory and flush them yourself with
+``save()`` — useful when applying many settings at once:
+
+.. code-block:: python
+
+   store = bs.Store("settings", autosave=False)
+   store.update(collected_settings)
+   store.save()
+
+Call ``reload()`` to discard in-memory state and re-read the file (for example
+if another process may have written it).
+
+Remembering the theme
+---------------------
+
+A common use is restoring the user's theme across launches — read it before
+creating the app, and write it whenever it changes:
+
+.. code-block:: python
+
+   store = bs.Store("settings")
+
+   with bs.App(theme=store.get("theme", "bootstrap-light")) as app:
+       def on_toggle():
+           bs.toggle_theme()
+           store.set("theme", bs.get_theme())
+       bs.Button("Toggle theme", on_click=on_toggle)
+   app.run()
+
+See also
+--------
+
+- :doc:`/reference/data-sources` — record-oriented data with querying and paging.
+- :doc:`/reference/theming` — themes and the values worth persisting with a store.
+- :doc:`/reference/errors` — ``SerializationError`` and the other public errors.
+
+API reference
+-------------
+
+.. autoclass:: bootstack.store.Store
+   :members:
+   :exclude-members: __init__

--- a/src/bootstack/__init__.py
+++ b/src/bootstack/__init__.py
@@ -35,6 +35,9 @@ from bootstack.style import (
 # ── Signals ───────────────────────────────────────────────────────────────────
 from bootstack.signals import Signal, TraceOperation
 
+# ── Preferences store ───────────────────────────────────────────────────────────
+from bootstack.store import Store
+
 # ── Data sources ──────────────────────────────────────────────────────────────
 from bootstack.data import (
     BaseDataSource, MemoryDataSource, SqliteDataSource,
@@ -145,6 +148,8 @@ __all__ = [
     "get_font_families", "set_font_family", "update_font_token",
     # Signals
     "Signal", "TraceOperation",
+    # Preferences store
+    "Store",
     # Data sources
     "BaseDataSource", "MemoryDataSource", "SqliteDataSource", "FileDataSource",
     "FileSourceConfig", "DataSourceProtocol", "Record", "Primitive",

--- a/src/bootstack/_core/paths.py
+++ b/src/bootstack/_core/paths.py
@@ -1,0 +1,49 @@
+"""Platform configuration paths for bootstack apps.
+
+A single home for the per-platform config directory convention so window-state
+persistence, `Store`, and anything else that writes user state all agree on
+where files live.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+__all__ = ["user_config_dir", "app_config_dir", "app_config_file"]
+
+
+def user_config_dir() -> Path:
+    """Return the OS user-configuration base directory.
+
+    `~/Library/Application Support` on macOS, `%APPDATA%` on Windows, and
+    `$XDG_CONFIG_HOME` (falling back to `~/.config`) elsewhere.
+    """
+    if sys.platform == "darwin":
+        return Path.home() / "Library" / "Application Support"
+    if sys.platform == "win32":
+        return Path(os.environ.get("APPDATA") or (Path.home() / "AppData" / "Roaming"))
+    return Path(os.environ.get("XDG_CONFIG_HOME") or (Path.home() / ".config"))
+
+
+def app_config_dir(app_name: str | None = None) -> Path:
+    """Return the per-app config directory under `user_config_dir()`.
+
+    The leaf is `app_name` (or `'bootstack'` when not given) so multiple
+    bootstack apps on one machine do not collide.
+
+    Args:
+        app_name: The application name, used as the directory leaf.
+    """
+    return user_config_dir() / (app_name or "bootstack")
+
+
+def app_config_file(filename: str, app_name: str | None = None) -> Path:
+    """Return the path to a named file inside the per-app config directory.
+
+    Args:
+        filename: The leaf file name (for example `'settings.json'`).
+        app_name: The application name, used as the directory leaf.
+    """
+    return app_config_dir(app_name) / filename

--- a/src/bootstack/_runtime/app.py
+++ b/src/bootstack/_runtime/app.py
@@ -705,19 +705,12 @@ class App(BaseWindow, WidgetCapabilitiesMixin, tkinter.Tk):
     def _state_file_path(self):
         """Return the path where this App's window state is persisted."""
         from pathlib import Path
-        import os
+        from bootstack._core.paths import app_config_file
         if self.settings.state_path:
             return Path(self.settings.state_path)
         # Per-platform config dir; leaf includes app_name to avoid collisions
         # between multiple bootstack apps installed on the same machine.
-        app_name = self.settings.app_name or 'bootstack'
-        if sys.platform == 'darwin':
-            base = Path.home() / 'Library' / 'Application Support'
-        elif sys.platform == 'win32':
-            base = Path(os.environ.get('APPDATA') or (Path.home() / 'AppData' / 'Roaming'))
-        else:
-            base = Path(os.environ.get('XDG_CONFIG_HOME') or (Path.home() / '.config'))
-        return base / app_name / 'window_state.json'
+        return app_config_file('window_state.json', self.settings.app_name)
 
     def _read_saved_geometry(self):
         """Return the persisted 'WxH+X+Y' string, or None if not present/valid."""

--- a/src/bootstack/errors.py
+++ b/src/bootstack/errors.py
@@ -21,11 +21,13 @@ class DuplicateIdError(BootstackError):
 
 
 class SerializationError(BootstackError):
-    """Raised when a persistent data source receives a value it cannot store.
+    """Raised when a file-backed store or data source receives a value it
+    cannot persist.
 
-    File- and database-backed sources carry non-scalar record fields as JSON,
-    so those values must be JSON-serializable (scalars, lists, dicts). Store
-    arbitrary Python objects in an in-memory source instead.
+    File- and database-backed sources carry non-scalar fields as JSON, and
+    `Store` persists its values as JSON, so values must be JSON-serializable
+    (scalars, lists, dicts). Store arbitrary Python objects in an in-memory
+    source instead.
     """
 
 

--- a/src/bootstack/store.py
+++ b/src/bootstack/store.py
@@ -1,0 +1,276 @@
+"""`Store` — a small, file-backed key-value store for application preferences.
+
+`Store` is the place to keep the little pieces of state an app wants to remember
+between runs: the chosen theme, a "show tips on startup" flag, recent files, the
+last-opened tab. It behaves like a dict, persists to a JSON file under the OS
+config directory, and writes through on every change by default.
+
+It is deliberately *not* a data source — there are no rows, ids, pagination, or
+queries. Reach for `MemoryDataSource` / `SqliteDataSource` for record-oriented
+data, and `Store` for "remember this setting".
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import os
+import threading
+from pathlib import Path
+from typing import Any, Iterator
+
+from bootstack._core.paths import app_config_file
+from bootstack.errors import SerializationError
+
+__all__ = ["Store"]
+
+_MISSING = object()
+
+
+def _active_app_name() -> str | None:
+    """Return the current App's name, or None when there is no active App."""
+    try:
+        from bootstack._runtime.app import get_app_settings
+
+        return get_app_settings().app_name
+    except Exception:
+        return None
+
+
+class Store:
+    """A persistent, dict-like key-value store for app preferences.
+
+    Construct one with a logical name and it lives at `<config>/<app>/<name>.json`
+    (the per-platform config directory — `Library/Application Support` on macOS,
+    `%APPDATA%` on Windows, `$XDG_CONFIG_HOME` on Linux), or pass an explicit
+    `path`. Read with `get()` or `store[key]`, write with `set()` or
+    `store[key] = value`; by default every change is saved immediately with an
+    atomic write, so a crash cannot corrupt the file.
+
+    Values must be JSON-serializable (scalars, lists, dicts); anything else
+    raises `SerializationError`. Keys must be strings. A missing or unreadable
+    file simply starts the store empty rather than raising.
+
+    `Store` does not require a running `App` — it is plain file I/O. When no
+    `app_name` is given it uses the active App's name if there is one, otherwise
+    `'bootstack'`.
+
+    Args:
+        name: Logical store name; the file is `<name>.json` under the per-app
+            config directory. Ignored when `path` is given.
+        path: An explicit file path, overriding `name`/`app_name`.
+        app_name: Override the per-app config sub-directory. Defaults to the
+            active App's name, or `'bootstack'`.
+        autosave: When True (default), persist on every change. When False,
+            changes stay in memory until `save()` is called.
+
+    Example:
+        ```python
+        store = bs.Store("settings")
+        app = bs.App(theme=store.get("theme", "light"))
+        # later, when the user switches theme:
+        store.set("theme", "bootstrap-dark")
+        ```
+    """
+
+    def __init__(
+        self,
+        name: str = "settings",
+        *,
+        path: str | os.PathLike[str] | None = None,
+        app_name: str | None = None,
+        autosave: bool = True,
+    ) -> None:
+        if path is not None:
+            self._path = Path(path)
+        else:
+            if not name:
+                raise ValueError("Store: provide a name or an explicit path=.")
+            leaf = str(name)
+            if not leaf.endswith(".json"):
+                leaf = f"{leaf}.json"
+            self._path = app_config_file(leaf, app_name or _active_app_name())
+        self._autosave = autosave
+        self._lock = threading.RLock()
+        self._data: dict[str, Any] = {}
+        self._load()
+
+    # ----- persistence -----
+
+    def _load(self) -> None:
+        try:
+            raw = self._path.read_text(encoding="utf-8")
+        except (FileNotFoundError, OSError):
+            self._data = {}
+            return
+        try:
+            data = json.loads(raw)
+        except (json.JSONDecodeError, ValueError):
+            # A corrupt file starts the store empty — prefs are not worth
+            # crashing an app over.
+            self._data = {}
+            return
+        self._data = data if isinstance(data, dict) else {}
+
+    def save(self) -> None:
+        """Write the store to disk now, atomically.
+
+        Useful when `autosave=False`, or to force a flush. Writes to a temporary
+        file and renames it over the target so a partial write never replaces
+        good data.
+
+        Raises:
+            OSError: If the directory cannot be created or the file written.
+        """
+        with self._lock:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            tmp = self._path.with_name(f"{self._path.name}.tmp")
+            try:
+                tmp.write_text(
+                    json.dumps(self._data, indent=2, sort_keys=True),
+                    encoding="utf-8",
+                )
+                os.replace(tmp, self._path)
+            except BaseException:
+                try:
+                    tmp.unlink()
+                except OSError:
+                    pass
+                raise
+
+    def reload(self) -> None:
+        """Discard in-memory state and re-read the store from disk."""
+        with self._lock:
+            self._load()
+
+    def _autosaved(self) -> None:
+        if self._autosave:
+            self.save()
+
+    @staticmethod
+    def _check_key(key: Any) -> None:
+        if not isinstance(key, str):
+            raise TypeError(
+                f"Store keys must be strings, got {type(key).__name__}."
+            )
+
+    @staticmethod
+    def _check_value(key: str, value: Any) -> None:
+        try:
+            json.dumps(value)
+        except (TypeError, ValueError) as exc:
+            raise SerializationError(
+                f"Store value for key {key!r} is not JSON-serializable: {exc}. "
+                f"A Store holds JSON values only (scalars, lists, dicts)."
+            ) from exc
+
+    @property
+    def path(self) -> Path:
+        """The file this store reads from and writes to."""
+        return self._path
+
+    # ----- core access -----
+
+    def get(self, key: str, default: Any = None) -> Any:
+        """Return the value for `key`, or `default` if it is not present."""
+        with self._lock:
+            return self._data.get(key, default)
+
+    def set(self, key: str, value: Any) -> None:
+        """Set `key` to `value` and (by default) persist immediately.
+
+        Args:
+            key: A string key.
+            value: A JSON-serializable value.
+
+        Raises:
+            TypeError: If `key` is not a string.
+            SerializationError: If `value` is not JSON-serializable.
+        """
+        self._check_key(key)
+        self._check_value(key, value)
+        with self._lock:
+            self._data[key] = value
+            self._autosaved()
+
+    def delete(self, key: str) -> None:
+        """Remove `key` if present; a no-op when it is missing."""
+        with self._lock:
+            if key in self._data:
+                del self._data[key]
+                self._autosaved()
+
+    def setdefault(self, key: str, default: Any = None) -> Any:
+        """Return `key`'s value, inserting `default` first if it is missing."""
+        self._check_key(key)
+        with self._lock:
+            if key not in self._data:
+                self._check_value(key, default)
+                self._data[key] = default
+                self._autosaved()
+            return self._data[key]
+
+    def update(self, values: "dict[str, Any]") -> None:
+        """Merge a mapping of values in, persisting once at the end."""
+        for key, value in values.items():
+            self._check_key(key)
+            self._check_value(key, value)
+        with self._lock:
+            if values:
+                self._data.update(values)
+                self._autosaved()
+
+    def clear(self) -> None:
+        """Remove every key, persisting the now-empty store."""
+        with self._lock:
+            if self._data:
+                self._data.clear()
+                self._autosaved()
+
+    def keys(self) -> list[str]:
+        """Return the keys, as a list snapshot."""
+        with self._lock:
+            return list(self._data.keys())
+
+    def values(self) -> list[Any]:
+        """Return the values, as a list snapshot."""
+        with self._lock:
+            return list(self._data.values())
+
+    def items(self) -> list[tuple[str, Any]]:
+        """Return the `(key, value)` pairs, as a list snapshot."""
+        with self._lock:
+            return list(self._data.items())
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return a deep copy of the store's contents as a plain dict."""
+        with self._lock:
+            return copy.deepcopy(self._data)
+
+    # ----- mapping protocol -----
+
+    def __getitem__(self, key: str) -> Any:
+        with self._lock:
+            return self._data[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.set(key, value)
+
+    def __delitem__(self, key: str) -> None:
+        with self._lock:
+            del self._data[key]
+            self._autosaved()
+
+    def __contains__(self, key: object) -> bool:
+        with self._lock:
+            return key in self._data
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self.keys())
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._data)
+
+    def __repr__(self) -> str:
+        return f"Store(path={str(self._path)!r}, keys={len(self)})"

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,0 +1,156 @@
+"""Tests for the public bs.Store preferences store.
+
+Store is plain file I/O (no App required), so these are headless and write to
+pytest's tmp_path.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+import bootstack as bs
+from bootstack.errors import SerializationError
+
+
+def _store(tmp_path, **kw):
+    return bs.Store(path=tmp_path / "settings.json", **kw)
+
+
+def test_set_get_roundtrip_and_persists(tmp_path):
+    s = _store(tmp_path)
+    s.set("theme", "dark")
+    assert s.get("theme") == "dark"
+    # A fresh store over the same file sees the persisted value.
+    assert _store(tmp_path).get("theme") == "dark"
+
+
+def test_get_default_for_missing_key(tmp_path):
+    s = _store(tmp_path)
+    assert s.get("missing") is None
+    assert s.get("missing", "fallback") == "fallback"
+
+
+def test_mapping_protocol(tmp_path):
+    s = _store(tmp_path)
+    s["a"] = 1
+    assert s["a"] == 1
+    assert "a" in s
+    assert len(s) == 1
+    assert list(s) == ["a"]
+    del s["a"]
+    assert "a" not in s
+    with pytest.raises(KeyError):
+        _ = s["a"]
+    with pytest.raises(KeyError):
+        del s["a"]
+
+
+def test_delete_is_noop_when_missing(tmp_path):
+    s = _store(tmp_path)
+    s.delete("nope")  # must not raise
+    s["x"] = 1
+    s.delete("x")
+    assert "x" not in s
+
+
+def test_update_setdefault_clear(tmp_path):
+    s = _store(tmp_path)
+    s.update({"a": 1, "b": 2})
+    assert s.as_dict() == {"a": 1, "b": 2}
+    assert s.setdefault("a", 99) == 1      # existing untouched
+    assert s.setdefault("c", 3) == 3       # inserted
+    assert sorted(s.keys()) == ["a", "b", "c"]
+    s.clear()
+    assert len(s) == 0
+    assert _store(tmp_path).as_dict() == {}  # cleared state persisted
+
+
+def test_keys_values_items_are_snapshots(tmp_path):
+    s = _store(tmp_path)
+    s.update({"a": 1, "b": 2})
+    assert sorted(s.keys()) == ["a", "b"]
+    assert sorted(s.values()) == [1, 2]
+    assert dict(s.items()) == {"a": 1, "b": 2}
+
+
+def test_json_values_supported(tmp_path):
+    s = _store(tmp_path)
+    s.set("nested", {"list": [1, 2, 3], "flag": True, "n": None})
+    assert _store(tmp_path).get("nested") == {"list": [1, 2, 3], "flag": True, "n": None}
+
+
+def test_non_json_value_raises(tmp_path):
+    s = _store(tmp_path)
+    with pytest.raises(SerializationError):
+        s.set("bad", object())
+    # Nothing was stored or written.
+    assert "bad" not in s
+    assert _store(tmp_path).as_dict() == {}
+
+
+def test_non_string_key_raises(tmp_path):
+    s = _store(tmp_path)
+    with pytest.raises(TypeError):
+        s.set(5, "v")  # type: ignore[arg-type]
+
+
+def test_missing_file_starts_empty(tmp_path):
+    s = bs.Store(path=tmp_path / "does_not_exist.json")
+    assert s.as_dict() == {}
+
+
+def test_corrupt_file_starts_empty(tmp_path):
+    p = tmp_path / "settings.json"
+    p.write_text("{not valid json", encoding="utf-8")
+    s = bs.Store(path=p)
+    assert s.as_dict() == {}
+
+
+def test_autosave_false_defers_until_save(tmp_path):
+    p = tmp_path / "settings.json"
+    s = bs.Store(path=p, autosave=False)
+    s.set("theme", "dark")
+    assert not p.exists()                 # nothing written yet
+    assert bs.Store(path=p).as_dict() == {}
+    s.save()
+    assert bs.Store(path=p).get("theme") == "dark"
+
+
+def test_reload_picks_up_external_change(tmp_path):
+    p = tmp_path / "settings.json"
+    s = bs.Store(path=p)
+    s.set("a", 1)
+    # Simulate another writer.
+    p.write_text(json.dumps({"a": 2}), encoding="utf-8")
+    assert s.get("a") == 1                # still cached
+    s.reload()
+    assert s.get("a") == 2
+
+
+def test_atomic_write_uses_real_filename(tmp_path):
+    p = tmp_path / "settings.json"
+    s = bs.Store(path=p)
+    s.set("k", "v")
+    assert p.exists()
+    assert not (tmp_path / "settings.json.tmp").exists()  # temp cleaned up
+
+
+def test_named_store_lands_in_config_dir(tmp_path, monkeypatch):
+    # name= resolves under the per-app config dir; redirect it to tmp_path.
+    import bootstack._core.paths as paths
+
+    monkeypatch.setattr(paths, "user_config_dir", lambda: tmp_path)
+    s = bs.Store("prefs", app_name="MyApp")
+    s.set("x", 1)
+    expected = tmp_path / "MyApp" / "prefs.json"
+    assert expected.exists()
+    assert s.path == expected
+
+
+def test_name_without_app_uses_bootstack(tmp_path, monkeypatch):
+    import bootstack._core.paths as paths
+
+    monkeypatch.setattr(paths, "user_config_dir", lambda: tmp_path)
+    s = bs.Store("prefs")
+    assert s.path == tmp_path / "bootstack" / "prefs.json"


### PR DESCRIPTION
## `bs.Store` — a file-backed preferences store

Adds a public, dict-like, JSON file-backed key-value store for the small pieces of state an app wants to remember between runs — the chosen theme, a "show tips" flag, recent files, the last-opened tab. It fills a real gap: there was no persistent K-V primitive (`MemoryDataSource` is RAM, `SqliteDataSource` is record-oriented, `AppSettings` is window-geometry-only).

It is deliberately **not** a data source — no rows, ids, paging, or queries.

```python
store = bs.Store("settings")                  # <config>/<app>/settings.json
app = bs.App(theme=store.get("theme", "bootstrap-light"))
# later, when the user switches theme:
store.set("theme", bs.get_theme())
```

### API

- `get` / `set` / `delete` / `setdefault` / `update` / `clear` / `keys` / `values` / `items` / `as_dict` / `reload` / `save` / `path`, plus the full mapping protocol (`store[k]`, `k in store`, `len(store)`, `iter(store)`).
- **Write-through by default** (`autosave=True`) with **atomic writes** (temp file + `os.replace`) so a crash mid-write can't corrupt prefs. `autosave=False` batches until `save()`.
- **JSON-only values** (`SerializationError` otherwise), **string keys**; a corrupt or missing file **starts the store empty** rather than raising.
- **No running `App` required** — plain file I/O. Files resolve to `<config>/<app>/<name>.json` (per-platform config dir), or pass `path=` / `app_name=`.

### Shared config-dir helper

Extracted the per-platform config-dir convention (previously inline in `app.py`) into `_core/paths.py` — `user_config_dir` / `app_config_dir` / `app_config_file` — and routed `App._state_file_path` (window-state) through it, so window-state and `Store` agree on locations. (The window-state JSON read/write itself was not otherwise changed.)

### Scope (decided, pre-release)

Standalone first. The `App(remember_theme=True)` convenience flag (mirroring `remember_window_state`) is a **queued fast-follow**, intentionally not built here — so the new `Store` API can settle through real use before `App` couples to it. Window-state persistence was deliberately **not** folded into `Store` (risk without user-facing value).

## Testing

`tests/test_store.py` (16 tests): set/get roundtrip + persistence, defaults, mapping protocol, no-op delete, `update`/`setdefault`/`clear`, snapshot views, nested JSON values, `SerializationError` on non-JSON, non-string keys, missing/corrupt file → empty, `autosave=False` deferral, `reload`, atomic-write cleanup, and config-dir resolution (with/without app name). Docs build generates `reference/store.html` with no new warnings. Existing data/cli suites pass (the pre-existing flaky `test_observable` is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
