### PR TITLE
feat(widgets): add .text (selected label) to RadioGroup and ToggleGroup

### DIFF
--- a/docs/widgets/radiogroup.rst
+++ b/docs/widgets/radiogroup.rst
@@ -28,7 +28,9 @@ the display text should differ from the stored value.
 
 .. code-block:: python
 
-   bs.RadioGroup([("Small", "s"), ("Medium", "m"), ("Large", "l")], value="m")
+   size = bs.RadioGroup([("Small", "s"), ("Medium", "m"), ("Large", "l")], value="m")
+   size.value   # -> "m"        (the selected value)
+   size.text    # -> "Medium"   (the selected label)
 
 Orientation
 ~~~~~~~~~~~

--- a/docs/widgets/togglegroup.rst
+++ b/docs/widgets/togglegroup.rst
@@ -34,6 +34,23 @@ initial selection as a ``set``.
    bs.ToggleGroup(["Bold", "Italic", "Underline"],
                   mode="multi", value={"Bold", "Underline"})
 
+Decoupled labels and the selected text
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Options accept ``(text, value)`` tuples or ``{"text": ..., "value": ...}`` dicts,
+so a label can differ from its value. ``value`` is value-space; ``text`` mirrors
+it as the selected label(s).
+
+.. code-block:: python
+
+   view = bs.ToggleGroup([("Grid view", "grid"), ("List view", "list")], value="grid")
+   view.value   # -> "grid"        (single mode: the value)
+   view.text    # -> "Grid view"   (single mode: the label)
+
+   tools = bs.ToggleGroup([("Bold", "b"), ("Italic", "i")], mode="multi", value={"b"})
+   tools.value  # -> {"b"}          (multi mode: a set of values)
+   tools.text   # -> {"Bold"}       (multi mode: a set of labels)
+
 .. image:: /_static/examples/togglegroup-multi-light.png
    :class: bs-screenshot-light
    :alt: ToggleGroup multi-select — light theme

--- a/src/bootstack/widgets/_impl/composites/radiogroup.py
+++ b/src/bootstack/widgets/_impl/composites/radiogroup.py
@@ -306,6 +306,19 @@ class RadioGroup(Frame):
     def value(self, value: str) -> None:
         self.set(value)
 
+    def text_for(self, value: Any) -> str | None:
+        """Return the display text of the option with the given value, or None.
+
+        The selection variable coerces values to strings, so match on the
+        stringified key when an exact lookup misses.
+        """
+        if value is None or value == "":
+            return None
+        button = self._buttons.get(value)
+        if button is None:
+            button = next((b for k, b in self._buttons.items() if str(k) == str(value)), None)
+        return button.cget('text') if button is not None else None
+
     def remove(self, key: str):
         """Remove a button by its key.
 

--- a/src/bootstack/widgets/_impl/composites/togglegroup.py
+++ b/src/bootstack/widgets/_impl/composites/togglegroup.py
@@ -287,6 +287,19 @@ class ToggleGroup(Frame):
     def value(self, value: str | set[str]) -> None:
         self.set(value)
 
+    def text_for(self, value: Any) -> str | None:
+        """Return the display text of the option with the given value, or None.
+
+        The selection variable coerces values to strings, so match on the
+        stringified key when an exact lookup misses.
+        """
+        if value is None or value == "":
+            return None
+        button = self._buttons.get(value)
+        if button is None:
+            button = next((b for k, b in self._buttons.items() if str(k) == str(value)), None)
+        return button.cget('text') if button is not None else None
+
     def remove(self, key: str):
         """Remove a button by its key."""
         if key in self._buttons:

--- a/src/bootstack/widgets/radiogroup.py
+++ b/src/bootstack/widgets/radiogroup.py
@@ -111,6 +111,14 @@ class RadioGroup(SelectionGroupMixin, PublicWidgetBase):
         self._internal.value = v
 
     @property
+    def text(self) -> str | None:
+        """The label of the selected option, or `None` if nothing is selected.
+
+        Read-only; the display complement of `value` (the selection's value).
+        """
+        return self._internal.text_for(self._internal.value)
+
+    @property
     def disabled(self) -> bool:
         """Whether all buttons in the group are non-interactive."""
         return self._internal._state == "disabled"

--- a/src/bootstack/widgets/togglegroup.py
+++ b/src/bootstack/widgets/togglegroup.py
@@ -121,6 +121,19 @@ class ToggleGroup(SelectionGroupMixin, PublicWidgetBase):
         self._internal.set(v)
 
     @property
+    def text(self) -> str | set[str] | None:
+        """The label(s) of the selected option(s) — the display complement of `value`.
+
+        In single mode, the selected option's label (or `None` if nothing is
+        selected). In multi mode, a `set` of the selected options' labels.
+        Read-only.
+        """
+        value = self._internal.get()
+        if isinstance(value, set):
+            return {t for v in value if (t := self._internal.text_for(v)) is not None}
+        return self._internal.text_for(value)
+
+    @property
     def disabled(self) -> bool:
         """Whether all buttons in the group are non-interactive."""
         return self._internal._state == "disabled"

--- a/tests/widgets/public/test_select_options.py
+++ b/tests/widgets/public/test_select_options.py
@@ -106,6 +106,37 @@ def test_togglegroup_accepts_all_forms(app, options, set_value, expected):
 
 
 # --------------------------------------------------------------------------
+# Group .text (selected label) — value/text duality for the group widgets
+# --------------------------------------------------------------------------
+
+def test_radiogroup_text_is_selected_label(app):
+    rg = bs.RadioGroup(options=[("Small", "s"), ("Medium", "m")], value="m")
+    assert rg.value == "m" and rg.text == "Medium"
+    rg.value = "s"
+    assert rg.text == "Small"
+
+
+def test_radiogroup_text_none_when_empty(app):
+    rg = bs.RadioGroup(options=[("A", "a")])
+    assert rg.text is None
+
+
+def test_togglegroup_single_text_is_label(app):
+    tg = bs.ToggleGroup(options=[("Grid", "grid"), ("List", "list")], value="grid")
+    assert tg.value == "grid" and tg.text == "Grid"
+
+
+def test_togglegroup_multi_text_is_label_set(app):
+    tg = bs.ToggleGroup(
+        options=[("Grid", "grid"), ("List", "list"), ("Card", "card")],
+        mode="multi",
+        value={"grid", "card"},
+    )
+    assert tg.value == {"grid", "card"}
+    assert tg.text == {"Grid", "Card"}
+
+
+# --------------------------------------------------------------------------
 # Text / value divergence
 # --------------------------------------------------------------------------
 


### PR DESCRIPTION
Completes the field value/text contract (PR #114) for the **group selection widgets**: a public read-only `.text` that mirrors `.value`'s shape — the selected option's label.

| widget | `.value` | `.text` |
|---|---|---|
| RadioGroup | the selected value | the selected label (`str \| None`) |
| ToggleGroup (single) | the selected value | the selected label (`str \| None`) |
| ToggleGroup (multi) | `set[str]` of values | `set[str]` of labels |

```python
size = bs.RadioGroup([("Small", "s"), ("Medium", "m")], value="m")
size.value  # "m"        size.text  # "Medium"

tools = bs.ToggleGroup([("Bold", "b"), ("Italic", "i")], mode="multi", value={"b"})
tools.value  # {"b"}      tools.text  # {"Bold"}
```

## Implementation
The button-text knowledge lives in a new `text_for(value)` on the **internal composites** (they own the `_buttons` map); the wrappers own the value/text shape logic. The lookup matches on the **stringified key** — an int-valued option keeps an `int` key in `_buttons` while `.value` returns the StringVar-coerced string, so a naive lookup would miss it. That edge is handled.

## Verification
- `test_select_options.py` — 39 passed (4 new group-text cases: single label, multi label-set, empty → `None`)
- `test_field_text_value.py` (15), `test_public_surface.py` (141) — green
- Clean `-W --keep-going` docs build; radiogroup/togglegroup examples run; guides note `.text`

Small and contained (~98 lines, 7 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
