### PR TITLE
refactor(widgets): resolve code-review follow-ups #4–#10

### DIFF
--- a/docs/_dev/widget-api-audit.md
+++ b/docs/_dev/widget-api-audit.md
@@ -36,26 +36,27 @@ bugs (commit `55e2d12b`): non-string group option keys, the `configure_item`
 "independent of group disabled" overclaim, and DateField `disabled_dates`
 generator exhaustion (added coercing `set_*` mutators to the internal DateEntry).
 Two findings were refuted (NumberField `clear()` is path-safe; the two
-`_coerce_date` copies are identical, not divergent). The rest are cleanup/altitude,
-**deferred** (none block the branch):
+`_coerce_date` copies are identical, not divergent). The rest were cleanup/altitude;
+all six are now **resolved** on `feat/code-review-followups`:
 
-- **#4** `SelectButton.options` setter rebuilds the dropdown but does not reconcile
-  the current `value` — the button can show a value no longer in the list.
-- **#5** `docs/scripts/take_screenshots.py`: `GetParent`/`GetWindowRect` are called
-  with no ctypes `argtypes`/`restype` — Win64 HWND-truncation risk (works only
-  because handles are small). Wrap the HWND like the adjacent DWM call does.
-- **#6** RadioGroup/ToggleGroup duplicate `configure_item`/`remove`/`__len__`/
-  `__contains__` verbatim → lift onto a shared selection-group base (folds into
-  `project_select_options_databag`).
-- **#7** `WindowControlsMixin` re-declares `close`/`show`/`add_close_handler`/
-  `remove_close_handler` that `Window` overrides, and `mixin.close()` calls
-  `self._internal.close()` which the `Toplevel` lacks — scope the mixin to
-  App/AppShell, or give the internals a uniform close contract.
-- **#9** Duplicate `_coerce_date` in `calendar.py` and `dateentry.py` (identical) →
-  extract one shared date-utils helper.
-- **#10** Calendar `set_min_date`/`set_max_date`/`set_disabled_dates` each call
-  `_refresh_calendar()` → a batch of constraint changes redraws ~42 cells N times;
-  coalesce to one redraw.
+- **#4 ✅** `SelectButton.options` setter now reconciles the current `value` — if it
+  is no longer one of the new options it is cleared, so the button never shows a
+  value the list can't offer. (`optionmenu.py` `_delegate_options`.)
+- **#5 ✅** `docs/scripts/take_screenshots.py`: `GetParent`/`GetWindowRect` now declare
+  HWND `argtypes`/`restype`, fixing the Win64 handle-truncation risk.
+- **#6 ✅** RadioGroup/ToggleGroup `configure_item`/`remove`/`__len__`/`__contains__`
+  lifted onto a shared `SelectionGroupMixin` (`widgets/_core/selection_group.py`).
+  The wider `project_select_options_databag` work can build on this mixin.
+- **#7 ✅** Gave the internals a uniform close contract: `BaseWindow.close()` performs
+  a programmatic, handler-bypassing close (`_do_close()`); `App` still overrides it to
+  quit the event loop. `Window` dropped its redundant `close`/`add_close_handler`/
+  `remove_close_handler` overrides — they now come from `WindowControlsMixin`.
+- **#9 ✅** Extracted one shared `coerce_date` helper
+  (`widgets/_impl/composites/_dateutils.py`); `calendar.py` and `dateentry.py` both
+  delegate via `_coerce_date = staticmethod(coerce_date)`.
+- **#10 ✅** Calendar constraint setters now route through `_request_refresh()`, which
+  coalesces a batch of `min_date`/`max_date`/`disabled_dates` changes into a single
+  idle-time redraw.
 
 ---
 

--- a/docs/scripts/take_screenshots.py
+++ b/docs/scripts/take_screenshots.py
@@ -76,13 +76,20 @@ def _patch(cls):
                 win.update_idletasks()
                 import ctypes
                 from ctypes import wintypes
-                hwnd = ctypes.windll.user32.GetParent(win.winfo_id()) or win.winfo_id()
+                user32 = ctypes.windll.user32
+                # Declare HWND-returning/taking signatures so 64-bit handles are
+                # not silently truncated to a 32-bit c_int (the ctypes default).
+                user32.GetParent.argtypes = [wintypes.HWND]
+                user32.GetParent.restype = wintypes.HWND
+                user32.GetWindowRect.argtypes = [wintypes.HWND, ctypes.POINTER(wintypes.RECT)]
+                user32.GetWindowRect.restype = wintypes.BOOL
+                hwnd = user32.GetParent(win.winfo_id()) or win.winfo_id()
                 rect = wintypes.RECT()
                 ok = ctypes.windll.dwmapi.DwmGetWindowAttribute(
                     wintypes.HWND(hwnd), ctypes.c_uint(9),  # DWMWA_EXTENDED_FRAME_BOUNDS
                     ctypes.byref(rect), ctypes.sizeof(rect))
                 if ok != 0:  # fall back to the full window rect (incl. shadow margin)
-                    ctypes.windll.user32.GetWindowRect(hwnd, ctypes.byref(rect))
+                    user32.GetWindowRect(hwnd, ctypes.byref(rect))
                 x, y = rect.left, rect.top
                 w, h = rect.right - rect.left, rect.bottom - rect.top
                 inset = 2  # cut just inside the native window border; the docs

--- a/src/bootstack/_runtime/base_window.py
+++ b/src/bootstack/_runtime/base_window.py
@@ -341,6 +341,17 @@ class BaseWindow:
         except tkinter.TclError:
             pass
 
+    def close(self) -> None:
+        """Close the window programmatically, bypassing the close handlers.
+
+        This is the uniform close contract every top-level window honors. It
+        performs the default close action directly (``_do_close()``), so the
+        veto handlers registered with ``add_close_handler()`` — which guard the
+        user clicking the window's close button — are not run. The application
+        root overrides this to quit its event loop instead.
+        """
+        self._do_close()
+
     def add_close_handler(self, callback: Callable[[], bool | None]) -> None:
         """Register a callback invoked when the window's close button is clicked.
 

--- a/src/bootstack/widgets/_core/selection_group.py
+++ b/src/bootstack/widgets/_core/selection_group.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+class SelectionGroupMixin:
+    """Shared item-management surface for the option-group widgets.
+
+    Mixed into `RadioGroup` and `ToggleGroup`, which both wrap an internal
+    composite exposing `keys()`, `configure_item()`, and `remove()`. Each class
+    keeps its own `add()` (the option semantics differ) and its own value /
+    change surface; only the value-keyed item operations live here.
+    """
+
+    _internal: Any
+
+    def remove(self, value: Any) -> None:
+        """Remove the option identified by `value`.
+
+        Args:
+            value: The value the option was added with.
+
+        Raises:
+            KeyError: If no option with that value exists.
+        """
+        self._internal.remove(value)
+
+    def configure_item(
+        self,
+        value: Any,
+        *,
+        label: str | None = None,
+        disabled: bool | None = None,
+    ) -> None:
+        """Update a single option in place, without rebuilding the group.
+
+        Args:
+            value: The option to update (the value it was added with).
+            label: New display text, when given.
+            disabled: When given, disable (`True`) or re-enable (`False`) just
+                this option. A later group-level `disabled` change resets every
+                option's state, so apply per-option states after it.
+
+        Raises:
+            KeyError: If no option with that value exists.
+        """
+        if label is not None:
+            self._internal.configure_item(value, text=label)
+        if disabled is not None:
+            self._internal.configure_item(value, state="disabled" if disabled else "normal")
+
+    def __len__(self) -> int:
+        """The number of options in the group."""
+        return len(self._internal.keys())
+
+    def __contains__(self, value: Any) -> bool:
+        """Whether an option with the given `value` is in the group."""
+        return value in self._internal.keys()

--- a/src/bootstack/widgets/_impl/composites/_dateutils.py
+++ b/src/bootstack/widgets/_impl/composites/_dateutils.py
@@ -1,0 +1,33 @@
+"""Shared date helpers for the date-picker composites."""
+from __future__ import annotations
+
+from datetime import date, datetime
+
+
+def coerce_date(value: date | datetime | str | None) -> date | None:
+    """Coerce a date, datetime, or date string to a plain `date`, or `None`.
+
+    Accepts `date`/`datetime` instances (a `datetime` is narrowed to its
+    `date`), `'YYYY-MM-DD'` or `'MM/DD/YYYY'` strings, and any ISO-8601 string.
+    Returns `None` for `None` or anything unparseable.
+
+    Args:
+        value: The value to coerce.
+    """
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    if isinstance(value, str):
+        for fmt in ("%Y-%m-%d", "%m/%d/%Y"):
+            try:
+                return datetime.strptime(value, fmt).date()
+            except Exception:
+                continue
+        try:
+            return datetime.fromisoformat(value).date()
+        except Exception:
+            return None
+    return None

--- a/src/bootstack/widgets/_impl/composites/calendar.py
+++ b/src/bootstack/widgets/_impl/composites/calendar.py
@@ -16,6 +16,7 @@ from bootstack.widgets.types import Master
 from bootstack.constants import BOTH, CENTER, LEFT, NSEW, X, Y, YES
 from bootstack.i18n import MessageCatalog
 from bootstack._runtime.utility import bind_right_click
+from bootstack.widgets._impl.composites._dateutils import coerce_date
 from bootstack.widgets._impl.mixins import configure_delegate
 
 ttk = SimpleNamespace(
@@ -279,19 +280,41 @@ class Calendar(ttk.Frame):
     def set_min_date(self, value: date | datetime | str | None) -> None:
         """Set the earliest selectable date and redraw. None clears the bound."""
         self._min_date = self._coerce_date(value)
-        self._refresh_calendar()
+        self._request_refresh()
 
     def set_max_date(self, value: date | datetime | str | None) -> None:
         """Set the latest selectable date and redraw. None clears the bound."""
         self._max_date = self._coerce_date(value)
-        self._refresh_calendar()
+        self._request_refresh()
 
     def set_disabled_dates(self, dates: Iterable[date | datetime | str] | None) -> None:
         """Replace the set of non-selectable dates and redraw."""
         self._disabled_dates = {
             d for d in (self._coerce_date(x) for x in (dates or [])) if d is not None
         }
-        self._refresh_calendar()
+        self._request_refresh()
+
+    def _request_refresh(self) -> None:
+        """Coalesce constraint changes into a single redraw.
+
+        Setting `min_date`, `max_date`, and `disabled_dates` in sequence would
+        otherwise redraw the whole grid once per setter. Schedule a single
+        idle-time refresh instead so a batch of constraint changes collapses to
+        one redraw.
+        """
+        if getattr(self, "_refresh_pending", False):
+            return
+        self._refresh_pending = True
+
+        def _do() -> None:
+            self._refresh_pending = False
+            self._refresh_calendar()
+
+        try:
+            self.after_idle(_do)
+        except tkinter.TclError:
+            self._refresh_pending = False
+            self._refresh_calendar()
 
     @property
     def range(self) -> tuple[date | None, date | None]:
@@ -916,25 +939,7 @@ class Calendar(ttk.Frame):
         month = (d.month - 1 + n) % 12 + 1
         return date(year, month, 1)
 
-    @staticmethod
-    def _coerce_date(value: date | datetime | str | None) -> date | None:
-        if value is None:
-            return None
-        if isinstance(value, date) and not isinstance(value, datetime):
-            return value
-        if isinstance(value, datetime):
-            return value.date()
-        if isinstance(value, str):
-            for fmt in ("%Y-%m-%d", "%m/%d/%Y"):
-                try:
-                    return datetime.strptime(value, fmt).date()
-                except Exception:
-                    continue
-            try:
-                return datetime.fromisoformat(value).date()
-            except Exception:
-                return None
-        return None
+    _coerce_date = staticmethod(coerce_date)
 
     def _normalize_range(
         self,

--- a/src/bootstack/widgets/_impl/composites/dateentry.py
+++ b/src/bootstack/widgets/_impl/composites/dateentry.py
@@ -12,6 +12,7 @@ from typing_extensions import Unpack
 
 from bootstack.events import ChangeEvent
 from bootstack.widgets._impl.primitives.button import Button
+from bootstack.widgets._impl.composites._dateutils import coerce_date
 from bootstack.widgets._impl.composites.field import Field, FieldOptions
 from bootstack.widgets._impl.mixins import configure_delegate
 from bootstack.widgets.types import Master
@@ -230,26 +231,7 @@ class DateEntry(Field):
         end_str = fmt.format(end, self._value_format)
         return f"{start_str} – {end_str}"
 
-    @staticmethod
-    def _coerce_date(value) -> date | None:
-        """Coerce a date/datetime/ISO-string to a date, or return None."""
-        if value is None:
-            return None
-        if isinstance(value, datetime):
-            return value.date()
-        if isinstance(value, date):
-            return value
-        if isinstance(value, str):
-            for fmt in ("%Y-%m-%d", "%m/%d/%Y"):
-                try:
-                    return datetime.strptime(value, fmt).date()
-                except Exception:
-                    continue
-            try:
-                return datetime.fromisoformat(value).date()
-            except Exception:
-                return None
-        return None
+    _coerce_date = staticmethod(coerce_date)
 
     def set_min_date(self, value: date | datetime | str | None) -> None:
         """Set the earliest selectable date for the picker. None clears the bound."""

--- a/src/bootstack/widgets/_impl/primitives/optionmenu.py
+++ b/src/bootstack/widgets/_impl/primitives/optionmenu.py
@@ -201,6 +201,11 @@ class OptionMenu(MenuButton):
             return self._menu_options
         else:
             self._menu_options = value
+            # Reconcile the current selection: if it is no longer one of the
+            # options, clear it so the button never displays a value the list
+            # can't offer (and no menu item stays phantom-selected).
+            if self._textvariable.get() not in {str(item) for item in value}:
+                self._textvariable.set("")
             if self._context_menu:
                 self._context_menu.destroy()
             self._context_menu = self._build_context_menu()

--- a/src/bootstack/widgets/radiogroup.py
+++ b/src/bootstack/widgets/radiogroup.py
@@ -5,6 +5,7 @@ from typing import overload, Any, Callable, TYPE_CHECKING
 
 from bootstack.widgets._impl.composites.radiogroup import RadioGroup as _InternalRadioGroup
 from bootstack.widgets._core.base import PublicWidgetBase
+from bootstack.widgets._core.selection_group import SelectionGroupMixin
 from bootstack.widgets._core.events import register_widget_events
 from bootstack.events import Subscription, ChangeEvent
 from bootstack.streams import Stream
@@ -18,7 +19,7 @@ _RADIOGROUP_EVENTS: dict[str, str] = {
 }
 
 
-class RadioGroup(PublicWidgetBase):
+class RadioGroup(SelectionGroupMixin, PublicWidgetBase):
     """A group of mutually exclusive radio buttons.
 
     Exactly one option can be selected at a time. Options are supplied at
@@ -144,43 +145,6 @@ class RadioGroup(PublicWidgetBase):
             value: Value assigned when this button is selected. Defaults to `label`.
         """
         self._internal.add(text=label, value=value if value is not None else label, **kwargs)
-
-    def remove(self, value: Any) -> None:
-        """Remove the button identified by `value`."""
-        self._internal.remove(value)
-
-    def configure_item(
-        self,
-        value: Any,
-        *,
-        label: str | None = None,
-        disabled: bool | None = None,
-    ) -> None:
-        """Update a single option in place, without rebuilding the group.
-
-        Args:
-            value: The option to update (the value it was added with).
-            label: New display text, when given.
-            disabled: When given, disable (`True`) or re-enable (`False`) just
-                this option. A later group-level `disabled` change resets every
-                option's state, so apply per-option states after it.
-
-        Raises:
-            KeyError: If no option with that value exists.
-        """
-        key = value
-        if label is not None:
-            self._internal.configure_item(key, text=label)
-        if disabled is not None:
-            self._internal.configure_item(key, state="disabled" if disabled else "normal")
-
-    def __len__(self) -> int:
-        """The number of options in the group."""
-        return len(self._internal.keys())
-
-    def __contains__(self, value: Any) -> bool:
-        """Whether an option with the given `value` is in the group."""
-        return value in self._internal.keys()
 
     # ----- Event shorthands -----
 

--- a/src/bootstack/widgets/togglegroup.py
+++ b/src/bootstack/widgets/togglegroup.py
@@ -5,6 +5,7 @@ from typing import overload, Any, Callable, Literal, TYPE_CHECKING
 
 from bootstack.widgets._impl.composites.togglegroup import ToggleGroup as _InternalToggleGroup
 from bootstack.widgets._core.base import PublicWidgetBase
+from bootstack.widgets._core.selection_group import SelectionGroupMixin
 from bootstack.widgets._core.events import register_widget_events
 from bootstack.events import Subscription, ChangeEvent
 from bootstack.streams import Stream
@@ -18,7 +19,7 @@ _TOGGLEGROUP_EVENTS: dict[str, str] = {
 }
 
 
-class ToggleGroup(PublicWidgetBase):
+class ToggleGroup(SelectionGroupMixin, PublicWidgetBase):
     """A group of toggle buttons — single-select or multi-select.
 
     Options are supplied at construction via `options=` and can be added
@@ -142,50 +143,6 @@ class ToggleGroup(PublicWidgetBase):
             value: Value this button represents. Defaults to `label`.
         """
         self._internal.add(text=label, value=value if value is not None else label, **kwargs)
-
-    def remove(self, value: Any) -> None:
-        """Remove the option identified by `value`.
-
-        Args:
-            value: The value the option was added with.
-
-        Raises:
-            KeyError: If no option with that value exists.
-        """
-        self._internal.remove(value)
-
-    def configure_item(
-        self,
-        value: Any,
-        *,
-        label: str | None = None,
-        disabled: bool | None = None,
-    ) -> None:
-        """Update a single option in place, without rebuilding the group.
-
-        Args:
-            value: The option to update (the value it was added with).
-            label: New display text, when given.
-            disabled: When given, disable (`True`) or re-enable (`False`) just
-                this option. A later group-level `disabled` change resets every
-                option's state, so apply per-option states after it.
-
-        Raises:
-            KeyError: If no option with that value exists.
-        """
-        key = value
-        if label is not None:
-            self._internal.configure_item(key, text=label)
-        if disabled is not None:
-            self._internal.configure_item(key, state="disabled" if disabled else "normal")
-
-    def __len__(self) -> int:
-        """The number of options in the group."""
-        return len(self._internal.keys())
-
-    def __contains__(self, value: Any) -> bool:
-        """Whether an option with the given `value` is in the group."""
-        return value in self._internal.keys()
 
     # ----- Event shorthands -----
 

--- a/src/bootstack/widgets/window.py
+++ b/src/bootstack/widgets/window.py
@@ -137,15 +137,6 @@ class Window(WindowControlsMixin, PublicContainer):
         self._tk_toplevel.show()
         return self
 
-    def close(self) -> None:
-        """Destroy the window immediately.
-
-        This is a programmatic close: it bypasses the `on_close` callback and any
-        handlers registered with `add_close_handler()` (which guard the user
-        clicking the window's close button), so it cannot be vetoed.
-        """
-        self._tk_toplevel.destroy()
-
     def block_until_closed(self) -> Any:
         """Show the window and block until it is destroyed.
 
@@ -153,23 +144,6 @@ class Window(WindowControlsMixin, PublicContainer):
             The value of `result` at the time the window was closed.
         """
         return self._tk_toplevel.block_until_closed()
-
-    def add_close_handler(self, callback: Callable[[], bool | None]) -> None:
-        """Register an additional close handler.
-
-        Args:
-            callback: Called when the user attempts to close the window.
-                Return `False` to veto the close.
-        """
-        self._tk_toplevel.add_close_handler(callback)
-
-    def remove_close_handler(self, callback: Callable) -> None:
-        """Remove a previously registered close handler.
-
-        Args:
-            callback: The same callable passed to `add_close_handler()`.
-        """
-        self._tk_toplevel.remove_close_handler(callback)
 
     # ----- Properties -----
 


### PR DESCRIPTION
Resolves the six cleanup/altitude follow-ups (#4–#10) deferred from the high-effort code review of the widget-API-gap-audit branch (the 3 correctness bugs and 2 refuted findings were already handled in `55e2d12b`). None block anything; this is deduplication and hardening. **Net −95 lines.**

| # | Fix |
|---|-----|
| **#4** | `SelectButton.options` setter reconciles the current value — clears it when no longer one of the new options, so the button never displays an unavailable value. |
| **#5** | `take_screenshots.py`: `GetParent`/`GetWindowRect` declare HWND `argtypes`/`restype`, fixing the Win64 handle-truncation risk. |
| **#6** | Lift `RadioGroup`/`ToggleGroup` `configure_item`/`remove`/`__len__`/`__contains__` onto a shared `SelectionGroupMixin`. The wider `project_select_options_databag` work can build on this mixin. |
| **#7** | Uniform close contract: `BaseWindow.close()` does a programmatic, handler-bypassing close; `App` still overrides it to quit the loop. `Window` drops its redundant `close`/`add_close_handler`/`remove_close_handler` overrides (now from `WindowControlsMixin`). |
| **#9** | Extract one shared `coerce_date` helper (`_dateutils.py`); `calendar.py` and `dateentry.py` delegate. |
| **#10** | `Calendar` constraint setters coalesce into a single idle-time redraw via `_request_refresh()` (a batch of `min_date`/`max_date`/`disabled_dates` changes now redraws once instead of N times). State reads stay immediate. |

## Notes
- **#6** was flagged in the audit as "folds into `project_select_options_databag`". Done now as a clean, low-risk extraction so that initiative can build on the mixin rather than re-extract.
- **#10** moves the redraw to `after_idle` (that's what enables coalescing); constraint *state* reads (`cal.min_date`, etc.) remain synchronous.

## Verification
- Dedicated functional scripts confirm #4, #6, #7, #9, #10 behave correctly.
- `tests/test_public_surface.py` — 137 passed.
- Clean docs build (`-W --keep-going`) — warning-free.
- Broad-suite Tk crashes seen locally (`element_create` access-violation / `tcl_findLibrary` init errors) are pre-existing environment flakiness from Tk root churn — confirmed identical on clean `main`, none touch this changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
