### PR TITLE
Flatten AppSettings into flat App()/AppShell() configuration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,23 +91,25 @@ memories (see them for rationale and gotchas).
 
 ## Next up — candidates (pick one)
 
-- **Flatten `AppSettings` into the `App` constructor** (DESIGN DECIDED 2026-06-07,
-  not started; full design in memory `project_app_settings_flattening`) — config
-  is split-brain today (`title`/`size`/`theme` top-level but `locale`/`window_style`/
-  `remember_*` only via `settings={...}`). Promote settings fields to direct
-  `App(...)` kwargs as the single config path. **No public `AppSettings`, no
-  `app.settings`** — config is read/written as **app properties** (`app.theme`,
-  `app.title`, `app.locale`; derived ones like `app.date_format` read-only;
-  cohesive clusters may get a sub-namespace, likely just `app.localization.*`).
-  `AppSettings` survives only as an internal resolved-config holder. Drop public
-  `settings=` (pre-release, no shims — touch `AppShell` + examples). Persistence
-  falls out for free and retires `remember_*`: `bs.App(**store.as_dict())` restore
-  + explicit write-back; keep ONE built-in `remember_window_state` flag for the
-  fiddly geometry string; consider a tolerant `App.from_store()` (version-skew
-  filtering). `bs.Store` stays the separate persistence layer. Riskiest change
-  (central constructor) → its own focused PR.
+- **Flatten `AppSettings` into the `App` constructor** — DONE (branch
+  `feat/app-settings-flatten`, awaiting test/merge; memory
+  `project_app_settings_flattening`). All former `AppSettings` fields are now flat
+  `App(...)`/`AppShell(...)` kwargs (the single config path); public
+  `settings=`/`AppSettings`/`get_app_settings`/`app.settings` are GONE (clean
+  break — `settings=` raises `TypeError`). Config reads/writes as symmetric
+  `app.*` properties (LOCALE SURFACE IS FLAT, not a namespace — decided this
+  session: `app.locale`/`app.localize_mode` set live, derived read-only
+  `app.locale_date_format`/`_time_format`/`_decimal`/`_thousands`/`_language`).
+  The derived format fields were dropped as *inputs* (they were dead — nothing
+  reads them; `IntlFormatter` re-derives from `locale`). `AppConfigMixin` +
+  `APP_CONFIG_KWARGS` in `widgets/_core/app_config.py`; `app.on_theme_change`/
+  `on_locale_change` events; `App.from_store(store)` (version-skew tolerant) +
+  `Store.update(**kwargs)`. `remember_theme` was DEFERRED (store-splat covers it;
+  `remember_window_state` stays the only built-in remember flag).
 - **Deferred file-streaming items** — background/progressive ingest, keyset
   pagination, auto-index (memory `project_file_source_streaming`).
+- **Reference docs example pass** — enrich `docs/reference/*` (esp. `store.rst`
+  persistence patterns now that `from_store`/`update(**kwargs)` exist).
 
 ## Carryover (deferred)
 
@@ -495,9 +497,23 @@ Path is file-relative from `docs/api/`. Omit from dialog pages.
 ### Widgets and API
 - **`disabled` on Label** — not appropriate. Label is display-only.
 - **`color=` / `background_color=`** — removed. Use `accent=` / `surface=`.
-- **`bs.App` accepts `theme=`** directly (overrides the `"theme"` key in
-  `settings` if both given). `light_theme=`/`dark_theme=` are NOT direct params —
-  set those via `settings={"light_theme": ..., "dark_theme": ...}`.
+- **`bs.App` / `bs.AppShell` config is FLAT kwargs** (settings-flattening, branch
+  `feat/app-settings-flatten`). All former `AppSettings` fields are direct
+  constructor kwargs — `theme`, `light_theme`, `dark_theme`,
+  `follow_system_appearance`, `available_themes`, `inherit_surface_color`,
+  `locale`, `localize_mode`, `window_style`, `macos_quit_behavior`,
+  `remember_window_state`, `state_path`, `app_author`, `app_version`. There is
+  **NO public `settings=` / `AppSettings` / `app.settings`** (clean break, no
+  shim — passing `settings=` raises `TypeError`). `AppSettings` survives only as
+  an internal resolved-config holder; `get_app_settings()` is internal-only.
+  Read/write config as symmetric `app.*` properties: `app.theme`/`app.locale`/
+  `app.title` set live; locale-derived values are flat read-only props
+  (`app.locale_date_format`, `app.locale_time_format`, `app.locale_decimal`,
+  `app.locale_thousands`, `app.locale_language`). Config-change events:
+  `app.on_theme_change(fn)` (→ theme name) and `app.on_locale_change(fn)`
+  (→ locale code). Persistence: `bs.App.from_store(store)` (tolerant of version
+  skew — filters to known kwargs) + `store.update(theme=...)` write-back. Shared
+  impl in `widgets/_core/app_config.py` (`AppConfigMixin`, `APP_CONFIG_KWARGS`).
 - **`bs.Signal()` crashes at module level** — must be inside `with bs.App():`.
 - **`textsignal=`** — standard kwarg for text-bearing widgets. `signal=` for non-text
   (Slider, Checkbox, etc.). Never expose `textvariable=` / `variable=` publicly.
@@ -663,7 +679,7 @@ with bs.App(title="My App", size=(800,600), padding=16, gap=8) as app:
 app.run()
 
 # AppShell
-with bs.AppShell(title="My App", settings={"theme": "bootstrap-light"}) as shell:
+with bs.AppShell(title="My App", theme="bootstrap-light") as shell:
     shell.toolbar.add_button(icon="sun", command=bs.toggle_theme)
     with shell.add_page("home", text="Home", icon="house"):
         bs.Label("Welcome!")

--- a/docs/production/app-settings.rst
+++ b/docs/production/app-settings.rst
@@ -1,4 +1,190 @@
-App Settings
-============
+App configuration
+=================
 
-.. note:: Coming soon.
+An app is configured entirely through flat constructor keyword arguments, and
+that same configuration is read and changed at runtime through matching ``app.*``
+properties. What goes in comes back out symmetrically — ``bs.App(theme=...)`` in,
+``app.theme`` out — so there is no separate settings object to construct, inject,
+or look up. The same surface is shared by :class:`App
+<bootstack.widgets.app.App>` and :class:`AppShell
+<bootstack.widgets.appshell.AppShell>`.
+
+.. code-block:: python
+
+   import bootstack as bs
+
+   with bs.App(
+       title="My App",
+       theme="bootstrap-dark",
+       locale="de_DE",
+       size=(900, 600),
+   ) as app:
+       bs.Label("Hallo!")
+   app.run()
+
+Reading and changing configuration
+----------------------------------
+
+Every configuration option is a property on the app. Reading returns the current
+value; assigning changes it, and for the options the toolkit can change live
+(theme, locale, title) the change takes effect immediately:
+
+.. code-block:: python
+
+   app.theme                       # 'bootstrap-dark'
+   app.theme = "bootstrap-light"   # switches the theme now
+   app.title = "Renamed window"    # updates the title bar now
+   app.locale = "fr_FR"            # re-localizes now
+
+The available options:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 18 52
+
+   * - Property
+     - Access
+     - Meaning
+   * - ``title``
+     - read/write
+     - Window title bar text and the app's display name.
+   * - ``theme``
+     - read/write
+     - Active theme name; assigning switches the theme live.
+   * - ``light_theme`` / ``dark_theme``
+     - read/write
+     - The pair ``toggle_theme()`` and system-appearance tracking switch between.
+   * - ``follow_system_appearance``
+     - read/write
+     - Track the OS light/dark setting (currently effective on macOS).
+   * - ``available_themes``
+     - read/write
+     - Theme names to expose to theme pickers; empty means all registered.
+   * - ``inherit_surface_color``
+     - read/write
+     - Whether child widgets inherit the parent's surface color.
+   * - ``locale``
+     - read/write
+     - Active locale (e.g. ``'en_US'``); assigning re-localizes live.
+   * - ``localize_mode``
+     - read/write
+     - Localization behavior — ``'auto'``, ``True``, or ``False``.
+   * - ``locale_language``
+     - read-only
+     - Base language derived from the locale (e.g. ``'de'``).
+   * - ``locale_date_format`` / ``locale_time_format``
+     - read-only
+     - Short date / time pattern for the active locale.
+   * - ``locale_decimal`` / ``locale_thousands``
+     - read-only
+     - Decimal / thousands separator for the active locale.
+   * - ``window_style``
+     - read/write
+     - Windows-only window effect (``'mica'``, ``'acrylic'``, …) or ``None``.
+   * - ``macos_quit_behavior``
+     - read/write
+     - macOS close / Cmd+Q behavior — ``'native'`` or ``'classic'``.
+   * - ``remember_window_state``
+     - read/write
+     - Save the window geometry on close and restore it next launch.
+   * - ``state_path``
+     - read/write
+     - Override path for the persisted window-state file.
+
+Theme and appearance
+--------------------
+
+Set the startup theme with ``theme=``; switch it later through ``app.theme`` or
+the global ``bs.toggle_theme()`` / ``bs.set_theme()`` helpers. ``toggle_theme``
+flips between the ``light_theme`` and ``dark_theme`` pair:
+
+.. code-block:: python
+
+   app = bs.App(theme="bootstrap-light",
+                light_theme="bootstrap-light",
+                dark_theme="bootstrap-dark")
+
+   bs.Button("Toggle", on_click=bs.toggle_theme)
+
+On macOS, ``follow_system_appearance=True`` switches between the light and dark
+themes automatically when the user changes the OS appearance. See
+:doc:`/reference/theming` for defining and installing custom themes.
+
+Localization
+------------
+
+``locale=`` sets the active locale; ``localize_mode=`` controls whether widget
+text is auto-localized. The locale-derived formatting values are exposed as
+read-only properties (they are computed from the locale, so they update whenever
+``app.locale`` changes):
+
+.. code-block:: python
+
+   app = bs.App(locale="de_DE")
+   app.locale_date_format    # 'dd.MM.yy'
+   app.locale_decimal        # ','
+
+   app.locale = "en_US"
+   app.locale_decimal        # '.'
+
+Reacting to changes
+-------------------
+
+Subscribe to configuration changes to keep other state in sync — the handler
+receives the new value directly:
+
+.. code-block:: python
+
+   app.on_theme_change(lambda theme: print("theme is now", theme))
+   app.on_locale_change(lambda locale: print("locale is now", locale))
+
+Like other event hooks, calling these without a handler returns a composable
+:doc:`stream </reference/streams>`.
+
+Persisting configuration
+------------------------
+
+Because configuration is flat keyword arguments and a :class:`Store
+<bootstack.store.Store>` is a flat dict, persistence is symmetric: splat the
+store in to restore on startup, and write each value back when it changes.
+``App.from_store()`` does the restore and *tolerantly ignores keys that are not
+valid configuration*, so a settings file from an older or newer version (with
+renamed or removed keys) still loads cleanly instead of raising:
+
+.. code-block:: python
+
+   store = bs.Store("settings")          # app config, in its own store
+
+   app = bs.App.from_store(store)        # restore; empty store → defaults
+   app.on_theme_change(lambda theme: store.update(theme=theme))
+   app.on_locale_change(lambda locale: store.update(locale=locale))
+   app.run()
+
+``AppShell.from_store()`` works the same way. A few practices keep this clean:
+
+- **Keep app *config* separate from app *state*.** Put restorable configuration
+  (theme, locale) in one store and transient state (recent files, last-opened
+  tab) in another, so ``from_store`` only ever sees real configuration keys.
+- **Window geometry is the one exception.** It is a fiddly ``"WxH+X+Y"`` string
+  updated continuously as the window moves, not a clean keyword — let the
+  built-in ``remember_window_state=True`` flag handle it rather than the store.
+- **Per-value write-back, not a config dump.** React to the specific change
+  events and write just that key.
+
+Window state persistence
+------------------------
+
+``remember_window_state=True`` saves the window's size and position when it
+closes and restores them on the next launch (off-screen positions are clamped
+back onto a visible monitor). It is stored in a per-app file under the OS config
+directory; pass ``state_path=`` to override the location.
+
+.. code-block:: python
+
+   bs.App(title="My App", remember_window_state=True)
+
+See also
+--------
+
+- :doc:`/reference/theming` — defining themes and the values worth persisting.
+- :doc:`/reference/store` — the preferences store and persistence patterns.

--- a/docs/reference/store.rst
+++ b/docs/reference/store.rst
@@ -59,11 +59,12 @@ Bulk and dict-like operations
 -----------------------------
 
 ``Store`` supports the familiar mapping methods; ``update()`` writes once at the
-end rather than per key:
+end rather than per key, and accepts a mapping, keyword arguments, or both:
 
 .. code-block:: python
 
    store.update({"theme": "dark", "font_scale": 1.2})
+   store.update(theme="dark", locale="de_DE")     # keyword form
    store.setdefault("locale", "en_US")
    store.keys(); store.values(); store.items()
    len(store); list(store)
@@ -96,11 +97,39 @@ creating the app, and write it whenever it changes:
    store = bs.Store("settings")
 
    with bs.App(theme=store.get("theme", "bootstrap-light")) as app:
-       def on_toggle():
-           bs.toggle_theme()
-           store.set("theme", bs.get_theme())
-       bs.Button("Toggle theme", on_click=on_toggle)
+       app.on_theme_change(lambda theme: store.update(theme=theme))
+       bs.Button("Toggle theme", on_click=bs.toggle_theme)
    app.run()
+
+Persisting app configuration
+----------------------------
+
+Because app configuration is flat ``App(...)`` kwargs and a ``Store`` is a flat
+dict, the whole persistence story is symmetric: splat the store in to restore,
+and write each value back when it changes. ``App.from_store()`` does the restore
+and *tolerantly ignores keys that are not valid configuration*, so a settings
+file written by an older or newer version (with renamed or removed keys) still
+loads cleanly instead of raising:
+
+.. code-block:: python
+
+   store = bs.Store("settings")          # app config, in its own store
+
+   app = bs.App.from_store(store)        # restore; empty store → defaults
+   app.on_theme_change(lambda theme: store.update(theme=theme))
+   app.on_locale_change(lambda locale: store.update(locale=locale))
+   app.run()
+
+A few practices keep this clean:
+
+- **Keep app *config* separate from app *state*.** Put restorable configuration
+  (theme, locale) in one store and transient state (recent files, last-opened
+  tab) in another, so ``App.from_store`` only ever sees real config keys.
+- **Window geometry is the one exception.** It is a fiddly ``"WxH+X+Y"`` string
+  updated continuously as the window moves, not a clean kwarg — let the built-in
+  ``remember_window_state=True`` flag handle it rather than the store.
+- **Per-value write-back, not a config dump.** React to the specific change
+  events (``on_theme_change``/``on_locale_change``) and write just that key.
 
 See also
 --------

--- a/docs/reference/theming.rst
+++ b/docs/reference/theming.rst
@@ -30,11 +30,11 @@ Choose the starting theme through the app settings, then switch at runtime with
 
 .. note::
 
-   ``bs.App`` accepts ``theme=`` directly; it overrides the ``"theme"`` key in
-   ``settings`` if both are given. The pair that ``toggle_theme`` switches between
-   comes from the ``light_theme`` and ``dark_theme`` settings (default
-   ``"bootstrap-light"`` and ``"bootstrap-dark"``), which are set through
-   ``settings=``.
+   ``bs.App`` accepts ``theme=`` directly to set the startup theme, and the
+   active theme can be read or changed at runtime through ``app.theme``. The
+   pair that ``toggle_theme`` switches between comes from the ``light_theme``
+   and ``dark_theme`` options (default ``"bootstrap-light"`` and
+   ``"bootstrap-dark"``), passed as ``bs.App`` kwargs.
 
 Listing the available themes
 ----------------------------
@@ -135,7 +135,7 @@ once.
 
    Custom themes work best in pairs. Providing a light **and** a dark variant lets
    users switch appearance with ``toggle_theme()``. Point the ``light_theme`` and
-   ``dark_theme`` settings at your two themes to make them the toggle pair — it is
+   ``dark_theme`` options at your two themes to make them the toggle pair — it is
    not required, but recommended:
 
    .. code-block:: python
@@ -147,7 +147,8 @@ once.
 
       with bs.App(
           theme="amber-light",
-          settings={"light_theme": "amber-light", "dark_theme": "amber-dark"},
+          light_theme="amber-light",
+          dark_theme="amber-dark",
       ) as app:
           bs.Button("Toggle", on_click=bs.toggle_theme)
       app.run()

--- a/docs/scripts/take_screenshots.py
+++ b/docs/scripts/take_screenshots.py
@@ -57,9 +57,8 @@ def _patch(cls):
     orig_run  = cls.run
 
     def _init(self, *args, **kwargs):
-        settings = dict(kwargs.pop("settings", None) or {})
-        settings["theme"] = theme
-        orig_init(self, *args, settings=settings, **kwargs)
+        kwargs.pop("theme", None)
+        orig_init(self, *args, theme=theme, **kwargs)
 
     def _run(self):
         def _grab():

--- a/docs/widgets/appshell.rst
+++ b/docs/widgets/appshell.rst
@@ -145,6 +145,41 @@ Events
    # Stream form
    shell.on_page_change().listen(lambda e: print(shell.current))
 
+Theme, locale, and configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Like :class:`App <bootstack.widgets.app.App>`, an ``AppShell`` is configured
+through flat constructor keyword arguments, and the same options are read and
+changed at runtime through ``shell.*`` properties. Assigning ``shell.theme`` or
+``shell.locale`` takes effect live.
+
+.. code-block:: python
+
+   shell = bs.AppShell(
+       title="My App",
+       theme="bootstrap-dark",
+       light_theme="ocean-light",
+       dark_theme="ocean-dark",
+       locale="de_DE",
+   )
+
+   shell.theme = "bootstrap-light"     # switch the theme now
+   shell.toolbar.add_button(icon="sun-moon", command=bs.toggle_theme)
+
+React to changes and persist them across launches with a :class:`Store
+<bootstack.store.Store>` — ``from_store()`` restores configuration and tolerates
+version skew, and the change events write each value back:
+
+.. code-block:: python
+
+   store = bs.Store("settings")
+   shell = bs.AppShell.from_store(store, title="My App")
+   shell.on_theme_change(lambda theme: store.update(theme=theme))
+
+See :doc:`/production/app-settings` for the full configuration reference —
+every option, the locale-derived read-only properties, and window-state
+persistence.
+
 Window options
 ~~~~~~~~~~~~~~
 

--- a/src/bootstack/__init__.py
+++ b/src/bootstack/__init__.py
@@ -53,7 +53,7 @@ from bootstack.validation import ValidationRule, ValidationResult
 
 # ── Utilities ─────────────────────────────────────────────────────────────────
 from bootstack._core.images import Image
-from bootstack._runtime.app import AppSettings, get_app_settings, get_current_app
+from bootstack._runtime.app import get_current_app
 from bootstack.shortcuts import Shortcuts, Shortcut, get_shortcuts
 
 # ── Widget type aliases ───────────────────────────────────────────────────────
@@ -163,7 +163,7 @@ __all__ = [
     "BootstackError", "UnknownEventError", "ParentResolutionError", "DuplicateIdError",
     "SerializationError",
     # App, shortcuts, images
-    "AppSettings", "get_app_settings", "get_current_app",
+    "get_current_app",
     "Shortcuts", "Shortcut", "get_shortcuts", "Image",
     # Type aliases
     "BaseWidgetKwargs", "StyledKwargs", "Anchor", "BorderMode", "CompoundMode",

--- a/src/bootstack/_runtime/app.py
+++ b/src/bootstack/_runtime/app.py
@@ -26,9 +26,6 @@ from bootstack._runtime.utility import enable_high_dpi_awareness
 
 _current_app: App | None = None
 
-# Sentinel for "use settings default"
-_USE_SETTINGS = object()
-
 
 def set_current_app(app: App) -> None:
     """Set the process-wide current App instance.
@@ -215,11 +212,14 @@ LocalizeMode = Union[bool, Literal['auto']]
 
 @dataclass
 class AppSettings:
-    """Application-wide settings for bootstack applications.
+    """Internal resolved-configuration holder for an `App`.
 
-    This dataclass holds configuration for theming, localization, and
-    application metadata. It is automatically populated with sensible
-    defaults based on the system locale.
+    This is an INTERNAL detail — it is not part of the public API. Users
+    configure an app through flat `App(...)` constructor kwargs and read or
+    write configuration through `app.*` properties; `App.__init__` assembles
+    those kwargs into one of these instances. It holds configuration for
+    theming, localization, and application metadata, and is automatically
+    populated with sensible locale-based defaults in `__post_init__`.
 
     Attributes:
         app_name: The application name displayed in the title bar.
@@ -270,24 +270,6 @@ class AppSettings:
             directory (Library/Application Support on macOS, %APPDATA% on
             Windows, $XDG_CONFIG_HOME on Linux). The leaf filename includes
             `app_name` so multiple bootstack apps don't collide.
-
-    Examples:
-        ```python
-        # Create app with default settings
-        app = App()
-
-        # Create app with custom settings
-        settings = AppSettings(
-            app_name="My App",
-            theme="dark",
-            locale="de_DE"
-        )
-        app = App(settings=settings)
-
-        # Access settings
-        print(app.settings.locale)  # 'de_DE'
-        print(app.settings.date_format)  # 'd.M.yy'
-        ```
     """
     # information
     app_name: str | None = None
@@ -324,36 +306,6 @@ class AppSettings:
     def __post_init__(self):
         """Populate localization defaults when not explicitly configured."""
         _apply_localization_defaults(self)
-
-
-class AppSettingsKwargs(TypedDict, total=False):
-    app_name: str
-    app_author: str
-    app_version: str
-
-    # theme
-    theme: str
-    light_theme: str
-    dark_theme: str
-    follow_system_appearance: bool
-    available_themes: Sequence[str]
-    inherit_surface_color: bool
-
-    # localization
-    locale: str
-    language: str
-    date_format: str
-    time_format: str
-    number_decimal: str
-    number_thousands: str
-
-    # platform-specific
-    window_style: str | None
-    macos_quit_behavior: str
-
-    # window state persistence
-    remember_window_state: bool
-    state_path: str | None
 
 
 DEFAULT_LOCALE = "en_US"
@@ -446,11 +398,32 @@ class App(BaseWindow, WidgetCapabilitiesMixin, tkinter.Tk):
     def __init__(
             self,
             title: str | None = None,
+            *,
             theme: str | None = None,
             icon: tkinter.PhotoImage | None = None,
 
-            settings: AppSettings | AppSettingsKwargs | None = None,
-            localize: LocalizeMode | None = None,
+            # application identity
+            app_author: str | None = None,
+            app_version: str | None = None,
+
+            # theme
+            light_theme: str = "bootstrap-light",
+            dark_theme: str = "bootstrap-dark",
+            follow_system_appearance: bool = False,
+            available_themes: Sequence[str] = (),
+            inherit_surface_color: bool = True,
+
+            # localization
+            locale: str | None = None,
+            localize_mode: LocalizeMode = "auto",
+
+            # platform
+            window_style: str | None = "mica",
+            macos_quit_behavior: str = "native",
+
+            # window-state persistence
+            remember_window_state: bool = False,
+            state_path: str | None = None,
 
             # window settings
             size: tuple[int, int] | None = None,
@@ -463,7 +436,6 @@ class App(BaseWindow, WidgetCapabilitiesMixin, tkinter.Tk):
             alpha: float = 1.0,
             transient: object | None = None,
             override_redirect: bool = False,
-            window_style: str | None | object = _USE_SETTINGS,
             center_on_screen: bool = True,
             on_close: Callable | None = None,
             **kwargs: Unpack[TkKwargs],
@@ -471,18 +443,39 @@ class App(BaseWindow, WidgetCapabilitiesMixin, tkinter.Tk):
         """Initializes the application window.
 
         Args:
-            title: The text to display in the window's title bar. This
-                overrides the `app_name` in `settings` if provided.
-            theme: The name of the theme to use. This overrides the `theme`
-                in `settings` if provided.
+            title: The text to display in the window's title bar, and the
+                application name used for config-directory and taskbar
+                identity. Defaults to `'bootstack'`.
+            theme: The name of the theme to use on startup (e.g.
+                `'bootstrap-dark'`). Defaults to the built-in light theme.
             icon: A PhotoImage or file path used for the window's icon.
                 If None, the default bootstack.png icon is used.
-            settings: A dictionary or `AppSettings` object containing
-                application-wide settings. If not provided, default settings
-                are used.
-            localize: The localization mode for the application. Can be
-                'auto', `True`, or `False`. This overrides the `localize_mode`
-                in `settings`.
+            app_author: Application author. Reserved for config-path use.
+            app_version: Application version string.
+            light_theme: Theme used when following system appearance and the
+                OS is in light mode, and as the light end of `toggle_theme`.
+            dark_theme: Theme used when following system appearance and the
+                OS is in dark mode, and as the dark end of `toggle_theme`.
+            follow_system_appearance: If True, switch between `light_theme`
+                and `dark_theme` to match the OS and track changes at runtime
+                (currently effective on macOS).
+            available_themes: Sequence of theme names to expose to theme
+                pickers. Empty means all registered themes.
+            inherit_surface_color: If True, child widgets inherit the
+                parent's surface color for consistent backgrounds.
+            locale: Locale identifier (e.g. `'en_US'`, `'de_DE'`).
+                Auto-detected from the system when not given.
+            localize_mode: Controls localization behavior. `'auto'` enables
+                localization based on locale, `True` always enables, `False`
+                disables.
+            window_style: Windows-only effect for all windows (`'mica'`,
+                `'acrylic'`, `'aero'`, `'transparent'`, `'win7'`). Defaults
+                to `'mica'`; set to None to disable.
+            macos_quit_behavior: How close/Cmd+Q behave on macOS, `'native'`
+                (default) or `'classic'`. No-op on Win/Linux.
+            remember_window_state: If True, the window geometry is saved on
+                close and restored on next launch.
+            state_path: Optional override for where window state is stored.
             size: A tuple specifying the window's initial width and height.
             position: A tuple specifying the window's initial x and y
                 coordinates on the screen.
@@ -508,25 +501,30 @@ class App(BaseWindow, WidgetCapabilitiesMixin, tkinter.Tk):
                 underlying `tkinter.Tk` constructor.
         """
         # --- Settings ---------------------------------------------------
-        if settings is None:
-            self.settings = AppSettings()
-        elif isinstance(settings, AppSettings):
-            self.settings = settings
-        else:
-            self.settings = AppSettings(**settings)
+        # Flat constructor kwargs are the single configuration path; they are
+        # assembled into an internal AppSettings holder (which derives locale
+        # formats in __post_init__). There is no public AppSettings / settings=.
+        self.settings = AppSettings(
+            app_name=title,
+            app_author=app_author,
+            app_version=app_version,
+            theme=theme if theme is not None else "light",
+            light_theme=light_theme,
+            dark_theme=dark_theme,
+            follow_system_appearance=follow_system_appearance,
+            available_themes=available_themes,
+            inherit_surface_color=inherit_surface_color,
+            locale=locale,
+            localize_mode=localize_mode,
+            window_style=window_style,
+            macos_quit_behavior=macos_quit_behavior,
+            remember_window_state=remember_window_state,
+            state_path=state_path,
+        )
 
-        # App-level overrides from ctor
-        if theme is not None:
-            self.settings.theme = theme
-        if title is not None:
-            self.settings.app_name = title
-
-        # If app_name is still None, give it a sensible default
+        # If no title/app_name was given, fall back to a sensible default.
         if self.settings.app_name is None:
             self.settings.app_name = "bootstack"
-
-        if localize is not None:
-            self.settings.localize_mode = localize
 
         # --- Window options ---------------------------------------------
         self._size = size
@@ -627,8 +625,6 @@ class App(BaseWindow, WidgetCapabilitiesMixin, tkinter.Tk):
             saved_geometry = self._read_saved_geometry()
 
         # Setup window using BaseWindow
-        # Use window_style from parameter if explicitly provided, otherwise use settings
-        _window_style = self.settings.window_style if window_style is _USE_SETTINGS else window_style
         self._setup_window(
             title=self.settings.app_name,
             size=self._size,
@@ -639,7 +635,7 @@ class App(BaseWindow, WidgetCapabilitiesMixin, tkinter.Tk):
             transient=self._transient,
             overrideredirect=self._override_redirect,
             alpha=self._alpha,
-            window_style=_window_style,
+            window_style=self.settings.window_style,
         )
 
         if saved_geometry is not None:

--- a/src/bootstack/cli/demo.py
+++ b/src/bootstack/cli/demo.py
@@ -689,7 +689,7 @@ def run_demo():
     """Run the bootstack widget gallery as an AppShell application."""
     with bs.AppShell(
         title="Widget Gallery",
-        settings={"theme": "bootstrap-light"},
+        theme="bootstrap-light",
         size=(1100, 750),
     ) as shell:
 

--- a/src/bootstack/cli/templates/__init__.py
+++ b/src/bootstack/cli/templates/__init__.py
@@ -31,7 +31,7 @@ def main() -> None:
     """Application entry point."""
     with bs.App(
         title="{app_name}",
-        settings={{"theme": os.environ.get("BOOTSTACK_THEME", "{theme}")}},
+        theme=os.environ.get("BOOTSTACK_THEME", "{theme}"),
         size=(800, 600),
     ) as app:
         MainView()
@@ -322,7 +322,7 @@ def main() -> None:
     """Application entry point."""
     with bs.AppShell(
         title="{app_name}",
-        settings={{"theme": os.environ.get("BOOTSTACK_THEME", "{theme}")}},
+        theme=os.environ.get("BOOTSTACK_THEME", "{theme}"),
         size=(1000, 650),
     ) as shell:
         shell.toolbar.add_button(icon="sun", on_click=bs.toggle_theme)

--- a/src/bootstack/store.py
+++ b/src/bootstack/store.py
@@ -210,14 +210,24 @@ class Store:
                 self._autosaved()
             return self._data[key]
 
-    def update(self, values: "dict[str, Any]") -> None:
-        """Merge a mapping of values in, persisting once at the end."""
-        for key, value in values.items():
+    def update(self, values: "dict[str, Any] | None" = None, **kwargs: Any) -> None:
+        """Merge values in, persisting once at the end.
+
+        Accepts a mapping, keyword arguments, or both (mirroring `dict.update`),
+        so `store.update(theme="dark")` and `store.update({"theme": "dark"})`
+        are equivalent.
+        """
+        merged: dict[str, Any] = {}
+        if values:
+            merged.update(values)
+        if kwargs:
+            merged.update(kwargs)
+        for key, value in merged.items():
             self._check_key(key)
             self._check_value(key, value)
         with self._lock:
-            if values:
-                self._data.update(values)
+            if merged:
+                self._data.update(merged)
                 self._autosaved()
 
     def clear(self) -> None:

--- a/src/bootstack/widgets/_core/app_config.py
+++ b/src/bootstack/widgets/_core/app_config.py
@@ -1,0 +1,323 @@
+"""Flat configuration properties shared by `App` and `AppShell`.
+
+The public app surface exposes configuration as flat `app.*` properties, so
+that what goes in through the constructor comes back out symmetrically:
+`App(theme=...)` in, `app.theme` out. Settable knobs reflect live where the
+machinery supports a runtime change (theme, locale, title); locale-derived
+formats are read-only.
+
+`AppConfigMixin` delegates to the internal runtime `App` returned by
+`_config_app()`, which each public class implements.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Callable, Sequence, overload
+
+from bootstack.events import Subscription
+
+if TYPE_CHECKING:
+    from bootstack.streams import Stream
+
+
+class AppConfigMixin:
+    """Mixin providing flat configuration properties for the public app.
+
+    Subclasses must implement `_config_app()` to return the internal runtime
+    `App` (a `tkinter.Tk` subclass) whose `settings` holds the resolved
+    configuration.
+    """
+
+    def _config_app(self) -> Any:
+        """Return the internal runtime `App` backing this public app."""
+        raise NotImplementedError
+
+    @property
+    def _settings(self) -> Any:
+        return self._config_app().settings
+
+    # ----- identity -----
+
+    @property
+    def title(self) -> str:
+        """The window title bar text (also the app's display name)."""
+        return self._config_app().title()
+
+    @title.setter
+    def title(self, value: str) -> None:
+        app = self._config_app()
+        app.title(value)
+        app.settings.app_name = value
+
+    @property
+    def name(self) -> str | None:
+        """The application name used for config-directory and taskbar identity."""
+        return self._settings.app_name
+
+    @name.setter
+    def name(self, value: str) -> None:
+        self._settings.app_name = value
+
+    @property
+    def app_author(self) -> str | None:
+        """The application author (reserved for config-path use)."""
+        return self._settings.app_author
+
+    @app_author.setter
+    def app_author(self, value: str | None) -> None:
+        self._settings.app_author = value
+
+    @property
+    def app_version(self) -> str | None:
+        """The application version string."""
+        return self._settings.app_version
+
+    @app_version.setter
+    def app_version(self, value: str | None) -> None:
+        self._settings.app_version = value
+
+    # ----- theme -----
+
+    @property
+    def theme(self) -> str:
+        """The active theme name. Setting it switches the theme live."""
+        from bootstack.style.style import get_theme
+        return get_theme()
+
+    @theme.setter
+    def theme(self, value: str) -> None:
+        from bootstack.style.style import set_theme
+        set_theme(value)
+        self._settings.theme = value
+
+    @property
+    def light_theme(self) -> str:
+        """Theme used for the light end of system-appearance / `toggle_theme`."""
+        return self._settings.light_theme
+
+    @light_theme.setter
+    def light_theme(self, value: str) -> None:
+        self._settings.light_theme = value
+
+    @property
+    def dark_theme(self) -> str:
+        """Theme used for the dark end of system-appearance / `toggle_theme`."""
+        return self._settings.dark_theme
+
+    @dark_theme.setter
+    def dark_theme(self, value: str) -> None:
+        self._settings.dark_theme = value
+
+    @property
+    def follow_system_appearance(self) -> bool:
+        """Whether the app tracks the OS light/dark appearance (macOS)."""
+        return self._settings.follow_system_appearance
+
+    @follow_system_appearance.setter
+    def follow_system_appearance(self, value: bool) -> None:
+        self._settings.follow_system_appearance = value
+
+    @property
+    def available_themes(self) -> Sequence[str]:
+        """Theme names exposed to theme pickers (empty means all registered)."""
+        return self._settings.available_themes
+
+    @available_themes.setter
+    def available_themes(self, value: Sequence[str]) -> None:
+        self._settings.available_themes = value
+
+    @property
+    def inherit_surface_color(self) -> bool:
+        """Whether child widgets inherit the parent's surface color."""
+        return self._settings.inherit_surface_color
+
+    @inherit_surface_color.setter
+    def inherit_surface_color(self, value: bool) -> None:
+        self._settings.inherit_surface_color = value
+
+    # ----- localization -----
+
+    @property
+    def locale(self) -> str | None:
+        """The active locale (e.g. `'en_US'`). Setting it switches locale live."""
+        return self._settings.locale
+
+    @locale.setter
+    def locale(self, value: str) -> None:
+        from bootstack.i18n.msgcat import MessageCatalog
+        MessageCatalog.locale(value)
+        self._settings.locale = value
+
+    @property
+    def localize_mode(self) -> Any:
+        """Localization behavior — `'auto'`, `True`, or `False`."""
+        return self._settings.localize_mode
+
+    @localize_mode.setter
+    def localize_mode(self, value: Any) -> None:
+        self._settings.localize_mode = value
+
+    @property
+    def locale_language(self) -> str | None:
+        """Base language code derived from the locale (e.g. `'en'`). Read-only."""
+        from bootstack._runtime.app import _language_from_locale
+        loc = self._settings.locale
+        return _language_from_locale(loc) if loc else None
+
+    @property
+    def locale_date_format(self) -> str | None:
+        """Short date pattern for the active locale (e.g. `'M/d/yy'`). Read-only."""
+        from bootstack._runtime.app import _safe_date_format
+        loc = self._settings.locale
+        return _safe_date_format(loc) if loc else None
+
+    @property
+    def locale_time_format(self) -> str | None:
+        """Short time pattern for the active locale (e.g. `'h:mm a'`). Read-only."""
+        from bootstack._runtime.app import _safe_time_format
+        loc = self._settings.locale
+        return _safe_time_format(loc) if loc else None
+
+    @property
+    def locale_decimal(self) -> str | None:
+        """Decimal separator for the active locale (e.g. `'.'`). Read-only."""
+        from bootstack._runtime.app import _safe_decimal_symbol
+        loc = self._settings.locale
+        return _safe_decimal_symbol(loc) if loc else None
+
+    @property
+    def locale_thousands(self) -> str | None:
+        """Thousands separator for the active locale (e.g. `','`). Read-only."""
+        from bootstack._runtime.app import _safe_group_symbol
+        loc = self._settings.locale
+        return _safe_group_symbol(loc) if loc else None
+
+    # ----- platform / window state -----
+
+    @property
+    def window_style(self) -> str | None:
+        """Windows-only window effect (`'mica'`, `'acrylic'`, …) or None."""
+        return self._settings.window_style
+
+    @window_style.setter
+    def window_style(self, value: str | None) -> None:
+        app = self._config_app()
+        app.settings.window_style = value
+        # Best-effort live re-apply (Windows / pywinstyles only).
+        try:
+            app._window_style = value
+            app._window_style_applied = False
+            app._apply_window_style()
+        except Exception:
+            pass
+
+    @property
+    def macos_quit_behavior(self) -> str:
+        """How close / Cmd+Q behave on macOS — `'native'` or `'classic'`."""
+        return self._settings.macos_quit_behavior
+
+    @macos_quit_behavior.setter
+    def macos_quit_behavior(self, value: str) -> None:
+        self._settings.macos_quit_behavior = value
+
+    @property
+    def remember_window_state(self) -> bool:
+        """Whether window geometry is saved on close and restored on launch."""
+        return self._settings.remember_window_state
+
+    @remember_window_state.setter
+    def remember_window_state(self, value: bool) -> None:
+        self._settings.remember_window_state = value
+
+    @property
+    def state_path(self) -> str | None:
+        """Override path for the persisted window-state file, or None."""
+        return self._settings.state_path
+
+    @state_path.setter
+    def state_path(self, value: str | None) -> None:
+        self._settings.state_path = value
+
+    # ----- configuration-change events -----
+
+    def _bind_value_event(
+        self,
+        sequence: str,
+        key: str,
+        handler: Callable[[Any], Any] | None,
+    ) -> "Stream | Subscription":
+        app = self._config_app()
+
+        def _decode(h: Callable[[Any], Any]) -> Callable[[Any], Any]:
+            def _wrapped(raw: Any) -> Any:
+                data = getattr(raw, "data", None)
+                value = data.get(key) if isinstance(data, dict) else data
+                return h(value)
+            return _wrapped
+
+        if handler is None:
+            from bootstack.streams import Stream
+
+            def _source(h: Callable[[Any], Any]) -> Subscription:
+                bid = app.bind(sequence, _decode(h), add="+")
+                return Subscription(app, sequence, bid)
+
+            return Stream(app, _source=_source)
+        bid = app.bind(sequence, _decode(handler), add="+")
+        return Subscription(app, sequence, bid)
+
+    @overload
+    def on_theme_change(self) -> "Stream": ...
+    @overload
+    def on_theme_change(self, handler: Callable[[str], Any]) -> Subscription: ...
+    def on_theme_change(
+        self, handler: Callable[[str], Any] | None = None
+    ) -> "Stream | Subscription":
+        """React to theme changes; the handler receives the new theme name.
+
+        Fired after the theme is fully rebuilt, so handlers can safely read new
+        colors. Useful for persisting the choice, e.g.
+        `app.on_theme_change(lambda t: store.update(theme=t))`.
+
+        Returns:
+            `Subscription` (with handler) or `Stream` (without handler).
+        """
+        return self._bind_value_event("<<BsThemeChanged>>", "theme", handler)
+
+    @overload
+    def on_locale_change(self) -> "Stream": ...
+    @overload
+    def on_locale_change(self, handler: Callable[[str], Any]) -> Subscription: ...
+    def on_locale_change(
+        self, handler: Callable[[str], Any] | None = None
+    ) -> "Stream | Subscription":
+        """React to locale changes; the handler receives the new locale code.
+
+        Returns:
+            `Subscription` (with handler) or `Stream` (without handler).
+        """
+        return self._bind_value_event("<<LocaleChanged>>", "locale", handler)
+
+
+# The set of App() constructor kwargs that map to configuration. Used by
+# App.from_store() to tolerantly filter a persisted dict (version skew).
+APP_CONFIG_KWARGS: frozenset[str] = frozenset({
+    "title",
+    "theme",
+    "app_author",
+    "app_version",
+    "light_theme",
+    "dark_theme",
+    "follow_system_appearance",
+    "available_themes",
+    "inherit_surface_color",
+    "locale",
+    "localize_mode",
+    "window_style",
+    "macos_quit_behavior",
+    "remember_window_state",
+    "state_path",
+})
+
+
+__all__ = ["AppConfigMixin", "APP_CONFIG_KWARGS"]

--- a/src/bootstack/widgets/app.py
+++ b/src/bootstack/widgets/app.py
@@ -1,24 +1,48 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 
-from typing import Any
+from typing import Any, Sequence
 
-from bootstack._runtime.app import App as _InternalApp
+from bootstack._runtime.app import App as _InternalApp, LocalizeMode
 from bootstack.widgets._impl.primitives.packframe import PackFrame
+from bootstack.widgets._core.app_config import AppConfigMixin, APP_CONFIG_KWARGS
 from bootstack.widgets._core.container import PublicContainer, PACK_KEYS, normalize_fill
 
 
-class App(PublicContainer):
+class App(AppConfigMixin, PublicContainer):
     """The application window. Behaves as an implicit VStack from the user's
     perspective: accepts `padding`, `gap`, `fill_items`, `expand_items`, and
     `anchor_items` and applies them to its internal content frame.
 
+    Configuration is a single flat path: pass options as constructor kwargs and
+    read or change them through matching `app.*` properties (e.g. `app.theme`,
+    `app.locale`). Setting `app.theme` or `app.locale` takes effect live.
+
     Args:
-        title: Window title bar text.
-        size: Initial window size as ``(width, height)``.
-        theme: Theme name to apply on startup (e.g. ``'bootstrap-dark'``).
-            Overrides the ``'theme'`` key in ``settings`` if both are given.
-        settings: ``AppSettings`` dict or instance for theme, locale, etc.
-        localize: Locale or ``MessageCatalog`` for internationalisation.
+        title: Window title bar text and the app's display name.
+        size: Initial window size as `(width, height)`.
+        theme: Theme name to apply on startup (e.g. `'bootstrap-dark'`).
+        app_author: Application author. Reserved for config-path use.
+        app_version: Application version string.
+        light_theme: Theme used for the light end of system-appearance
+            tracking and `toggle_theme`.
+        dark_theme: Theme used for the dark end of system-appearance
+            tracking and `toggle_theme`.
+        follow_system_appearance: If True, switch between `light_theme` and
+            `dark_theme` to match the OS (currently effective on macOS).
+        available_themes: Theme names to expose to theme pickers. Empty means
+            all registered themes.
+        inherit_surface_color: If True, child widgets inherit the parent's
+            surface color for consistent backgrounds.
+        locale: Locale identifier (e.g. `'en_US'`, `'de_DE'`). Auto-detected
+            from the system when not given.
+        localize_mode: Localization behavior — `'auto'`, `True`, or `False`.
+        window_style: Windows-only window effect (`'mica'`, `'acrylic'`,
+            `'aero'`, `'transparent'`, `'win7'`) or None to disable.
+        macos_quit_behavior: macOS close / Cmd+Q behavior — `'native'` or
+            `'classic'`. No-op on Win/Linux.
+        remember_window_state: If True, window geometry is saved on close and
+            restored on next launch.
+        state_path: Optional override for the persisted window-state file.
 
     `app.tk` returns the underlying `tk.Tk` root window.
     """
@@ -31,8 +55,23 @@ class App(PublicContainer):
         title: str | None = None,
         size: tuple[int, int] | None = None,
         theme: str | None = None,
-        settings: Any = None,
-        localize: Any = None,
+        # application identity
+        app_author: str | None = None,
+        app_version: str | None = None,
+        # theme
+        light_theme: str = "bootstrap-light",
+        dark_theme: str = "bootstrap-dark",
+        follow_system_appearance: bool = False,
+        available_themes: Sequence[str] = (),
+        inherit_surface_color: bool = True,
+        # localization
+        locale: str | None = None,
+        localize_mode: LocalizeMode = "auto",
+        # platform / window-state persistence
+        window_style: str | None = "mica",
+        macos_quit_behavior: str = "native",
+        remember_window_state: bool = False,
+        state_path: str | None = None,
         # Child-guidance (applied to the internal content frame)
         padding: Any = None,
         gap: int = 0,
@@ -40,22 +79,32 @@ class App(PublicContainer):
         expand_items: bool | None = None,
         anchor_items: str | None = None,
         surface: str | None = None,
-        # Extra kwargs forwarded to the internal App (theme, icon, etc.)
+        # Extra kwargs forwarded to the internal App (icon, position, etc.)
         **app_kwargs: Any,
     ) -> None:
         self._parent = None
 
-        init_kwargs: dict[str, Any] = {}
+        init_kwargs: dict[str, Any] = {
+            "app_author": app_author,
+            "app_version": app_version,
+            "light_theme": light_theme,
+            "dark_theme": dark_theme,
+            "follow_system_appearance": follow_system_appearance,
+            "available_themes": available_themes,
+            "inherit_surface_color": inherit_surface_color,
+            "locale": locale,
+            "localize_mode": localize_mode,
+            "window_style": window_style,
+            "macos_quit_behavior": macos_quit_behavior,
+            "remember_window_state": remember_window_state,
+            "state_path": state_path,
+        }
         if title is not None:
             init_kwargs["title"] = title
         if size is not None:
             init_kwargs["size"] = size
         if theme is not None:
             init_kwargs["theme"] = theme
-        if settings is not None:
-            init_kwargs["settings"] = settings
-        if localize is not None:
-            init_kwargs["localize"] = localize
         init_kwargs.update(app_kwargs)
 
         self._tk_root = _InternalApp(**init_kwargs)
@@ -76,6 +125,40 @@ class App(PublicContainer):
         self._content_frame.pack(fill="both", expand=True)
 
         self._internal = self._tk_root
+
+    @classmethod
+    def from_store(cls, store: Any, **overrides: Any) -> "App":
+        """Construct an `App` from a persisted `Store` (or plain dict).
+
+        Reads configuration from `store` and applies it as constructor kwargs,
+        tolerantly ignoring any keys that are not valid `App` configuration —
+        so a settings file written by an older or newer version (with renamed
+        or removed keys) still restores cleanly instead of raising. Explicit
+        keyword `overrides` win over stored values.
+
+        Args:
+            store: A `Store` (anything with `as_dict()`) or a mapping of
+                configuration values.
+            **overrides: Configuration kwargs that take precedence over the
+                stored values.
+
+        Returns:
+            A new `App` configured from the store.
+
+        Example:
+            ```python
+            store = bs.Store("settings")
+            app = bs.App.from_store(store)
+            app.on_theme_change(lambda t: store.update(theme=t))
+            ```
+        """
+        data = store.as_dict() if hasattr(store, "as_dict") else dict(store)
+        kwargs = {k: v for k, v in data.items() if k in APP_CONFIG_KWARGS}
+        kwargs.update(overrides)
+        return cls(**kwargs)
+
+    def _config_app(self) -> Any:
+        return self._tk_root
 
     def _child_master(self):
         """Children pack into the content frame, not the Tk root."""

--- a/src/bootstack/widgets/appshell.py
+++ b/src/bootstack/widgets/appshell.py
@@ -1,8 +1,10 @@
 ﻿from __future__ import annotations
 
-from typing import Any, Callable, Literal, overload
+from typing import Any, Callable, Literal, Sequence, overload
 
+from bootstack._runtime.app import LocalizeMode
 from bootstack.widgets._impl.composites.appshell import AppShell as _InternalAppShell
+from bootstack.widgets._core.app_config import AppConfigMixin, APP_CONFIG_KWARGS
 from bootstack.widgets._core.base import adapt_handler
 from bootstack.widgets._core.container import PACK_KEYS, normalize_fill
 from bootstack.widgets._core.context import push_container, pop_container
@@ -38,7 +40,7 @@ class _PageFrame:
         pop_container(self)
 
 
-class AppShell:
+class AppShell(AppConfigMixin):
     """Application window with built-in toolbar, sidebar navigation, and page stack.
 
     Wraps the internal AppShell to provide the standard desktop app scaffold:
@@ -49,12 +51,32 @@ class AppShell:
     Pages support context-manager syntax so widgets inside the ``with`` block
     are automatically parented to that page.
 
+    Like `App`, configuration is a single flat path: pass options as
+    constructor kwargs and read or change them through matching `app.*`
+    properties (e.g. `shell.theme`, `shell.locale`).
+
     Args:
         title: Window title and (in undecorated mode) toolbar label.
         size: Initial window size as `(width, height)`.
         theme: Theme name to apply on startup (e.g. ``'bootstrap-dark'``).
-        settings: ``AppSettings`` dict or instance for theme, locale, etc.
-        localize: Locale or ``MessageCatalog`` for internationalisation.
+        app_author: Application author. Reserved for config-path use.
+        app_version: Application version string.
+        light_theme: Theme used for the light end of system-appearance
+            tracking and `toggle_theme`.
+        dark_theme: Theme used for the dark end of system-appearance
+            tracking and `toggle_theme`.
+        follow_system_appearance: If True, switch between `light_theme` and
+            `dark_theme` to match the OS (currently effective on macOS).
+        available_themes: Theme names to expose to theme pickers.
+        inherit_surface_color: If True, child widgets inherit the parent's
+            surface color.
+        locale: Locale identifier (e.g. `'en_US'`, `'de_DE'`).
+        localize_mode: Localization behavior — `'auto'`, `True`, or `False`.
+        window_style: Windows-only window effect or None to disable.
+        macos_quit_behavior: macOS close / Cmd+Q behavior — `'native'` or
+            `'classic'`.
+        remember_window_state: If True, window geometry is saved and restored.
+        state_path: Optional override for the persisted window-state file.
         position: Initial window position as `(x, y)`.
         min_size: Minimum window size as `(width, height)`.
         max_size: Maximum window size as `(width, height)`.
@@ -70,7 +92,6 @@ class AppShell:
         nav_display_mode: Initial sidebar mode — `'expanded'`, `'compact'`,
             or `'minimal'`.
         nav_accent: Accent color for the active nav item. Default `'primary'`.
-        settings: `AppSettings` dict or instance for theme, locale, etc.
     """
 
     def __init__(
@@ -79,12 +100,29 @@ class AppShell:
         title: str = "",
         size: tuple[int, int] | None = None,
         theme: str | None = None,
-        settings: Any = None,
-        localize: Any = None,
+        # application identity
+        app_author: str | None = None,
+        app_version: str | None = None,
+        # theme
+        light_theme: str = "bootstrap-light",
+        dark_theme: str = "bootstrap-dark",
+        follow_system_appearance: bool = False,
+        available_themes: Sequence[str] = (),
+        inherit_surface_color: bool = True,
+        # localization
+        locale: str | None = None,
+        localize_mode: LocalizeMode = "auto",
+        # platform / window-state persistence
+        window_style: str | None = "mica",
+        macos_quit_behavior: str = "native",
+        remember_window_state: bool = False,
+        state_path: str | None = None,
+        # window placement
         position: tuple[int, int] | None = None,
         min_size: tuple[int, int] | None = None,
         max_size: tuple[int, int] | None = None,
         resizable: tuple[bool, bool] | None = None,
+        # scaffold
         undecorated: bool = False,
         show_toolbar: bool = True,
         show_window_controls: bool = False,
@@ -97,6 +135,19 @@ class AppShell:
     ) -> None:
         init_kwargs: dict[str, Any] = {
             "title": title,
+            "app_author": app_author,
+            "app_version": app_version,
+            "light_theme": light_theme,
+            "dark_theme": dark_theme,
+            "follow_system_appearance": follow_system_appearance,
+            "available_themes": available_themes,
+            "inherit_surface_color": inherit_surface_color,
+            "locale": locale,
+            "localize_mode": localize_mode,
+            "window_style": window_style,
+            "macos_quit_behavior": macos_quit_behavior,
+            "remember_window_state": remember_window_state,
+            "state_path": state_path,
             "show_toolbar": show_toolbar,
             "show_window_controls": show_window_controls,
             "draggable": draggable,
@@ -118,13 +169,25 @@ class AppShell:
             init_kwargs["maxsize"] = max_size
         if resizable is not None:
             init_kwargs["resizable"] = resizable
-        if settings is not None:
-            init_kwargs["settings"] = settings
-        if localize is not None:
-            init_kwargs["localize"] = localize
         init_kwargs.update(kwargs)
 
         self._internal = _InternalAppShell(**init_kwargs)
+
+    @classmethod
+    def from_store(cls, store: Any, **overrides: Any) -> "AppShell":
+        """Construct an `AppShell` from a persisted `Store` (or plain dict).
+
+        Reads configuration from `store`, tolerantly ignoring keys that are not
+        valid configuration (so version skew does not raise). Explicit keyword
+        `overrides` win over stored values. See `App.from_store`.
+        """
+        data = store.as_dict() if hasattr(store, "as_dict") else dict(store)
+        kwargs = {k: v for k, v in data.items() if k in APP_CONFIG_KWARGS}
+        kwargs.update(overrides)
+        return cls(**kwargs)
+
+    def _config_app(self) -> Any:
+        return self._internal
 
     def __enter__(self) -> "AppShell":
         return self

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -66,6 +66,18 @@ def test_update_setdefault_clear(tmp_path):
     assert _store(tmp_path).as_dict() == {}  # cleared state persisted
 
 
+def test_update_accepts_kwargs(tmp_path):
+    s = _store(tmp_path)
+    s.update(theme="dark", locale="de_DE")
+    assert s.as_dict() == {"theme": "dark", "locale": "de_DE"}
+    # mapping and kwargs together; kwargs win on conflict
+    s.update({"theme": "light", "extra": 1}, theme="ocean")
+    assert s.get("theme") == "ocean"
+    assert s.get("extra") == 1
+    # persisted
+    assert _store(tmp_path).get("theme") == "ocean"
+
+
 def test_keys_values_items_are_snapshots(tmp_path):
     s = _store(tmp_path)
     s.update({"a": 1, "b": 2})

--- a/tests/widgets/public/test_app_config.py
+++ b/tests/widgets/public/test_app_config.py
@@ -1,0 +1,118 @@
+"""Tests for the flat App configuration surface.
+
+Covers the settings-flattening work: configuration as flat constructor kwargs,
+symmetric `app.*` properties (read + live write), locale-derived read-only
+properties, `App.from_store` version-skew tolerance, and the removal of the
+public `AppSettings` / `settings=` surface.
+"""
+from __future__ import annotations
+
+import pytest
+
+import bootstack as bs
+
+
+@pytest.fixture
+def make_app():
+    """Factory creating public `App`s, all destroyed on teardown."""
+    created = []
+
+    def _make(**kwargs):
+        app = bs.App(**kwargs)
+        app._tk_root.withdraw()
+        created.append(app)
+        return app
+
+    try:
+        yield _make
+    finally:
+        for app in created:
+            try:
+                app._tk_root.destroy()
+            except Exception:
+                pass
+
+
+@pytest.mark.gui
+def test_flat_kwargs_map_to_properties(make_app):
+    app = make_app(
+        title="Demo",
+        theme="bootstrap-dark",
+        locale="de_DE",
+        remember_window_state=True,
+        window_style=None,
+        macos_quit_behavior="classic",
+    )
+    assert app.title == "Demo"
+    assert app.theme == "bootstrap-dark"
+    assert app.locale == "de_DE"
+    assert app.remember_window_state is True
+    assert app.window_style is None
+    assert app.macos_quit_behavior == "classic"
+
+
+@pytest.mark.gui
+def test_theme_setter_is_live(make_app):
+    app = make_app(theme="bootstrap-dark")
+    assert app.theme == "bootstrap-dark"
+    app.theme = "bootstrap-light"
+    assert app.theme == "bootstrap-light"
+    assert bs.get_theme() == "bootstrap-light"
+
+
+@pytest.mark.gui
+def test_locale_derived_properties_are_read_only(make_app):
+    app = make_app(locale="de_DE")
+    assert app.locale_language == "de"
+    assert app.locale_decimal == ","
+    assert app.locale_thousands == "."
+    assert app.locale_date_format  # non-empty derived pattern
+    with pytest.raises(AttributeError):
+        app.locale_date_format = "yyyy-MM-dd"
+
+
+@pytest.mark.gui
+def test_locale_setter_updates_derived(make_app):
+    app = make_app(locale="en_US")
+    assert app.locale_decimal == "."
+    app.locale = "de_DE"
+    assert app.locale == "de_DE"
+    assert app.locale_decimal == ","
+
+
+@pytest.mark.gui
+def test_from_store_ignores_unknown_keys(make_app):
+    # Simulate version skew: a stale key that is no longer a valid App kwarg.
+    store = {"theme": "bootstrap-dark", "locale": "fr_FR", "bogus_old_key": 123}
+    # plain App(**store) would raise TypeError; from_store filters it out.
+    app = bs.App.from_store(store)
+    app._tk_root.withdraw()
+    try:
+        assert app.theme == "bootstrap-dark"
+        assert app.locale == "fr_FR"
+    finally:
+        app._tk_root.destroy()
+
+
+@pytest.mark.gui
+def test_from_store_overrides_win(make_app):
+    store = {"theme": "bootstrap-dark"}
+    app = bs.App.from_store(store, theme="bootstrap-light")
+    app._tk_root.withdraw()
+    try:
+        assert app.theme == "bootstrap-light"
+    finally:
+        app._tk_root.destroy()
+
+
+def test_no_public_appsettings_surface():
+    # Configuration is flat kwargs + properties; the old object surface is gone.
+    assert not hasattr(bs, "AppSettings")
+    assert not hasattr(bs, "get_app_settings")
+
+
+@pytest.mark.gui
+def test_settings_kwarg_rejected(make_app):
+    # Pre-release clean break: there is no settings= shim.
+    with pytest.raises(TypeError):
+        make_app(settings={"theme": "bootstrap-dark"})

--- a/tools/gen_api_docs.py
+++ b/tools/gen_api_docs.py
@@ -20,9 +20,7 @@ API_MODULES = {
             "App": "bootstack.runtime.app.App",
             "Window": "bootstack.runtime.app.App",  # Alias
             "Toplevel": "bootstack.runtime.toplevel.Toplevel",
-            "AppSettings": "bootstack.runtime.app.AppSettings",
             "get_current_app": "bootstack.runtime.app.get_current_app",
-            "get_app_settings": "bootstack.runtime.app.get_app_settings",
             "MenuManager": "bootstack.runtime.menu.MenuManager",
             "create_menu": "bootstack.runtime.menu.create_menu",
         },


### PR DESCRIPTION
## Summary

Configuration is now a single flat path. Every former `AppSettings` field is a direct `App(...)` / `AppShell(...)` constructor kwarg, read and changed at runtime through symmetric `app.*` properties — `App(theme=...)` in, `app.theme` out. The split-brain config surface (some fields top-level, others only via `settings={...}`) is gone.

**Clean break (pre-release, no shim):** the public `settings=` input, `AppSettings`, `get_app_settings`, and `app.settings` are removed. Passing `settings=` raises `TypeError`. `AppSettings` survives only as an internal resolved-config holder.

## What changed

- **`widgets/_core/app_config.py`** (new) — `AppConfigMixin` (+ `APP_CONFIG_KWARGS`), shared by public `App` and `AppShell`. Flat properties with **live setters** for `theme`/`locale`/`title`; the rest read/write through the holder. Locale-derived values (`locale_date_format`/`_time_format`/`_decimal`/`_thousands`/`_language`) are flat **read-only** props computed from `locale`. Adds `on_theme_change` / `on_locale_change` events (deliver the bare new value).
- **`_runtime/app.py`** — `App.__init__` takes the fields as flat kwargs and assembles the internal `AppSettings`; drops `settings=`, the `_USE_SETTINGS` sentinel, and `AppSettingsKwargs`.
- **Locale surface is flat** (not an `app.localization.*` namespace) — chosen for symmetry, consistency with `app.theme`, and discoverability. The derived format fields were dropped as *inputs* (they were dead — nothing read them; `IntlFormatter` re-derives from `locale`).
- **Persistence** — `App.from_store()` / `AppShell.from_store()` restore from a `Store`/dict, tolerant of version skew (filter to `APP_CONFIG_KWARGS`). `Store.update(**kwargs)` write-back. `remember_theme` deferred (store-splat covers it; `remember_window_state` stays the only built-in remember flag).
- **Call sites** — CLI templates, demo, screenshot harness, `gen_api_docs.py`.
- **Docs** — `production/app-settings.rst` fleshed out from a stub into the App configuration reference (full property table, theme/locale/events/persistence/window-state); configuration section added to `widgets/appshell.rst`; `store.rst` persistence section; `theming.rst` flat kwargs.

## Tests

- `tests/widgets/public/test_app_config.py` (new) — flat kwargs → properties, live theme/locale setters, derived read-only props, `from_store` version-skew tolerance, removed public surface, `settings=` rejected.
- `Store.update(**kwargs)` coverage in `tests/test_store.py`.

Green: `test_store.py` 17, `test_app_config.py` 8, `signals` 10, `cli` 15, `data` (excl. pre-existing flaky observable threading tests) 106. Docs build succeeds with no new warnings. Note: the local GUI suite hits an environmental Tcl many-Tk-roots crash when many App-creating files run in one process — confirmed identical on `main`, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)