### PR TITLE
feat(widgets): option data bag + universal selection accessor

### DIFF
--- a/docs/_dev/option-databag.md
+++ b/docs/_dev/option-databag.md
@@ -1,0 +1,111 @@
+# Initiative — Option data bag + the universal `selection` accessor
+
+**Status:** IN PROGRESS. Branch `feat/option-databag` off `main`. Started 2026-06-11.
+**Builds on:** the field value/text/label model (`project_field_value_text_model`)
+and the shared `Option` shape shipped in PRs #114/#115.
+
+---
+
+## Motivation
+
+An option's dict form is meant to be the *extensible* member of
+`Option = str | tuple[str, Any] | OptionDict`, but today the normalizer
+**rejects** any key beyond `text`/`value`/`icon`/`disabled`. That contradicts the
+framework's **data-bag principle** (Tree/DataTable/ListView records are flat
+dicts that carry undisplayed fields transparently; `SqliteDataSource` rides them
+in a hidden `_bs_data` JSON column). Options should follow the same principle:
+an option is a flat record, and unrecognized keys ride along as carried data.
+
+Decision (maintainer, 2026-06-11): a mistyped key in the dict form is the user's
+risk to accept — the dict route is opt-in. So **drop the strict rejection** and
+carry the extras.
+
+## Two parts
+
+### 1. Carry the bag (this is the foundation — option family only)
+
+- `normalize_option` stops rejecting unknown dict keys. The normalized record is
+  the **full flat dict**: `{"text", "value", ...everything else}`. `text` is still
+  required; `value` still defaults to `text`.
+- The recognized keys that *do* something stay `text` (display), `value`
+  (emitted), and the future-reserved `icon`/`disabled` (rendering/behavior, not
+  yet wired). Every other key is inert carried data.
+
+### 2. The `selection` accessor (universal, polymorphic)
+
+One neutral-noun property on every selection widget that returns the selected
+**record(s)** — the bag, indexed by key like any other record:
+
+```python
+radio.value      # "m"                                   (the value)
+radio.text       # "Medium"                              (the label)
+radio.selection  # {"text":"Medium","value":"m", ...}    (the record / bag) or None
+
+tools.value      # {"b", "i"}                            (multi: set of values)
+tools.selection  # [ {...}, {...} ]                      (multi: list of records)
+```
+
+- **Polymorphic by cardinality** (matches the house idiom — `value`/`text` are
+  already `str | set[str]` on ToggleGroup): single-select -> `dict | None`;
+  multi-select -> `list[dict]` (empty list when none). Multi is a **list** not a
+  set (records are unhashable dicts, unlike `value`'s `set[str]`).
+- **Neutral noun on purpose** — "the selection" reads correctly whether one or
+  many, unlike `selected_item`/`selected_items`. Chosen over a singular/plural
+  pair because the pair would follow a *different* convention than the
+  `value`/`text` next to it.
+
+## Scope — which widgets get `.selection`
+
+Seven widgets. The bag arrives two ways:
+
+| widget | `.selection` returns | bag source |
+|---|---|---|
+| Select, SelectButton, RadioGroup, ToggleGroup | record dict, indexed directly | **gained here** (carry extras) |
+| ListView, DataTable | record dict, indexed directly | already native (rows are dicts) |
+| Tree | `TreeNode \| list[TreeNode]` | one level in — `node.data` is the dict |
+
+Tree is the principled exception: a node carries structure (children/expand), so
+`selection` returns the node handle and the bag is at `node.data`.
+
+OUT (no records, so no bag): Calendar (`value` is a date), Checkbox/Switch/
+ToggleButton (boolean), MenuButton/ContextMenu (action items, no persistent
+selection), Tabs/SideNav/PageStack (navigation).
+
+## This branch vs follow-up
+
+- **This branch (foundation):** parts 1+2 for the **option family only**
+  (Select, SelectButton, RadioGroup, ToggleGroup). The four already expose
+  `value`/`text`; add `selection` returning the full record.
+- **Follow-up PR (naming alignment):** add `.selection` to ListView/DataTable/
+  Tree, mapping/replacing their existing `get_selected()` / `selected_rows` /
+  `selected_nodes`. Separate because it renames shipped API.
+
+## Work surface (option family)
+
+1. **`widgets/_core/options.py`** — drop the unknown-key `ValueError` in
+   `normalize_option`; `extras` already captures all non-text/value keys, so the
+   record carries the full bag. `record_to_dict` already flattens to
+   `{"text","value",**extras}` — that IS the `selection` payload for one option.
+2. **SelectBox / OptionMenu** — both keep `_records`. Add a way to get the
+   selected record(s): map current value -> record -> `record_to_dict`.
+3. **RadioGroup / ToggleGroup** — they currently normalize then *discard* the
+   records (only `add(text, value)` reaches the internal). To carry the bag they
+   must **keep the records** (a value -> record map in the wrapper, kept in sync
+   with `add()`/`remove()`), or thread extras through the internal `add`. Wrapper
+   map is simpler and self-contained.
+4. **Public `.selection`** on each of the four — polymorphic per cardinality
+   (ToggleGroup mirrors its mode like `value` does).
+5. **Tests** — `selection` returns the bag for all three input forms; extras
+   carried; single vs multi shape; unknown keys no longer raise.
+6. **Docs** — selection guide + the `OptionDict` note (extras now carried, not
+   rejected); `Option`/`OptionDict` docstrings.
+
+## Verify
+- `python -m pytest tests/test_public_surface.py tests/widgets/public/test_select_options.py -q`
+- Clean `-W` docs build; run the select/group examples.
+
+## Deferred / future
+- Wire up `icon` (render beside each option) and per-item `disabled` — separate
+  PRs once the carry ships.
+- **Select grouping** (optgroup-style) — see `project_select_grouping`; discuss
+  after this lands.

--- a/docs/widgets/radiogroup.rst
+++ b/docs/widgets/radiogroup.rst
@@ -29,8 +29,14 @@ the display text should differ from the stored value.
 .. code-block:: python
 
    size = bs.RadioGroup([("Small", "s"), ("Medium", "m"), ("Large", "l")], value="m")
-   size.value   # -> "m"        (the selected value)
-   size.text    # -> "Medium"   (the selected label)
+   size.value      # -> "m"        (the selected value)
+   size.text       # -> "Medium"   (the selected label)
+   size.selection  # -> {"text": "Medium", "value": "m"}   (the full record)
+
+Options are a *data bag* — alongside the recognized keys (``text``, ``value``,
+and the reserved ``icon``/``disabled``), any other key you add (e.g.
+``{"text": "Medium", "value": "m", "px": 16}``) rides along and is returned by
+``.selection`` (see :doc:`select` for details).
 
 Orientation
 ~~~~~~~~~~~

--- a/docs/widgets/select.rst
+++ b/docs/widgets/select.rst
@@ -47,6 +47,32 @@ Setting ``.value`` to something that is not one of the options raises
 ``ValueError`` (unless ``allow_custom_values=True``, where a typed value is kept
 as its own text).
 
+Carrying extra data (the data bag)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The dict form is a *data bag* — alongside the recognized keys (``text``,
+``value``, and the reserved ``icon``/``disabled``), any other key you add rides
+along as carried data. Read the whole selected record, indexed by key, via
+``.selection``:
+
+.. code-block:: python
+
+   country = bs.Select(options=[
+       {"text": "Canada", "value": "CA", "phone": "+1"},
+       {"text": "Japan",  "value": "JP", "phone": "+81"},
+   ], value="JP")
+
+   country.value             # -> "JP"
+   country.selection         # -> {"text": "Japan", "value": "JP", "phone": "+81"}
+   country.selection["phone"]  # -> "+81"
+
+   country.on_change(lambda e: dial(country.selection["phone"]))
+
+``.selection`` is the selected option's full dict (the same shape you'd get from a
+``ListView`` row), or ``None`` when nothing is selected. Unrecognized keys are
+*accepted, not validated* — the dict route is opt-in, so a mistyped key rides
+along silently rather than raising.
+
 Label and message
 ~~~~~~~~~~~~~~~~~
 

--- a/docs/widgets/selectbutton.rst
+++ b/docs/widgets/selectbutton.rst
@@ -35,7 +35,12 @@ Like `Select`, an option's label can differ from its value — pass a
    mode = bs.SelectButton([("Light theme", "light"), ("Dark theme", "dark")], value="dark")
    mode.value             # -> "dark"          (the value)
    mode.text              # -> "Dark theme"    (the displayed label)
+   mode.selection         # -> {"text": "Dark theme", "value": "dark"}   (the full record)
    mode.on_change(lambda e: apply_theme(e.value))
+
+Options are a *data bag* — alongside the recognized keys (``text``, ``value``,
+and the reserved ``icon``/``disabled``), any other key you add rides along and is
+returned by ``.selection`` (see :doc:`select` for details).
 
 Accent colors
 ~~~~~~~~~~~~~

--- a/docs/widgets/togglegroup.rst
+++ b/docs/widgets/togglegroup.rst
@@ -44,12 +44,18 @@ it as the selected label(s).
 .. code-block:: python
 
    view = bs.ToggleGroup([("Grid view", "grid"), ("List view", "list")], value="grid")
-   view.value   # -> "grid"        (single mode: the value)
-   view.text    # -> "Grid view"   (single mode: the label)
+   view.value      # -> "grid"        (single mode: the value)
+   view.text       # -> "Grid view"   (single mode: the label)
+   view.selection  # -> {"text": "Grid view", "value": "grid"}   (single: one record)
 
    tools = bs.ToggleGroup([("Bold", "b"), ("Italic", "i")], mode="multi", value={"b"})
-   tools.value  # -> {"b"}          (multi mode: a set of values)
-   tools.text   # -> {"Bold"}       (multi mode: a set of labels)
+   tools.value      # -> {"b"}          (multi mode: a set of values)
+   tools.text       # -> {"Bold"}       (multi mode: a set of labels)
+   tools.selection  # -> [{"text": "Bold", "value": "b"}]   (multi: list of records)
+
+Options are a *data bag* — alongside the recognized keys (``text``, ``value``,
+and the reserved ``icon``/``disabled``), any other key you add rides along and is
+returned by ``.selection`` (see :doc:`select` for details).
 
 .. image:: /_static/examples/togglegroup-multi-light.png
    :class: bs-screenshot-light

--- a/src/bootstack/widgets/_core/options.py
+++ b/src/bootstack/widgets/_core/options.py
@@ -11,9 +11,6 @@ from typing import Any, Iterable, NamedTuple
 
 from bootstack.widgets.types import Option
 
-# Keys an OptionDict may carry. `text` is required; `value` defaults to `text`.
-_KNOWN_OPTION_KEYS = frozenset({"text", "value", "icon", "disabled"})
-
 
 class OptionRecord(NamedTuple):
     """A normalized option — what every selection widget consumes internally."""
@@ -29,6 +26,12 @@ class OptionRecord(NamedTuple):
 def normalize_option(opt: Option) -> OptionRecord:
     """Coerce a single `Option` to an `OptionRecord`.
 
+    The dict form is a *data bag*: only `text` is required (and `value` defaults
+    to it). `text`/`value` and the reserved `icon`/`disabled` are the recognized
+    keys; every other key rides along as carried data, retrievable via the
+    widget's `selection`. Unrecognized keys are NOT rejected — the dict route is
+    opt-in, so the caller accepts the risk of a mistyped key.
+
     Args:
         opt: A plain string, a `(text, value)` tuple, or an `OptionDict`.
 
@@ -39,7 +42,7 @@ def normalize_option(opt: Option) -> OptionRecord:
         TypeError: If `opt` is not a string, 2-tuple, or dict, or if a dict
             `text` is not a string.
         ValueError: If a tuple does not have exactly two items, or a dict is
-            missing `text` or carries an unknown key.
+            missing `text`.
     """
     if isinstance(opt, str):
         return OptionRecord(opt, opt, {})
@@ -47,16 +50,12 @@ def normalize_option(opt: Option) -> OptionRecord:
     if isinstance(opt, dict):
         if "text" not in opt:
             raise ValueError(f"option dict is missing the required 'text' key: {opt!r}")
-        unknown = set(opt) - _KNOWN_OPTION_KEYS
-        if unknown:
-            raise ValueError(
-                f"option dict has unknown key(s) {sorted(unknown)}: {opt!r} "
-                f"(allowed: {sorted(_KNOWN_OPTION_KEYS)})"
-            )
         text = opt["text"]
         if not isinstance(text, str):
             raise TypeError(f"option 'text' must be a string, got {type(text).__name__}: {opt!r}")
         value = opt["value"] if "value" in opt else text
+        # The bag: every key except text/value, including the reserved
+        # icon/disabled (carried now, interpreted by the widget later).
         extras = {k: opt[k] for k in opt if k not in ("text", "value")}
         return OptionRecord(text, value, extras)
 

--- a/src/bootstack/widgets/_core/selection_group.py
+++ b/src/bootstack/widgets/_core/selection_group.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from bootstack.widgets._core.options import OptionRecord, record_to_dict
+
 
 class SelectionGroupMixin:
     """Shared item-management surface for the option-group widgets.
@@ -10,9 +12,33 @@ class SelectionGroupMixin:
     composite exposing `keys()`, `configure_item()`, and `remove()`. Each class
     keeps its own `add()` (the option semantics differ) and its own value /
     change surface; only the value-keyed item operations live here.
+
+    The internal composites store only each option's text and value, so the
+    mixin keeps the normalized records here (the data bag) — keyed by the
+    stringified value, matching the selection variable's coercion — so
+    `selection` can hand back each option's full `{text, value, ...extras}`.
     """
 
     _internal: Any
+
+    def _set_option_records(self, records: list[OptionRecord]) -> None:
+        """Seed the option records from a normalized construction list."""
+        self._option_records: dict[str, OptionRecord] = {
+            str(rec.value): rec for rec in records
+        }
+
+    def _add_option_record(self, text: str, value: Any, extras: dict | None = None) -> None:
+        """Register a record for an option added at runtime."""
+        if not hasattr(self, "_option_records"):
+            self._option_records = {}
+        self._option_records[str(value)] = OptionRecord(text, value, extras or {})
+
+    def _record_dict_for(self, value: Any) -> dict | None:
+        """Return the `{text, value, ...extras}` dict for a value, or None."""
+        if value is None or value == "":
+            return None
+        rec = getattr(self, "_option_records", {}).get(str(value))
+        return record_to_dict(rec) if rec is not None else None
 
     def remove(self, value: Any) -> None:
         """Remove the option identified by `value`.
@@ -24,6 +50,7 @@ class SelectionGroupMixin:
             KeyError: If no option with that value exists.
         """
         self._internal.remove(value)
+        getattr(self, "_option_records", {}).pop(str(value), None)
 
     def configure_item(
         self,

--- a/src/bootstack/widgets/_impl/composites/selectbox.py
+++ b/src/bootstack/widgets/_impl/composites/selectbox.py
@@ -5,7 +5,7 @@ from typing_extensions import Unpack
 from typing import Any
 
 from bootstack.events import ChangeEvent
-from bootstack.widgets._core.options import normalize_options
+from bootstack.widgets._core.options import normalize_options, record_to_dict
 from bootstack.widgets._impl.primitives.button import Button
 from bootstack.widgets._impl.primitives.frame import Frame
 from bootstack.widgets._impl.composites.scrollview import ScrollView
@@ -615,6 +615,22 @@ class SelectBox(Field):
     def text(self) -> str:
         """The current display text shown in the field (the formatted string)."""
         return self.entry_widget.get()
+
+    @property
+    def selection(self) -> dict | None:
+        """The selected option as a full record dict (the data bag), or None.
+
+        Returns the matching option's `{text, value, ...extras}`; None when
+        nothing is selected or the current value is a custom/off-list one (not
+        one of the options).
+        """
+        value = self.value
+        if value is None:
+            return None
+        for rec in self._records:
+            if rec.value == value:
+                return record_to_dict(rec)
+        return None
 
     @property
     def value(self):

--- a/src/bootstack/widgets/_impl/primitives/optionmenu.py
+++ b/src/bootstack/widgets/_impl/primitives/optionmenu.py
@@ -6,7 +6,7 @@ from typing import Any, Callable, TypedDict, TYPE_CHECKING
 from typing_extensions import Unpack
 
 from bootstack.events import ChangeEvent
-from bootstack.widgets._core.options import normalize_options
+from bootstack.widgets._core.options import normalize_options, record_to_dict
 from bootstack.widgets._impl.composites.contextmenu import ContextMenu, ContextMenuItem
 from bootstack.widgets._impl.primitives._menubutton import MenuButton
 from bootstack.widgets._impl.mixins import configure_delegate
@@ -205,6 +205,17 @@ class OptionMenu(MenuButton):
     def text(self) -> str:
         """The display label currently shown on the button."""
         return self._textvariable.get()
+
+    @property
+    def selection(self) -> dict | None:
+        """The selected option as a full record dict (the data bag), or None."""
+        text = self._textvariable.get()
+        if text == "":
+            return None
+        for rec in self._records:
+            if rec.text == text:
+                return record_to_dict(rec)
+        return None
 
     def get(self) -> Any:
         """Return the current value (value-space), or `None` if nothing is selected."""

--- a/src/bootstack/widgets/radiogroup.py
+++ b/src/bootstack/widgets/radiogroup.py
@@ -79,8 +79,11 @@ class RadioGroup(SelectionGroupMixin, PublicWidgetBase):
 
         self._internal = _InternalRadioGroup(tk_master, **internal_kwargs)
 
-        # Populate options passed at construction.
-        for record in normalize_options(options):
+        # Populate options passed at construction; keep the records (the data
+        # bag) so `selection` can return each option's full dict.
+        records = normalize_options(options)
+        self._set_option_records(records)
+        for record in records:
             self._internal.add(text=record.text, value=record.value)
 
         # Trace the signal so <<Change>> fires on the internal Frame whenever
@@ -119,6 +122,15 @@ class RadioGroup(SelectionGroupMixin, PublicWidgetBase):
         return self._internal.text_for(self._internal.value)
 
     @property
+    def selection(self) -> dict | None:
+        """The selected option as a full record dict — the data bag — or `None`.
+
+        `{'text': ..., 'value': ..., ...any extra keys}`, indexed by key like any
+        record. Read-only.
+        """
+        return self._record_dict_for(self._internal.value)
+
+    @property
     def disabled(self) -> bool:
         """Whether all buttons in the group are non-interactive."""
         return self._internal._state == "disabled"
@@ -148,7 +160,9 @@ class RadioGroup(SelectionGroupMixin, PublicWidgetBase):
             label: Display text for the button.
             value: Value assigned when this button is selected. Defaults to `label`.
         """
-        self._internal.add(text=label, value=value if value is not None else label, **kwargs)
+        resolved = value if value is not None else label
+        self._internal.add(text=label, value=resolved, **kwargs)
+        self._add_option_record(label, resolved)
 
     # ----- Event shorthands -----
 

--- a/src/bootstack/widgets/select.py
+++ b/src/bootstack/widgets/select.py
@@ -174,6 +174,16 @@ class Select(PublicWidgetBase):
         return self._internal.text
 
     @property
+    def selection(self) -> dict | None:
+        """The selected option as a full record dict — the data bag — or `None`.
+
+        `{'text': ..., 'value': ..., ...any extra keys}`, indexed by key like
+        any record. `None` when nothing is selected or the value is a custom
+        off-list one. Read-only.
+        """
+        return self._internal.selection
+
+    @property
     def options(self) -> list[OptionDict]:
         """The available options as normalized `{'text', 'value'}` records.
 

--- a/src/bootstack/widgets/selectbutton.py
+++ b/src/bootstack/widgets/selectbutton.py
@@ -111,6 +111,15 @@ class SelectButton(PublicWidgetBase):
         return self._internal.text
 
     @property
+    def selection(self) -> dict | None:
+        """The selected option as a full record dict — the data bag — or `None`.
+
+        `{'text': ..., 'value': ..., ...any extra keys}`, indexed by key like
+        any record. Read-only.
+        """
+        return self._internal.selection
+
+    @property
     def options(self) -> list[OptionDict]:
         """The available options as normalized `{'text', 'value'}` records.
 

--- a/src/bootstack/widgets/togglegroup.py
+++ b/src/bootstack/widgets/togglegroup.py
@@ -90,8 +90,11 @@ class ToggleGroup(SelectionGroupMixin, PublicWidgetBase):
 
         self._internal = _InternalToggleGroup(tk_master, **internal_kwargs)
 
-        # Populate options passed at construction.
-        for record in normalize_options(options):
+        # Populate options passed at construction; keep the records (the data
+        # bag) so `selection` can return each option's full dict.
+        records = normalize_options(options)
+        self._set_option_records(records)
+        for record in records:
             self._internal.add(text=record.text, value=record.value)
 
         # Trace signal → <<Change>> for consistent Subscription-based on_change().
@@ -134,6 +137,18 @@ class ToggleGroup(SelectionGroupMixin, PublicWidgetBase):
         return self._internal.text_for(value)
 
     @property
+    def selection(self) -> dict | list[dict] | None:
+        """The selected option(s) as full record dicts — the data bag.
+
+        In single mode, the selected option's `{text, value, ...extras}` dict
+        (or `None`). In multi mode, a `list` of those dicts. Read-only.
+        """
+        value = self._internal.get()
+        if isinstance(value, set):
+            return [d for v in value if (d := self._record_dict_for(v)) is not None]
+        return self._record_dict_for(value)
+
+    @property
     def disabled(self) -> bool:
         """Whether all buttons in the group are non-interactive."""
         return self._internal._state == "disabled"
@@ -151,7 +166,9 @@ class ToggleGroup(SelectionGroupMixin, PublicWidgetBase):
             label: Display text.
             value: Value this button represents. Defaults to `label`.
         """
-        self._internal.add(text=label, value=value if value is not None else label, **kwargs)
+        resolved = value if value is not None else label
+        self._internal.add(text=label, value=resolved, **kwargs)
+        self._add_option_record(label, resolved)
 
     # ----- Event shorthands -----
 

--- a/src/bootstack/widgets/types.py
+++ b/src/bootstack/widgets/types.py
@@ -225,9 +225,13 @@ class FormOptions(TypedDict, total=False):
 class OptionDict(TypedDict, total=False):
     """A single choice for a selection widget, in dict form.
 
-    The dict form is the extensible member of the `Option` shape: only `text`
-    is required, and `value` defaults to `text` when omitted. The remaining
-    keys are reserved for per-option extras and are not yet wired up.
+    The dict form is a *data bag*: only `text` is required (and `value` defaults
+    to it). `text`/`value` and the reserved `icon`/`disabled` are the recognized
+    keys; every *other* key rides along as carried data — retrievable as the
+    widget's `selection` (the selected option's full record). Unrecognized keys
+    are accepted, not rejected, so the dict route trades key-typo safety for
+    extensibility. `icon`/`disabled` are reserved to drive rendering/behavior in
+    a future release; until then they are carried like any other key.
     """
 
     text: Required[str]
@@ -235,9 +239,9 @@ class OptionDict(TypedDict, total=False):
     value: Any
     """Stored and emitted value. Defaults to `text` when omitted."""
     icon: str
-    """Reserved for a future per-option icon. Not yet rendered."""
+    """Reserved for a future per-option icon. Carried but not yet rendered."""
     disabled: bool
-    """Reserved for a future non-selectable option. Not yet honored."""
+    """Reserved for a future non-selectable option. Carried but not yet honored."""
 
 
 Option = str | tuple[str, Any] | OptionDict

--- a/tests/widgets/public/test_select_options.py
+++ b/tests/widgets/public/test_select_options.py
@@ -53,14 +53,23 @@ def test_normalize_preserves_extras():
     assert record_to_dict(rec) == {"text": "S", "value": "s", "icon": "star"}
 
 
+def test_normalize_carries_arbitrary_extras_as_databag():
+    # The dict form is a data bag: any key beyond text/value rides along (it is
+    # NOT rejected — the dict route is opt-in, the caller owns the typo risk).
+    rec = normalize_option({"text": "Canada", "value": "CA", "phone": "+1", "region": "americas"})
+    assert rec.extras == {"phone": "+1", "region": "americas"}
+    assert record_to_dict(rec) == {
+        "text": "Canada", "value": "CA", "phone": "+1", "region": "americas",
+    }
+
+
 def test_normalize_options_list_and_none():
     assert normalize_options(None) == []
     assert [r.text for r in normalize_options(["a", ("B", "b")])] == ["a", "B"]
 
 
 @pytest.mark.parametrize("bad, exc", [
-    ({"value": "x"}, ValueError),       # missing text
-    ({"text": "a", "bogus": 1}, ValueError),  # unknown key
+    ({"value": "x"}, ValueError),       # missing required text
     (("a", "b", "c"), ValueError),      # bad tuple arity
     ({"text": 1}, TypeError),           # non-string text
     (123, TypeError),                   # wrong type
@@ -103,6 +112,56 @@ def test_radiogroup_accepts_all_forms(app, options, set_value, expected):
 def test_togglegroup_accepts_all_forms(app, options, set_value, expected):
     tg = bs.ToggleGroup(options=options, value=set_value)
     assert tg.value == expected
+
+
+# --------------------------------------------------------------------------
+# selection — the selected option's full record (the data bag)
+# --------------------------------------------------------------------------
+
+def test_select_selection_is_record_with_bag(app):
+    s = bs.Select(options=[
+        {"text": "Canada", "value": "CA", "phone": "+1"},
+        {"text": "Japan", "value": "JP", "phone": "+81"},
+    ], value="JP")
+    assert s.selection == {"text": "Japan", "value": "JP", "phone": "+81"}
+    assert s.selection["phone"] == "+81"
+    s.value = "CA"
+    assert s.selection["phone"] == "+1"
+
+
+def test_selectbutton_selection_is_record_with_bag(app):
+    sb = bs.SelectButton(options=[{"text": "Dark", "value": "dark", "accent": "x"}], value="dark")
+    assert sb.selection == {"text": "Dark", "value": "dark", "accent": "x"}
+
+
+def test_radiogroup_selection_is_record_with_bag(app):
+    rg = bs.RadioGroup(options=[{"text": "Small", "value": "s", "px": 12}], value="s")
+    assert rg.selection == {"text": "Small", "value": "s", "px": 12}
+
+
+def test_togglegroup_single_selection_is_record(app):
+    tg = bs.ToggleGroup(options=[("Grid", "grid"), {"text": "List", "value": "list", "icon": "rows"}], value="list")
+    assert tg.selection == {"text": "List", "value": "list", "icon": "rows"}
+
+
+def test_togglegroup_multi_selection_is_list_of_records(app):
+    tg = bs.ToggleGroup(
+        options=[("Bold", "b"), ("Italic", "i"), ("Underline", "u")],
+        mode="multi", value={"b", "u"},
+    )
+    sel = tg.selection
+    assert isinstance(sel, list)
+    assert {d["value"] for d in sel} == {"b", "u"}
+
+
+def test_select_selection_none_when_unselected(app):
+    s = bs.Select(options=["a", "b"])
+    assert s.selection is None
+
+
+def test_plain_string_option_selection_is_minimal_record(app):
+    s = bs.Select(options=["a", "b"], value="a")
+    assert s.selection == {"text": "a", "value": "a"}
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
Turns the option dict form into a **data bag** (consistent with the framework's record/data-bag principle) and adds a universal **`selection`** accessor that returns the selected option's full record.

## Carry the bag
`normalize_option` no longer rejects unknown dict keys. `text` is required; `text`/`value` and the reserved `icon`/`disabled` are the *recognized* keys, and every **other** key rides along as carried data:

```python
bs.Select(options=[{"text": "Canada", "value": "CA", "phone": "+1"}])   # no longer errors
```

The dict route is opt-in, so the caller accepts the key-typo risk (a maintainer decision).

## `selection`
A neutral-noun property on each option-family widget returning the selected option as a flat record dict — indexed by key like any record — polymorphic by cardinality (matching the `value`/`text` idiom):

```python
country.value             # "JP"
country.text              # "Japan"
country.selection         # {"text": "Japan", "value": "JP", "phone": "+81"}
country.selection["phone"]  # "+81"
```

| widget | `.selection` |
|---|---|
| Select / SelectButton / RadioGroup | `dict \| None` |
| ToggleGroup (single / multi) | `dict \| None` / `list[dict]` |

**Implementation:** Select/SelectButton map the current value to their kept `_records`. RadioGroup/ToggleGroup previously *discarded* extras — `SelectionGroupMixin` now keeps a value→record map (seeded at construction, updated on `add()`, cleaned on `remove()`). Plain string/tuple options yield a minimal `{text, value}` record; a custom/off-list value → `selection is None`.

## Scope
Option family only. `.selection` on **ListView/DataTable/Tree** (already record-native — `get_selected()`/`selected_rows`/`selected_nodes`) is the **naming-alignment follow-up**, since it renames shipped API. Wiring up `icon`/`disabled` behavior and **Select grouping** are also logged as follow-ups. Full brief: `docs/_dev/option-databag.md`.

## Verification
- `test_select_options.py` — 46 passed (bag carry no longer raises on extra keys; `.selection` across all four; multi→list; None when unselected; minimal record for string/tuple options)
- `test_field_text_value.py` (15), `test_public_surface.py` (141) — green
- Clean `-W --keep-going` docs build; all four option-family examples run
- All four guides note `.selection` + the data bag; `OptionDict`/`normalize_option` docstrings clarify recognized-vs-carried keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)
