### PR TITLE
docs+api: zero out Sphinx build warnings and curate global API surface

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -629,8 +629,11 @@ Path is file-relative from `docs/api/`. Omit from dialog pages.
 - **Run examples after editing** — always `python docs/examples/<widget>.py` before committing.
 - **Dark mode Note admonition** — override in `custom.css` inside `html[data-theme="dark"]`:
   `--pst-color-info: #6ea8fe; --pst-color-info-bg: #0d306e`.
-- **`Shortcuts` service** — `register(key, "Mod+S", fn)` + `bind_to(app)` wires the keyboard
-  handler. `format_shortcut(spec)` resolves display text only (no binding side effect).
+- **`Shortcuts` service** — public surface is `bootstack.shortcuts`: the `Shortcuts`
+  class, the `Shortcut` dataclass, and the `get_shortcuts()` accessor.
+  `register(key, "Mod+S", fn)` + `bind_to(app)` wires the keyboard handler.
+  `format_shortcut(spec)` (in `_runtime/shortcuts.py`) resolves display text only
+  (no binding side effect) — it is INTERNAL, not exported from `bootstack.shortcuts`.
 
 ---
 

--- a/docs/reference/data-sources.rst
+++ b/docs/reference/data-sources.rst
@@ -373,6 +373,6 @@ Reading and writing files directly (the format registries behind
 
 .. autofunction:: bootstack.data.register_writer
 
-.. autofunction:: bootstack.data.supported_extensions
+.. autofunction:: bootstack.data.supported_read_extensions
 
 .. autofunction:: bootstack.data.supported_write_extensions

--- a/docs/widgets/togglebutton.rst
+++ b/docs/widgets/togglebutton.rst
@@ -74,7 +74,7 @@ activation without needing a separate inactive icon.
 
 .. code-block:: python
 
-kt   bs.ToggleButton("Favorite", on_icon="star-fill", off_icon="star",
+   bs.ToggleButton("Favorite", on_icon="star-fill", off_icon="star",
                    accent="warning", value=True)
    bs.ToggleButton("Favorite", on_icon="star-fill", off_icon="star",
                    accent="warning", value=False)

--- a/src/bootstack/_core/capabilities/bind.py
+++ b/src/bootstack/_core/capabilities/bind.py
@@ -32,7 +32,7 @@ class EventGenerateKwargs(TypedDict, total=False):
     keysym: str
     """Key symbol name for keyboard events (e.g., `'Return'`, `'Escape'`, `'a'`)."""
     button: int
-    """Mouse button number: 1=left, 2=middle, 3=right."""
+    """Mouse button number — 1=left, 2=middle, 3=right."""
     delta: int
     """Scroll wheel delta (positive = up, negative = down)."""
     width: int
@@ -40,7 +40,7 @@ class EventGenerateKwargs(TypedDict, total=False):
     height: int
     """Height value for Configure events."""
     when: str
-    """When to deliver the event: `'now'`, `'tail'`, `'mark'`, or `'head'`. Defaults to `'tail'`."""
+    """When to deliver the event — `'now'`, `'tail'`, `'mark'`, or `'head'`. Defaults to `'tail'`."""
 
 
 class BindingsMixin:

--- a/src/bootstack/_core/capabilities/pack.py
+++ b/src/bootstack/_core/capabilities/pack.py
@@ -12,9 +12,9 @@ if TYPE_CHECKING:
 class PackKwargs(TypedDict, total=False):
     """Keyword options for `pack()` and `pack_configure()`."""
     side: str
-    """Side to pack against: `'top'`, `'bottom'`, `'left'`, or `'right'`. Defaults to `'top'`."""
+    """Side to pack against — `'top'`, `'bottom'`, `'left'`, or `'right'`. Defaults to `'top'`."""
     fill: str
-    """How to fill extra space: `'x'`, `'y'`, `'both'`, or `'none'`. Defaults to `'none'`."""
+    """How to fill extra space — `'x'`, `'y'`, `'both'`, or `'none'`. Defaults to `'none'`."""
     expand: bool | int
     """If True/1, the widget expands to fill extra space in the packing direction. Defaults to False."""
     anchor: str

--- a/src/bootstack/_core/capabilities/place.py
+++ b/src/bootstack/_core/capabilities/place.py
@@ -29,7 +29,7 @@ class PlaceKwargs(TypedDict, total=False):
     anchor: str
     """Which point of the widget is placed at (x, y)/(relx, rely) (e.g., `'nw'`, `'center'`, `'se'`). Defaults to `'nw'`."""
     bordermode: str
-    """How x/y are interpreted relative to container borders: `'inside'`, `'outside'`, or `'ignore'`."""
+    """How x/y are interpreted relative to container borders — `'inside'`, `'outside'`, or `'ignore'`."""
     in_: Any
     """Parent widget to place into (rarely needed — defaults to the widget's own master)."""
 

--- a/src/bootstack/_runtime/shortcuts.py
+++ b/src/bootstack/_runtime/shortcuts.py
@@ -70,16 +70,16 @@ _BINDING_MODIFIERS = {
 
 @dataclass
 class Shortcut:
-    """A registered keyboard shortcut.
+    """A registered keyboard shortcut."""
 
-    Attributes:
-        key: Unique identifier for lookup (e.g., "save", "file.open")
-        pattern: Shortcut pattern (e.g., "Mod+S", "Shift+Alt+N")
-        command: Function to execute when triggered
-    """
     key: str
+    """Unique identifier for lookup (e.g. `'save'`, `'file.open'`)."""
+
     pattern: str
+    """Shortcut pattern (e.g. `'Mod+S'`, `'Shift+Alt+N'`)."""
+
     command: Callable
+    """Function to execute when triggered."""
 
     @property
     def display(self) -> str:

--- a/src/bootstack/cli/demo.py
+++ b/src/bootstack/cli/demo.py
@@ -8,7 +8,7 @@ Each sidebar item opens a page demonstrating a widget group.
 import bootstack as bs
 from bootstack.signals import Signal
 from bootstack.dialogs import FormDialog
-from bootstack.style import get_style
+from bootstack.style.style import get_style
 
 
 # =============================================================================

--- a/src/bootstack/cli/icons.py
+++ b/src/bootstack/cli/icons.py
@@ -94,7 +94,7 @@ def run_icons() -> None:
 
     def _theme_colors() -> tuple[str, str]:
         try:
-            from bootstack.style import get_style
+            from bootstack.style.style import get_style
             style = get_style()
             return style.colors.get("background", "#ffffff"), style.colors.get("foreground", "#212529")
         except Exception:

--- a/src/bootstack/data/__init__.py
+++ b/src/bootstack/data/__init__.py
@@ -43,7 +43,7 @@ from bootstack.data.readers import (
     register_reader,
     read_records,
     get_reader,
-    supported_extensions,
+    supported_read_extensions,
 )
 from bootstack.data.writers import (
     register_writer,
@@ -70,7 +70,7 @@ __all__ = [
     'register_reader',
     'read_records',
     'get_reader',
-    'supported_extensions',
+    'supported_read_extensions',
     'register_writer',
     'write_records',
     'get_writer',

--- a/src/bootstack/data/file_source.py
+++ b/src/bootstack/data/file_source.py
@@ -38,7 +38,7 @@ import tempfile
 import weakref
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Dict, Iterator, List, Literal, Optional
+from typing import Any, Callable, Dict, Iterator, List, Literal, Optional, Type
 
 from bootstack.data.sqlite_source import SqliteDataSource
 from bootstack.data.types import Record
@@ -67,31 +67,6 @@ def _cleanup_temp_store(conn: "sqlite3.Connection", path: str) -> None:
 class FileSourceConfig:
     """Configuration for file parsing and the per-record transformation pipeline.
 
-    Attributes:
-        file_format: Format override; auto-detected from the extension if 'auto'.
-        encoding: Character encoding for reading the file.
-        delimiter: Field separator (None = auto: ',' for CSV, tab for TSV).
-        quotechar: Quote character for fields containing the delimiter.
-        skip_rows: Number of leading rows to skip before the header (CSV/TSV).
-        header_row: Row index containing column names (None = no header).
-        has_header: Whether the first row contains column names.
-        json_lines: True for line-delimited JSON (JSONL/NDJSON).
-        json_records_key: Key whose value is the records list in a JSON object
-            (e.g. "data" for {"data": [...]}); None = a top-level array, or the
-            object itself as one record.
-        xml_record_tag: Element tag that marks one record (None = direct children of the root).
-        hdf5_key: Dataset/table key to read from an HDF5 file (None = the first key).
-        column_renames: Map {old_name: new_name} for renaming columns.
-        column_types: Map {column: type} for type conversions.
-        column_transforms: Map {column: func} for custom transformations.
-        columns_to_load: List of columns to keep (None = all columns).
-        default_values: Map {column: value} for missing/null values.
-        row_filter: Function(row_dict) -> bool to filter rows during load.
-        row_transform: Function(row_dict) -> row_dict for row-level transforms.
-        chunk_size: Rows ingested per batch (bounds memory during load).
-        progress_callback: Function(count) called after each ingested chunk with
-            the running total of rows loaded so far.
-
     Example:
         .. code-block:: python
 
@@ -99,31 +74,72 @@ class FileSourceConfig:
                 column_renames={'emp_id': 'id'},
                 column_types={'age': int},
             )
-
     """
 
     file_format: Literal[
         'auto', 'csv', 'tsv', 'json', 'jsonl', 'ndjson', 'xml', 'parquet', 'feather', 'hdf5'
     ] = 'auto'
+    """Format override; auto-detected from the extension when `'auto'`."""
+
     encoding: str = 'utf-8'
+    """Character encoding for reading the file."""
+
     delimiter: Optional[str] = None
+    """Field separator. `None` auto-selects `','` for CSV and a tab for TSV."""
+
     quotechar: str = '"'
+    """Quote character for fields containing the delimiter."""
+
     skip_rows: int = 0
+    """Number of leading rows to skip before the header (CSV/TSV)."""
+
     header_row: Optional[int] = 0
+    """Row index containing column names (`None` = no header)."""
+
     has_header: bool = True
+    """Whether the first row contains column names."""
+
     json_lines: bool = False
+    """`True` for line-delimited JSON (JSONL/NDJSON)."""
+
     json_records_key: Optional[str] = None
+    """Key whose value is the records list in a JSON object (e.g. `'data'` for
+    `{'data': [...]}`); `None` = a top-level array, or the object itself as one
+    record."""
+
     xml_record_tag: Optional[str] = None
+    """Element tag that marks one record (`None` = direct children of the root)."""
+
     hdf5_key: Optional[str] = None
+    """Dataset/table key to read from an HDF5 file (`None` = the first key)."""
+
     column_renames: Optional[Dict[str, str]] = None
-    column_types: Optional[Dict[str, type]] = None
+    """Mapping from each existing column name to its replacement."""
+
+    column_types: Optional[Dict[str, Type]] = None
+    """Mapping from a column name to the target type to convert its values to."""
+
     column_transforms: Optional[Dict[str, Callable[[Any], Any]]] = None
+    """Mapping from a column name to a transform applied to its values."""
+
     columns_to_load: Optional[List[str]] = None
+    """List of columns to keep (`None` = all columns)."""
+
     default_values: Optional[Dict[str, Any]] = None
+    """Mapping from a column name to a fill value for missing or null entries."""
+
     row_filter: Optional[Callable[[Dict[str, Any]], bool]] = None
+    """Function `(row_dict) -> bool` to filter rows during load."""
+
     row_transform: Optional[Callable[[Dict[str, Any]], Dict[str, Any]]] = None
+    """Function `(row_dict) -> row_dict` for row-level transforms."""
+
     chunk_size: int = 10_000
+    """Rows ingested per batch (bounds memory during load)."""
+
     progress_callback: Optional[Callable[[int], None]] = None
+    """Function `(count)` called after each ingested chunk with the running total
+    of rows loaded so far."""
 
 
 class FileDataSource(SqliteDataSource):

--- a/src/bootstack/data/readers.py
+++ b/src/bootstack/data/readers.py
@@ -81,8 +81,8 @@ def register_reader(*extensions: str, reader: Optional[Reader] = None):
     return _apply(reader) if reader is not None else _apply
 
 
-def supported_extensions() -> List[str]:
-    """Return the sorted list of registered file extensions."""
+def supported_read_extensions() -> List[str]:
+    """Return the sorted list of registered readable file extensions."""
     return sorted(_READERS)
 
 
@@ -105,7 +105,7 @@ def get_reader(path_or_ext: "str | Path") -> Reader:
     except KeyError:
         raise ValueError(
             f"No reader registered for {ext!r}. Supported formats: "
-            f"{', '.join(supported_extensions())}."
+            f"{', '.join(supported_read_extensions())}."
         ) from None
 
 

--- a/src/bootstack/data/types.py
+++ b/src/bootstack/data/types.py
@@ -48,9 +48,6 @@ class DataSourceProtocol(Protocol):
         - CSV export capabilities
         - Direct index-based data access
 
-    Attributes:
-        page_size: Number of records per page
-
     Notes:
         - Records are represented as Dict[str, Any] with at least 'id' and 'selected' fields
         - Filtering and sorting are expressed with the `col` expression API, not SQL
@@ -59,6 +56,7 @@ class DataSourceProtocol(Protocol):
 
     # public attrs
     page_size: int
+    """Number of records per page."""
 
     # ---------- data & view config ----------
     def load(self, records: Sequence[Primitive] | Sequence[Mapping[str, Any]]) -> DataSourceProtocol:

--- a/src/bootstack/dialogs/_impl/dialog.py
+++ b/src/bootstack/dialogs/_impl/dialog.py
@@ -30,32 +30,37 @@ DialogMode = Literal["modal", "popover", "sheet"]
 
 @dataclass
 class DialogButton:
-    """Specification for a dialog button.
+    """Specification for a dialog button."""
 
-    Attributes:
-        text (str): Button label text displayed to the user.
-        role (ButtonRole): Button role determining styling and behavior.
-            - `"primary"`: Main action (blue solid); triggered by Enter when ``default=True``.
-            - `"secondary"`: Neutral action (gray solid); no keyboard shortcut.
-            - `"danger"`: Destructive action (red solid); not focused by default.
-            - `"cancel"`: Cancel action (gray outline); triggered by Escape.
-        result (Any | None): Value assigned to dialog.result when clicked.
-        closes (bool): Whether button closes the dialog when clicked.
-        default (bool): Whether this is the default button (focused, triggered by Enter).
-        command (Callable[[Dialog], None] | None): Callback called when clicked.
-        accent (str | None): Accent token for styling (e.g., 'primary', 'danger').
-        variant (str | None): Style variant (e.g., 'outline', 'link').
-        icon (str | dict | None): Optional icon specification for the button.
-    """
     text: str
+    """Button label text displayed to the user."""
+
     role: ButtonRole = "secondary"
+    """Role that determines the button's styling and keyboard behavior. One of
+    `'primary'` (main action, triggered by Enter when `default=True`),
+    `'secondary'` (neutral action, no keyboard shortcut), `'danger'` (destructive
+    action, not focused by default), or `'cancel'` (triggered by Escape)."""
+
     result: Any | None = None  # value assigned to dialog.result
+    """Value assigned to `dialog.result` when clicked."""
+
     closes: bool = True  # close dialog after click
+    """Whether the button closes the dialog when clicked."""
+
     default: bool = False  # default button (Enter)
+    """Whether this is the default button (focused, triggered by Enter)."""
+
     command: Callable[[Dialog], None] | None = None
+    """Callback invoked when clicked."""
+
     accent: AccentToken | str | None = None
+    """Accent token for styling (e.g. `'primary'`, `'danger'`)."""
+
     variant: VariantToken | str | None = None
+    """Style variant (e.g. `'outline'`, `'link'`)."""
+
     icon: str | dict[str, Any] | None = None  # passed straight to _Button(icon=...)
+    """Optional icon specification for the button."""
 
 
 ButtonSpec = Union[DialogButton, Mapping[str, Any]]
@@ -191,16 +196,13 @@ class Dialog:
         Args:
             position: Optional (x, y) coordinates to position the dialog.
                 If provided, takes precedence over anchor-based positioning.
-            modal: Override the mode's default modality.
-                - If None, uses mode:
-                    - "modal": grab_set + wait_window
-                    - "popover": no grab, but wait_window
-            anchor_to: Positioning target. Can be:
-                - Widget: Anchor to a specific widget
-                - "screen": Anchor to screen edges/corners
-                - "cursor": Anchor to mouse cursor location
-                - "parent": Anchor to parent window (same as widget)
-                - None: Centers on parent (default)
+            modal: Override the mode's default modality. When `None`, follows the
+                mode — `"modal"` grabs focus and waits for the dialog to close;
+                `"popover"` waits without grabbing.
+            anchor_to: Positioning target. A widget anchors to that widget;
+                `"screen"` anchors to the screen edges/corners; `"cursor"` anchors
+                to the mouse cursor; `"parent"` anchors to the parent window; and
+                `None` (default) centers on the parent.
             anchor_point: Point on the anchor target (n, s, e, w, ne, nw, se, sw, center).
                 Default 'center'.
             window_point: Point on the dialog window (n, s, e, w, ne, nw, se, sw, center).

--- a/src/bootstack/style/__init__.py
+++ b/src/bootstack/style/__init__.py
@@ -5,13 +5,14 @@ their modules (`bootstack.style.style`, `bootstack.style.typography`) if you nee
 them. They are deliberately not part of the public API: `Style` subclasses
 `ttk.Style` (a Tkinter leak), and `Typography`/`Font` are internal registries
 slated to be replaced by a public font-token API.
+
+The low-level engine accessors `get_style`, `get_style_builder`, and
+`get_theme_provider` return those internal objects and are likewise not public —
+import them from `bootstack.style.style` if you need them internally.
 """
 from bootstack.style.style import (
-    get_style,
-    get_style_builder,
     get_theme,
     get_theme_color,
-    get_theme_provider,
     get_themes,
     set_theme,
     toggle_theme,
@@ -25,11 +26,8 @@ from bootstack.style.fonts import (
 
 __all__ = [
     "Theme",
-    "get_style",
-    "get_style_builder",
     "get_theme",
     "get_theme_color",
-    "get_theme_provider",
     "get_themes",
     "set_theme",
     "toggle_theme",

--- a/src/bootstack/style/theme.py
+++ b/src/bootstack/style/theme.py
@@ -81,7 +81,7 @@ class Theme:
     """Reference black (hex). Defaults to `'#000000'`."""
 
     shades: dict[str, str] = field(default_factory=dict)
-    """Mapping of base hue name to hex color, e.g. `{'orange': '#fd7e14'}`.
+    """Mapping of base hue name to hex color, e.g. orange to `'#fd7e14'`.
     Merged onto the base's shades."""
 
     semantic: dict[str, str] = field(default_factory=dict)

--- a/src/bootstack/widgets/form.py
+++ b/src/bootstack/widgets/form.py
@@ -31,9 +31,6 @@ class Form(PublicWidgetBase):
         accent: Accent token for the form container.
         buttons: Footer buttons — strings, `DialogButton` instances, or dicts.
         parent: Override the context-stack parent.
-
-    Attributes:
-        result: Set by button commands. None until a button is pressed.
     """
 
     def __init__(

--- a/src/bootstack/widgets/tree.py
+++ b/src/bootstack/widgets/tree.py
@@ -255,7 +255,7 @@ class Tree(PublicWidgetBase):
         """The top-level nodes, in order.
 
         Useful for reaching handles after declarative construction
-        (`Tree(nodes=...)`), which otherwise returns no `TreeNode`s.
+        (`Tree(nodes=...)`), which otherwise returns no `TreeNode` handles.
         """
         return list(self._internal.roots)
 

--- a/tests/data/test_readers.py
+++ b/tests/data/test_readers.py
@@ -19,7 +19,7 @@ from bootstack.data import (
     get_reader,
     read_records,
     register_reader,
-    supported_extensions,
+    supported_read_extensions,
 )
 
 
@@ -31,7 +31,7 @@ def _has(module: str) -> bool:
 
 
 def test_supported_extensions_includes_stdlib_and_optional():
-    exts = supported_extensions()
+    exts = supported_read_extensions()
     for e in (".csv", ".tsv", ".txt", ".json", ".jsonl", ".ndjson", ".xml",
               ".parquet", ".feather", ".h5"):
         assert e in exts

--- a/tests/test_public_surface.py
+++ b/tests/test_public_surface.py
@@ -76,7 +76,7 @@ MOVED = {
         "DuplicateIdError", "SerializationError",
     ],
     "bootstack.style": [
-        "Theme", "get_style", "get_theme", "get_theme_color", "get_themes",
+        "Theme", "get_theme", "get_theme_color", "get_themes",
         "get_font_families", "set_font_family", "update_font_token",
     ],
     "bootstack.types": [
@@ -125,3 +125,10 @@ def test_demoted_helpers_not_public():
     for name in ("Image", "get_current_app", "IntlFormatter", "MessageCatalog"):
         assert name not in bs.__all__
         assert not hasattr(bs, name)
+
+
+def test_internal_style_accessors_not_public():
+    """The Tk-leaking engine accessors stay out of the public style surface."""
+    import bootstack.style as style
+    for name in ("get_style", "get_style_builder", "get_theme_provider"):
+        assert name not in style.__all__, f"{name} should not be public in bootstack.style"


### PR DESCRIPTION
## Summary

Two cohesive pre-release polish efforts. The docs build goes from **39 warnings + 1 error → 0**, and the public global-items surface is audited for accessor/verb consistency.

### Docs build: warning-free

- **Dataclass double-documentation** — converted `Attributes:`/`Args:` blocks to per-field attribute docstrings (`FileSourceConfig`, `DataSourceProtocol`, `Shortcut`, `DialogButton`; `Form` drops a redundant `Attributes:` block) so napoleon and autodoc stop each emitting a copy.
- **Docutils nits + the one error** — `togglebutton.rst` code-block typo, `Dialog.show` doubly-nested bullet list (the error), `tree.roots` backtick glued to a letter, and the colon-space-inside-backticks autodoc bug on several `FileSourceConfig` fields + `Theme.shades`.
- **Ambiguous `type` xref** — `column_types` annotated as `typing.Type` so the builtin `type` no longer collides with `Signal.type`/`ValidationRule.type`.

### Colon-space attribute-docstring sweep

Root-caused a latent, mostly-**silent** bug: a colon on the **first line** of an attribute docstring makes napoleon split it and jam the pre-colon text into a bogus `:type:` field (only warns when it also splits a backtick pair). An AST sweep found all **7** instances; all fixed (`delimiter`, `role`, and 5 internal `_core` kwargs docstrings).

### Pre-release global-items / verb audit

- **Demote internal engine accessors** — `get_style`, `get_style_builder`, `get_theme_provider` removed from the public `bootstack.style` surface (they leak ttk types); still importable from `bootstack.style.style`. CLI callers repointed; guard test added.
- **Registry symmetry** — `supported_extensions` → `supported_read_extensions` to match `supported_write_extensions` (clean break, pre-release; no shim).
- **`format_shortcut`** — clarified in `CLAUDE.md` that it's internal (not exported).

Left as-is by decision: `get_theme()`/`get_themes()` return shapes (documented); `update_font_token` (correctly a partial-update verb); the dual `set_theme`/`app.theme` path (by design).

## Testing

- Public-surface guard, readers, intl, validation, schema tests pass.
- Clean Sphinx build (`-W --keep-going`): **EXIT 0, zero warnings**.
- Import smoke confirms the demotion/rename took effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)