### PR TITLE
docs: API Reference restructure — Stages 2+3 (subsystem sweep)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,15 +176,26 @@ memories (see them for rationale and gotchas).
   the Guide-page recipe = table-only summary, no bottom `autoclass`, cross-links;
   shallowest-path-wins re-export rule; clean-build verify). Marked the old
   "Reference page pattern" SUPERSEDED and flagged the Widget pattern for its Stage 4
-  autoclass-drop. **NEXT: Stage 3** (sweep subsystems).
+  autoclass-drop.
+- **API Reference restructure — Stage 3** (same branch `feat/api-reference-stage2`) —
+  subsystem sweep. Built API-ref pages for all 10 remaining subsystems (signals,
+  streams, events, errors, i18n, scheduling, shortcuts, store, validation, style —
+  style covers theming+typography), each the autodoc home; converted all 11
+  `reference/*` prose pages to Guides (autoclass → cross-link + table-only summary;
+  zero autodoc homes left under `reference/`). Added `exception.rst`/`signal.rst`
+  templates (bare titles; per-class `:template:` takes **NO** `.rst`). Grouping
+  conventions baked into the recipe. Hygiene: **demoted `TraceOperation`** (internal),
+  **recategorized `TabRef`** (supporting type). `Signal`/`set_theme`/`toggle_theme`
+  hold a TEMP home (Stage 4 relocates up); `FontChoice` home removed (Stage 4 dialogs
+  page). Side fix: `--pst-color-link` brand-blue override in `custom.css`. Flagged
+  out-of-band: `project_signal_subscribe_subscription`. Clean-build warning-free.
+  **NEXT: Stage 4.**
 
 ## Next up — candidates (pick one)
 
-- **★ API Reference restructure — Stage 3+ (docs)** — LEAD CANDIDATE, IN PROGRESS
-  (Stage 1 merged PR #107; Stage 2 recipe-lock done on `feat/api-reference-stage2`).
-  Continue the staged sweep from the brief:
-  **Stage 3** sweep subsystems (move each `reference/*` autodoc home into API
-  Reference, convert prose → Guides, dissolve `reference/`); **Stage 4** sweep
+- **★ API Reference restructure — Stage 4+ (docs)** — LEAD CANDIDATE, IN PROGRESS
+  (Stage 1 merged PR #107; Stages 2+3 done on `feat/api-reference-stage2`).
+  Continue the staged sweep from the brief: **Stage 4** sweep
   widgets (single category-grouped `bootstack` page; `AppShell`→Application; widget
   clusters as flat sibling stubs; doubles as an `__all__`-hygiene audit —
   `ColumnSpec`/`EditFilter`/`EditorType`); **Stage 5** nav re-cut (back to 5).
@@ -464,6 +475,11 @@ adopt callable-setter `signal(x)`.
 - Past-tense event names still pending rename: `SideNav.on_pane_toggled` /
   `on_display_mode_changed`, `ListView.on_selection_changed`,
   `Calendar.on_date_selected` (memory `project_event_naming_revisit`).
+- `Signal.subscribe()` returns a `str` token + `unsubscribe(id)`/`unsubscribe_all()`,
+  unlike events (`Subscription.cancel()`) and streams (`Handle.cancel()`) — flagged
+  to unify to a cancelable handle (memory `project_signal_subscribe_subscription`).
+  Gotcha: `events.Subscription` is Tk-binding-specific, so this needs a shared
+  cancelable-handle abstraction, not a direct reuse. Own branch, not the docs sweep.
 
 ---
 
@@ -517,6 +533,16 @@ header.
   `Primitive`), others as data and pick up `data.rst` (e.g. `Record`) — both now
   title bare, so it no longer matters which. A new documenter kind a future module
   needs (e.g. `exception.rst`) must get the SAME bare-title treatment.
+- **Per-class curation** (a class needing different members than the global
+  `class.rst`): add a per-class template file `_templates/autosummary/<name>.rst`
+  and point that class's `autosummary` entry at it with `:template: <name>` —
+  **WITHOUT the `.rst` extension**. Sphinx's autosummary resolves `:template: X`
+  as `autosummary/X.rst`; passing `signal.rst` builds `autosummary/signal.rst.rst`,
+  silently misses, and falls back to the built-in `base.rst` (full title, no
+  members) — NOT even `class.rst`. `:template:` applies to every name in that
+  directive block, so put the curated class in its own one-name block. Exemplar:
+  `signal.rst` (Signal needs `__call__` shown + `tk`/`var`/`name`/`from_variable`
+  excluded); wired in `api-reference/signals.rst` as `:template: signal`.
 
 ### API Reference page recipe (the autodoc home — one per submodule)
 
@@ -529,6 +555,29 @@ A page like `docs/api-reference/data.rst`. Text-only, **NO screenshots, NO hero*
    `:nosignatures:`. The table renders as a two-column **name | first-line-summary**
    table (pandas/SciPy style) and toctrees each name into an auto-generated per-object
    stub under `docs/api-reference/generated/` (gitignored — regenerates at build).
+   **Grouping conventions** (from the batch-1 review, applied across all pages):
+   (a) **Don't mix kinds in one list** — separate the things you *call*
+   (functions/constructors) from the *supporting types* they produce/consume, from
+   *enumerations/aliases*. E.g. `events` = payload sections + "Supporting types"
+   (`TabRef`, a value carried *inside* a payload) + "Enumerations" (`ChangeReason`…);
+   `data` = "Query language" (`col`/`any_of`/`all_of`) vs "Query expression types"
+   (`Column`/`Condition`/`SortKey`) vs "Type aliases" (`Record`/`Primitive`). A type
+   that only appears *inside* another object (not handed to the user directly) is a
+   supporting type, not a primary entry. (b) **Order sections most-reached-for first,
+   lowest-level lookups last** — primary objects → common callables → their supporting
+   types → feature areas → bare type aliases at the bottom (`data` order: Data sources
+   → Query language → Query expression types → Readers and writers → Type aliases).
+   (c) **Don't sub-section a small/uniform module** — follow the
+   `bootstack.streams` model (intro prose + ONE `autosummary` table, no `---`
+   sub-headings) whenever a module is just a few names of the same kind. Sub-section
+   only when the surface is large OR genuinely mixes kinds (a). `streams`
+   (`Stream`/`Handle`), `validation` (`ValidationRule`/`ValidationResult`),
+   `scheduling` (`Schedule`/`Job`), `shortcuts` (3), and `errors` (5 exceptions) are
+   all single-table; `data`/`events`/`style` earn their groups. The intro carries
+   any rule-vs-result / base-vs-specific nuance — don't spend a heading on it.
+   (d) The audit also surfaces half-public names to demote — e.g. `TraceOperation`
+   (internal trace tag, no public signature exposes it) was dropped from
+   `bootstack.signals.__all__` during this sweep.
 4. List **exactly** the module's `__all__` across the grouped tables (the reference
    IS `__all__`). Good first-line docstrings matter — that line is the summary cell.
 5. Wire the page into `docs/api-reference/index.rst`'s toctree.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,15 +167,22 @@ memories (see them for rationale and gotchas).
   reference; replaced with a cross-link + a table-only `autosummary` summary).
   Navbar temporarily 6 (Stage 5 re-cut returns it to 5). Clean-build warning-free.
   **Full brief + all review-stage decisions in `docs/_dev/api-reference-restructure.md`**;
-  memory `project_api_reference_restructure`. **NEXT: Stage 2** (lock the
-  templates/recipe into this file, replacing the curated-autoclass page pattern).
+  memory `project_api_reference_restructure`.
+- **API Reference restructure — Stage 2** (branch `feat/api-reference-stage2`) —
+  recipe-locking, CLAUDE.md only (no docs/code change). Added the canonical
+  **"## API Reference & Guide page pattern (established — follow exactly)"** section
+  (the locked `class.rst` autosummary template + facts; the API-Reference-page recipe
+  = autodoc home, grouped `autosummary` with `:toctree: generated` + `:nosignatures:`;
+  the Guide-page recipe = table-only summary, no bottom `autoclass`, cross-links;
+  shallowest-path-wins re-export rule; clean-build verify). Marked the old
+  "Reference page pattern" SUPERSEDED and flagged the Widget pattern for its Stage 4
+  autoclass-drop. **NEXT: Stage 3** (sweep subsystems).
 
 ## Next up — candidates (pick one)
 
-- **★ API Reference restructure — Stage 2+ (docs)** — LEAD CANDIDATE, IN PROGRESS
-  (Stage 1 merged, PR #107). Continue the staged sweep from the brief:
-  **Stage 2** lock the autosummary template + the new "API Reference page" / "Guide
-  page" recipes into this CLAUDE.md (replacing the curated-autoclass recipe);
+- **★ API Reference restructure — Stage 3+ (docs)** — LEAD CANDIDATE, IN PROGRESS
+  (Stage 1 merged PR #107; Stage 2 recipe-lock done on `feat/api-reference-stage2`).
+  Continue the staged sweep from the brief:
   **Stage 3** sweep subsystems (move each `reference/*` autodoc home into API
   Reference, convert prose → Guides, dissolve `reference/`); **Stage 4** sweep
   widgets (single category-grouped `bootstack` page; `AppShell`→Application; widget
@@ -229,17 +236,18 @@ Top-level sections (pydata horizontal navbar — keep this set SMALL, ~5):
   needs internal organization (e.g. if Common Tasks grows).
 - Do NOT promote widget groups to top-level — ~14 navbar items overflow pydata.
 
-**Reference page pattern** (distinct from widgets — non-visual, NO screenshots):
-prose intro → task-ordered usage sections (code blocks) → See also → curated
-`autoclass`. **Inline usage only — NO separate "Full Example" / `docs/examples/<topic>.py`
-for reference pages** (decided 2026-06-05; widget pages DO keep their Full Example).
-When dropping a Full Example, make sure the inline usage covers the same patterns
-(memory `feedback_reference_page_examples`). The **API reference section is FLAT** —
-no `~~~` sub-group headers (the sidebar is narrow); use a prose lead-in to group.
-Autoclass at the **PUBLIC home path** (`bootstack.signals.Signal`, NOT
-`signals.signal.Signal`); `:members:`, curating internal members with
-`:exclude-members:` where needed. Single backticks, Google style.
-**Exemplars: `docs/reference/signals.rst`, `docs/reference/events.rst`.**
+**Reference page pattern** — ⚠ **SUPERSEDED by the API Reference restructure**
+(PR #107 + the staged sweep; see "## API Reference & Guide page pattern" below for
+the canonical recipe). The historical pattern was: prose intro → task-ordered
+usage → See also → a hand-**curated** `autoclass` at the bottom (`:members:` at the
+PUBLIC home path, `:exclude-members:` to hide internals). The curated autoclass is
+being REMOVED page by page — the single autodoc home now lives in the **API
+Reference** (autosummary-generated), and these pages become **Guides** that
+cross-link in. Until Stage 3 sweeps a given `reference/*` page, it may still carry
+the old curated `autoclass`; do NOT add new ones. Still in force from the old
+pattern: non-visual (NO screenshots), inline usage only (NO separate Full Example),
+single backticks, Google style. **Exemplars (NEW model): `docs/reference/data-sources.rst`
+(Guide) + `docs/api-reference/data.rst` (API Reference).**
 
 DONE to this pattern (2026-06-05): signals, events, streams, scheduling,
 shortcuts, validation, data-sources, **theming**; errors already fine. **PARKED:
@@ -459,7 +467,111 @@ adopt callable-setter `signal(x)`.
 
 ---
 
+## API Reference & Guide page pattern (established — follow exactly)
+
+The docs are a **Diátaxis-style split** (PR #107): a narrative layer (**Widgets** +
+**Guides**) plus a **unified, complete API Reference** that mirrors each submodule's
+`__all__`. **Load-bearing rule: every object has exactly ONE autodoc home, and it
+lives in the API Reference.** Narrative pages cross-link in (`:class:` / `:func:` /
+`:meth:`) and may carry a *table-only* `autosummary` summary; they never re-document.
+A second autodoc home reintroduces the "duplicate object description" warnings PR #106
+removed. Full brief + all staged-sweep decisions: `docs/_dev/api-reference-restructure.md`.
+Memory `project_api_reference_restructure`.
+
+### The autosummary templates (locked, PR #107 + Stage 2)
+
+THREE custom templates under `docs/_templates/autosummary/`, one per documenter
+kind autosummary uses for the data surface — `class.rst`, `function.rst`,
+`data.rst`. **All THREE must title the stub page with the bare `{{ objname }}`**
+(not `{{ fullname }}`). This is load-bearing: autosummary picks the template by
+object kind, and the **stub's title is what the sidebar shows**. The built-in
+fallback templates title with the full dotted path (`bootstack.data.col`), so
+relying on the fallback for functions/data produces a sidebar where classes read
+bare (`MemoryDataSource`) but functions/aliases read fully-qualified
+(`bootstack.data.col`) — the exact inconsistency Stage 2 fixed. Keep the bare-title
+line identical across all three.
+
+`class.rst` (also serves dataclasses + Protocols):
+
+```rst
+{{ objname | escape | underline }}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}
+   :members:
+   :inherited-members:
+   :show-inheritance:
+```
+
+`function.rst` → `.. autofunction:: {{ objname }}`; `data.rst` →
+`.. autodata:: {{ objname }}` — each with the same bare-title + `currentmodule`
+header.
+
+- `:inherited-members:` (class template) is what makes a concrete-source stub
+  **complete** (e.g. `SqliteDataSource` shows inherited
+  `save`/`on_change`/`observe`/`export_csv`).
+- The Protocol page stays noise-free because `undoc-members` is off and there is no
+  `:special-members:` — `_private`/dunder/Generic members are filtered out.
+- Some type aliases classify as class-like and pick up `class.rst` (e.g.
+  `Primitive`), others as data and pick up `data.rst` (e.g. `Record`) — both now
+  title bare, so it no longer matters which. A new documenter kind a future module
+  needs (e.g. `exception.rst`) must get the SAME bare-title treatment.
+
+### API Reference page recipe (the autodoc home — one per submodule)
+
+A page like `docs/api-reference/data.rst`. Text-only, **NO screenshots, NO hero**.
+
+1. Title = the dotted module path (`bootstack.data`), then `.. currentmodule::` it.
+2. One prose paragraph orienting the module + a `:doc:` link to its Guide.
+3. **Group the surface into labeled sections** (`---` headings), each: a one-sentence
+   prose lead-in, then an `.. autosummary::` table with `:toctree: generated` and
+   `:nosignatures:`. The table renders as a two-column **name | first-line-summary**
+   table (pandas/SciPy style) and toctrees each name into an auto-generated per-object
+   stub under `docs/api-reference/generated/` (gitignored — regenerates at build).
+4. List **exactly** the module's `__all__` across the grouped tables (the reference
+   IS `__all__`). Good first-line docstrings matter — that line is the summary cell.
+5. Wire the page into `docs/api-reference/index.rst`'s toctree.
+
+Re-exported names (shallowest path wins): a name exported at two public paths gets
+ONE stub, on the **shallowest** page (`Signal` → top-level `bootstack` page). Deeper
+module pages list it in a **table-only** summary (no `:toctree:`, links up to the
+stub) and own only their module-local names.
+
+### Guide page recipe (the former `reference/*` prose pages)
+
+A page like `docs/reference/data-sources.rst`. This is the teaching layer.
+**Guiding principle: the API Reference is a LAST RESORT — the Guide carries the
+practical teaching load** (generous worked examples, common compositions, recipes,
+do/don't). A user should build real things from the Guide alone.
+
+1. Prose intro → task-ordered usage sections (code blocks) → See also.
+2. **No bottom `autoclass`** — instead end with an **"API reference"** section: a
+   one-line pointer (`:doc:` link to the API Reference page) + an at-a-glance
+   `.. autosummary::` table **WITHOUT `:toctree:`** (a table is NOT an object
+   description, so it's not a second autodoc home; its links resolve to the stubs).
+3. Cross-link types inline with roles (`:class:` / `:func:` / `:meth:` / `:data:`)
+   at the **public home path** (`bootstack.data.SqliteDataSource`, not the impl path).
+4. Inline usage only — NO separate Full Example file. Non-visual: NO screenshots.
+
+### Verify (every stage)
+
+Clean-build, always — incremental builds MASK warnings:
+`rm -rf docs/_build && sphinx-build -b html docs docs/_build/html -W --keep-going`.
+Build is warning-free; keep it there. Attribute-docstring rules (PR #106) still
+apply (no `Attributes:`/`Args:` for dataclass fields; no colon on the first line of
+an attribute docstring). A `-n` nitpicky build surfaces dangling cross-refs once a
+home moves — fix the link or add a `nitpick_ignore_regex`.
+
+---
+
 ## Widget documentation pattern (established — follow exactly)
+
+> ⚠ Stage 4 of the API Reference restructure will modify this pattern: the bottom
+> `autoclass` gets DROPPED (the autodoc home moves to the single top-level
+> `bootstack` API Reference page) and replaced with a table-only `autosummary`
+> summary + cross-links, per the Guide-page recipe above. Until then, in-flight
+> widget pages keep the autoclass.
 
 1. **Audit** — Explore agent comparing public wrapper vs `_impl/` internals.
 2. **Fix wrapper** — typed params (`AccentToken`, `VariantToken`, `WidgetDensity`);

--- a/docs/_dev/api-reference-restructure.md
+++ b/docs/_dev/api-reference-restructure.md
@@ -1,10 +1,43 @@
 # Initiative — API Reference restructure (docs)
 
 **Status:** Stage 1 (the `bootstack.data` prototype slice) MERGED (PR #107).
-Stage 2 (recipe-lock) done on `feat/api-reference-stage2` — the templates + the
-API-Reference-page / Guide-page recipes are now locked into `CLAUDE.md` under
-"## API Reference & Guide page pattern". Stages 3–5 not started. Decided 2026-06-08
-with the maintainer.
+Stage 2 (recipe-lock) + Stage 3 (subsystem sweep) done on `feat/api-reference-stage2`.
+Stages 4–5 not started. Decided 2026-06-08 with the maintainer.
+
+**Stage 3 outcome (2026-06-08):** Built API-Reference pages for all 10 remaining
+subsystems — `signals`, `streams`, `events`, `errors`, `i18n`, `scheduling`,
+`shortcuts`, `store`, `validation`, `style` (the last covers both the theming and
+typography guides) — each the autodoc home; converted all 11 `reference/*` prose
+pages into Guides (curated `autoclass` removed → cross-link + table-only summary;
+verified zero autodoc directives remain under `reference/`); wired every page into
+`api-reference/index.rst`. Clean-build warning-free. Decisions made during the
+sweep (carry into Stage 4):
+- **Template kinds:** added `function.rst` + `data.rst` (Stage 2) and
+  `exception.rst` (Stage 3) so functions / data-aliases / exceptions all title bare
+  like `class.rst`. Per-class curation via `:template: <name>` (NO `.rst`
+  extension — autosummary resolves it as `autosummary/<name>.rst`; with the
+  extension it silently falls back to `base.rst`). `signal.rst` is the exemplar
+  (`__call__` shown, `tk`/`var`/`name`/`from_variable` excluded).
+- **Grouping conventions** (applied to every page): separate callables from
+  supporting types from enums/aliases; order sections most-reached-for first,
+  bare aliases last.
+- **`__all__` hygiene found + acted on:** `TraceOperation` DEMOTED from
+  `bootstack.signals.__all__` (internal trace tag, no public signature exposes it;
+  now `bootstack.signals` = just `Signal`). `TabRef` recategorized (it is a value
+  type carried *inside* tab payloads, not a payload → "Supporting types").
+- **Re-export temp-homing:** `Signal` (signals) and `set_theme`/`toggle_theme`
+  (style) are top-level re-exports; they hold a TEMPORARY autodoc home on their
+  subsystem page now. **Stage 4 must relocate the home to the top-level `bootstack`
+  page and convert the subsystem entry to a table-only link.**
+- **`FontChoice`:** its old autodoc home was in `typography.rst` (it is a
+  `bootstack.dialogs` type). Home REMOVED; nothing `:class:`-links it (only plain
+  literals), so the build stays clean. **Stage 4 dialogs page must home it.**
+- **`bootstack.signals` page is now Signal-only** (TraceOperation gone, Signal
+  homes top-level in Stage 4) — Stage 4 decides whether this page becomes a
+  table-only pointer up to the top-level Signal stub, or is dropped.
+- **Side fix (independent of the sweep):** `--pst-color-link` was never overridden
+  in `custom.css`, so links rendered in pydata's default teal instead of the brand
+  blue; set `--pst-color-link`/`-hover` in both themes.
 
 > `docs/_dev/` is excluded from the Sphinx build (`conf.py` `exclude_patterns`).
 > This is a dev note, not a published page.
@@ -284,6 +317,32 @@ path**: `Signal`'s stub lives on the top-level `bootstack` page (State), and the
 links UP to the top-level stub — the same trick the data Guide uses) while owning
 the signals-only names (`TraceOperation`, …). Apply this uniformly in the Stage 3
 subsystem sweep so a re-exported name is never documented twice.
+
+**Complete re-export inventory (2026-06-08, full cross-module scan).** Only THREE
+groups of names are exported at both top level and a submodule; everything else
+has a single home already:
+
+1. **`bootstack.signals` → `Signal`** — Stage 3 gave it a TEMP home on
+   `api-reference/signals.rst`. Stage 4 relocates the home to the top-level page
+   (State) and makes `bootstack.signals` table-link up. With `TraceOperation`
+   demoted, signals is then Signal-only → its page likely becomes a table-only
+   pointer, or is dropped.
+2. **`bootstack.style` → `set_theme`, `toggle_theme`** — TEMP home on
+   `api-reference/style.rst` now. Stage 4 relocates these two to the top-level page
+   (Theme verbs); `bootstack.style` keeps its other 7 (`Theme`, `get_theme`,
+   `get_themes`, `get_theme_color`, `get_font_families`, `set_font_family`,
+   `update_font_token`) and table-links the two up.
+3. **`bootstack.widgets` → ~80 names** (every widget, `App`/`AppShell`/`Window`,
+   the dialog verbs, `toast`). The top-level `bootstack` page is their single home
+   (category-grouped — Stage 4). `bootstack.widgets` is internal plumbing and does
+   NOT get its own API-reference page. Their CURRENT homes are the bottom
+   `autoclass` blocks on the `docs/widgets/*` guide pages — Stage 4 drops those.
+
+Single home already (no relocation): `data`, `events`, `i18n`, `scheduling`,
+`shortcuts`, `store`, `streams`, `validation`, `types`. **`bootstack.dialogs` has
+NO `__all__`** — Stage 4 must add one and home `FontChoice`/`FormDialog`/`Dialog`/
+`DialogButton`/`ColorChooserDialog`/`ColorChoice`/`FontDialog`/`FilterDialog` there
+(`FontChoice` lost its old typography-page home in Stage 3).
 
 ### Presentation — the grouped links must read as tables, not a wall of links
 

--- a/docs/_dev/api-reference-restructure.md
+++ b/docs/_dev/api-reference-restructure.md
@@ -1,8 +1,10 @@
 # Initiative — API Reference restructure (docs)
 
-**Status:** Stage 1 (the `bootstack.data` prototype slice) BUILT and under
-maintainer review on branch `feat/api-reference-data-prototype` (2026-06-08).
-Stages 2–5 not started. Decided 2026-06-08 with the maintainer.
+**Status:** Stage 1 (the `bootstack.data` prototype slice) MERGED (PR #107).
+Stage 2 (recipe-lock) done on `feat/api-reference-stage2` — the templates + the
+API-Reference-page / Guide-page recipes are now locked into `CLAUDE.md` under
+"## API Reference & Guide page pattern". Stages 3–5 not started. Decided 2026-06-08
+with the maintainer.
 
 > `docs/_dev/` is excluded from the Sphinx build (`conf.py` `exclude_patterns`).
 > This is a dev note, not a published page.
@@ -163,12 +165,18 @@ Built on `feat/api-reference-data-prototype`, clean-build warning-free
   Stage 5 re-cut returns it to 5 by dissolving `reference/` into Guides + API
   Reference.
 
-Templates/recipe to LOCK in Stage 2 from this: the single `class.rst` template
-above works unchanged for plain classes, dataclasses (`FileSourceConfig`), and
-Protocols; functions/data aliases fall back to autosummary's built-in
-`function.rst`/`base.rst` (no custom template needed). Per-object-kind templates
-are selectable with `:template:` on the autosummary directive if a future module
-needs it, but `data` didn't.
+Templates/recipe LOCKED in Stage 2: the `class.rst` template above works unchanged
+for plain classes, dataclasses (`FileSourceConfig`), and Protocols. **Stage 2 also
+added `function.rst` + `data.rst`** — NOT for completeness (the built-in fallbacks
+documented the objects fine) but to fix a **sidebar-title inconsistency**: the
+sidebar shows each stub's page title, and the built-in `function.rst`/`base.rst`
+fallbacks title with the full dotted path (`bootstack.data.col`) while our custom
+`class.rst` titles bare (`MemoryDataSource`) — so functions/aliases rendered
+fully-qualified next to bare classes. All three custom templates now title with the
+bare `{{ objname }}`. Type aliases split across templates by how autosummary
+classifies them (`Primitive` → class-like → `class.rst`; `Record` → data →
+`data.rst`), so both must title bare. Any future documenter kind (`exception.rst`,
+`method.rst`, …) needs the same bare-title treatment.
 
 ## Stage 4 detail — the widget page shape
 

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -2,10 +2,15 @@
 
 html,
 html[data-theme="light"] {
-    --pst-color-primary:       #0d6efd;
-    --pst-color-primary-bg:    #cfe2ff;
-    --pst-color-secondary:     #6c757d;
-    --pst-color-secondary-bg:  #e2e3e5;
+    --pst-color-primary:               #0d6efd;
+    --pst-color-primary-bg:            #cfe2ff;
+    --pst-color-primary-highlight:     #0a58ca;
+    --pst-color-link:                  #0d6efd;
+    --pst-color-link-hover:            #0a58ca;
+    --pst-color-link-higher-contrast:  #0a58ca;
+    --pst-color-secondary:             #6c757d;
+    --pst-color-secondary-bg:          #e2e3e5;
+    --pst-color-secondary-highlight:   #5c636a;
     --pst-color-background:    #ffffff;
     --pst-color-on-background: #ffffff;
     --pst-color-surface:       #f8f9fa;
@@ -15,13 +20,21 @@ html[data-theme="light"] {
     --pst-color-border:        #dee2e6;
     --pst-color-border-muted:  #e9ecef;
     --pst-color-inline-code:   #d63384;
+    /* :target anchor-flash + search highlight — soft amber (highlighter
+       convention), distinct from the blue link/primary palette */
+    --pst-color-target:        #fff3cd;
 }
 
 html[data-theme="dark"] {
-    --pst-color-primary:       #6ea8fe;
-    --pst-color-primary-bg:    #031633;
-    --pst-color-secondary:     #adb5bd;
-    --pst-color-secondary-bg:  #343a40;
+    --pst-color-primary:               #6ea8fe;
+    --pst-color-primary-bg:            #031633;
+    --pst-color-primary-highlight:     #8bb9fe;
+    --pst-color-link:                  #6ea8fe;
+    --pst-color-link-hover:            #8bb9fe;
+    --pst-color-link-higher-contrast:  #8bb9fe;
+    --pst-color-secondary:             #adb5bd;
+    --pst-color-secondary-bg:          #343a40;
+    --pst-color-secondary-highlight:   #bcc4cc;
     --pst-color-background:    #212529;
     --pst-color-on-background: #212529;
     --pst-color-surface:       #343a40;
@@ -31,6 +44,9 @@ html[data-theme="dark"] {
     --pst-color-border:        #495057;
     --pst-color-border-muted:  #373b3e;
     --pst-color-inline-code:   #e685b5;
+    /* :target anchor-flash + search highlight — soft amber (highlighter
+       convention), distinct from the blue link/primary palette */
+    --pst-color-target:        #6e5611;
     /* Admonition note/info — align with primary palette */
     --pst-color-info:          #6ea8fe;
     --pst-color-info-bg:       #0d306e;

--- a/docs/_templates/autosummary/data.rst
+++ b/docs/_templates/autosummary/data.rst
@@ -1,0 +1,5 @@
+{{ objname | escape | underline }}
+
+.. currentmodule:: {{ module }}
+
+.. autodata:: {{ objname }}

--- a/docs/_templates/autosummary/exception.rst
+++ b/docs/_templates/autosummary/exception.rst
@@ -1,0 +1,7 @@
+{{ objname | escape | underline }}
+
+.. currentmodule:: {{ module }}
+
+.. autoexception:: {{ objname }}
+   :members:
+   :show-inheritance:

--- a/docs/_templates/autosummary/function.rst
+++ b/docs/_templates/autosummary/function.rst
@@ -1,0 +1,5 @@
+{{ objname | escape | underline }}
+
+.. currentmodule:: {{ module }}
+
+.. autofunction:: {{ objname }}

--- a/docs/_templates/autosummary/signal.rst
+++ b/docs/_templates/autosummary/signal.rst
@@ -5,6 +5,6 @@
 .. autoclass:: {{ objname }}
    :members:
    :special-members: __call__
-   :exclude-members: tk, var
+   :exclude-members: tk, var, name, from_variable
    :inherited-members:
    :show-inheritance:

--- a/docs/api-reference/data.rst
+++ b/docs/api-reference/data.rst
@@ -31,29 +31,31 @@ Query language
 --------------
 
 The ``col`` expression API for building filter conditions and sort keys, free of
-SQL. Pass conditions to a source's ``where()`` and sort keys to ``order()``.
+SQL. Call these to construct a query, then pass conditions to a source's
+``where()`` and sort keys to ``order()``.
 
 .. autosummary::
    :toctree: generated
    :nosignatures:
 
    col
-   Column
-   Condition
-   SortKey
    any_of
    all_of
 
-Type aliases
-------------
+Query expression types
+----------------------
 
-The record and cell types shared across the module.
+The objects the query API produces and that ``where()`` / ``order()`` accept —
+handy for type annotations. You rarely construct these directly; build them from
+``col`` and the comparison operators.
 
 .. autosummary::
    :toctree: generated
+   :nosignatures:
 
-   Record
-   Primitive
+   Column
+   Condition
+   SortKey
 
 Readers and writers
 -------------------
@@ -73,3 +75,14 @@ The pluggable format registries behind ``FileDataSource`` and a source's
    register_writer
    supported_read_extensions
    supported_write_extensions
+
+Type aliases
+------------
+
+The record and cell types shared across the module.
+
+.. autosummary::
+   :toctree: generated
+
+   Record
+   Primitive

--- a/docs/api-reference/errors.rst
+++ b/docs/api-reference/errors.rst
@@ -1,0 +1,21 @@
+bootstack.errors
+================
+
+.. currentmodule:: bootstack.errors
+
+The exception types the framework raises. All inherit from a single base, so you
+can catch every framework error with one ``except`` clause or narrow to a
+specific failure.
+
+For when each one is raised and how to handle it, see the :doc:`/reference/errors`
+guide.
+
+.. autosummary::
+   :toctree: generated
+   :nosignatures:
+
+   BootstackError
+   DuplicateIdError
+   ParentResolutionError
+   SerializationError
+   UnknownEventError

--- a/docs/api-reference/events.rst
+++ b/docs/api-reference/events.rst
@@ -1,0 +1,133 @@
+bootstack.events
+================
+
+.. currentmodule:: bootstack.events
+
+The event catalog. Every widget announces what it does as a named event;
+data-carrying events hand the handler a typed payload, while native events hand
+it a curated, toolkit-free :class:`Event`. This module is the home of all of
+those types, so editors can autocomplete the attributes on each one.
+
+For a task-oriented introduction — listening, reading a payload, cancelling a
+subscription, emitting your own — see the :doc:`/reference/events` guide.
+
+Event handling
+--------------
+
+The curated event handed to native handlers and the cancellable handle returned
+by every binding.
+
+.. autosummary::
+   :toctree: generated
+   :nosignatures:
+
+   Event
+   Subscription
+
+Value and input payloads
+------------------------
+
+Handed to handlers for value commits, live input, validation, and toggles.
+
+.. autosummary::
+   :toctree: generated
+   :nosignatures:
+
+   ChangeEvent
+   InputEvent
+   ValidationEvent
+   TextModifiedEvent
+   ToggleEvent
+
+Slider payloads
+---------------
+
+The live and committed payloads for the single- and range-value sliders.
+
+.. autosummary::
+   :toctree: generated
+   :nosignatures:
+
+   SliderEvent
+   SliderCommitEvent
+   RangeSliderEvent
+   RangeSliderCommitEvent
+
+Date payloads
+-------------
+
+.. autosummary::
+   :toctree: generated
+   :nosignatures:
+
+   DateSelectEvent
+
+Navigation and layout payloads
+------------------------------
+
+Page, nav-pane, display-mode, and accordion activity.
+
+.. autosummary::
+   :toctree: generated
+   :nosignatures:
+
+   PageChangeEvent
+   NavEvent
+   PaneToggleEvent
+   DisplayModeEvent
+   AccordionChangeEvent
+
+Tab payloads
+------------
+
+The change/activate/deactivate/close payloads for a tab strip.
+
+.. autosummary::
+   :toctree: generated
+   :nosignatures:
+
+   TabChangeEvent
+   TabActivateEvent
+   TabDeactivateEvent
+   TabCloseEvent
+
+Data and selection payloads
+---------------------------
+
+Row CRUD, selection, export, tree selection, button-group clicks, and the
+data-source change broadcast.
+
+.. autosummary::
+   :toctree: generated
+   :nosignatures:
+
+   RowEvent
+   RowsEvent
+   SelectionEvent
+   TreeSelectionEvent
+   ExportEvent
+   ButtonGroupClickEvent
+   DataChangeEvent
+
+Supporting types
+----------------
+
+Value types carried *inside* payloads, rather than handed to a handler directly.
+
+.. autosummary::
+   :toctree: generated
+   :nosignatures:
+
+   TabRef
+
+Enumerations
+------------
+
+The string-literal tags carried by the change and data-change payloads.
+
+.. autosummary::
+   :toctree: generated
+
+   ChangeReason
+   ChangeMethod
+   ChangeKind

--- a/docs/api-reference/i18n.rst
+++ b/docs/api-reference/i18n.rst
@@ -1,0 +1,19 @@
+bootstack.i18n
+==============
+
+.. currentmodule:: bootstack.i18n
+
+Localization helpers. Wrap a string with ``L`` to mark it translatable, or a
+value with ``LV`` to format it for the active locale; both update live when the
+app's locale changes.
+
+For a task-oriented introduction — message catalogs, locale-aware dates and
+numbers, switching locale at runtime — see the :doc:`/reference/localization`
+guide.
+
+.. autosummary::
+   :toctree: generated
+   :nosignatures:
+
+   L
+   LV

--- a/docs/api-reference/index.rst
+++ b/docs/api-reference/index.rst
@@ -12,10 +12,21 @@ guides, which cross-link into the pages here. The
 
 .. note::
 
-   This section is being built out module by module. The ``bootstack.data``
-   reference below is the first slice; the remaining submodules follow.
+   This section is being built out module by module. The submodules below are
+   complete; the top-level ``bootstack`` widget surface and ``bootstack.types`` /
+   ``bootstack.dialogs`` follow.
 
 .. toctree::
    :maxdepth: 1
 
    data
+   style
+   events
+   signals
+   streams
+   validation
+   i18n
+   scheduling
+   shortcuts
+   store
+   errors

--- a/docs/api-reference/scheduling.rst
+++ b/docs/api-reference/scheduling.rst
@@ -1,0 +1,18 @@
+bootstack.scheduling
+====================
+
+.. currentmodule:: bootstack.scheduling
+
+Timed callbacks tied to a widget's lifetime. ``Schedule`` runs work after a
+delay, on idle, or on a repeating interval; each call returns a ``Job`` handle
+you can cancel.
+
+For a task-oriented introduction — one-shot, idle, and repeating patterns, and
+``App.schedule`` — see the :doc:`/reference/scheduling` guide.
+
+.. autosummary::
+   :toctree: generated
+   :nosignatures:
+
+   Schedule
+   Job

--- a/docs/api-reference/shortcuts.rst
+++ b/docs/api-reference/shortcuts.rst
@@ -1,0 +1,18 @@
+bootstack.shortcuts
+===================
+
+.. currentmodule:: bootstack.shortcuts
+
+Application-wide keyboard shortcuts. Get the service with ``get_shortcuts()``,
+register key combinations against it, and bind it to an app.
+
+For a task-oriented introduction — registering, binding, the ``"Mod+S"`` spec
+syntax, display labels — see the :doc:`/reference/shortcuts` guide.
+
+.. autosummary::
+   :toctree: generated
+   :nosignatures:
+
+   get_shortcuts
+   Shortcuts
+   Shortcut

--- a/docs/api-reference/signals.rst
+++ b/docs/api-reference/signals.rst
@@ -1,0 +1,18 @@
+bootstack.signals
+=================
+
+.. currentmodule:: bootstack.signals
+
+Reactive values. A signal holds a value, binds two-way to widgets, and notifies
+subscribers when it changes — the link between application state and the
+interface.
+
+For a task-oriented introduction — creating signals, binding them to widgets,
+deriving one from another — see the :doc:`/reference/signals` guide.
+
+.. autosummary::
+   :toctree: generated
+   :nosignatures:
+   :template: signal
+
+   Signal

--- a/docs/api-reference/store.rst
+++ b/docs/api-reference/store.rst
@@ -1,0 +1,16 @@
+bootstack.store
+===============
+
+.. currentmodule:: bootstack.store
+
+A persistent, dict-like key-value store for application preferences, backed by a
+JSON file and written through on every change.
+
+For a task-oriented introduction — creating a store, autosave, JSON-only values,
+remembering app state — see the :doc:`/reference/store` guide.
+
+.. autosummary::
+   :toctree: generated
+   :nosignatures:
+
+   Store

--- a/docs/api-reference/streams.rst
+++ b/docs/api-reference/streams.rst
@@ -1,0 +1,19 @@
+bootstack.streams
+=================
+
+.. currentmodule:: bootstack.streams
+
+Event pipelines. A stream transforms, filters, and times events before they
+reach a handler, so the handler sees only what it cares about — the basis for
+"search once the user stops typing" or "ignore clicks faster than twice a
+second" without hand-rolled timers.
+
+For a task-oriented introduction — building a pipeline, the timing operators,
+activating and cancelling — see the :doc:`/reference/streams` guide.
+
+.. autosummary::
+   :toctree: generated
+   :nosignatures:
+
+   Stream
+   Handle

--- a/docs/api-reference/style.rst
+++ b/docs/api-reference/style.rst
@@ -1,0 +1,49 @@
+bootstack.style
+===============
+
+.. currentmodule:: bootstack.style
+
+Themes, theme switching, and fonts. Declare a color theme in code, switch the
+active theme at runtime, look up theme colors, and adjust the application fonts.
+
+For task-oriented introductions see the :doc:`/reference/theming` and
+:doc:`/reference/typography` guides.
+
+Themes
+------
+
+The declarable color theme. Build one in code and install it.
+
+.. autosummary::
+   :toctree: generated
+   :nosignatures:
+
+   Theme
+
+Theme control
+-------------
+
+Switch and query the active theme, and resolve a color token to a hex value.
+
+.. autosummary::
+   :toctree: generated
+   :nosignatures:
+
+   set_theme
+   toggle_theme
+   get_theme
+   get_themes
+   get_theme_color
+
+Fonts
+-----
+
+Inspect and adjust the application fonts at runtime.
+
+.. autosummary::
+   :toctree: generated
+   :nosignatures:
+
+   get_font_families
+   set_font_family
+   update_font_token

--- a/docs/api-reference/validation.rst
+++ b/docs/api-reference/validation.rst
@@ -1,0 +1,18 @@
+bootstack.validation
+=====================
+
+.. currentmodule:: bootstack.validation
+
+Field and form validation. A ``ValidationRule`` checks a value and reports a
+``ValidationResult`` — the building blocks behind a field's ``rules=`` and
+``Form.validate()``.
+
+For a task-oriented introduction — built-in rules, triggers, custom rules,
+whole-form validation — see the :doc:`/reference/validation` guide.
+
+.. autosummary::
+   :toctree: generated
+   :nosignatures:
+
+   ValidationRule
+   ValidationResult

--- a/docs/reference/errors.rst
+++ b/docs/reference/errors.rst
@@ -99,22 +99,16 @@ object, use an in-memory source instead:
 API reference
 -------------
 
-.. autoclass:: bootstack.errors.BootstackError
-   :members:
-   :undoc-members:
+The complete reference for every exception type lives in
+:doc:`/api-reference/errors`. At a glance:
 
-.. autoclass:: bootstack.errors.UnknownEventError
-   :members:
-   :undoc-members:
+.. currentmodule:: bootstack.errors
 
-.. autoclass:: bootstack.errors.ParentResolutionError
-   :members:
-   :undoc-members:
+.. autosummary::
+   :nosignatures:
 
-.. autoclass:: bootstack.errors.DuplicateIdError
-   :members:
-   :undoc-members:
-
-.. autoclass:: bootstack.errors.SerializationError
-   :members:
-   :undoc-members:
+   BootstackError
+   DuplicateIdError
+   ParentResolutionError
+   SerializationError
+   UnknownEventError

--- a/docs/reference/events.rst
+++ b/docs/reference/events.rst
@@ -120,75 +120,21 @@ See also
 API reference
 -------------
 
-Everything in the ``bootstack.events`` catalog: the curated :class:`Event` for
-native events, the :class:`Subscription` handle returned by every binding, and
-the typed payload classes handed to data-carrying handlers.
+The complete catalog — the curated :class:`Event <bootstack.events.Event>`, the
+:class:`Subscription <bootstack.events.Subscription>` handle, and every typed
+payload — lives in :doc:`/api-reference/events`. The most common payloads at a
+glance:
 
-The curated event handed to native/context handlers:
+.. currentmodule:: bootstack.events
 
-.. autoclass:: bootstack.events.Event
-   :members:
+.. autosummary::
+   :nosignatures:
 
-The cancellable handle returned by every binding:
-
-.. autoclass:: bootstack.events.Subscription
-   :members:
-   :exclude-members: __init__
-
-The typed payloads handed to data-carrying handlers. Import them from
-``bootstack.events`` (e.g. ``from bootstack.events import ChangeEvent``).
-
-.. autoclass:: bootstack.events.AccordionChangeEvent
-   :members:
-.. autoclass:: bootstack.events.ButtonGroupClickEvent
-   :members:
-.. autoclass:: bootstack.events.ChangeEvent
-   :members:
-.. autoclass:: bootstack.events.DataChangeEvent
-   :members:
-.. autoclass:: bootstack.events.DateSelectEvent
-   :members:
-.. autoclass:: bootstack.events.DisplayModeEvent
-   :members:
-.. autoclass:: bootstack.events.ExportEvent
-   :members:
-.. autoclass:: bootstack.events.InputEvent
-   :members:
-.. autoclass:: bootstack.events.NavEvent
-   :members:
-.. autoclass:: bootstack.events.PageChangeEvent
-   :members:
-.. autoclass:: bootstack.events.PaneToggleEvent
-   :members:
-.. autoclass:: bootstack.events.RangeSliderCommitEvent
-   :members:
-.. autoclass:: bootstack.events.RangeSliderEvent
-   :members:
-.. autoclass:: bootstack.events.RowEvent
-   :members:
-.. autoclass:: bootstack.events.RowsEvent
-   :members:
-.. autoclass:: bootstack.events.SelectionEvent
-   :members:
-.. autoclass:: bootstack.events.SliderCommitEvent
-   :members:
-.. autoclass:: bootstack.events.SliderEvent
-   :members:
-.. autoclass:: bootstack.events.TabActivateEvent
-   :members:
-.. autoclass:: bootstack.events.TabChangeEvent
-   :members:
-.. autoclass:: bootstack.events.TabCloseEvent
-   :members:
-.. autoclass:: bootstack.events.TabDeactivateEvent
-   :members:
-.. autoclass:: bootstack.events.TabRef
-   :members:
-.. autoclass:: bootstack.events.TextModifiedEvent
-   :members:
-.. autoclass:: bootstack.events.TreeSelectionEvent
-   :members:
-.. autoclass:: bootstack.events.ToggleEvent
-   :members:
-.. autoclass:: bootstack.events.ValidationEvent
-   :members:
+   Event
+   Subscription
+   ChangeEvent
+   InputEvent
+   ValidationEvent
+   SelectionEvent
+   RowsEvent
+   DataChangeEvent

--- a/docs/reference/localization.rst
+++ b/docs/reference/localization.rst
@@ -155,6 +155,12 @@ See also
 API reference
 -------------
 
-.. autofunction:: bootstack.i18n.L
+The complete reference lives in :doc:`/api-reference/i18n`. At a glance:
 
-.. autofunction:: bootstack.i18n.LV
+.. currentmodule:: bootstack.i18n
+
+.. autosummary::
+   :nosignatures:
+
+   L
+   LV

--- a/docs/reference/scheduling.rst
+++ b/docs/reference/scheduling.rst
@@ -113,8 +113,14 @@ See also
 API reference
 -------------
 
-.. autoclass:: bootstack.scheduling.Schedule
-   :members:
+The complete reference for :class:`Schedule <bootstack.scheduling.Schedule>` and
+the :class:`Job <bootstack.scheduling.Job>` handle lives in
+:doc:`/api-reference/scheduling`. At a glance:
 
-.. autoclass:: bootstack.scheduling.Job
-   :members:
+.. currentmodule:: bootstack.scheduling
+
+.. autosummary::
+   :nosignatures:
+
+   Schedule
+   Job

--- a/docs/reference/shortcuts.rst
+++ b/docs/reference/shortcuts.rst
@@ -97,8 +97,16 @@ See also
 API reference
 -------------
 
-.. autoclass:: bootstack.shortcuts.Shortcuts
-   :members:
+The complete reference — the :class:`Shortcuts <bootstack.shortcuts.Shortcuts>`
+service, ``get_shortcuts()``, and the :class:`Shortcut
+<bootstack.shortcuts.Shortcut>` record — lives in :doc:`/api-reference/shortcuts`.
+At a glance:
 
-.. autoclass:: bootstack.shortcuts.Shortcut
-   :members:
+.. currentmodule:: bootstack.shortcuts
+
+.. autosummary::
+   :nosignatures:
+
+   get_shortcuts
+   Shortcuts
+   Shortcut

--- a/docs/reference/signals.rst
+++ b/docs/reference/signals.rst
@@ -127,8 +127,12 @@ See also
 API reference
 -------------
 
-.. autoclass:: bootstack.signals.Signal
-   :members:
-   :undoc-members:
-   :special-members: __call__
-   :exclude-members: tk, var, name, from_variable
+The complete reference — every method on :class:`Signal
+<bootstack.signals.Signal>` — lives in :doc:`/api-reference/signals`. At a glance:
+
+.. currentmodule:: bootstack.signals
+
+.. autosummary::
+   :nosignatures:
+
+   Signal

--- a/docs/reference/store.rst
+++ b/docs/reference/store.rst
@@ -143,6 +143,12 @@ See also
 API reference
 -------------
 
-.. autoclass:: bootstack.store.Store
-   :members:
-   :exclude-members: __init__
+The complete reference for :class:`Store <bootstack.store.Store>` — every mapping
+method — lives in :doc:`/api-reference/store`. At a glance:
+
+.. currentmodule:: bootstack.store
+
+.. autosummary::
+   :nosignatures:
+
+   Store

--- a/docs/reference/streams.rst
+++ b/docs/reference/streams.rst
@@ -96,12 +96,14 @@ See also
 API reference
 -------------
 
-.. autoclass:: bootstack.streams.Stream
-   :members:
-   :undoc-members:
-   :exclude-members: __init__
+The complete reference — every operator on :class:`Stream
+<bootstack.streams.Stream>` and the :class:`Handle <bootstack.streams.Handle>`
+it returns — lives in :doc:`/api-reference/streams`. At a glance:
 
-.. autoclass:: bootstack.streams.Handle
-   :members:
-   :undoc-members:
-   :exclude-members: __init__
+.. currentmodule:: bootstack.streams
+
+.. autosummary::
+   :nosignatures:
+
+   Stream
+   Handle

--- a/docs/reference/theming.rst
+++ b/docs/reference/theming.rst
@@ -185,14 +185,18 @@ See also
 API reference
 -------------
 
-Functions for controlling and reading the active theme, and the ``Theme`` class
-for declaring your own.
+The complete reference — the :class:`Theme <bootstack.style.Theme>` class and the
+theme-control functions — lives in :doc:`/api-reference/style` (which also covers
+the font functions). At a glance:
 
-.. autoclass:: bootstack.style.theme.Theme
-   :members:
+.. currentmodule:: bootstack.style
 
-.. autofunction:: bootstack.style.set_theme
-.. autofunction:: bootstack.style.toggle_theme
-.. autofunction:: bootstack.style.get_theme
-.. autofunction:: bootstack.style.get_themes
-.. autofunction:: bootstack.style.get_theme_color
+.. autosummary::
+   :nosignatures:
+
+   Theme
+   set_theme
+   toggle_theme
+   get_theme
+   get_themes
+   get_theme_color

--- a/docs/reference/typography.rst
+++ b/docs/reference/typography.rst
@@ -194,10 +194,17 @@ See also
 API reference
 -------------
 
-Functions for setting fonts at runtime, plus the ``FontChoice`` result type.
+The complete reference for the runtime font functions lives in
+:doc:`/api-reference/style` (alongside the theme functions). At a glance:
 
-.. autofunction:: bootstack.style.set_font_family
-.. autofunction:: bootstack.style.update_font_token
-.. autofunction:: bootstack.style.get_font_families
+.. currentmodule:: bootstack.style
 
-.. autoclass:: bootstack.dialogs.FontChoice
+.. autosummary::
+   :nosignatures:
+
+   set_font_family
+   update_font_token
+   get_font_families
+
+The ``FontChoice`` result type returned by ``ask_font()`` is documented with the
+:doc:`/widgets/font-dialog` selector.

--- a/docs/reference/validation.rst
+++ b/docs/reference/validation.rst
@@ -205,8 +205,15 @@ See also
 API reference
 -------------
 
-.. autoclass:: bootstack.validation.ValidationRule
-   :members:
+The complete reference for :class:`ValidationRule
+<bootstack.validation.ValidationRule>` and :class:`ValidationResult
+<bootstack.validation.ValidationResult>` lives in
+:doc:`/api-reference/validation`. At a glance:
 
-.. autoclass:: bootstack.validation.ValidationResult
-   :members:
+.. currentmodule:: bootstack.validation
+
+.. autosummary::
+   :nosignatures:
+
+   ValidationRule
+   ValidationResult

--- a/src/bootstack/events/_payloads.py
+++ b/src/bootstack/events/_payloads.py
@@ -221,7 +221,12 @@ class DisplayModeEvent:
 # ---------------------------------------------------------------------------
 
 ChangeReason = Literal["user", "api", "hide", "forget", "unknown"]
+"""Why a change event fired — a direct `user` edit, an `api` call, a `hide` or
+`forget` of carried data, or `unknown`."""
+
 ChangeMethod = Literal["click", "key", "programmatic", "unknown"]
+"""How a change was made — by mouse `click`, by `key`, `programmatic`ally, or
+`unknown`."""
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/bootstack/signals/__init__.py
+++ b/src/bootstack/signals/__init__.py
@@ -1,8 +1,10 @@
 """Reactive signal primitives for bootstack widgets."""
 from .signal import Signal
-from .types import TraceOperation
 
 __all__ = [
     "Signal",
-    "TraceOperation",
 ]
+
+# TraceOperation is an internal low-level type for variable-trace callbacks
+# (no public Signal method exposes it). Import it from `bootstack.signals.types`
+# if internal code needs it.

--- a/src/bootstack/signals/types.py
+++ b/src/bootstack/signals/types.py
@@ -2,3 +2,5 @@
 from typing import Literal
 
 TraceOperation = Literal["array", "read", "write", "unset"]
+"""The kind of variable access a trace callback reports — an `array` element
+access, a `read`, a `write`, or an `unset`."""


### PR DESCRIPTION
Continues the API Reference restructure (Stage 1 = PR #107). Splits the docs into a narrative layer (Guides) and a complete, by-module **API Reference**, and brings every framework subsystem into it.

## Stage 2 — recipe-lock (`bf223e27`)
- Adds the canonical **"API Reference & Guide page pattern"** to `CLAUDE.md`: the locked autosummary templates, the API-Reference-page recipe (autodoc home), the Guide-page recipe (table-only summary + cross-links), shallowest-path-wins re-exports, clean-build verification.
- Marks the old curated-`autoclass` recipe SUPERSEDED.
- Fixes autosummary stub **titles** (functions/aliases were rendering fully-qualified in the sidebar while classes were bare) by adding `function.rst` / `data.rst` templates.

## Theming fix (`3798ee67`)
`custom.css` overrode `--pst-color-primary` but not the sibling variables the pydata theme derives from its teal/purple palette, so links and highlights stayed off-brand. Now pointed at the brand palette:
- `--pst-color-link-higher-contrast` (the API-table / code cross-ref links), `--pst-color-primary-highlight`, `--pst-color-secondary-highlight`, `--pst-color-link`/`-hover`.
- `--pst-color-target` (the `:target` anchor-flash + search highlight): gold → soft amber (`#fff3cd` light / `#6e5611` dark) — highlighter convention, distinct from the now blue-heavy palette.

## Stage 3 — subsystem sweep (`404b4191`)
- **10 new API Reference pages** (autodoc homes): `signals`, `streams`, `events`, `errors`, `i18n`, `scheduling`, `shortcuts`, `store`, `validation`, `style` (style covers theming + typography).
- **11 guides converted** — every `reference/*` page drops its curated `autoclass` for a `:doc:` cross-link + table-only autosummary. Zero autodoc directives remain under `docs/reference/`.
- **Templates:** `class.rst` shows `__call__` and excludes the `tk`/`var` escape hatches; new `exception.rst` + `signal.rst`. Per-class `:template:` takes the name **without** `.rst`.
- **Grouping conventions:** separate callables / supporting types / enums-aliases; order most-reached-for first; small/uniform modules use the single-table `streams` pattern.
- **`__all__` hygiene:** demote `TraceOperation` (internal), recategorize `TabRef` (supporting type), add docstrings to the `Literal` aliases.

## Notes
- Clean-build warning-free (`sphinx-build -W --keep-going`).
- Navbar is temporarily 6 items; Stage 5 re-cuts back to 5.
- Re-exports `Signal` / `set_theme` / `toggle_theme` hold a temporary home on their subsystem page; **Stage 4** relocates them to the top-level page. `FontChoice` will be homed on the Stage 4 dialogs page.
- Flags an out-of-band follow-up: `Signal.subscribe()` returns a `str` token rather than a cancelable handle like events/streams.

Full brief + decisions: `docs/_dev/api-reference-restructure.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)