### PR TITLE
docs: API Reference restructure — stage 1 (bootstack.data prototype)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ site
 *_build
 *_static
 !docs/_static
+# autosummary-generated API reference stubs (regenerated at build time)
+docs/api-reference/generated/
 .vscode
 __pycache__
 testing_notes.txt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,6 +158,18 @@ memories (see them for rationale and gotchas).
 
 ## Next up — candidates (pick one)
 
+- **★ API Reference restructure (docs)** — LEAD CANDIDATE, planned + spec'd. Split
+  the docs into a narrative layer (Widgets + Guides) and a **unified, complete,
+  by-module API Reference** that mirrors each submodule's `__all__` (pandas/Django
+  model), because the current per-page curated `autoclass` gives no browsable API
+  tree — worst for the non-widget subsystems. **Move the autodoc HOME into the new
+  API Reference** (single home per object — re-introducing a second home brings
+  back the PR #106 duplicate-description warnings); narrative pages cross-link in
+  (`:class:`/`:func:`) + an optional `autosummary` summary table. **Full brief +
+  staged PR plan in `docs/_dev/api-reference-restructure.md`** (excluded from the
+  Sphinx build). **Do stage 1 first:** a `bootstack.data` prototype slice, built
+  warning-free, for maintainer review BEFORE the ~50-page sweep. Best done in a
+  fresh session. Memory `project_api_reference_restructure`.
 - **Image / Icon public handle** — design a Tk-free public image/icon handle and
   re-promote (both currently internal). Memory `project_public_intent_backlog`.
 - **Deferred file-streaming items** — background/progressive ingest, keyset

--- a/docs/_dev/api-reference-restructure.md
+++ b/docs/_dev/api-reference-restructure.md
@@ -1,0 +1,361 @@
+# Initiative — API Reference restructure (docs)
+
+**Status:** Stage 1 (the `bootstack.data` prototype slice) BUILT and under
+maintainer review on branch `feat/api-reference-data-prototype` (2026-06-08).
+Stages 2–5 not started. Decided 2026-06-08 with the maintainer.
+
+> `docs/_dev/` is excluded from the Sphinx build (`conf.py` `exclude_patterns`).
+> This is a dev note, not a published page.
+
+---
+
+## The problem
+
+The docs currently mix two incompatible jobs on the same pages:
+
+1. **Narrative** — widget pages (`docs/widgets/*`) and subsystem pages
+   (`docs/reference/*`) are prose-first: intro, screenshots, task-ordered usage,
+   examples.
+2. **API reference** — each of those pages ends with a hand-**curated**
+   `.. autoclass:: ... :members:` block.
+
+Consequences:
+
+- There is **no traditional, complete, by-module API tree** anywhere. The
+  closest is `getting-started/api-overview.rst`, which is a *namespace map*
+  (names only), not a browsable reference. A Python dev who wants "everything on
+  `SqliteDataSource`" or "what's in `bootstack.data`?" has no canonical home.
+- The bottom-of-page `autoclass` is **curated** (hand-picked members), so the
+  page view and any tree view would diverge.
+- The tension is worst for the **non-widget subsystems** (data, signals, events,
+  query DSL, theming): they are more API-shaped and less visual than widgets, so
+  prose carries less of the weight and the missing tree hurts more.
+
+MUI ("Components" + "Components API") and Ant Design (all-on-one-page) are both
+**component-only**, so neither maps cleanly to a desktop framework that also has
+data sources, signals, theming, scheduling, etc.
+
+## The decision
+
+Adopt a **Diátaxis-style split**: one narrative layer + one **unified, complete
+API-reference layer** that mirrors the import tree. The narrative **links into**
+the reference rather than re-documenting it.
+
+Precedent (the audience's expectation): pandas / NumPy / SciPy (User Guide +
+exhaustive by-module API reference), Flask (User's Guide + API Reference),
+Django (topic guides + how-tos + reference) — the big multi-concern Python
+frameworks all keep the API reference as its own pillar.
+
+## Target structure (keep navbar at 5)
+
+| Section | Role | Source |
+|---|---|---|
+| **Getting Started** | onboarding | as-is |
+| **Widgets** | visual catalog — usage, screenshots, examples | as-is, but **drop the bottom `autoclass`**; cross-link to API Reference |
+| **Guides** | task + topic narrative for subsystems | merge today's `tasks/` + the **prose** from today's `reference/` (theming, data, signals, events, validation, i18n, scheduling, store, shortcuts) |
+| **API Reference** | **complete, by-module tree** — the new pillar | autosummary-generated, mirrors each submodule's `__all__` |
+| **Production** | packaging etc. | as-is |
+
+The current `reference/` section **dissolves**: its prose → **Guides**; its API
+role → **API Reference**. `api-overview.rst` becomes the **landing page of API
+Reference** (the map), drilling into per-module pages:
+
+```
+API Reference
+  bootstack                 # App/AppShell/Window, widgets, Signal, dialog verbs, set_theme/toggle_theme
+  bootstack.data            # SqliteDataSource/Memory/File, col, any_of/all_of, readers/writers
+  bootstack.style           # Theme, get_theme/get_themes/get_theme_color, font verbs
+  bootstack.events
+  bootstack.signals
+  bootstack.streams
+  bootstack.validation
+  bootstack.i18n
+  bootstack.scheduling
+  bootstack.shortcuts
+  bootstack.store
+  bootstack.errors
+  bootstack.types
+  bootstack.dialogs
+```
+
+Because the reference mirrors `__all__` exactly, the public structure becomes
+self-documenting and stays in lockstep with `tests/test_public_surface.py`.
+
+## THE load-bearing rule: one autodoc *home*
+
+Every object may be the autodoc home in **exactly one place**. Two `autoclass`
+directives for the same object = the "duplicate object description" warnings that
+PR #106 just eliminated. So:
+
+- **Move the autodoc home INTO API Reference** (full `:members:`).
+- Widgets/Guides **cross-link in** with roles —
+  `` :class:`bootstack.data.SqliteDataSource` ``, `` :func:`bootstack.data.col` ``
+  — instead of re-documenting. Narrative pages keep their prose/usage/examples.
+- **Optional best-of-both** (Django/pandas do this): a small `.. autosummary::`
+  *table* (names + one-line summaries, linking into the reference) at the top or
+  bottom of a narrative page, for at-a-glance members without leaving. This
+  closes the gap with Ant's inline feel WITHOUT creating a second autodoc home
+  (autosummary tables are not object descriptions).
+
+## Tooling
+
+Use `sphinx.ext.autosummary` (already enabled; `autosummary_generate = True`)
+with `:toctree:` + `:recursive:` and class/module templates so every
+class/function gets its own auto-generated page, grouped by module. This is the
+pandas/numpy approach and is **lower** maintenance than today's hand-curated
+`autoclass` blocks — the tree regenerates from the code.
+
+- Per-module landing pages (`bootstack.data`, etc.) with autosummary tables that
+  toctree into per-object stub pages.
+- The top-level `bootstack` page has 50+ widgets — use autosummary tables
+  grouped by category (Layout / Actions / Inputs / …), each linking to per-class
+  stubs, rather than one giant `automodule`.
+- Custom templates likely needed under `docs/_templates/autosummary/`
+  (`class.rst`, `module.rst`) to control member curation (e.g. exclude inherited
+  Tk noise, keep Google-style sections).
+
+## Staged plan (discrete PRs)
+
+1. **Prototype slice (FIRST DELIVERABLE, for maintainer review):**
+   `bootstack.data` only. Build the API-Reference page(s) for the data module
+   (autosummary tree + per-object stubs), strip the `autoclass` from
+   `reference/data-sources.rst` and re-point it as a Guide that **cross-links**
+   into the new reference, add the optional summary table. Wire a minimal "API
+   Reference" toctree. Build warning-free. **Stop and get reaction before
+   sweeping.**
+2. **Lock the pattern** — fold review feedback into the autosummary templates +
+   the page recipe; document the new "API Reference page" and "Guide page"
+   patterns (replacing the curated-autoclass recipe in `CLAUDE.md`).
+3. **Sweep subsystems** — move every `reference/*` page's autodoc home into API
+   Reference; convert the prose pages into Guides; dissolve the `reference/`
+   section.
+4. **Sweep widgets** — drop the bottom `autoclass` from ~40 widget pages; add
+   per-widget API entries under `bootstack` in API Reference; add summary tables.
+   **See "Stage 4 detail — the widget page shape" below** for the category
+   grouping, the widget-cluster handling, and the `__all__`-hygiene audit this
+   stage doubles as.
+5. **Nav re-cut** — `tasks/` + subsystem prose → **Guides**; new **API
+   Reference** section; `api-overview.rst` becomes its landing page. Update
+   `docs/index.rst` toctree and `conf.py` `show_nav_level`/captions as needed.
+
+Each stage ends with a clean-build verification (below) and is its own PR.
+
+## Stage 1 prototype — outcome (2026-06-08)
+
+Built on `feat/api-reference-data-prototype`, clean-build warning-free
+(non-nitpicky `-W`). Shipped:
+
+- `docs/api-reference/index.rst` (section landing) + `docs/api-reference/data.rst`
+  (the `bootstack.data` module page: grouped autosummary tables → 22
+  auto-generated per-object stubs under `docs/api-reference/generated/`).
+- `docs/_templates/autosummary/class.rst` — one custom class template:
+  `:members: :inherited-members: :show-inheritance:`. `:inherited-members:` is
+  what makes concrete-source pages complete — `SqliteDataSource` shows inherited
+  `save`/`on_change`/`observe`/`export_csv`/`reload` alongside its own methods,
+  and (verified) the Protocol page stays clean (no `_private`/dunder/Generic
+  leak) because `undoc-members: False` + no `:special-members:` filter it.
+- `reference/data-sources.rst` re-pointed: curated `autoclass` block removed,
+  replaced with a cross-link to `/api-reference/data` + an at-a-glance
+  `autosummary` table WITHOUT `:toctree:` (a table only — NOT a second autodoc
+  home; links resolve to the stubs).
+- `docs/api-reference/generated/` gitignored (stubs regenerate at build time).
+- Root toctree gained `api-reference/index` → navbar is temporarily **6** items;
+  Stage 5 re-cut returns it to 5 by dissolving `reference/` into Guides + API
+  Reference.
+
+Templates/recipe to LOCK in Stage 2 from this: the single `class.rst` template
+above works unchanged for plain classes, dataclasses (`FileSourceConfig`), and
+Protocols; functions/data aliases fall back to autosummary's built-in
+`function.rst`/`base.rst` (no custom template needed). Per-object-kind templates
+are selectable with `:template:` on the autosummary directive if a future module
+needs it, but `data` didn't.
+
+## Stage 4 detail — the widget page shape
+
+The widget API reference is NOT ~40 separate module pages. It is the **single
+top-level `bootstack` module page** (same role `data.rst` plays), but because
+the top-level surface is large (85 names: 68 classes, 15 functions — see
+`tests/test_public_surface.py`) it uses **autosummary tables grouped by
+category**, each entry linking to a per-class stub. Categories mirror the
+widget-guide caption groups:
+
+Resolved category map (accounts for all 85 `__all__` names; companions shown
+indented only to mark the cluster — they render as flat siblings). **`AppShell`
+lives under Application, NOT Navigation** (it is a top-level app shell, not a nav
+control — decided 2026-06-08; the Widgets caption toctree should move it too):
+
+```
+bootstack
+├─ Application       App · AppShell · Window
+├─ State             Signal
+│
+├─ Actions           Button · ButtonGroup
+├─ Inputs            TextField · PasswordField · NumberField · SpinnerField ·
+│                    PathField · Slider · RangeSlider · TextArea · CodeEditor ·
+│                    DateField · TimeField
+├─ Selection         Checkbox · Switch · ToggleButton · ToggleGroup ·
+│                    RadioGroup [Radio · RadioToggleButton] · Select ·
+│                    SelectButton · Calendar
+├─ Data Display      Label · Badge · ProgressBar · Gauge · ListView ·
+│                    DataTable [EditFilter? · EditorType?] · Tree [TreeNode]
+├─ Layout            Separator · Card · GroupBox · VStack · HStack · Grid ·
+│                    ScrollView · Accordion [AccordionSection] · SplitView [SplitPane]
+├─ Menus & Toolbars  Toolbar · MenuButton · MenuBar · ContextMenu [ContextMenuItem]
+├─ Navigation        PageStack [StackPage] · Tabs [TabPage] ·
+│                    SideNav [SideNavGroup · SideNavHeader · SideNavItem · SideNavSeparator]
+├─ Overlays          Tooltip · Toast
+├─ Forms             Form [FormItem · FieldItem · GroupItem · TabsItem · TabItem]
+│
+├─ Dialogs  (verbs)  alert · confirm · toast · ask_string · ask_integer ·
+│                    ask_float · ask_date · ask_date_range · ask_color ·
+│                    ask_font · ask_item · ask_filter
+└─ Theme    (verbs)  set_theme · toggle_theme
+```
+
+Most widgets are a single stub (one widget → one page). The exceptions are
+**widget clusters** — a parent widget plus companion classes that are ALSO in
+the top-level `__all__`. They render as **flat adjacent siblings within the same
+category group** (no nesting); each gets its own stub. The legibility lever is
+ordering + a one-line group lead-in (companions listed right after their parent).
+Known clusters (from `__all__`, 2026-06-08):
+
+| Widget | Companion classes (also top-level public) |
+|---|---|
+| `Tree` | `TreeNode` |
+| `SideNav` | `SideNavGroup`, `SideNavHeader`, `SideNavItem`, `SideNavSeparator` |
+| `Form` | `FormItem`, `FieldItem`, `GroupItem`, `TabsItem`, `TabItem` |
+| `RadioGroup` | `Radio`, `RadioToggleButton` |
+| `Accordion` | `AccordionSection` |
+| `Tabs` | `TabPage` |
+| `PageStack` | `StackPage` |
+| `SplitView` | `SplitPane` |
+| `ContextMenu` | `ContextMenuItem` |
+
+Deliberately NOT on the widget page (cross-linked from their own module instead,
+documented once):
+- **Event payloads** (`ChangeEvent`, `SliderEvent`, `RowsEvent`, …) → live in
+  the `bootstack.events` reference page; a widget guide's "what `on_change`
+  hands you" is a `:class:` link into events.
+- **Token/keyword types** (`AccentToken`, `WidgetDensity`, …) → `bootstack.types`.
+
+The widget GUIDE (`widgets/<w>.rst`) keeps its screenshots/usage/examples, drops
+its bottom `autoclass`, and its summary table lists the whole cluster (e.g.
+`tree.rst` → `Tree` + `TreeNode`).
+
+### Stage 4 doubles as an `__all__`-hygiene audit
+
+Because the reference renders **exactly** `__all__`, the sweep surfaces every
+half-public type. First case already found: **`ColumnSpec`** (`DataTable`'s
+primary column-config object) is a `TypedDict` in `widgets/datatable.py` that is
+in **no `__all__`** — not top-level, not `bootstack.types` — yet `datatable.rst`
+documents it heavily. So it currently has **no reference home**. Per-case
+decision the sweep must make:
+
+- **Promote** to a public home (lean: `bootstack.types` for config TypedDicts, or
+  expose as a `DataTable` companion in top-level `__all__`) — then it gets a stub
+  and the guide can `:class:`-link it; **or**
+- **Leave guide-only** — then the guide must NOT `:class:`-link it (a `-n`
+  nitpicky build flags the dangling xref).
+
+Recommendation: promote the compose-surface config types (`ColumnSpec` and any
+siblings the audit turns up). Settle each case in Stage 4, not before. Keep
+`tests/test_public_surface.py` in lockstep with whatever is promoted.
+
+Also-flagged, same bucket: **`EditFilter`** and **`EditorType`** are both in the
+top-level `__all__` but have no natural widget category (both are
+DataTable/filter companions). The audit must decide whether they are genuine
+compose-surface (place them, likely near DataTable) or should be demoted.
+
+### Re-exports: shallowest path wins (the "one home" rule for duplicated names)
+
+Several objects are exported at more than one public path — `Signal` is in BOTH
+`bootstack.__all__` and `bootstack.signals.__all__`; likewise widgets re-exported
+from `bootstack.widgets`. The single autodoc home is the **shallowest public
+path**: `Signal`'s stub lives on the top-level `bootstack` page (State), and the
+`bootstack.signals` page lists it in a **table-only** summary (no `:toctree:`,
+links UP to the top-level stub — the same trick the data Guide uses) while owning
+the signals-only names (`TraceOperation`, …). Apply this uniformly in the Stage 3
+subsystem sweep so a re-exported name is never documented twice.
+
+### Presentation — the grouped links must read as tables, not a wall of links
+
+CONCERN raised 2026-06-08: a category with 11 entries must not render as an
+unreadable block of hyperlinks. It does not — `.. autosummary::` renders a
+**two-column table: linked name | first-line docstring summary**, exactly the
+pandas/SciPy reference style. The Stage 1 prototype already proves this in-repo —
+see the rendered `docs/_build/html/api-reference/data.html` (e.g.
+`SqliteDataSource | SQLite-backed data manager with pagination, filtering, …`).
+
+Precedent to mirror for the big `bootstack` page (one large namespace, many
+objects, sectioned): **SciPy module pages** — `scipy.stats`, `scipy.signal` —
+which chunk ~100 functions into labeled sections, each a prose lead-in + an
+autosummary name/summary table. (pandas' per-object reference pages, e.g.
+`DataFrame`, do the same with method groups.)
+
+Readability levers, all already available:
+- `:nosignatures:` on each `autosummary` → compact rows (name + summary only).
+- A one-sentence prose lead-in before each category table (SciPy pattern; the
+  prototype's "Query language"/"Readers and writers" lead-ins are the model).
+- The category headers chunk the page and populate the right-sidebar page-TOC
+  (`secondary_sidebar_items: ["page-toc"]`), so a reader jumps by category.
+- DEPENDS ON good first-line docstrings: the summary column is the object's
+  docstring first line. Widget classes all have one; the audit gap is type
+  aliases (`Record`/`Primitive` render a blank summary cell). The sweep should
+  ensure every newly-homed object has a one-line summary, or accept the blank.
+
+### Follow-on (post-migration) — enrich the widget Guides
+
+**Guiding principle: the API Reference is a last resort.** The Guides must carry
+essentially all of the *practical* teaching load — a user should be able to build
+real things from the Guides alone and only drop to the API Reference for an
+exhaustive-lookup edge case (the one method the Guide didn't cover, an exact
+signature, the full member list). The reference exists to *guarantee
+completeness*, not to be the primary path. If a user routinely has to leave a
+Guide for the reference to get something done, the Guide is underwritten.
+
+This is the *payoff* of the split, and an explicit deliverable AFTER the
+structural sweep (its own pass/PR, not blocking the migration). Once each widget
+page is a pure Guide — the long API surface lifted out into the reference, no
+bottom `autoclass` competing for the page — the Guide is free to be generous.
+So the widget pages should be **fleshed out with far more examples and usage
+patterns** than today: multiple worked snippets per feature, common compositions
+("X inside a Form", "X bound to a Signal/DataSource"), recipes, and do/don't
+guidance. Completeness is no longer the page's job (the reference guarantees it),
+so the page can spend all its room on *teaching how to use the widget well* — to
+the point that reaching for the reference is the exception.
+
+Keep the established widget-page pattern (intro → hero → usage sections with
+screenshots → Widget sizing → See also → cross-link/summary-table into the
+reference), but treat the example density as a feature, not a budget. Applies
+first to widget Guides; the subsystem Guides (former `reference/*` prose) benefit
+the same way. Ties into the existing "Reference docs examples" carryover and the
+`project_docs_initiative` memory.
+
+## Gotchas / guardrails
+
+- **Clean-build to verify, always.** Incremental Sphinx builds MASK warnings.
+  `rm -rf docs/_build && sphinx-build -b html docs docs/_build/html -W
+  --keep-going`. The build is currently warning-free (PR #106) — keep it there.
+- **`__all__` IS the reference now.** Member hygiene and `__all__` accuracy
+  directly determine reference quality. `tests/test_public_surface.py` already
+  guards the surface; the reference should render the same shape.
+- **No duplicate autodoc home** (see the load-bearing rule). This is the single
+  easiest way to reintroduce the warnings we just removed.
+- **Attribute-docstring rules still apply** (from PR #106): no `Attributes:`/
+  `Args:` block for dataclass fields; **no colon on the first line** of an
+  attribute docstring (napoleon mangles the rendered `:type:`).
+- **Cross-ref hygiene** — `conf.py` already has `nitpick_ignore_regex` for
+  stdlib/typing/Tk/private names; a `-n` nitpicky build will surface narrative
+  pages whose cross-refs don't resolve once the home moves. Expect to add a few
+  ignores or fix links.
+- **No Tkinter leakage** — the reference will now expose *complete* public
+  members; double-check nothing internal/Tk-typed sneaks into a public `__all__`
+  (the style-accessor demotion in PR #106 was exactly this class of issue).
+- **Screenshots stay on widget pages** — the API Reference is text-only
+  (no hero images), like the current `reference/` page pattern.
+
+## First task for the next session
+
+Read this brief, then build **stage 1 (the `bootstack.data` prototype slice)**
+and present it warning-free for maintainer review. Do NOT proceed to the full
+sweep until the prototype is approved.

--- a/docs/_templates/autosummary/class.rst
+++ b/docs/_templates/autosummary/class.rst
@@ -1,0 +1,8 @@
+{{ objname | escape | underline }}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}
+   :members:
+   :inherited-members:
+   :show-inheritance:

--- a/docs/api-reference/data.rst
+++ b/docs/api-reference/data.rst
@@ -1,0 +1,75 @@
+bootstack.data
+==============
+
+.. currentmodule:: bootstack.data
+
+Data sources and the ``col`` filter language. A data source owns a set of records
+and serves them a page at a time, so a data-bound widget works the same whether
+the records live in memory, a SQLite database, or a file on disk.
+
+For a task-oriented introduction — when to reach for each source, the data bag,
+observing changes, exporting — see the :doc:`/reference/data-sources` guide.
+
+Data sources
+------------
+
+The concrete sources, the file-source config object, and the base class and
+protocol for writing your own.
+
+.. autosummary::
+   :toctree: generated
+   :nosignatures:
+
+   MemoryDataSource
+   SqliteDataSource
+   FileDataSource
+   FileSourceConfig
+   BaseDataSource
+   DataSourceProtocol
+
+Query language
+--------------
+
+The ``col`` expression API for building filter conditions and sort keys, free of
+SQL. Pass conditions to a source's ``where()`` and sort keys to ``order()``.
+
+.. autosummary::
+   :toctree: generated
+   :nosignatures:
+
+   col
+   Column
+   Condition
+   SortKey
+   any_of
+   all_of
+
+Type aliases
+------------
+
+The record and cell types shared across the module.
+
+.. autosummary::
+   :toctree: generated
+
+   Record
+   Primitive
+
+Readers and writers
+-------------------
+
+The pluggable format registries behind ``FileDataSource`` and a source's
+``save()``. Register a reader or writer to teach the framework a new file format.
+
+.. autosummary::
+   :toctree: generated
+   :nosignatures:
+
+   read_records
+   write_records
+   get_reader
+   get_writer
+   register_reader
+   register_writer
+   supported_read_extensions
+   supported_write_extensions

--- a/docs/api-reference/index.rst
+++ b/docs/api-reference/index.rst
@@ -1,0 +1,21 @@
+API Reference
+=============
+
+The complete, by-module reference for the public API. Each page mirrors a
+submodule's import surface — every public class, function, and type — so you can
+browse "everything in ``bootstack.data``" or jump straight to a single class.
+
+This is the lookup layer. For task-oriented introductions and worked examples,
+start from the :doc:`/widgets/index` catalog and the :doc:`/reference/index`
+guides, which cross-link into the pages here. The
+:doc:`/getting-started/api-overview` maps where each name lives.
+
+.. note::
+
+   This section is being built out module by module. The ``bootstack.data``
+   reference below is the first slice; the remaining submodules follow.
+
+.. toctree::
+   :maxdepth: 1
+
+   data

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -124,7 +124,7 @@ html_short_title = "bootstack"
 html_show_sourcelink = False
 html_copy_source     = False
 
-exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+exclude_patterns = ["_build", "_dev", "Thumbs.db", ".DS_Store"]
 
 # ---------------------------------------------------------------------------
 # Autodoc mock imports (unavailable on Linux CI runners)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,4 +11,5 @@ bootstack
    tasks/index
    widgets/index
    reference/index
+   api-reference/index
    production/index

--- a/docs/reference/data-sources.rst
+++ b/docs/reference/data-sources.rst
@@ -340,39 +340,22 @@ See also
 API reference
 -------------
 
-The concrete sources:
+The complete reference — every method, the ``col`` expression API, and the
+reader/writer registries — lives in :doc:`/api-reference/data`. At a glance:
 
-.. autoclass:: bootstack.data.MemoryDataSource
-   :members:
+.. currentmodule:: bootstack.data
 
-.. autoclass:: bootstack.data.SqliteDataSource
-   :members:
+.. autosummary::
+   :nosignatures:
 
-.. autoclass:: bootstack.data.FileDataSource
-   :members:
-
-.. autoclass:: bootstack.data.FileSourceConfig
-   :members:
-
-The interface and base class for writing your own:
-
-.. autoclass:: bootstack.data.DataSourceProtocol
-   :members:
-
-.. autoclass:: bootstack.data.BaseDataSource
-   :members:
-
-Reading and writing files directly (the format registries behind
-``FileDataSource`` and ``save()``):
-
-.. autofunction:: bootstack.data.read_records
-
-.. autofunction:: bootstack.data.write_records
-
-.. autofunction:: bootstack.data.register_reader
-
-.. autofunction:: bootstack.data.register_writer
-
-.. autofunction:: bootstack.data.supported_read_extensions
-
-.. autofunction:: bootstack.data.supported_write_extensions
+   MemoryDataSource
+   SqliteDataSource
+   FileDataSource
+   FileSourceConfig
+   DataSourceProtocol
+   BaseDataSource
+   col
+   any_of
+   all_of
+   read_records
+   write_records


### PR DESCRIPTION
## What

Stage 1 of the **API Reference restructure** initiative: introduce a unified, complete, by-module API Reference pillar (pandas/numpy-style autosummary tree) alongside the narrative docs — prototyped on `bootstack.data` only, for review **before** the full sweep.

Full brief + staged PR plan lives in `docs/_dev/api-reference-restructure.md` (excluded from the Sphinx build).

## The problem this solves

The docs currently end every widget/reference page with a hand-**curated** `autoclass` block. There is **no complete, browsable, by-module API tree** anywhere — worst for the non-widget subsystems (data, signals, events, query DSL). This adopts a Diátaxis-style split: narrative Guides that teach + an exhaustive API Reference that guarantees completeness, with **one autodoc home per object** (re-introducing a second home brings back the PR #106 duplicate-description warnings).

## What's in this slice

- **New `docs/api-reference/` section** — index landing + a `bootstack.data` module page with grouped autosummary tables (Data sources / Query language / Type aliases / Readers and writers) toctree'd into **22 auto-generated per-object stubs**.
- **New `docs/_templates/autosummary/class.rst`** — single class template (`:members: :inherited-members: :show-inheritance:`) that renders *complete* pages (concrete sources show inherited `save`/`on_change`/`observe`/`export_csv`) while staying noise-free on the Protocol (verified: no `_private`/dunder/Generic leak).
- **`reference/data-sources.rst` re-pointed as a Guide** — curated `autoclass`/`autofunction` block removed (the single autodoc home now lives in the reference), replaced with a cross-link + a **table-only** `autosummary` summary (no `:toctree:`, so it is *not* a second home).
- **Wiring** — `api-reference/index` added to the root toctree (navbar temporarily **6** items; stage 5 re-cut returns it to 5 by dissolving `reference/` into Guides + API Reference). `docs/api-reference/generated/` gitignored (stubs regenerate at build time).

## Verification

- **Clean build, 0 warnings** — `rm -rf docs/_build && sphinx-build -b html docs docs/_build/html -W --keep-going` → `build succeeded`, exit 0.
- **Single autodoc home** preserved — no duplicate-description warnings.
- **Complete pages** + **Protocol clean** + summary-table links resolve to the stubs (checked the rendered HTML).
- The `-n` nitpicky build shows only **pre-existing** unresolved xrefs (App, Expander, Form, toast, `bootstack.Stream`, …) — none from this change.

## Review focus

This is a **prototype for reaction before the ~50-page sweep**. Worth a look:
- `docs/_build/html/api-reference/data.html` — the new module page
- `docs/_build/html/api-reference/generated/bootstack.data.SqliteDataSource.html` — a stub
- `docs/_build/html/reference/data-sources.html` — the re-pointed Guide

The brief also records decisions made during review for the later stages: the resolved widget category tree (`AppShell` → Application, not Navigation), the `__all__`-hygiene audit (`ColumnSpec`/`EditFilter`/`EditorType`), shallowest-path-wins for re-exported names, the autosummary presentation pattern (SciPy/pandas precedent), and the post-migration guiding principle — **Guides are primary; the API Reference is a last resort.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)