### PR TITLE
feat(widgets): field value/text/label contract + shared option shape

### DIFF
--- a/docs/api-reference/types.rst
+++ b/docs/api-reference/types.rst
@@ -145,6 +145,13 @@ Literals for selection behavior and tabular data export.
    Which rows an export covers — `'all'` rows, the current `'page'`, or the
    current `'selection'`.
 
+.. py:type:: Option
+
+   A single choice for `Select`, `SelectButton`, `RadioGroup`, or
+   `ToggleGroup` — a plain `str` (text and value are the same), a
+   `(text, value)` tuple, or an `OptionDict`. Lets an option's displayed label
+   differ from its stored value.
+
 .. py:type:: SelectionMode
 
    How many rows or items can be selected — `'none'`, `'single'`, or `'multi'`.
@@ -169,6 +176,9 @@ that ``DataTable`` and ``Form`` accept.
    `'spinnerfield'`, `'switch'`, `'checkbox'`, `'slider'`.
 
 .. autoclass:: FormOptions
+   :members:
+
+.. autoclass:: OptionDict
    :members:
 
 .. autoclass:: StyledKwargs

--- a/docs/widgets/radiogroup.rst
+++ b/docs/widgets/radiogroup.rst
@@ -23,8 +23,8 @@ Pass a list of strings — the label and value are the same for each option.
 
    bs.RadioGroup(["Small", "Medium", "Large"], value="Medium")
 
-Use ``(label, value)`` tuples when the display text should differ from the
-stored value.
+Use ``(text, value)`` tuples — or ``{"text": ..., "value": ...}`` dicts — when
+the display text should differ from the stored value.
 
 .. code-block:: python
 

--- a/docs/widgets/select.rst
+++ b/docs/widgets/select.rst
@@ -22,6 +22,31 @@ Basic
    bs.Select(["Red", "Green", "Blue"])
    bs.Select(["Red", "Green", "Blue"], value="Green")
 
+Option values
+~~~~~~~~~~~~~
+
+An option's displayed label can differ from its stored value. Each option is a
+plain string, a ``(text, value)`` tuple, or a ``{"text": ..., "value": ...}``
+dict. ``value=``, ``.value``, and the change event all work in *value-space* —
+the value, not the label. The label currently shown is available as ``.text``.
+
+.. code-block:: python
+
+   theme = bs.Select(
+       [("Light theme", "light"), ("Dark theme", "dark"), {"text": "Follow system", "value": "auto"}],
+       value="dark",
+   )
+   theme.value            # -> "dark"          (the value)
+   theme.text             # -> "Dark theme"    (the displayed label)
+   theme.value = "auto"   # selects "Follow system"
+   theme.on_change(lambda e: apply_theme(e.value))
+
+   theme.options          # -> [{"text": "Light theme", "value": "light"}, ...]
+
+Setting ``.value`` to something that is not one of the options raises
+``ValueError`` (unless ``allow_custom_values=True``, where a typed value is kept
+as its own text).
+
 Label and message
 ~~~~~~~~~~~~~~~~~
 

--- a/docs/widgets/selectbutton.rst
+++ b/docs/widgets/selectbutton.rst
@@ -23,6 +23,20 @@ Pass a list of options. The button displays the currently selected value.
 
    bs.SelectButton(["Light", "Dark", "Auto"], value="Light")
 
+Option values
+~~~~~~~~~~~~~
+
+Like `Select`, an option's label can differ from its value — pass a
+``(text, value)`` tuple or a ``{"text": ..., "value": ...}`` dict. ``value=``,
+``.value``, and the change event are in value-space.
+
+.. code-block:: python
+
+   mode = bs.SelectButton([("Light theme", "light"), ("Dark theme", "dark")], value="dark")
+   mode.value             # -> "dark"          (the value)
+   mode.text              # -> "Dark theme"    (the displayed label)
+   mode.on_change(lambda e: apply_theme(e.value))
+
 Accent colors
 ~~~~~~~~~~~~~
 

--- a/src/bootstack/types.py
+++ b/src/bootstack/types.py
@@ -17,6 +17,7 @@ from bootstack.widgets.types import (
     WidgetState, WidgetDensity,
     AccentToken, VariantToken, SurfaceToken, WindowStyle,
     ColumnSpec, EditorType, FormOptions,
+    Option, OptionDict,
 )
 
 __all__ = [
@@ -28,4 +29,5 @@ __all__ = [
     "WidgetState", "WidgetDensity",
     "AccentToken", "VariantToken", "SurfaceToken", "WindowStyle",
     "ColumnSpec", "EditorType", "FormOptions",
+    "Option", "OptionDict",
 ]

--- a/src/bootstack/widgets/_core/field_mixin.py
+++ b/src/bootstack/widgets/_core/field_mixin.py
@@ -87,6 +87,16 @@ class FieldAddonMixin:
         """Named addon widgets inserted via `insert_addon()`."""
         return self._internal.addons
 
+    @property
+    def text(self) -> str:
+        """The current display text shown in the field.
+
+        This is the formatted string the user sees, as opposed to `value`, which
+        is the raw parsed datum (e.g. for a `DateField`, `text` is `'Jan 2, 2024'`
+        while `value` is a `date`). Read-only — assign to `value` to change it.
+        """
+        return self._internal.get()
+
     def add_validation_rule(self, rule_type: RuleType, **kwargs: Any) -> None:
         """Add a validation rule to the field.
 

--- a/src/bootstack/widgets/_core/options.py
+++ b/src/bootstack/widgets/_core/options.py
@@ -1,0 +1,89 @@
+"""Shared normalization for the selection family's option shape.
+
+`Select`, `SelectButton`, `RadioGroup`, and `ToggleGroup` all accept the same
+`Option` shape (a plain string, a `(text, value)` tuple, or an `OptionDict`).
+This module turns any of those into a canonical `OptionRecord` so every widget
+shares one coercion + validation path.
+"""
+from __future__ import annotations
+
+from typing import Any, Iterable, NamedTuple
+
+from bootstack.widgets.types import Option
+
+# Keys an OptionDict may carry. `text` is required; `value` defaults to `text`.
+_KNOWN_OPTION_KEYS = frozenset({"text", "value", "icon", "disabled"})
+
+
+class OptionRecord(NamedTuple):
+    """A normalized option — what every selection widget consumes internally."""
+
+    text: str
+    """Display label."""
+    value: Any
+    """Stored and emitted value."""
+    extras: dict
+    """Reserved per-option extras (e.g. `icon`, `disabled`); empty for now."""
+
+
+def normalize_option(opt: Option) -> OptionRecord:
+    """Coerce a single `Option` to an `OptionRecord`.
+
+    Args:
+        opt: A plain string, a `(text, value)` tuple, or an `OptionDict`.
+
+    Returns:
+        The normalized `(text, value, extras)` record.
+
+    Raises:
+        TypeError: If `opt` is not a string, 2-tuple, or dict, or if a dict
+            `text` is not a string.
+        ValueError: If a tuple does not have exactly two items, or a dict is
+            missing `text` or carries an unknown key.
+    """
+    if isinstance(opt, str):
+        return OptionRecord(opt, opt, {})
+
+    if isinstance(opt, dict):
+        if "text" not in opt:
+            raise ValueError(f"option dict is missing the required 'text' key: {opt!r}")
+        unknown = set(opt) - _KNOWN_OPTION_KEYS
+        if unknown:
+            raise ValueError(
+                f"option dict has unknown key(s) {sorted(unknown)}: {opt!r} "
+                f"(allowed: {sorted(_KNOWN_OPTION_KEYS)})"
+            )
+        text = opt["text"]
+        if not isinstance(text, str):
+            raise TypeError(f"option 'text' must be a string, got {type(text).__name__}: {opt!r}")
+        value = opt["value"] if "value" in opt else text
+        extras = {k: opt[k] for k in opt if k not in ("text", "value")}
+        return OptionRecord(text, value, extras)
+
+    if isinstance(opt, tuple):
+        if len(opt) != 2:
+            raise ValueError(f"option tuple must be (text, value), got {len(opt)} items: {opt!r}")
+        text, value = opt
+        if not isinstance(text, str):
+            raise TypeError(f"option text must be a string, got {type(text).__name__}: {opt!r}")
+        return OptionRecord(text, value, {})
+
+    raise TypeError(
+        f"option must be a str, (text, value) tuple, or dict, got {type(opt).__name__}: {opt!r}"
+    )
+
+
+def normalize_options(opts: Iterable[Option] | None) -> list[OptionRecord]:
+    """Coerce an iterable of `Option` values to a list of `OptionRecord`.
+
+    Args:
+        opts: Options to normalize, or `None` for an empty list.
+    """
+    if not opts:
+        return []
+    return [normalize_option(opt) for opt in opts]
+
+
+def record_to_dict(record: OptionRecord) -> dict:
+    """Render an `OptionRecord` as a public `{'text', 'value', ...extras}` dict."""
+    return {"text": record.text, "value": record.value, **record.extras}

--- a/src/bootstack/widgets/_impl/composites/selectbox.py
+++ b/src/bootstack/widgets/_impl/composites/selectbox.py
@@ -2,13 +2,16 @@ from tkinter import Toplevel
 
 from typing_extensions import Unpack
 
+from typing import Any
+
 from bootstack.events import ChangeEvent
+from bootstack.widgets._core.options import normalize_options
 from bootstack.widgets._impl.primitives.button import Button
 from bootstack.widgets._impl.primitives.frame import Frame
 from bootstack.widgets._impl.composites.scrollview import ScrollView
 from bootstack.widgets._impl.composites.field import Field, FieldOptions
 from bootstack.widgets._impl.mixins import configure_delegate
-from bootstack.widgets.types import Master
+from bootstack.widgets.types import Master, Option
 
 
 class SelectBox(Field):
@@ -23,11 +26,12 @@ class SelectBox(Field):
     def __init__(
             self,
             master: Master = None,
-            value: str = None,
-            items: list[str] = None,
+            value: Any = None,
+            items: list[Option] = None,
             label: str = None,
             message: str = None,
             allow_custom_values: bool = False,
+            strict_value: bool = False,
             show_dropdown_button: bool = True,
             dropdown_button_icon: str = None,
             enable_search: bool = False,
@@ -35,8 +39,12 @@ class SelectBox(Field):
     ):
         """Args:
             master: Parent widget. If None, uses the default root window.
-            value: Initial selected value; should typically be present in `items`.
-            items: Sequence of string options to present in the popup list.
+            value: Initial selected value (value-space). Should match one of the
+                options unless `allow_custom_values` is set.
+            items: Options to present in the popup — each a string,
+                `(text, value)` tuple, or `{'text', 'value'}` dict. The popup
+                and field display each option's text; the selected value is
+                emitted in value-space.
             label: Optional label text shown above the field.
             message: Optional helper/error message shown below the field.
             allow_custom_values: If True, the entry is editable so users can type
@@ -65,12 +73,18 @@ class SelectBox(Field):
             width: Width of the entry in characters.
             required: If True, field cannot be empty.
         """
-        super().__init__(master, value=value, label=label, message=message, **kwargs)
-
+        # Normalize options once. The maps only decouple an option's *display
+        # text* from its *value*; the entry keeps owning the raw value (so
+        # `value_format` parsing, e.g. TimeField's time objects, is preserved).
+        self._records = normalize_options(items)
         self._allow_custom_values = allow_custom_values
+        self._strict_value = strict_value
+        self._rebuild_option_maps()
+
+        # Seed the entry with the display form of the initial value.
+        super().__init__(master, value=self._resolve_display(value), label=label, message=message, **kwargs)
+
         self._search_enabled = enable_search
-        self._items = items or []
-        self._last_selected_value = value
         self._popup_open = False
         self._dropdown_button_icon = dropdown_button_icon or 'chevron-down'
         self._popup_frame = None
@@ -95,6 +109,53 @@ class SelectBox(Field):
             self.entry_widget.state(['readonly'])
             self.after_idle(self._bind_readonly_selection_on_click)
 
+    # ----- Option normalization + value<->text mapping -----
+
+    def _rebuild_option_maps(self) -> None:
+        """Rebuild text<->value lookups from the current records.
+
+        Duplicate texts keep the first value; duplicate values keep the first
+        text. Popup selection resolves by the chosen row's record, so duplicate
+        texts with distinct values still select correctly from the list — only
+        the `value` setter (which keys on value) is affected by duplicates.
+        """
+        self._value_by_text: dict[str, Any] = {}
+        self._text_by_value: dict[Any, str] = {}
+        for rec in self._records:
+            self._value_by_text.setdefault(rec.text, rec.value)
+            try:
+                self._text_by_value.setdefault(rec.value, rec.text)
+            except TypeError:
+                pass  # unhashable value — no reverse map; popup selection still works
+
+    def _resolve_display(self, value: Any) -> Any:
+        """Map a value-space value to what the entry should hold.
+
+        The entry owns the raw value <-> display text mapping (via
+        `value_format`); the option map only kicks in to decouple an option's
+        display text from its value:
+
+        - None/empty -> the value itself (the entry clears).
+        - A decoupled option (its text differs from its value) -> the option's
+          display text, which the entry shows verbatim.
+        - A known plain option, a custom value, or a typed value (e.g. a
+          `datetime.time`) -> the value itself, so the entry's `value_format`
+          parses/formats it.
+        - An unknown value, when `strict_value` is set and custom values are
+          off -> raises `ValueError`.
+        """
+        if value is None or value == "":
+            return value
+        try:
+            if value in self._text_by_value:
+                text = self._text_by_value[value]
+                return text if text != value else value
+        except TypeError:
+            pass
+        if self._strict_value and not self._allow_custom_values:
+            raise ValueError(f"{value!r} is not one of the options")
+        return value
+
     def _on_dropdown_click(self):
         """Handle dropdown button click by focusing entry then showing popup."""
         self.entry_widget.focus_set()
@@ -107,7 +168,7 @@ class SelectBox(Field):
 
     def _show_selection_options(self):
         """Create and display the popup list of selectable items."""
-        if not self._items or self._popup_open:
+        if not self._records or self._popup_open:
             return
         if self.entry_widget.instate(['disabled']):
             return
@@ -248,28 +309,29 @@ class SelectBox(Field):
         inner_frame.bind('<Configure>', on_inner_frame_configure, add='+')
 
         self._item_labels = []
-        current_value = self.entry_widget.get()
+        current_text = self.entry_widget.get()
 
         # Get accent from Field's _accent attribute, fallback to primary if None
         accent = getattr(self, '_accent', None) or 'primary'
 
-        for i, item in enumerate(self._items):
+        for i, rec in enumerate(self._records):
             btn = Button(
                 inner_frame,
-                text=item,
+                text=rec.text,
                 accent=accent,
                 variant='selectbox_item',
                 takefocus=False,
-                command=lambda v=item: self._on_item_click(v, toplevel, popup_state)
+                command=lambda v=rec.value: self._on_item_click(v, toplevel, popup_state)
             )
             btn.pack(fill='x')
 
-            # Store item value on button for retrieval
-            btn._item_value = item
+            # Store the option's value (for selection) and text (for filtering).
+            btn._item_value = rec.value
+            btn._item_text = rec.text
             btn._item_index = i
 
-            # Apply selected state if this is the current value
-            if item == current_value:
+            # Apply selected state if this row matches the displayed text
+            if rec.text == current_text:
                 btn.state(['selected'])
 
             self._item_labels.append(btn)
@@ -360,9 +422,9 @@ class SelectBox(Field):
 
     def _setup_search_bindings(self, toplevel, popup_state, close_popup):
         """Setup search-specific event bindings."""
-        # Initialize first filtered item
-        if self._items:
-            popup_state['first_filtered_item'] = self._items[0]
+        # Initialize first filtered item (stored in value-space)
+        if self._records:
+            popup_state['first_filtered_item'] = self._records[0].value
         popup_state['last_search_text'] = self.entry_widget.get().lower()
 
         # Filter function
@@ -377,17 +439,17 @@ class SelectBox(Field):
                 return
             popup_state['last_search_text'] = search_text
 
-            # Show/hide buttons based on filter
+            # Show/hide buttons based on filter — match on the visible TEXT
             first_visible = None
             for btn in self._item_labels:
-                if search_text in btn._item_value.lower():
+                if search_text in btn._item_text.lower():
                     btn.pack(fill='x')
                     if first_visible is None:
                         first_visible = btn
                 else:
                     btn.pack_forget()
 
-            # Track first filtered item for auto-select
+            # Track first filtered item for auto-select (value-space)
             popup_state['first_filtered_item'] = first_visible._item_value if first_visible else None
 
             # Reset highlight to first visible item
@@ -481,12 +543,17 @@ class SelectBox(Field):
         self._close_popup(toplevel, popup_state)
 
     @configure_delegate('items')
-    def _delegate_items(self, value: list[str] = None):
-        """Get or set the available items for the SelectBox."""
+    def _delegate_items(self, value: list[Option] = None):
+        """Get the normalized option records, or set new options."""
         if value is None:
-            return self._items
+            return list(self._records)
         else:
-            self._items = value or []
+            self._records = normalize_options(value)
+            self._rebuild_option_maps()
+            # Reconcile the displayed selection: if its text is no longer an
+            # option (and custom values aren't allowed), clear it.
+            if self.entry_widget.get() not in self._value_by_text and not self._allow_custom_values:
+                self.value = None
         return None
 
     @configure_delegate('allow_custom_values')
@@ -517,55 +584,78 @@ class SelectBox(Field):
 
     @configure_delegate('value')
     def _delegate_value(self, value=None):
-        if value is not None:
+        if value is None:
             return self.value
-        else:
-            self.value = value
-            return None
+        self.value = value
+        return None
 
     @property
     def selected_index(self) -> int:
         """Get or set the selected index.
 
-        Returns -1 if the current value is not in the items list.
-        Setting to -1 or None clears the selection.
+        Returns -1 if nothing is selected (the displayed text matches no
+        option). Setting to -1 or None clears the selection.
         """
-        try:
-            return self._items.index(self.entry_widget.get())
-        except:
-            return -1
+        text = self.entry_widget.get()
+        for i, rec in enumerate(self._records):
+            if rec.text == text:
+                return i
+        return -1
 
     @selected_index.setter
     def selected_index(self, index):
         if index is None or index == -1:
-            self.value = ""
-        elif 0 <= index < len(self._items):
-            self.value = self._items[index]
+            self.value = None
+        elif 0 <= index < len(self._records):
+            self.value = self._records[index].value
         else:
-            raise IndexError(f"index {index} out of range for {len(self._items)} items")
+            raise IndexError(f"index {index} out of range for {len(self._records)} options")
 
     @property
-    def value(self) -> str:
-        """Get or set the selected value."""
+    def text(self) -> str:
+        """The current display text shown in the field (the formatted string)."""
+        return self.entry_widget.get()
+
+    @property
+    def value(self):
+        """The selected value, or None when the field is empty.
+
+        For a decoupled option (its display text differs from its value) this
+        returns the option's value. Otherwise it returns the entry's own raw
+        value, so `value_format` parsing — e.g. TimeField's `datetime.time` —
+        is preserved.
+        """
+        text = self.entry_widget.get()
+        if text == "":
+            return None
+        if text in self._value_by_text and self._value_by_text[text] != text:
+            return self._value_by_text[text]
         return Field.value.fget(self)
 
     @value.setter
     def value(self, value):
-        """Set the selected value and emit `<<Change>>` when it differs."""
-        prev_value = Field.value.fget(self)
+        """Select `value`, updating the displayed text and emitting `<<Change>>`.
+
+        A decoupled option shows its text; a plain/typed/custom value is handed
+        to the entry, which owns the raw value <-> text formatting. An unknown
+        value raises `ValueError` when `strict_value` is set and custom values
+        are off.
+        """
+        prev_value = self.value
+        display = self._resolve_display(value)
         is_readonly = self.entry_widget.instate(['readonly'])
         if is_readonly:
             self.entry_widget.state(['!readonly'])
-        Field.value.fset(self, value)
-        new_value = Field.value.fget(self)
-        display_text = str(new_value) if new_value is not None else ''
-        try:
+        if display is None or display == "":
+            # The entry part's value() setter doesn't reliably clear the field;
+            # empty it directly.
             self.entry_widget.delete(0, 'end')
-            self.entry_widget.insert(0, display_text)
-        except Exception:
-            pass
+        else:
+            # The entry owns raw<->text; setting its value is programmatic (no emit).
+            Field.value.fset(self, display)
         if is_readonly:
             self.entry_widget.state(['readonly'])
+        new_value = self.value
         if new_value != prev_value:
             self.entry_widget._prev_changed_value = new_value
             if not getattr(self, "_suppress_changed_event", False):

--- a/src/bootstack/widgets/_impl/primitives/optionmenu.py
+++ b/src/bootstack/widgets/_impl/primitives/optionmenu.py
@@ -6,10 +6,11 @@ from typing import Any, Callable, TypedDict, TYPE_CHECKING
 from typing_extensions import Unpack
 
 from bootstack.events import ChangeEvent
+from bootstack.widgets._core.options import normalize_options
 from bootstack.widgets._impl.composites.contextmenu import ContextMenu, ContextMenuItem
 from bootstack.widgets._impl.primitives._menubutton import MenuButton
 from bootstack.widgets._impl.mixins import configure_delegate
-from bootstack.widgets.types import Master, StyledKwargs, CompoundMode, WidgetState
+from bootstack.widgets.types import Master, StyledKwargs, CompoundMode, WidgetState, Option
 
 if TYPE_CHECKING:
     from bootstack.signals import Signal
@@ -45,15 +46,18 @@ class OptionMenu(MenuButton):
             self,
             master: Master = None,
             value: Any = None,
-            options: list[Any] = None,
+            options: list[Option] = None,
             **kwargs: Unpack[OptionMenuKwargs],
     ):
         """Create an OptionMenu backed by a ContextMenu.
 
         Args:
             master: Parent widget. If None, uses the default root window.
-            value: Initial selected value.
-            options: List of values to populate the menu.
+            value: Initial selected value (value-space). Must match one of the
+                options unless it is None/empty.
+            options: Options to populate the menu — each a string,
+                `(text, value)` tuple, or `{'text', 'value'}` dict. The menu
+                shows each option's text; selecting one emits its value.
 
         Other Parameters:
             command: Callback invoked when the value changes via menu selection.
@@ -86,14 +90,18 @@ class OptionMenu(MenuButton):
         )
 
         self._bind_id = None
-        self._menu_options = options if options is not None else []
+        # Normalize options once; keep bidirectional text<->value maps so the
+        # menu can display text while the public value stays in value-space.
+        self._records = normalize_options(options)
+        self._rebuild_option_maps()
 
-        # Store the textvariable if provided, or create a new one
+        # Store the textvariable if provided, or create a new one. The variable
+        # holds the DISPLAY TEXT (it drives the button face + radio highlight).
         self._textvariable = kwargs.pop('textvariable', None)
         if self._textvariable is None:
-            self._textvariable = StringVar(value=str(value) if value is not None else "")
+            self._textvariable = StringVar(value=self._resolve_initial_text(value))
 
-        super().__init__(master, text=value, style_options=style_options, **kwargs)
+        super().__init__(master, text=self._textvariable.get(), style_options=style_options, **kwargs)
 
         # Configure the menubutton to use the textvariable
         self.configure(textvariable=self._textvariable)
@@ -109,11 +117,48 @@ class OptionMenu(MenuButton):
         self.bind('<Return>', lambda _: self.show_menu(), add="+")
         self.bind('<KP_Enter>', lambda _: self.show_menu(), add="+")
 
+    def _rebuild_option_maps(self) -> None:
+        """Rebuild the text<->value lookups from the current records.
+
+        Duplicate texts keep the first value; duplicate values keep the first
+        text. A SelectButton uses a single shared variable keyed on text, so
+        duplicate texts with distinct values cannot be told apart — keep option
+        texts unique.
+        """
+        self._value_by_text: dict[str, Any] = {}
+        self._text_by_value: dict[Any, str] = {}
+        for rec in self._records:
+            self._value_by_text.setdefault(rec.text, rec.value)
+            try:
+                self._text_by_value.setdefault(rec.value, rec.text)
+            except TypeError:
+                pass  # unhashable value — no reverse mapping; display still works
+
+    def _resolve_initial_text(self, value: Any) -> str:
+        """Map an initial value-space value to its display text.
+
+        Returns the empty string for None/empty; raises if the value matches no
+        option.
+        """
+        if value is None or value == "":
+            return ""
+        try:
+            if value in self._text_by_value:
+                return self._text_by_value[value]
+        except TypeError:
+            pass
+        raise ValueError(f"{value!r} is not one of the options")
+
     def _bind_change_event(self):
-        """(Re)bind textsignal to emit <<Change>> Tk events."""
+        """(Re)bind textsignal to emit <<Change>> Tk events (in value-space)."""
         if self._bind_id is not None:
             self.textsignal.unsubscribe(self._bind_id)
-        return self.textsignal.subscribe(lambda v: self.event_generate('<<Change>>', data=ChangeEvent(value=v)))
+        return self.textsignal.subscribe(
+            lambda text: self.event_generate(
+                '<<Change>>',
+                data=ChangeEvent(value=self._value_by_text.get(text, text) if text else None),
+            )
+        )
 
     def _build_context_menu(self):
         # Affordance baked into the button image (focus ring + border line in
@@ -127,11 +172,11 @@ class OptionMenu(MenuButton):
         menu_items = [
             ContextMenuItem(
                 type="radiobutton",
-                text=str(item),
+                text=rec.text,
                 variable=self._textvariable,
-                value=str(item)
+                value=rec.text,
             )
-            for item in self._menu_options
+            for rec in self._records
         ]
         return ContextMenu(
             self, target=self, items=menu_items,
@@ -156,13 +201,32 @@ class OptionMenu(MenuButton):
             self._context_menu.configure(minwidth=max(150, target_w))
         self._context_menu.show()
 
-    def get(self) -> str:
-        """Return the current value."""
+    @property
+    def text(self) -> str:
+        """The display label currently shown on the button."""
         return self._textvariable.get()
 
+    def get(self) -> Any:
+        """Return the current value (value-space), or `None` if nothing is selected."""
+        text = self._textvariable.get()
+        if text == "":
+            return None
+        return self._value_by_text.get(text, text)
+
     def set(self, value: Any) -> None:
-        """Set the current value (coerced to string)."""
-        self._textvariable.set(str(value))
+        """Select the option whose value is `value`, updating the displayed text.
+
+        Passing None or `''` clears the selection. A value that matches no
+        option raises `ValueError`.
+        """
+        if value is None or value == "":
+            self._textvariable.set("")
+            return
+        try:
+            text = self._text_by_value[value]
+        except (KeyError, TypeError):
+            raise ValueError(f"{value!r} is not one of the options")
+        self._textvariable.set(text)
 
     @property
     def value(self) -> str:
@@ -196,15 +260,16 @@ class OptionMenu(MenuButton):
 
     @configure_delegate('options')
     def _delegate_options(self, value=None):
-        """Get or set the menu options list."""
+        """Get the normalized option records, or set new options."""
         if value is None:
-            return self._menu_options
+            return list(self._records)
         else:
-            self._menu_options = value
-            # Reconcile the current selection: if it is no longer one of the
-            # options, clear it so the button never displays a value the list
-            # can't offer (and no menu item stays phantom-selected).
-            if self._textvariable.get() not in {str(item) for item in value}:
+            self._records = normalize_options(value)
+            self._rebuild_option_maps()
+            # Reconcile the current selection: if its display text is no longer
+            # one of the options, clear it so the button never shows a value the
+            # list can't offer (and no menu item stays phantom-selected).
+            if self._textvariable.get() not in self._value_by_text:
                 self._textvariable.set("")
             if self._context_menu:
                 self._context_menu.destroy()

--- a/src/bootstack/widgets/codeeditor.py
+++ b/src/bootstack/widgets/codeeditor.py
@@ -200,6 +200,12 @@ class CodeEditor(PublicWidgetBase):
         self._internal.value = v
 
     @property
+    def text(self) -> str:
+        """The current display text. Same as `value` for a code editor (no
+        formatting layer). Read-only — assign to `value` to change it."""
+        return self._internal.value
+
+    @property
     def signal(self) -> "Signal[str] | None":
         """The reactive `Signal` bound to this editor, or `None`."""
         return getattr(self._internal._core, "signal", None)

--- a/src/bootstack/widgets/radiogroup.py
+++ b/src/bootstack/widgets/radiogroup.py
@@ -6,10 +6,11 @@ from typing import overload, Any, Callable, TYPE_CHECKING
 from bootstack.widgets._impl.composites.radiogroup import RadioGroup as _InternalRadioGroup
 from bootstack.widgets._core.base import PublicWidgetBase
 from bootstack.widgets._core.selection_group import SelectionGroupMixin
+from bootstack.widgets._core.options import normalize_options
 from bootstack.widgets._core.events import register_widget_events
 from bootstack.events import Subscription, ChangeEvent
 from bootstack.streams import Stream
-from bootstack.widgets.types import AccentToken, Event, Orient
+from bootstack.widgets.types import AccentToken, Event, Option, Orient
 
 if TYPE_CHECKING:
     from bootstack.signals import Signal
@@ -27,9 +28,9 @@ class RadioGroup(SelectionGroupMixin, PublicWidgetBase):
     using `add()` and `remove()`.
 
     Args:
-        options: Choices for the group. Each item is either a plain string
-            (label and value are the same) or a `(label, value)` tuple,
-            e.g. `["S", "M", "L"]` or
+        options: Choices for the group. Each item is a plain string (text and
+            value are the same), a `(text, value)` tuple, or a
+            `{'text': ..., 'value': ...}` dict — e.g. `["S", "M", "L"]` or
             `[("Small", "s"), ("Medium", "m"), ("Large", "l")]`.
         signal: Reactive `Signal` holding the selected value. When
             provided, `value=` is ignored — seed the Signal directly.
@@ -48,7 +49,7 @@ class RadioGroup(SelectionGroupMixin, PublicWidgetBase):
 
     def __init__(
         self,
-        options: list[str | tuple[str, Any]] | None = None,
+        options: list[Option] | None = None,
         *,
         signal: "Signal | None" = None,
         value: Any = None,
@@ -79,13 +80,8 @@ class RadioGroup(SelectionGroupMixin, PublicWidgetBase):
         self._internal = _InternalRadioGroup(tk_master, **internal_kwargs)
 
         # Populate options passed at construction.
-        if options:
-            for opt in options:
-                if isinstance(opt, str):
-                    self._internal.add(text=opt, value=opt)
-                else:
-                    lbl, val = opt
-                    self._internal.add(text=lbl, value=val)
+        for record in normalize_options(options):
+            self._internal.add(text=record.text, value=record.value)
 
         # Trace the signal so <<Change>> fires on the internal Frame whenever
         # the value changes — this lets on_change() use standard Subscription binding.

--- a/src/bootstack/widgets/select.py
+++ b/src/bootstack/widgets/select.py
@@ -6,10 +6,11 @@ from typing import overload, Any, Callable, TYPE_CHECKING
 from bootstack.widgets._impl.composites.selectbox import SelectBox as _InternalSelectBox
 from bootstack.widgets._core.base import PublicWidgetBase, adapt_handler
 from bootstack.widgets._core.events import resolve_event, register_widget_events
+from bootstack.widgets._core.options import record_to_dict
 from bootstack.events import ChangeEvent, Subscription
 from bootstack.streams import Stream
 from bootstack.widgets.textfield import _INNER_ENTRY_SEQUENCES
-from bootstack.widgets.types import AccentToken, Event, WidgetDensity
+from bootstack.widgets.types import AccentToken, Event, Option, OptionDict, WidgetDensity
 
 if TYPE_CHECKING:
     from bootstack.signals import Signal
@@ -26,11 +27,15 @@ class Select(PublicWidgetBase):
     keyword-only.
 
     Args:
-        options: List of string choices presented in the popup. Defaults to
-            an empty list.
-        value: Initially selected value.
-        signal: Reactive `Signal[str]` linked to the selected value. The
-            field and signal stay in sync automatically.
+        options: Choices presented in the popup. Each item is a plain string,
+            a `(text, value)` tuple, or a `{'text': ..., 'value': ...}` dict —
+            so an option's displayed label can differ from its stored value.
+            Defaults to an empty list.
+        value: Initially selected value (value-space — matches an option's
+            value, not its label).
+        signal: Reactive `Signal` two-way bound to the field's displayed text.
+            With decoupled options (text differs from value), bind to the value
+            via `on_change`/`value`; the signal carries the display text.
         label: Label displayed above the field.
         message: Hint or helper text displayed below the field.
         required: If `True`, marks the field as required and prevents
@@ -54,9 +59,9 @@ class Select(PublicWidgetBase):
 
     def __init__(
         self,
-        options: list[str] | None = None,
+        options: list[Option] | None = None,
         *,
-        value: str | None = None,
+        value: Any = None,
         signal: "Signal[str] | None" = None,
         label: str | None = None,
         message: str | None = None,
@@ -76,9 +81,12 @@ class Select(PublicWidgetBase):
         tk_master = self._parent._child_master() if self._parent else None
 
         internal_kwargs: dict[str, Any] = {
-            "items":              options or [],
-            "enable_search":      searchable,
+            "items":               options or [],
+            "enable_search":       searchable,
             "allow_custom_values": allow_custom_values,
+            # Public Select rejects an unknown value (unless custom values are
+            # allowed); internal/embedded SelectBoxes stay lenient.
+            "strict_value":        not allow_custom_values,
         }
         if value is not None:
             internal_kwargs["value"] = value
@@ -144,22 +152,39 @@ class Select(PublicWidgetBase):
     # ----- Properties -----
 
     @property
-    def value(self) -> str:
-        """The currently selected value."""
+    def value(self) -> Any:
+        """The currently selected value, or `None` if unselected.
+
+        This is the option's *value* (value-space). For the displayed label, see
+        `text`.
+        """
         return self._internal.value
 
     @value.setter
-    def value(self, v: str) -> None:
+    def value(self, v: Any) -> None:
         self._internal.value = v
 
     @property
-    def options(self) -> list[str]:
-        """The list of available options."""
-        return list(self._internal._items)
+    def text(self) -> str:
+        """The label currently shown in the field — the selected option's text.
+
+        Read-only; the complement of `value` (the selection's value). Assign to
+        `value` to change the selection.
+        """
+        return self._internal.text
+
+    @property
+    def options(self) -> list[OptionDict]:
+        """The available options as normalized `{'text', 'value'}` records.
+
+        Assigning a new list rebuilds the popup. Accepts the same `Option`
+        forms as the constructor (strings, `(text, value)` tuples, or dicts).
+        """
+        return [record_to_dict(r) for r in self._internal.cget("items")]
 
     @options.setter
-    def options(self, items: list[str]) -> None:
-        self._internal._items = list(items)
+    def options(self, items: list[Option]) -> None:
+        self._internal.configure(items=list(items))
 
     @property
     def selected_index(self) -> int:

--- a/src/bootstack/widgets/selectbutton.py
+++ b/src/bootstack/widgets/selectbutton.py
@@ -5,9 +5,10 @@ from typing import overload, Any, Callable, TYPE_CHECKING
 from bootstack.widgets._impl.primitives.optionmenu import OptionMenu as _InternalOptionMenu
 from bootstack.widgets._core.base import PublicWidgetBase
 from bootstack.widgets._core.events import register_widget_events
+from bootstack.widgets._core.options import record_to_dict
 from bootstack.events import ChangeEvent, Subscription
 from bootstack.streams import Stream
-from bootstack.widgets.types import AccentToken, Event, WidgetDensity, ButtonVariant
+from bootstack.widgets.types import AccentToken, Event, Option, OptionDict, WidgetDensity, ButtonVariant
 
 if TYPE_CHECKING:
     from bootstack.signals import Signal
@@ -25,9 +26,12 @@ class SelectButton(PublicWidgetBase):
     the button is the only interaction point.
 
     Args:
-        options: Values to display in the list. Each item is converted to a
-            string for display, e.g. `["Light", "Dark", "Auto"]`.
-        value: Initially selected value.
+        options: Choices shown in the popup. Each item is a plain string, a
+            `(text, value)` tuple, or a `{'text': ..., 'value': ...}` dict — so
+            an option's displayed label can differ from its stored value, e.g.
+            `["Light", "Dark"]` or `[("Light theme", "light")]`.
+        value: Initially selected value (value-space — matches an option's
+            value, not its label). Must match one of the options.
         signal: Reactive `Signal[str]` controlling the selected value. When
             provided, `value=` is ignored — seed the Signal directly.
         disabled: If `True`, the button is non-interactive and dimmed.
@@ -45,7 +49,7 @@ class SelectButton(PublicWidgetBase):
 
     def __init__(
         self,
-        options: list[Any] | None = None,
+        options: list[Option] | None = None,
         *,
         value: Any = None,
         signal: "Signal[str] | None" = None,
@@ -85,8 +89,12 @@ class SelectButton(PublicWidgetBase):
     # ----- Properties -----
 
     @property
-    def value(self) -> str:
-        """The currently selected value."""
+    def value(self) -> Any:
+        """The currently selected value, or `None` if unselected.
+
+        This is the option's *value* (value-space). For the displayed label, see
+        `text`.
+        """
         return self._internal.get()
 
     @value.setter
@@ -94,12 +102,25 @@ class SelectButton(PublicWidgetBase):
         self._internal.set(v)
 
     @property
-    def options(self) -> list[str]:
-        """The list of available options. Assigning a new list rebuilds the dropdown."""
-        return list(self._internal.cget("options"))
+    def text(self) -> str:
+        """The label currently shown on the button — the selected option's text.
+
+        Read-only; the complement of `value`. Assign to `value` to change the
+        selection.
+        """
+        return self._internal.text
+
+    @property
+    def options(self) -> list[OptionDict]:
+        """The available options as normalized `{'text', 'value'}` records.
+
+        Assigning a new list rebuilds the dropdown. Accepts the same `Option`
+        forms as the constructor (strings, `(text, value)` tuples, or dicts).
+        """
+        return [record_to_dict(r) for r in self._internal.cget("options")]
 
     @options.setter
-    def options(self, items: list[Any]) -> None:
+    def options(self, items: list[Option]) -> None:
         self._internal.configure(options=list(items))
 
     @property

--- a/src/bootstack/widgets/textarea.py
+++ b/src/bootstack/widgets/textarea.py
@@ -168,6 +168,12 @@ class TextArea(PublicWidgetBase):
         self._internal.value = v
 
     @property
+    def text(self) -> str:
+        """The current display text. Same as `value` for a text area (no
+        formatting layer). Read-only — assign to `value` to change it."""
+        return self._internal.value
+
+    @property
     def signal(self) -> "Signal[str] | None":
         """The reactive `Signal` bound to this field, or `None`."""
         return getattr(self._internal, "signal", None)

--- a/src/bootstack/widgets/togglegroup.py
+++ b/src/bootstack/widgets/togglegroup.py
@@ -6,10 +6,11 @@ from typing import overload, Any, Callable, Literal, TYPE_CHECKING
 from bootstack.widgets._impl.composites.togglegroup import ToggleGroup as _InternalToggleGroup
 from bootstack.widgets._core.base import PublicWidgetBase
 from bootstack.widgets._core.selection_group import SelectionGroupMixin
+from bootstack.widgets._core.options import normalize_options
 from bootstack.widgets._core.events import register_widget_events
 from bootstack.events import Subscription, ChangeEvent
 from bootstack.streams import Stream
-from bootstack.widgets.types import AccentToken, Event, Orient, ButtonVariant
+from bootstack.widgets.types import AccentToken, Event, Option, Orient, ButtonVariant
 
 if TYPE_CHECKING:
     from bootstack.signals import Signal
@@ -27,9 +28,9 @@ class ToggleGroup(SelectionGroupMixin, PublicWidgetBase):
     active at a time; in `'multi'` mode any combination can be active.
 
     Args:
-        options: Choices for the group. Each item is either a plain string
-            (label and value are the same) or a `(label, value)` tuple,
-            e.g. `["Grid", "List"]` or
+        options: Choices for the group. Each item is a plain string (text and
+            value are the same), a `(text, value)` tuple, or a
+            `{'text': ..., 'value': ...}` dict — e.g. `["Grid", "List"]` or
             `[("Grid view", "grid"), ("List view", "list")]`.
         mode: Selection behavior. `'single'` (default) enforces mutual
             exclusivity like a radio group; `'multi'` allows any number
@@ -55,7 +56,7 @@ class ToggleGroup(SelectionGroupMixin, PublicWidgetBase):
 
     def __init__(
         self,
-        options: list[str | tuple[str, Any]] | None = None,
+        options: list[Option] | None = None,
         *,
         mode: Literal["single", "multi"] = "single",
         signal: "Signal | None" = None,
@@ -90,13 +91,8 @@ class ToggleGroup(SelectionGroupMixin, PublicWidgetBase):
         self._internal = _InternalToggleGroup(tk_master, **internal_kwargs)
 
         # Populate options passed at construction.
-        if options:
-            for opt in options:
-                if isinstance(opt, str):
-                    self._internal.add(text=opt, value=opt)
-                else:
-                    lbl, val = opt
-                    self._internal.add(text=lbl, value=val)
+        for record in normalize_options(options):
+            self._internal.add(text=record.text, value=record.value)
 
         # Trace signal → <<Change>> for consistent Subscription-based on_change().
         self._prev_value = self._internal.signal()

--- a/src/bootstack/widgets/types.py
+++ b/src/bootstack/widgets/types.py
@@ -3,6 +3,8 @@
 import tkinter
 from typing import Any, Callable, Literal, TypedDict
 
+from typing_extensions import Required
+
 # ---------------------------------------------------------------------------
 # Primitive aliases
 # ---------------------------------------------------------------------------
@@ -214,3 +216,35 @@ class FormOptions(TypedDict, total=False):
     """Scroll the form when it is taller than the dialog. Default `True`."""
     resizable: bool
     """Allow the dialog to be resized. Default `True`."""
+
+
+# ---------------------------------------------------------------------------
+# Selection options (the shared "data bag" option shape)
+# ---------------------------------------------------------------------------
+
+class OptionDict(TypedDict, total=False):
+    """A single choice for a selection widget, in dict form.
+
+    The dict form is the extensible member of the `Option` shape: only `text`
+    is required, and `value` defaults to `text` when omitted. The remaining
+    keys are reserved for per-option extras and are not yet wired up.
+    """
+
+    text: Required[str]
+    """Display label for the option. Required."""
+    value: Any
+    """Stored and emitted value. Defaults to `text` when omitted."""
+    icon: str
+    """Reserved for a future per-option icon. Not yet rendered."""
+    disabled: bool
+    """Reserved for a future non-selectable option. Not yet honored."""
+
+
+Option = str | tuple[str, Any] | OptionDict
+"""A single choice for `Select`, `SelectButton`, `RadioGroup`, or `ToggleGroup`.
+
+Three interchangeable forms, all normalized to a `(text, value)` pair:
+
+- a plain `str` — text and value are the same (`'Small'`);
+- a `(text, value)` tuple — decoupled label and value (`('Small', 's')`);
+- an `OptionDict` — `{'text': 'Small', 'value': 's'}`; the extensible form."""

--- a/tests/test_public_surface.py
+++ b/tests/test_public_surface.py
@@ -81,7 +81,7 @@ MOVED = {
         "AccentToken", "VariantToken", "SurfaceToken", "WidgetDensity",
         "BaseWidgetKwargs", "StyledKwargs", "Anchor", "Fill", "Side", "Sticky",
         "Padding", "WindowStyle", "LayoutKind", "AutoFlow",
-        "ColumnSpec", "EditorType", "FormOptions",
+        "ColumnSpec", "EditorType", "FormOptions", "Option", "OptionDict",
     ],
     # EditFilter demoted from top-level (Tk-coupled CodeEditor extension hook);
     # stays importable here for power users. See project_editfilter_public_api.

--- a/tests/widgets/public/test_field_text_value.py
+++ b/tests/widgets/public/test_field_text_value.py
@@ -1,0 +1,83 @@
+"""The field-widget value/text contract: `.value` is the raw parsed datum,
+`.text` is the formatted display string. Regression guard for the option-databag
+work, which briefly made `.value` derive from the display text and broke the
+`value_format` widgets (TimeField returned a string instead of a `datetime.time`).
+"""
+import datetime
+
+import pytest
+
+import bootstack as bs
+
+
+@pytest.fixture(scope="module")
+def app():
+    a = bs.App()
+    a.__enter__()
+    a._tk_root.deiconify()
+    a._tk_root.update_idletasks()
+    try:
+        yield a
+    finally:
+        try:
+            a.__exit__(None, None, None)
+        except Exception:
+            pass
+        try:
+            a._tk_root.destroy()
+        except Exception:
+            pass
+
+
+# Every field widget exposes both .value and .text.
+FIELD_FACTORIES = [
+    ("TextField", lambda: bs.TextField(value="hello")),
+    ("NumberField", lambda: bs.NumberField(value=1234.5)),
+    ("PasswordField", lambda: bs.PasswordField(value="secret")),
+    ("DateField", lambda: bs.DateField(value="2024-01-02")),
+    ("TimeField", lambda: bs.TimeField(value="08:30")),
+    ("PathField", lambda: bs.PathField(value="/tmp/x")),
+    ("SpinnerField", lambda: bs.SpinnerField(value="3")),
+    ("TextArea", lambda: bs.TextArea(value="multi\nline")),
+    ("CodeEditor", lambda: bs.CodeEditor(value="print('hi')")),
+    ("Select", lambda: bs.Select(options=["a", "b"], value="a")),
+    ("SelectButton", lambda: bs.SelectButton(options=["a", "b"], value="a")),
+]
+
+
+@pytest.mark.parametrize("name, make", FIELD_FACTORIES, ids=[f[0] for f in FIELD_FACTORIES])
+def test_field_exposes_text_as_str(app, name, make):
+    w = make()
+    assert hasattr(w, "text"), f"{name} is missing the .text property"
+    assert isinstance(w.text, str), f"{name}.text should be a str, got {type(w.text).__name__}"
+
+
+def test_timefield_value_is_typed_text_is_formatted(app):
+    tf = bs.TimeField(value="08:30")
+    # .value is the raw datum (regression: was returning the formatted string)
+    assert isinstance(tf.value, datetime.time), f"value type={type(tf.value).__name__}"
+    # .text is the formatted display
+    assert isinstance(tf.text, str) and tf.text != str(tf.value)
+    # round-trips a time object through the value setter
+    tf.value = datetime.time(15, 30)
+    assert tf.value == datetime.time(15, 30)
+    assert "30" in tf.text
+
+
+def test_datefield_value_is_typed_text_is_formatted(app):
+    df = bs.DateField(value="2024-01-02")
+    assert df.value == datetime.date(2024, 1, 2)
+    assert df.text != str(df.value)        # 'January 2, 2024' vs '2024-01-02'
+    assert "2024" in df.text
+
+
+def test_numberfield_value_is_numeric(app):
+    nf = bs.NumberField(value=1234.5)
+    assert nf.value == 1234.5 and isinstance(nf.value, float)
+    assert isinstance(nf.text, str)
+
+
+def test_select_text_is_label_value_is_value(app):
+    s = bs.Select(options=[("Dark Mode", "dark")], value="dark")
+    assert s.value == "dark"        # value-space
+    assert s.text == "Dark Mode"    # display label

--- a/tests/widgets/public/test_select_options.py
+++ b/tests/widgets/public/test_select_options.py
@@ -1,0 +1,214 @@
+"""The shared option shape across the selection family (Select / SelectButton /
+RadioGroup / ToggleGroup): the three input forms, text<->value divergence,
+value round-trips, search-on-text, custom values, and unknown-value errors.
+"""
+import pytest
+
+import bootstack as bs
+from bootstack.widgets._core.options import (
+    normalize_option,
+    normalize_options,
+    record_to_dict,
+)
+
+
+@pytest.fixture(scope="module")
+def app():
+    """A single shown App so child widgets get mapped and styles build."""
+    a = bs.App()
+    a.__enter__()
+    root = a._tk_root
+    root.deiconify()
+    root.update_idletasks()
+    try:
+        yield a
+    finally:
+        try:
+            a.__exit__(None, None, None)
+        except Exception:
+            pass
+        try:
+            root.destroy()
+        except Exception:
+            pass
+
+
+# --------------------------------------------------------------------------
+# The normalizer
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("opt, expected", [
+    ("Small", ("Small", "Small", {})),
+    (("Small", "s"), ("Small", "s", {})),
+    ({"text": "Small", "value": "s"}, ("Small", "s", {})),
+    ({"text": "Small"}, ("Small", "Small", {})),
+])
+def test_normalize_forms(opt, expected):
+    assert tuple(normalize_option(opt)) == expected
+
+
+def test_normalize_preserves_extras():
+    rec = normalize_option({"text": "S", "value": "s", "icon": "star"})
+    assert rec.extras == {"icon": "star"}
+    assert record_to_dict(rec) == {"text": "S", "value": "s", "icon": "star"}
+
+
+def test_normalize_options_list_and_none():
+    assert normalize_options(None) == []
+    assert [r.text for r in normalize_options(["a", ("B", "b")])] == ["a", "B"]
+
+
+@pytest.mark.parametrize("bad, exc", [
+    ({"value": "x"}, ValueError),       # missing text
+    ({"text": "a", "bogus": 1}, ValueError),  # unknown key
+    (("a", "b", "c"), ValueError),      # bad tuple arity
+    ({"text": 1}, TypeError),           # non-string text
+    (123, TypeError),                   # wrong type
+])
+def test_normalize_rejects_bad_input(bad, exc):
+    with pytest.raises(exc):
+        normalize_option(bad)
+
+
+# --------------------------------------------------------------------------
+# Per-widget: all three forms, value-space round-trips
+# --------------------------------------------------------------------------
+
+FORMS = [
+    (["a", "b", "c"], "b", "b"),                              # plain strings
+    ([("A", "a"), ("B", "b")], "b", "b"),                     # tuples
+    ([{"text": "A", "value": "a"}, {"text": "B", "value": "b"}], "b", "b"),  # dicts
+]
+
+
+@pytest.mark.parametrize("options, set_value, expected", FORMS)
+def test_select_accepts_all_forms(app, options, set_value, expected):
+    s = bs.Select(options=options, value=set_value)
+    assert s.value == expected
+
+
+@pytest.mark.parametrize("options, set_value, expected", FORMS)
+def test_selectbutton_accepts_all_forms(app, options, set_value, expected):
+    sb = bs.SelectButton(options=options, value=set_value)
+    assert sb.value == expected
+
+
+@pytest.mark.parametrize("options, set_value, expected", FORMS)
+def test_radiogroup_accepts_all_forms(app, options, set_value, expected):
+    rg = bs.RadioGroup(options=options, value=set_value)
+    assert rg.value == expected
+
+
+@pytest.mark.parametrize("options, set_value, expected", FORMS)
+def test_togglegroup_accepts_all_forms(app, options, set_value, expected):
+    tg = bs.ToggleGroup(options=options, value=set_value)
+    assert tg.value == expected
+
+
+# --------------------------------------------------------------------------
+# Text / value divergence
+# --------------------------------------------------------------------------
+
+def test_select_text_value_divergence(app):
+    s = bs.Select(options=[("Dark Mode", "dark"), ("Light Mode", "light")], value="dark")
+    assert s.value == "dark"          # value-space
+    assert s.text == "Dark Mode"      # display label
+    assert s.options == [
+        {"text": "Dark Mode", "value": "dark"},
+        {"text": "Light Mode", "value": "light"},
+    ]
+
+
+def test_selectbutton_text_value_divergence(app):
+    sb = bs.SelectButton(options=[("Dark Mode", "dark")], value="dark")
+    assert sb.value == "dark"
+    assert sb.text == "Dark Mode"
+    assert sb.options == [{"text": "Dark Mode", "value": "dark"}]
+
+
+def test_select_no_plural_catalog_accessors(app):
+    # The catalog is `.options`; the singular `.text`/`.value` are the current
+    # selection. The earlier `.texts`/`.values` plural accessors were dropped.
+    s = bs.Select(options=["a", "b"])
+    assert not hasattr(s, "texts")
+    assert not hasattr(s, "values")
+
+
+def test_select_value_setter_is_value_space(app):
+    s = bs.Select(options=[("Big", "b"), ("Small", "s")])
+    s.value = "s"
+    assert s.value == "s"
+    assert s._internal.entry_widget.get() == "Small"
+
+
+# --------------------------------------------------------------------------
+# Unknown values
+# --------------------------------------------------------------------------
+
+def test_select_unknown_value_raises(app):
+    s = bs.Select(options=[("Big", "b")])
+    with pytest.raises(ValueError):
+        s.value = "nope"
+
+
+def test_selectbutton_unknown_value_raises(app):
+    sb = bs.SelectButton(options=[("Big", "b")])
+    with pytest.raises(ValueError):
+        sb.value = "nope"
+
+
+def test_select_unknown_initial_value_raises(app):
+    with pytest.raises(ValueError):
+        bs.Select(options=["a", "b"], value="z")
+
+
+# --------------------------------------------------------------------------
+# Search-on-text and custom values (Select-specific)
+# --------------------------------------------------------------------------
+
+def test_select_custom_value_is_typed_string(app):
+    s = bs.Select(options=[("Big", "b")], allow_custom_values=True)
+    s.value = "freeform"
+    assert s.value == "freeform"
+    assert s._internal.entry_widget.get() == "freeform"
+
+
+def test_select_options_reassignment_reconciles(app):
+    s = bs.Select(options=[("Big", "b"), ("Small", "s")], value="s")
+    assert s.value == "s"
+    s.options = [("Red", "r"), ("Green", "g")]
+    assert [o["value"] for o in s.options] == ["r", "g"]
+    assert s.value is None     # stale 's' cleared
+
+
+def test_select_selected_index(app):
+    s = bs.Select(options=[("Big", "b"), ("Small", "s")])
+    s.value = "s"
+    assert s.selected_index == 1
+    s.selected_index = 0
+    assert s.value == "b"
+
+
+# --------------------------------------------------------------------------
+# Change events carry value-space values
+# --------------------------------------------------------------------------
+
+def test_select_change_event_value_space(app):
+    s = bs.Select(options=[("Big", "b"), ("Small", "s")])
+    seen = []
+    s.on_change(lambda e: seen.append(e.value))
+    s.value = "s"
+    app.tk.update()
+    assert seen == ["s"]
+
+
+def test_selectbutton_change_event_value_space(app):
+    sb = bs.SelectButton(options=[("Big", "b"), ("Small", "s")])
+    seen = []
+    sb.on_change(lambda e: seen.append(e.value))
+    sb.value = "s"
+    app.tk.update()
+    # SelectButton's StringVar emits <<Change>> more than once per set (a
+    # pre-existing quirk, unrelated to the option shape) — assert every emit
+    # carries the value-space value rather than the exact count.
+    assert seen and set(seen) == {"s"}


### PR DESCRIPTION
Establishes a framework-wide **field-widget value/text/label contract** and unifies the selection widgets onto one decoupled option shape. Grew out of the option-databag idea; a high-effort code review caught that the first cut broke the `value_format` system, which reframed the work around the value/text duality.

## The model
| role | meaning |
|---|---|
| **`label`** | the caption *beside* a control (the field's name) |
| **`text`** | what the widget *displays* — the formatted string (**new, public, read-only**) |
| **`value`** | the raw, typed datum (`datetime.time`, `1234.5`, an option's value) |

## Value / text
- New read-only **`.text`** across the field family — `FieldAddonMixin` (the 7 entry fields) + `TextArea`, `CodeEditor`, `Select`, `SelectButton`. It's the complement of `.value`; the two genuinely differ for `value_format` widgets (`DateField` → `value=date(2024,1,2)`, `text="January 2, 2024"`).
- **Regression fixed:** `SelectBox.value` now defers to `Field.value` (the entry's raw, `value_format`-aware value); the option map only translates for *genuinely decoupled* options (`text != value`). The first cut derived value from the display text, which made `TimeField.value` return `'8:30 AM'` instead of `datetime.time(8, 30)`.
- **`strict_value` flag** on `SelectBox`: public `Select` is strict (unknown value → `ValueError`); internal/embedded SelectBoxes (form `'select'` editor, query dialog, `TimeEntry`) stay lenient and tolerate an off-list seed value. This resolved `Form.set()`/dialog regressions the review flagged and let the `form.py` bandaid be reverted.

## Option shape
- Shared `Option = str | tuple[str, Any] | OptionDict` + `OptionDict` in `bootstack.types`; one `normalize_option`/`normalize_options` in `widgets/_core/options.py`. `Select`/`SelectButton`/`RadioGroup`/`ToggleGroup` all accept the three forms.
- `.options` returns normalized `{text, value}` dicts. The plural `.texts`/`.values` accessors were dropped to avoid `.text` vs `.texts` confusion — derive from `.options`.

## Design notes
- Considered unifying button captions onto `label` (GTK-style) — **rejected**; kept `text` = "what the widget displays" (Qt/WinForms/Swing convention), reversing nothing. Buttons keep `text`; no `label` on buttons.

## Verification
- `tests/widgets/public/test_field_text_value.py` (15 — value/text contract + TimeField/DateField raw-value regression guard) and `test_select_options.py` (35 — three forms × four widgets, value-space, search-on-text, custom values, unknown-value errors); `test_public_surface.py` (141).
- Clean `-W --keep-going` docs build; all field/select examples run.
- Maintainer tested the change in-app: works.
- Pre-existing `test_app_config`/`test_base_layer` Tk-churn flakiness is unrelated (clean on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
