### PR TITLE
docs(reference): enrich reference docs + add localization; fix validation compare & i18n formatter

### DIFF
--- a/docs/reference/errors.rst
+++ b/docs/reference/errors.rst
@@ -1,18 +1,90 @@
 Errors
 ======
 
-Exceptions raised by the bootstack API. All inherit from :class:`BootstackError
-<bootstack.errors.BootstackError>`, so a single ``except bootstack.BootstackError``
-catches anything the framework raises.
+Every exception the framework raises inherits from :class:`BootstackError
+<bootstack.errors.BootstackError>`, so a single ``except bs.BootstackError``
+catches anything bootstack throws while letting ordinary Python errors propagate.
+The individual subclasses let you catch one specific failure when you want to
+handle it precisely.
 
 .. code-block:: python
 
    import bootstack as bs
 
    try:
-       widget.on("not-a-real-event", handler)
+       risky_setup()
+   except bs.BootstackError as err:
+       # any framework error — log it and fall back
+       log.warning("bootstack rejected the setup: %s", err)
+
+The errors
+----------
+
+``UnknownEventError``
+~~~~~~~~~~~~~~~~~~~~~~
+
+Raised by ``widget.on(name, ...)`` when ``name`` isn't an event the widget
+supports — almost always a typo. The message lists the widget and the bad name.
+Prefer the typed ``on_*()`` shorthands (``on_click``, ``on_change``), which can't
+be misspelled; reach for the string form only for dynamic event names:
+
+.. code-block:: python
+
+   try:
+       widget.on(event_name, handler)
    except bs.UnknownEventError as err:
-       print("bad event name:", err)
+       print("no such event:", err)
+
+``ParentResolutionError``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Raised when a widget can't find a container to attach to — typically because it
+was created outside any ``with`` container block, or under a parent that isn't a
+layout container. The fix is structural: create the widget inside an ``App`` or a
+layout container (``VStack``, ``HStack``, ``Card``, …):
+
+.. code-block:: python
+
+   with bs.App() as app:
+       with bs.VStack():
+           bs.Label("Inside a container — fine.")
+
+   bs.Label("Created with no container")   # ParentResolutionError
+
+``DuplicateIdError``
+~~~~~~~~~~~~~~~~~~~~~
+
+Raised by a data source when two records share an ``id`` — on ``load()`` of rows
+with a colliding id, or on ``insert()`` of a record whose id already exists. Ids
+identify rows for selection and events, so they must be unique. It is also raised
+if a source is asked to auto-assign an id but the existing ids aren't integers:
+
+.. code-block:: python
+
+   ds = bs.MemoryDataSource().load([{"id": 1, "name": "Ada"}])
+
+   try:
+       ds.insert({"id": 1, "name": "Linus"})   # 1 already exists
+   except bs.DuplicateIdError as err:
+       print("id clash:", err)
+
+``SerializationError``
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Raised when a JSON-backed store is handed a value it can't persist. A
+:doc:`Store </reference/store>` and the SQLite/file-backed
+:doc:`data sources </reference/data-sources>` keep their values as JSON, so
+values must be JSON-serializable (scalars, lists, dicts). To carry a live Python
+object, use an in-memory source instead:
+
+.. code-block:: python
+
+   store = bs.Store("settings")
+
+   try:
+       store.set("connection", open("db.sqlite"))   # not JSON-serializable
+   except bs.SerializationError as err:
+       print("can't persist that:", err)
 
 API reference
 -------------

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -1,14 +1,15 @@
 Reference
 =========
 
-Framework services and primitives: theming and typography, reactive state,
-events, validation, data sources, and app-level utilities.
+Framework services and primitives: theming and typography, localization,
+reactive state, events, validation, data sources, and app-level utilities.
 
 .. toctree::
    :maxdepth: 1
 
    theming
    typography
+   localization
    signals
    events
    streams

--- a/docs/reference/localization.rst
+++ b/docs/reference/localization.rst
@@ -1,0 +1,160 @@
+Localization
+============
+
+bootstack apps can speak the user's language and follow their regional
+conventions. There are two halves:
+
+- **Value formatting** — rendering numbers, dates, times, and money the way a
+  locale writes them (``LV``).
+- **Translation** — showing text in the active language. The framework's own
+  strings (dialog buttons, built-in labels) are translated into the bundled
+  locales automatically, and ``L`` marks your own text for translation.
+
+Most of this happens for free once you set a locale.
+
+Setting the locale
+------------------
+
+Pass ``locale=`` to the app. Omit it and bootstack auto-detects the system
+locale; ``localize_mode=`` controls whether localization is active at all:
+
+.. code-block:: python
+
+   import bootstack as bs
+
+   with bs.App(locale="de_DE") as app:          # explicit locale
+       ...
+   app.run()
+
+   bs.App()                                      # auto-detect from the system
+   bs.App(localize_mode=True)                    # force on
+   bs.App(localize_mode=False)                   # force off (use source strings)
+
+``localize_mode`` accepts ``"auto"`` (the default — localize when a locale is
+detected), ``True`` (always), or ``False`` (never). Read or change the active
+locale at runtime through ``app.locale``:
+
+.. code-block:: python
+
+   app.locale            # "de_DE"
+   app.locale = "fr_FR"  # switch at runtime (see "Reacting to locale changes")
+
+Formatting numbers, dates, and money
+------------------------------------
+
+``LV(value, spec)`` formats a value for the active locale. Drop it anywhere a
+widget takes text, and it re-formats itself when the locale changes:
+
+.. code-block:: python
+
+   from datetime import date
+   from bootstack.i18n import LV
+
+   bs.Label(LV(1234.56, "currency"))        # "$1,234.56" en_US · "1.234,56 €" de_DE
+   bs.Label(LV(0.42, "percent"))            # "42%"
+   bs.Label(LV(date(2025, 9, 2), "longDate"))
+
+Common format specs:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 78
+
+   * - Spec
+     - Formats…
+   * - ``"decimal"``
+     - a number with the locale's grouping and decimal marks.
+   * - ``"currency"``
+     - money in the locale's default currency.
+   * - ``"percent"``
+     - a fraction as a percentage (``0.42`` → ``42%``).
+   * - ``"thousands"`` / ``"largeNumber"``
+     - a compact number (``12000`` → ``12K``).
+   * - ``"shortDate"`` / ``"longDate"``
+     - a date, numeric or spelled out.
+   * - ``"shortTime"`` / ``"longTime"``
+     - a time of day.
+
+A CLDR pattern string (e.g. ``"yyyy-MM-dd"``) is also accepted for full control.
+
+Locale-aware input widgets — :doc:`/widgets/numberfield`,
+:doc:`/widgets/datefield`, :doc:`/widgets/timefield` — read user input back in the
+active locale automatically, so a German user can type ``1.234,56`` and you get
+``1234.56``.
+
+Marking text for translation
+----------------------------
+
+Wrap a message key in ``L(...)`` wherever a widget takes text and it resolves in
+the active locale, re-translating itself on a locale change:
+
+.. code-block:: python
+
+   from bootstack.i18n import L
+
+   bs.Label(L("greeting"))
+   bs.Button(L("button.save"), on_click=save)
+
+bootstack's own widget text is translated for every bundled locale out of the
+box (see below). A first-class API for registering your *own* application
+translation catalogs is still being finalized; until it lands, ``LV`` already
+covers locale-aware *values* in full, and ``L`` resolves the bundled strings.
+
+Reading locale conventions
+--------------------------
+
+When you need a locale's raw conventions — to configure a custom widget, say —
+the app exposes them as read-only properties derived from ``app.locale``:
+
+.. code-block:: python
+
+   app.locale_language       # "de"      — the base language
+   app.locale_decimal        # ","       — decimal separator
+   app.locale_thousands      # "."       — grouping separator
+   app.locale_date_format    # "dd.MM.yy"
+   app.locale_time_format    # "HH:mm"
+
+Reacting to locale changes
+--------------------------
+
+Setting ``app.locale`` switches the locale **live**: text and values bound with
+``L`` / ``LV`` re-resolve themselves, the framework's own strings update, and
+``on_locale_change`` fires with the new code. A language switcher needs no manual
+rebuild — just set the locale:
+
+.. code-block:: python
+
+   def switch_language(code):
+       app.locale = code          # L/LV-bound widgets refresh automatically
+
+   app.on_locale_change(lambda code: print("now speaking", code))
+
+.. note::
+
+   Automatic refresh covers text and values bound through ``L`` / ``LV`` (and a
+   ``Signal`` with a ``value_format``). Text you set imperatively — e.g.
+   ``label.text = "…"`` — is a plain string with no locale binding, so re-apply it
+   yourself from ``on_locale_change`` if it needs to follow the switch.
+
+Bundled translations
+---------------------
+
+bootstack ships its own UI strings translated into a range of locales — Arabic,
+Chinese (Simplified and Traditional), Czech, Danish, Dutch, English, French,
+German, Hebrew, Hindi, Italian, Japanese, Korean, Norwegian, Polish, Portuguese
+(and Brazilian), Spanish, Swedish, Turkish, and more. Selecting one of these
+locales translates the built-in widgets automatically.
+
+See also
+--------
+
+- :doc:`/reference/typography` — fonts and the ``font=`` token system.
+- :doc:`/widgets/datefield` — date input that respects the locale's date format.
+- :doc:`/widgets/numberfield` — number input parsed in the active locale.
+
+API reference
+-------------
+
+.. autofunction:: bootstack.i18n.L
+
+.. autofunction:: bootstack.i18n.LV

--- a/docs/reference/scheduling.rst
+++ b/docs/reference/scheduling.rst
@@ -3,50 +3,112 @@ Scheduling
 
 Every widget has a ``schedule`` — a small scheduler for running work later or
 repeatedly, tied to the widget's lifetime. When the widget is destroyed its
-pending and repeating jobs are cancelled automatically, so callbacks never fire
-on a dead widget.
+pending and repeating jobs are cancelled automatically, so a callback never fires
+on a dead widget and you rarely have to clean up by hand. The ``App`` has one
+too, which is the natural place for app-wide timers.
 
 Running work later
 ------------------
 
-``delay()`` runs a function once after a number of milliseconds; ``idle()``
-runs it as soon as the event loop is free; ``at()`` runs it at a specific
+``delay()`` runs a function once after a number of milliseconds; ``idle()`` runs
+it as soon as the event loop is free; ``at()`` runs it at a specific
 ``datetime``. Each returns a :class:`Job <bootstack.scheduling.Job>` you can
-cancel:
+cancel, and each forwards any extra arguments to your callback:
 
 .. code-block:: python
 
    job = widget.schedule.delay(500, lambda: print("half a second later"))
-   widget.schedule.idle(refresh)            # when the loop next goes idle
-   widget.schedule.at(deadline, on_due)     # at a datetime
+   widget.schedule.idle(refresh)                 # when the loop next goes idle
+   widget.schedule.at(deadline, on_due)          # at a datetime
+   widget.schedule.delay(1000, save, document)   # extra args forwarded to save()
 
-   job.cancel()                             # call off a pending job
+   job.cancel()                                  # call off a pending job
+
+Use ``idle()`` to defer work until the UI has finished laying out — measuring a
+widget, scrolling to a position, or moving focus all work better once the current
+batch of events has drained:
+
+.. code-block:: python
+
+   with bs.App() as app:
+       field = bs.TextField()
+       field.schedule.idle(field.focus)   # focus after the window is shown
+   app.run()
+
+``at()`` takes an absolute time; a time already in the past simply runs as soon
+as possible:
+
+.. code-block:: python
+
+   from datetime import datetime, timedelta
+
+   reminder = datetime.now() + timedelta(minutes=5)
+   widget.schedule.at(reminder, lambda: bs.alert("Five minutes are up."))
 
 Repeating work
 --------------
 
-``every()`` runs a function on a fixed millisecond interval until cancelled:
+``every()`` runs a function on a fixed millisecond interval until cancelled. It
+compensates for the callback's own run time to keep the interval from drifting:
 
 .. code-block:: python
 
-   ticker = widget.schedule.every(1000, update_clock)   # once a second
-   ...
-   ticker.cancel()                          # stop the repetition
+   from datetime import datetime
 
-``cancel_all()`` cancels every job on that widget's schedule at once:
+   clock = bs.Label("")
+
+   def tick():
+       clock.text = datetime.now().strftime("%H:%M:%S")
+
+   ticker = clock.schedule.every(1000, tick)     # once a second
+   ...
+   ticker.cancel()                               # stop the repetition
+
+If a repeating callback raises, the interval stops and the exception is re-raised
+into the application's error handler — a broken tick won't silently keep firing.
+
+A countdown combines the two: repeat on an interval, then cancel the job from
+inside the callback when you're done.
+
+.. code-block:: python
+
+   remaining = bs.Signal(10)
+
+   def countdown():
+       remaining.set(remaining() - 1)
+       if remaining() <= 0:
+           job.cancel()
+           bs.alert("Liftoff!")
+
+   job = app.schedule.every(1000, countdown)
+
+Cancelling jobs
+---------------
+
+A :class:`Job <bootstack.scheduling.Job>` is truthy while it is still pending and
+falsy once it has fired or been cancelled, so you can guard a re-schedule:
+
+.. code-block:: python
+
+   if not job:
+       job = widget.schedule.delay(500, run)
+
+``cancel_all()`` clears every job on a widget's schedule at once:
 
 .. code-block:: python
 
    widget.schedule.cancel_all()
 
-Because the schedule is bound to the widget, you rarely need to clean up
-manually — destroying the widget (or its window) cancels everything for you.
+Because the schedule is bound to the widget, destroying the widget (or its
+window) cancels everything for you — manual cleanup is the exception, not the
+rule.
 
 See also
 --------
 
 - :doc:`/reference/streams` — ``debounce`` / ``throttle`` / ``delay`` operators
-  time a stream of events rather than scheduling one-off work.
+  time a *stream of events* rather than scheduling one-off work. Reach for a
+  stream when you're reshaping events; for a plain timer, use ``schedule``.
 
 API reference
 -------------

--- a/docs/reference/shortcuts.rst
+++ b/docs/reference/shortcuts.rst
@@ -6,37 +6,50 @@ your app, and let menus display the resolved shortcut text. A pattern like
 ``Mod+S`` becomes ``Ctrl+S`` on Windows and Linux and ``⌘S`` on macOS, so you
 write the shortcut once and it reads correctly everywhere.
 
+A shortcut has three parts: a **key** (your own identifier, e.g. ``"save"``), a
+**pattern** (the key combination), and a **command** (the function to run).
+
 The shortcut service
 --------------------
 
-``bs.get_shortcuts()`` returns the shared service. Register a shortcut with a
-``key`` (your own identifier), a ``pattern``, and a command, then bind the
-service to the app so the keys become live:
+``bs.get_shortcuts()`` returns the shared service. Register your shortcuts, then
+call ``bind_to(app)`` once to make them live. ``register()`` returns the created
+:class:`Shortcut <bootstack.shortcuts.Shortcut>`, and raises ``ValueError`` if
+the key is already taken — so each key is registered exactly once:
 
 .. code-block:: python
 
    import bootstack as bs
 
-   shortcuts = bs.get_shortcuts()
-   shortcuts.register("save", "Mod+S", save_file)
-   shortcuts.register("find", "Mod+F", open_search)
-   shortcuts.register("quit", "Mod+Q", app.quit)
+   with bs.App(title="Editor") as app:
+       shortcuts = bs.get_shortcuts()
+       shortcuts.register("save", "Mod+S", save_file)
+       shortcuts.register("find", "Mod+F", open_search)
+       shortcuts.register("quit", "Mod+Q", app.quit)
 
-   shortcuts.bind_to(app)        # activate the bindings on the app window
+       shortcuts.bind_to(app)        # activate the bindings on the app window
+   app.run()
+
+Shortcuts registered *after* ``bind_to`` are bound to that window automatically,
+so you can register more as your app grows without binding again.
 
 Patterns
 --------
 
-A pattern is modifier names joined to a key with ``+``:
+A pattern is modifier names joined to a key with ``+``. Use ``Mod`` for the
+primary modifier and the framework picks the right one per platform:
 
 - ``Mod`` — the primary modifier: ``Ctrl`` on Windows/Linux, ``Command`` on macOS.
 - ``Shift``, ``Alt`` (``Option`` on macOS), ``Ctrl``.
+- Function keys (``F1``–``F12``) and ordinary letters/digits, with or without
+  modifiers.
 
 .. code-block:: python
 
-   shortcuts.register("new",       "Mod+N",        new_doc)
-   shortcuts.register("new_window","Mod+Shift+N",  new_window)
-   shortcuts.register("close",     "Alt+F4",       close_window)
+   shortcuts.register("new",        "Mod+N",        new_doc)
+   shortcuts.register("new_window", "Mod+Shift+N",  new_window)
+   shortcuts.register("refresh",    "F5",           reload_data)
+   shortcuts.register("close",      "Alt+F4",       close_window)
 
 Showing shortcuts in menus
 --------------------------
@@ -48,21 +61,31 @@ menus and tooltips can show the shortcut alongside the action:
 
    shortcuts.display("save")     # "Ctrl+S"  (Windows/Linux)  ·  "⌘S" (macOS)
 
-Menu items accept a registered key directly and format it for you:
+Menu items accept a registered key directly and format it for you — no need to
+call ``display`` yourself:
 
 .. code-block:: python
 
    menu.add_command(text="Save", shortcut="save", command=save_file)
 
-Managing bindings
------------------
+Inspecting and removing shortcuts
+---------------------------------
+
+Look a shortcut up by key, enumerate everything registered, or remove one. A
+:class:`Shortcut <bootstack.shortcuts.Shortcut>` exposes its ``key``,
+``pattern``, ``command``, and the read-only ``display`` label:
 
 .. code-block:: python
 
-   shortcuts.get("save")          # the Shortcut object, or None
-   shortcuts.all()                # {key: Shortcut} for everything registered
-   shortcuts.unregister("find")   # remove one
-   shortcuts.unbind_from(app)     # detach all bindings from a window
+   sc = shortcuts.get("save")     # the Shortcut, or None if unregistered
+   sc.pattern                     # "Mod+S"
+   sc.display                     # "Ctrl+S" / "⌘S"
+
+   for key, sc in shortcuts.all().items():
+       print(key, "→", sc.display)
+
+   shortcuts.unregister("find")   # remove one (KeyError if not registered)
+   shortcuts.unbind_from(app)     # detach every binding from a window
 
 See also
 --------

--- a/docs/reference/validation.rst
+++ b/docs/reference/validation.rst
@@ -1,18 +1,17 @@
 Validation
 ==========
 
-Input fields can validate what the user types against a set of rules. A rule has
-a type (``'required'``, ``'email'``, …), an optional message, and a trigger that
-decides when it runs. Rules report a :class:`ValidationResult
-<bootstack.validation.ValidationResult>`, and the field emits ``valid`` /
-``invalid`` events you can listen to.
+Input fields can check what the user types against a set of rules. A rule has a
+type (``'required'``, ``'email'``, …), an optional custom message, and a
+*trigger* that decides when it runs. Rules run in the order you add them and stop
+at the first failure, and the field emits ``valid`` / ``invalid`` events you can
+listen to. The same rule engine also works standalone, with no widget attached.
 
 Adding rules to a field
 -----------------------
 
-Call ``add_validation_rule()`` on a field with a rule type and its options.
-Rules run on blur (or as you type, depending on the rule) and stop at the first
-failure:
+Call ``add_validation_rule()`` on a field with a rule type and its options. Add
+as many as you like — they are checked in order, and the first failure wins:
 
 .. code-block:: python
 
@@ -23,52 +22,183 @@ failure:
    name = bs.TextField(label="Name")
    name.add_validation_rule("stringLength", min=2, max=50)
 
-Built-in rule types and their options:
+Built-in rule types
+-------------------
 
-- ``'required'`` — value must not be empty.
-- ``'email'`` — value must look like an email address.
-- ``'stringLength'`` — ``min`` / ``max`` character count.
-- ``'pattern'`` — ``pattern`` regex the value must match.
-- ``'compare'`` — ``other_field`` whose value must match (e.g. confirm-password).
-- ``'custom'`` — ``func`` callable ``(value: str) -> bool``.
+.. list-table::
+   :header-rows: 1
+   :widths: 18 42 40
 
-All rules accept ``message`` (override the default text) and ``trigger``
-(``'blur'`` default, ``'key'``, or ``'manual'``).
+   * - Type
+     - Options
+     - Checks that the value…
+   * - ``'required'``
+     - —
+     - is not empty or whitespace.
+   * - ``'email'``
+     - —
+     - looks like an email address.
+   * - ``'stringLength'``
+     - ``min``, ``max``
+     - has a length within the given bounds.
+   * - ``'pattern'``
+     - ``pattern`` (regex)
+     - matches the regular expression.
+   * - ``'compare'``
+     - ``other_field``
+     - equals another field's value (confirm-password, etc.).
+   * - ``'custom'``
+     - ``func`` — ``(value) -> bool``
+     - satisfies your own predicate.
+
+Every rule also accepts ``message`` (override the default text) and ``trigger``
+(see below).
+
+Custom rules
+~~~~~~~~~~~~
+
+A ``'custom'`` rule runs any predicate that takes the value and returns a bool.
+Pair it with a ``message`` so the user knows what went wrong:
+
+.. code-block:: python
+
+   code = bs.TextField(label="Invite code")
+   code.add_validation_rule(
+       "custom",
+       func=lambda v: v.isdigit() and len(v) == 6,
+       message="The code is 6 digits.",
+   )
+
+Confirming a second field
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A ``'compare'`` rule passes only when the value matches ``other_field``. The
+other field can be **another field widget**, a ``Signal``, or any zero-argument
+callable — its value is read fresh each time the rule runs, so it always
+compares against the current text:
+
+.. code-block:: python
+
+   password = bs.PasswordField(label="Password")
+   password.add_validation_rule("stringLength", min=8)
+
+   confirm = bs.PasswordField(label="Confirm password")
+   confirm.add_validation_rule(
+       "compare",
+       other_field=password,                 # a field widget…
+       message="Passwords don't match.",
+   )
+
+.. code-block:: python
+
+   # …or compare against a Signal / callable instead of a widget
+   pin = bs.Signal("")
+   confirm.add_validation_rule("compare", other_field=pin)
+   confirm.add_validation_rule("compare", other_field=lambda: expected_value())
+
+When does a rule run?
+---------------------
+
+The ``trigger`` controls *when* a rule fires during normal typing. Each rule type
+has a sensible default, which you can override per rule:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 18 82
+
+   * - Trigger
+     - Runs…
+   * - ``'always'``
+     - as the user types **and** when the field loses focus. Default for
+       ``'required'``, ``'email'``, ``'pattern'``.
+   * - ``'key'``
+     - only as the user types.
+   * - ``'blur'``
+     - only when the field loses focus. Default for ``'stringLength'`` and
+       ``'compare'`` — they read better once the user has finished a field.
+   * - ``'manual'``
+     - never automatically — only when you call ``validate()`` yourself.
+       Default for ``'custom'``.
+
+Auto-validation is debounced, so a fast typist doesn't trigger a check on every
+keystroke. Override the trigger when the default doesn't fit — for example, to
+check a length rule live:
+
+.. code-block:: python
+
+   name.add_validation_rule("stringLength", min=2, max=50, trigger="always")
 
 Reacting to validation
 ----------------------
 
-Run all rules on demand with ``validate()`` (returns ``True`` if every rule
-passes). Listen for outcomes with ``on_valid`` / ``on_invalid`` — both receive a
-:class:`ValidationEvent <bootstack.events.ValidationEvent>` carrying the
-``value``, ``is_valid``, and ``message``:
+Run every rule on demand with ``validate()`` (regardless of trigger); it returns
+``True`` when they all pass. Listen for outcomes with ``on_valid`` /
+``on_invalid`` — both receive a :class:`ValidationEvent
+<bootstack.events.ValidationEvent>` carrying ``value``, ``is_valid``, and
+``message``:
 
 .. code-block:: python
 
-   email.on_invalid(lambda e: print("nope:", e.message))
-   email.on_valid(lambda e: print("ok:", e.value))
+   status = bs.Label("", accent="danger")
 
-   if email.validate():
+   def show(e):
+       status.text = e.message      # "" when valid
+
+   email.on_invalid(show)
+   email.on_valid(show)
+
+   if email.validate():             # runs every rule, returns True if all pass
        submit()
+
+Validating a whole form before submit
+-------------------------------------
+
+A common pattern is to gate a submit button on every field passing. ``validate()``
+runs all rules and surfaces the messages through the fields' own events, so the
+guard itself stays short:
+
+.. code-block:: python
+
+   fields = [email, password, confirm]
+
+   def on_submit():
+       if all(f.validate() for f in fields):   # each shows its own error
+           save(email.value, password.value)
+
+   bs.Button("Create account", on_click=on_submit)
+
+Because ``all()`` short-circuits, call ``validate()`` on each field in a list
+comprehension first if you want *every* field to display its error at once:
+
+.. code-block:: python
+
+   results = [f.validate() for f in fields]   # validate them all
+   if all(results):
+       save(...)
 
 Standalone rules
 ----------------
 
-For validation outside a field, construct a :class:`ValidationRule
-<bootstack.validation.ValidationRule>` and call ``validate()`` directly:
+The rule engine doesn't need a widget. Construct a :class:`ValidationRule
+<bootstack.validation.ValidationRule>` and call ``validate()`` directly — useful
+for checking values from config, a CLI, or a background job:
 
 .. code-block:: python
 
    rule = bs.ValidationRule("stringLength", min=3, max=8)
    result = rule.validate("hi")
    result.is_valid     # False
-   result.message      # the failure text
+   result.message      # "Enter between 3 and 8 characters."
+
+   bs.ValidationRule("email").validate("a@b.co").is_valid       # True
+   bs.ValidationRule("compare", other_field="yes").validate("no").is_valid  # False
 
 See also
 --------
 
 - :doc:`/reference/events` — the ``ValidationEvent`` payload and the ``on_*`` model.
 - :doc:`/widgets/textfield` — the field widget these rules attach to.
+- :doc:`/widgets/formdialog` — collects and validates a set of fields at once.
 
 API reference
 -------------

--- a/docs/widgets/datatable.rst
+++ b/docs/widgets/datatable.rst
@@ -546,7 +546,7 @@ See also
 API
 ---
 
-.. autoclass:: bootstack.widgets.datatable.Table
+.. autoclass:: bootstack.widgets.datatable.DataTable
    :members:
    :undoc-members:
 

--- a/src/bootstack/i18n/intl_format.py
+++ b/src/bootstack/i18n/intl_format.py
@@ -280,8 +280,12 @@ class IntlFormatter:
             # Build a currency pattern with required precision; symbol first is a sane default
             p = max(0, int(prec))
             frac = "" if p == 0 else ("." + "0" * p)
-            currency_pattern = f"\\u00A4#,##0{frac}"
-            return format_currency(x, curr, format=currency_pattern, locale=self.locale)
+            currency_pattern = f"¤#,##0{frac}"   # ¤ is the CLDR currency placeholder
+            # currency_digits=False so the explicit precision wins over the
+            # currency's standard digit count (Babel forces the latter otherwise).
+            return format_currency(
+                x, curr, format=currency_pattern, locale=self.locale, currency_digits=False
+            )
 
         if opt["type"] == "exponential":
             return format_scientific(x, locale=self.locale)
@@ -408,22 +412,22 @@ class IntlFormatter:
         opt = self._normalize_date_spec(spec)
         t = opt["type"]
         if t == "custom": return format_date(d, format=opt["pattern"], locale=self.locale)
-        if t == "longDate": return format_date(d, "long", self.locale)
-        if t == "shortDate": return format_date(d, "short", self.locale)
-        if t == "monthAndDay": return format_date(d, "MMMM d", self.locale)
-        if t == "monthAndYear": return format_date(d, "MMMM y", self.locale)
-        if t == "quarterAndYear": return format_date(d, "QQQ y", self.locale)
-        if t == "day": return format_date(d, "d", self.locale)
-        if t == "dayOfWeek": return format_date(d, "EEEE", self.locale)
-        if t == "month": return format_date(d, "MMMM", self.locale)
-        if t == "quarter": return format_date(d, "QQQ", self.locale)
-        if t == "year": return format_date(d, "y", self.locale)
+        if t == "longDate": return format_date(d, "long", locale=self.locale)
+        if t == "shortDate": return format_date(d, "short", locale=self.locale)
+        if t == "monthAndDay": return format_date(d, "MMMM d", locale=self.locale)
+        if t == "monthAndYear": return format_date(d, "MMMM y", locale=self.locale)
+        if t == "quarterAndYear": return format_date(d, "QQQ y", locale=self.locale)
+        if t == "day": return format_date(d, "d", locale=self.locale)
+        if t == "dayOfWeek": return format_date(d, "EEEE", locale=self.locale)
+        if t == "month": return format_date(d, "MMMM", locale=self.locale)
+        if t == "quarter": return format_date(d, "QQQ", locale=self.locale)
+        if t == "year": return format_date(d, "y", locale=self.locale)
         if t in ("longTime", "shortTime"):
-            return format_time(time(0, 0), "long" if t == "longTime" else "short", self.locale)
+            return format_time(time(0, 0), "long" if t == "longTime" else "short", locale=self.locale)
         if t in ("longDateLongTime", "shortDateShortTime"):
             return format_datetime(
-                datetime.combine(d, time(0, 0)), "long" if t == "longDateLongTime" else "short", self.locale)
-        return format_date(d, "short", self.locale)
+                datetime.combine(d, time(0, 0)), "long" if t == "longDateLongTime" else "short", locale=self.locale)
+        return format_date(d, "short", locale=self.locale)
 
     def _format_time(self, t: time, spec: LooseSpec) -> str:
         opt = self._normalize_date_spec(spec)
@@ -431,41 +435,41 @@ class IntlFormatter:
         if typ == "custom": return format_time(t, format=opt["pattern"], locale=self.locale)
         if typ == "longTime": return format_time(t, "long", locale=self.locale)
         if typ == "shortTime": return format_time(t, "short", locale=self.locale)
-        if typ == "hour": return format_time(t, "H", self.locale)
-        if typ == "minute": return format_time(t, "m", self.locale)
-        if typ == "second": return format_time(t, "s", self.locale)
-        if typ == "millisecond": return format_datetime(datetime.combine(date.today(), t), "S", self.locale)
+        if typ == "hour": return format_time(t, "H", locale=self.locale)
+        if typ == "minute": return format_time(t, "m", locale=self.locale)
+        if typ == "second": return format_time(t, "s", locale=self.locale)
+        if typ == "millisecond": return format_datetime(datetime.combine(date.today(), t), "S", locale=self.locale)
         if typ in ("longDate", "shortDate", "monthAndDay", "monthAndYear", "quarterAndYear", "day", "dayOfWeek",
                    "month", "quarter", "year"):
-            return format_time(t, "short", self.locale)
+            return format_time(t, "short", locale=self.locale)
         if typ in ("longDateLongTime", "shortDateShortTime"):
             return format_datetime(
-                datetime.combine(date.today(), t), "long" if typ == "longDateLongTime" else "short", self.locale)
-        return format_time(t, "short", self.locale)
+                datetime.combine(date.today(), t), "long" if typ == "longDateLongTime" else "short", locale=self.locale)
+        return format_time(t, "short", locale=self.locale)
 
     def _format_datetime(self, dt: datetime, spec: LooseSpec) -> str:
         opt = self._normalize_date_spec(spec)
         typ = opt["type"]
         if typ == "custom": return format_datetime(dt, format=opt["pattern"], locale=self.locale)
-        if typ == "longDateLongTime": return format_datetime(dt, "long", self.locale)
-        if typ == "shortDateShortTime": return format_datetime(dt, "short", self.locale)
-        if typ == "longDate": return format_date(dt.date(), "long", self.locale)
-        if typ == "shortDate": return format_date(dt.date(), "short", self.locale)
+        if typ == "longDateLongTime": return format_datetime(dt, "long", locale=self.locale)
+        if typ == "shortDateShortTime": return format_datetime(dt, "short", locale=self.locale)
+        if typ == "longDate": return format_date(dt.date(), "long", locale=self.locale)
+        if typ == "shortDate": return format_date(dt.date(), "short", locale=self.locale)
         if typ == "longTime": return format_time(dt.time(), "long", locale=self.locale)
         if typ == "shortTime": return format_time(dt.time(), "short", locale=self.locale)
-        if typ == "monthAndDay": return format_date(dt.date(), "MMMM d", self.locale)
-        if typ == "monthAndYear": return format_date(dt.date(), "MMMM y", self.locale)
-        if typ == "quarterAndYear": return format_date(dt.date(), "QQQ y", self.locale)
-        if typ == "millisecond": return format_datetime(dt, "SSS", self.locale)
-        if typ == "second": return format_time(dt.time(), "s", self.locale)
-        if typ == "minute": return format_time(dt.time(), "m", self.locale)
-        if typ == "hour": return format_time(dt.time(), "H", self.locale)
-        if typ == "day": return format_date(dt.date(), "d", self.locale)
-        if typ == "dayOfWeek": return format_date(dt.date(), "EEEE", self.locale)
-        if typ == "month": return format_date(dt.date(), "MMMM", self.locale)
-        if typ == "quarter": return format_date(dt.date(), "QQQ", self.locale)
-        if typ == "year": return format_date(dt.date(), "y", self.locale)
-        return format_datetime(dt, "short", self.locale)
+        if typ == "monthAndDay": return format_date(dt.date(), "MMMM d", locale=self.locale)
+        if typ == "monthAndYear": return format_date(dt.date(), "MMMM y", locale=self.locale)
+        if typ == "quarterAndYear": return format_date(dt.date(), "QQQ y", locale=self.locale)
+        if typ == "millisecond": return format_datetime(dt, "SSS", locale=self.locale)
+        if typ == "second": return format_time(dt.time(), "s", locale=self.locale)
+        if typ == "minute": return format_time(dt.time(), "m", locale=self.locale)
+        if typ == "hour": return format_time(dt.time(), "H", locale=self.locale)
+        if typ == "day": return format_date(dt.date(), "d", locale=self.locale)
+        if typ == "dayOfWeek": return format_date(dt.date(), "EEEE", locale=self.locale)
+        if typ == "month": return format_date(dt.date(), "MMMM", locale=self.locale)
+        if typ == "quarter": return format_date(dt.date(), "QQQ", locale=self.locale)
+        if typ == "year": return format_date(dt.date(), "y", locale=self.locale)
+        return format_datetime(dt, "short", locale=self.locale)
 
     # ---------- Temporal parsing ----------
     def _parse_temporal(self, s: str, spec: LooseSpec) -> Any:

--- a/src/bootstack/validation/validation_rules.py
+++ b/src/bootstack/validation/validation_rules.py
@@ -9,16 +9,17 @@ class ValidationRule:
     """A single validation rule that can be applied to a string value.
 
     Supports the built-in rule types `'required'`, `'email'`,
-    `'stringLength'`, `'pattern'`, and `'custom'`, and carries a trigger
-    policy that controls when the rule is evaluated.
+    `'stringLength'`, `'pattern'`, `'compare'`, and `'custom'`, and carries a
+    trigger policy that controls when the rule is evaluated.
 
     Attributes:
         type (RuleType): The validation rule type.
         message (str): Custom error message; if empty a default is generated.
-        trigger (RuleTriggerType): When the rule fires — `'always'`, `'blur'`, or `'manual'`.
+        trigger (RuleTriggerType): When the rule fires — `'always'`, `'key'`,
+            `'blur'`, or `'manual'`.
         params (dict): Additional parameters specific to the rule type
             (e.g., `min`/`max` for `'stringLength'`, `pattern` for `'pattern'`,
-            `func` for `'custom'`).
+            `other_field` for `'compare'`, `func` for `'custom'`).
     """
 
     def __init__(
@@ -74,12 +75,36 @@ class ValidationRule:
             pattern = self.params.get("pattern", "")
             if not re.match(pattern, value):
                 return ValidationResult(False, msg)
+        elif self.type == "compare":
+            if value != self._read_other(self.params.get("other_field")):
+                return ValidationResult(False, msg)
         elif self.type == "custom":
             func: Callable[[str], bool] = self.params.get("func")
             if func and not func(value):
                 return ValidationResult(False, msg)
 
         return ValidationResult(True)
+
+    @staticmethod
+    def _read_other(other: object) -> object:
+        """Resolve the current value of a `'compare'` rule's `other_field`.
+
+        Accepts a `Signal` or any zero-argument callable (called to read), a
+        field wrapper exposing a `value` property, or a plain literal value.
+
+        Args:
+            other: The `other_field` parameter passed to the rule.
+
+        Returns:
+            The other field's current value, or `None` if `other` is `None`.
+        """
+        if other is None:
+            return None
+        if callable(other):
+            return other()
+        if hasattr(other, "value"):
+            return other.value
+        return other
 
     def _default_message(self) -> str:
         """Return a sensible default error message for this rule type."""
@@ -95,6 +120,8 @@ class ValidationRule:
             return f"Enter between {min_len} and {max_len} characters."
         elif self.type == "pattern":
             return "Value does not match the required pattern."
+        elif self.type == "compare":
+            return "Values do not match."
         elif self.type == "custom":
             return "Invalid value."
         return "Invalid input."
@@ -103,7 +130,7 @@ class ValidationRule:
         """Return the default trigger policy for this rule type."""
         if self.type == "required":
             return "always"
-        elif self.type in {"stringLength"}:
+        elif self.type in {"stringLength", "compare"}:
             return "blur"
         elif self.type in {"email", "pattern"}:
             return "always"

--- a/src/bootstack/widgets/_core/field_mixin.py
+++ b/src/bootstack/widgets/_core/field_mixin.py
@@ -64,8 +64,9 @@ class FieldAddonMixin:
             **kwargs: Rule-specific options:
 
                 - ``message`` *(all rules)* — override the default error message.
-                - ``trigger`` *(all rules)* — when to run: ``'blur'`` (default),
-                  ``'key'``, or ``'manual'``.
+                - ``trigger`` *(all rules)* — when to run: ``'always'`` (key and
+                  blur), ``'key'``, ``'blur'``, or ``'manual'``. Each rule type
+                  has its own sensible default (see the Validation reference).
                 - ``min``, ``max`` *(stringLength)* — minimum/maximum character count.
                 - ``pattern`` *(pattern)* — regex string the value must match.
                 - ``other_field`` *(compare)* — field whose value must match.

--- a/src/bootstack/widgets/_impl/composites/form.py
+++ b/src/bootstack/widgets/_impl/composites/form.py
@@ -244,9 +244,9 @@ class Form(Frame):
                 return True
             value = widget.value
             is_valid = True
+            # An explicit form.validate() is a manual action, so run every rule
+            # regardless of its auto-trigger (matching a field's own validate()).
             for rule in rules:
-                if rule.trigger not in ("always", "manual"):
-                    continue
                 result = rule.validate(value)
                 if not result.is_valid:
                     is_valid = False

--- a/src/bootstack/widgets/_impl/mixins/validation_mixin.py
+++ b/src/bootstack/widgets/_impl/mixins/validation_mixin.py
@@ -94,7 +94,8 @@ class ValidationMixin(Widget):
             trigger: Trigger type ('manual', 'key', 'blur', or 'always')
 
         Returns:
-            True if validation was performed (regardless of result)
+            True if every applicable rule passed (vacuously true when no rule
+            applies for this trigger), False on the first failure.
         """
         ran_rule = False
 
@@ -118,7 +119,8 @@ class ValidationMixin(Widget):
             self.event_generate(self.EVENT_VALID, data=payload)
             self.event_generate(self.EVENT_VALIDATED, data=payload)
 
-        return ran_rule
+        # Nothing failed — pass (vacuously when no rule ran for this trigger).
+        return True
 
     # Optional: ergonomic callback registration
     def on_invalid(self, func: Callable) -> None:

--- a/tests/test_intl_format.py
+++ b/tests/test_intl_format.py
@@ -1,0 +1,99 @@
+"""Tests for IntlFormatter locale-aware formatting.
+
+Regression coverage for two bugs:
+
+* date/time/datetime presets passed the locale into Babel's positional
+  ``tzinfo`` slot, crashing on every time-component and datetime preset.
+* the explicit-precision currency path built its pattern with a literal
+  ``\\u00A4`` (double backslash) instead of the ¤ currency placeholder, and
+  left ``currency_digits`` at its default so the precision was ignored.
+
+These run headless — IntlFormatter needs no App.
+"""
+from __future__ import annotations
+
+import re
+from datetime import date, datetime, time
+
+import pytest
+
+from bootstack import IntlFormatter
+
+TIME_SPECS = ["shortTime", "longTime", "hour", "minute", "second", "millisecond"]
+DATE_SPECS = [
+    "longDate", "shortDate", "monthAndDay", "monthAndYear", "quarterAndYear",
+    "day", "dayOfWeek", "month", "quarter", "year",
+    "longDateLongTime", "shortDateShortTime",
+]
+DATETIME_SPECS = DATE_SPECS + ["longTime", "shortTime", "hour", "minute", "second", "millisecond"]
+
+
+# ---------- regression: positional-locale-as-tzinfo crash ----------
+
+@pytest.mark.parametrize("loc", ["en_US", "de_DE", "fr_FR", "ja_JP"])
+@pytest.mark.parametrize("spec", TIME_SPECS)
+def test_time_specs_do_not_crash(loc, spec):
+    out = IntlFormatter(locale=loc).format(time(14, 30, 5), spec)
+    assert isinstance(out, str) and out != ""
+
+
+@pytest.mark.parametrize("loc", ["en_US", "de_DE"])
+@pytest.mark.parametrize("spec", DATETIME_SPECS)
+def test_datetime_specs_do_not_crash(loc, spec):
+    # A naive datetime used to crash on every datetime/time preset.
+    out = IntlFormatter(locale=loc).format(datetime(2025, 9, 2, 14, 30, 5), spec)
+    assert isinstance(out, str) and out != ""
+
+
+@pytest.mark.parametrize("loc", ["en_US", "de_DE"])
+@pytest.mark.parametrize("spec", DATE_SPECS)
+def test_date_specs_do_not_crash(loc, spec):
+    out = IntlFormatter(locale=loc).format(date(2025, 9, 2), spec)
+    assert isinstance(out, str) and out != ""
+
+
+# ---------- currency precision ----------
+
+def _frac_digits(s: str, mark: str = ".") -> int:
+    """Count digits after the locale's decimal mark (ignoring a trailing symbol)."""
+    m = re.search(re.escape(mark) + r"(\d+)", s)
+    return len(m.group(1)) if m else 0
+
+
+@pytest.mark.parametrize("prec", [0, 1, 2, 3])
+def test_currency_precision_honored(prec):
+    out = IntlFormatter(locale="en_US").format(
+        1234.5, {"type": "currency", "currency": "USD", "precision": prec}
+    )
+    assert "1,234" in out                  # grouping intact
+    assert _frac_digits(out) == prec       # precision wins over the currency default
+
+
+def test_currency_precision_de_uses_comma_decimal():
+    out = IntlFormatter(locale="de_DE").format(
+        1234.5, {"type": "currency", "currency": "EUR", "precision": 2}
+    )
+    assert _frac_digits(out, ",") == 2
+
+
+def test_currency_precision_not_garbled():
+    # Regression: the pattern used to render the literal text "¤#,##0.00".
+    out = IntlFormatter(locale="en_US").format(
+        1234.5, {"type": "currency", "currency": "USD", "precision": 2}
+    )
+    assert "u00A4" not in out
+    assert "#" not in out                  # no raw CLDR pattern leaking through
+    assert "$" in out
+
+
+def test_currency_preset_unaffected():
+    assert IntlFormatter(locale="en_US").format(1234.5, "currency") == "$1,234.50"
+
+
+# ---------- smoke: unchanged number/date wiring still correct ----------
+
+def test_locale_wiring_smoke():
+    f = IntlFormatter(locale="de_DE")
+    assert f.format(1234.56, "decimal") == "1.234,56"
+    long_date = f.format(date(2025, 9, 2), "longDate")
+    assert "September" in long_date and "2025" in long_date

--- a/tests/test_validation_rules.py
+++ b/tests/test_validation_rules.py
@@ -1,0 +1,152 @@
+"""Tests for the standalone ValidationRule engine and its widget/form wiring.
+
+The rule-engine tests run headless. The App-backed tests (Signal-based compare,
+field/form integration) share one module-scoped App and are marked ``gui``.
+"""
+from __future__ import annotations
+
+import pytest
+
+import bootstack as bs
+from bootstack.validation import ValidationRule
+
+
+@pytest.fixture(scope="module")
+def shown_app():
+    """A single App shared by the App-backed tests, torn down at the end."""
+    app = bs.App()
+    app.__enter__()
+    root = app._tk_root
+    root.withdraw()
+    root.update_idletasks()
+    try:
+        yield app
+    finally:
+        try:
+            app.__exit__(None, None, None)
+        except Exception:
+            pass
+        try:
+            root.destroy()
+        except Exception:
+            pass
+
+
+def test_required_rejects_empty_and_whitespace():
+    rule = ValidationRule("required")
+    assert rule.validate("ok").is_valid
+    assert not rule.validate("").is_valid
+    assert not rule.validate("   ").is_valid
+    assert rule.validate("").message == "This field is required."
+
+
+def test_email_shape():
+    rule = ValidationRule("email")
+    assert rule.validate("a@b.co").is_valid
+    assert not rule.validate("not-an-email").is_valid
+
+
+def test_string_length_bounds():
+    rule = ValidationRule("stringLength", min=3, max=5)
+    assert rule.validate("abcd").is_valid
+    assert not rule.validate("ab").is_valid
+    assert not rule.validate("abcdef").is_valid
+
+
+def test_pattern_match():
+    rule = ValidationRule("pattern", pattern=r"\d{4}")
+    assert rule.validate("2026").is_valid
+    assert not rule.validate("26").is_valid
+
+
+def test_custom_func():
+    rule = ValidationRule("custom", func=lambda v: v.isdigit())
+    assert rule.validate("123").is_valid
+    assert not rule.validate("12a").is_valid
+
+
+def test_compare_against_literal():
+    rule = ValidationRule("compare", other_field="secret")
+    assert rule.validate("secret").is_valid
+    assert not rule.validate("nope").is_valid
+    assert rule.validate("nope").message == "Values do not match."
+
+
+def test_compare_against_callable():
+    """A Signal — or any zero-arg callable — is read at validation time."""
+    box = {"v": "abc"}
+    rule = ValidationRule("compare", other_field=lambda: box["v"])
+    assert rule.validate("abc").is_valid
+    box["v"] = "xyz"
+    assert not rule.validate("abc").is_valid     # other field changed
+    assert rule.validate("xyz").is_valid
+
+
+def test_compare_against_value_object():
+    """An object exposing a `value` property (a field wrapper) is supported."""
+    class Field:
+        value = "hunter2"
+
+    rule = ValidationRule("compare", other_field=Field())
+    assert rule.validate("hunter2").is_valid
+    assert not rule.validate("hunter1").is_valid
+
+
+def test_compare_custom_message():
+    rule = ValidationRule("compare", other_field="a", message="Passwords must match.")
+    assert rule.validate("b").message == "Passwords must match."
+
+
+def test_compare_default_trigger_is_blur():
+    assert ValidationRule("compare", other_field="x").trigger == "blur"
+
+
+@pytest.mark.gui
+def test_compare_against_signal(shown_app):
+    """End-to-end with a real bs.Signal as the other field."""
+    other = bs.Signal("topsecret")
+    rule = ValidationRule("compare", other_field=other)
+    assert rule.validate("topsecret").is_valid
+    other.set("changed")
+    assert not rule.validate("topsecret").is_valid
+
+
+# ---------- widget/form integration ----------
+
+@pytest.mark.gui
+def test_field_with_no_rules_validates_true(shown_app):
+    """A field with no rules passes vacuously (regression: returned False)."""
+    assert bs.TextField().validate() is True
+
+
+@pytest.mark.gui
+def test_form_enforces_compare_on_submit(shown_app):
+    """Form.validate() must run blur-trigger rules like compare on submit."""
+    form = bs.Form(data={"pw": "secret", "confirm": ""})
+    form.field("confirm").add_validation_rule("compare", other_field=form.field("pw"))
+
+    form.field("confirm").value = "WRONG"
+    assert form.validate() is False
+    form.field("confirm").value = "secret"
+    assert form.validate() is True
+
+
+@pytest.mark.gui
+def test_form_enforces_string_length_on_submit(shown_app):
+    """stringLength (blur trigger) is also enforced on an explicit form submit."""
+    form = bs.Form(data={"name": ""})
+    form.field("name").add_validation_rule("stringLength", min=3)
+
+    form.field("name").value = "ab"
+    assert form.validate() is False
+    form.field("name").value = "abcd"
+    assert form.validate() is True
+
+
+@pytest.mark.gui
+def test_form_with_unruled_fields_still_validates(shown_app):
+    """Fields without rules don't block a form submit (regression for #4)."""
+    form = bs.Form(data={"name": "", "note": ""})
+    form.field("name").add_validation_rule("required")
+    form.field("name").value = "Ada"        # note has no rules
+    assert form.validate() is True


### PR DESCRIPTION
## Summary

A full review-and-enrich pass over `docs/reference/`, plus two correctness fixes the review surfaced (each with tests). Docs build is **warning-free**.

### Docs
- **Enriched** the thin/anemic reference pages with feature-organized usage and worked examples:
  - `errors` — each exception's real trigger condition + a handling example.
  - `scheduling` — `idle`/`at`/`every` patterns, `App.schedule`, a self-cancelling countdown.
  - `shortcuts` — full wired-up app, `register()` return value + duplicate-key error.
  - `validation` — accurate rule table & triggers, confirm-password via `compare`, whole-form validation.
- **New `localization` page** — locale switching (`App(locale=)`/`app.locale`/`localize_mode`), value formatting via `LV`, derived `app.locale_*` conventions, live `on_locale_change`, and bundled translations. Wired into the reference index.
- Fixed a stray `Table`→`DataTable` autoclass in `datatable.rst` (the only remaining build warning).

### Fixes (with tests)
- **`fix(i18n)`** — `IntlFormatter` passed the locale positionally into Babel's `tzinfo` slot, crashing on every time-component/datetime preset; now passes `locale=` by keyword. Also fixes explicit-precision currency formatting (real `¤` placeholder + `currency_digits=False`).
- **`feat(validation)`** — implements the documented-but-missing `compare` rule (`other_field` accepts a field/`Signal`/callable/literal); `field.validate()` now returns `True` for a ruleless field (vacuous truth); `Form.validate()` runs **all** rules on submit (was silently skipping `blur`/`key`-trigger rules like `compare`/`stringLength`).

New tests: `tests/test_intl_format.py`, `tests/test_validation_rules.py` — **107 passing**.

## Notes
- `localization.rst` intentionally documents `L`/`LV` via `from bootstack.i18n import …` and does **not** expose `MessageCatalog`/`IntlFormatter` — those are being demoted to internal in a follow-up namespace-curation PR. The page is correct on both sides of that change, so it needs no rework.

## Test plan
- [x] `pytest tests/test_intl_format.py tests/test_validation_rules.py` → 107 passed
- [x] Sphinx docs build is warning-free
- [x] Reviewer: spot-check the new localization page renders as intended

🤖 Generated with [Claude Code](https://claude.com/claude-code)