### PR TITLE
feat(selection): universal `.selection` accessor on ListView/DataTable/Tree

### DIFF
--- a/docs/widgets/datatable.rst
+++ b/docs/widgets/datatable.rst
@@ -141,15 +141,17 @@ Selection
 ~~~~~~~~~
 
 ``selection_mode`` is ``'single'`` (default), ``'multi'``, or ``'none'``. Read the
-current selection with ``selected_rows`` and react with ``on_selection_changed``,
-whose :class:`SelectionEvent <bootstack.events.SelectionEvent>` carries the
-selected ``records`` and their ``ids``:
+current selection with ``selection`` — a single record ``dict`` (or ``None``) in
+single mode, a ``list`` of record dicts in multi mode — and react with
+``on_selection_changed``, whose
+:class:`SelectionEvent <bootstack.events.SelectionEvent>` carries the selected
+``records`` and their ``ids``:
 
 .. code-block:: python
 
    table = bs.DataTable(columns=cols, rows=people, selection_mode="multi")
    table.on_selection_changed(lambda e: print(e.records, e.ids))
-   print(table.selected_rows)
+   print(table.selection)   # list of record dicts (multi mode)
 
 Manage the selection programmatically. Users can also press ``Escape`` over the
 table to clear it — handy in single-select mode, where clicking cannot return to

--- a/docs/widgets/listview.rst
+++ b/docs/widgets/listview.rst
@@ -52,7 +52,7 @@ Carrying extra data
 ~~~~~~~~~~~~~~~~~~~~
 
 The keys above are a *view* over the record, not the record itself. Extra keys
-are still carried through and handed back — ``get_selected()`` and the item
+are still carried through and handed back — ``selection`` and the item
 events return the full record dict, including the undisplayed fields:
 
 .. code-block:: python
@@ -117,19 +117,23 @@ selection, which the user drives separately via the checkboxes:
    bs.ListView(items=records, selection_mode="multi",
                show_selection_controls=True, select_on_click=False)
 
-Read the current selection via ``get_selected()``, which returns a list of
-the full record dicts:
+Read the current selection via ``selection``. In ``"multi"`` mode it returns a
+list of the full record dicts; in ``"single"`` mode the selected record dict (or
+``None``). Non-displayed fields ride along in each record:
 
 .. code-block:: python
 
    lv = bs.ListView(items=records, selection_mode="multi")
-   lv.on_selection_changed(lambda e: print(lv.get_selected()))
+   lv.on_selection_changed(lambda e: print(lv.selection))
 
-Clear or fill the selection programmatically:
+Set the selection programmatically by record ``id`` — ``select_items`` replaces
+the selection in single mode and adds in multi mode; ``deselect_items`` removes:
 
 .. code-block:: python
 
-   lv.select_all()       # multi mode only
+   lv.select_items([3, 7])   # by record id
+   lv.deselect_items([3])
+   lv.select_all()           # multi mode only
    lv.clear_selection()
 
 .. image:: /_static/examples/listview-selection-light.png
@@ -206,7 +210,7 @@ to unsubscribe:
    lv = bs.ListView(items=records, selection_mode="single")
 
    sub = lv.on_item_click(lambda e: print("clicked:", e["title"]))
-   lv.on_selection_changed(lambda e: print("selected:", lv.get_selected()))
+   lv.on_selection_changed(lambda e: print("selected:", lv.selection))
    lv.on_item_delete(lambda e: print("deleted:", e["id"]))
 
    sub.cancel()   # unsubscribe

--- a/docs/widgets/tree.rst
+++ b/docs/widgets/tree.rst
@@ -164,7 +164,10 @@ descendants, and a partially-checked parent shows a mixed (dash) marker.
    :class: bs-screenshot-dark
    :alt: Tree multi-select cascade — dark theme
 
-Read the selection through the ``selected_nodes`` property, or change it in code:
+Read the selection through the ``selection`` property — a single
+:class:`TreeNode <bootstack.TreeNode>` (or ``None``) in single mode, a ``list``
+of nodes in multi mode; each node's data bag is at ``node.data``. Or change it in
+code:
 
 .. code-block:: python
 

--- a/src/bootstack/widgets/_impl/composites/list/listview.py
+++ b/src/bootstack/widgets/_impl/composites/list/listview.py
@@ -1101,6 +1101,36 @@ class ListView(Frame):
         self._update_rows()
         self.event_generate('<<SelectionChange>>')
 
+    def select_items(self, ids: list) -> None:
+        """Select items by record `id`.
+
+        In single-selection mode the current selection is replaced; in multi
+        mode the given items are added. No-op when selection is disabled.
+        Generates a <<SelectionChange>> event.
+        """
+        if self._selection_mode == 'none':
+            return
+        with self._silence_source():
+            if self._selection_mode == 'single':
+                self._datasource.deselect_all()
+            for record_id in ids:
+                if record_id is not None:  # id 0 is valid, don't skip it
+                    self._datasource.select(record_id)
+        self._update_rows()
+        self.event_generate('<<SelectionChange>>')
+
+    def deselect_items(self, ids: list) -> None:
+        """Remove the given items from the selection by record `id`.
+
+        Generates a <<SelectionChange>> event.
+        """
+        with self._silence_source():
+            for record_id in ids:
+                if record_id is not None:
+                    self._datasource.deselect(record_id)
+        self._update_rows()
+        self.event_generate('<<SelectionChange>>')
+
     def scroll_to_top(self):
         """Scroll to the beginning of the list.
 

--- a/src/bootstack/widgets/datatable.py
+++ b/src/bootstack/widgets/datatable.py
@@ -121,6 +121,7 @@ class DataTable(PublicWidgetBase):
         **kwargs: Any,
     ) -> None:
         self._parent = self._resolve_parent(parent)
+        self._selection_mode = selection_mode
         layout_kw = self._split_layout_kwargs(kwargs)
         tk_master = self._parent._child_master() if self._parent else None
 
@@ -253,9 +254,18 @@ class DataTable(PublicWidgetBase):
         self._internal.deselect_all()
 
     @property
-    def selected_rows(self) -> list[dict]:
-        """Currently selected record dicts."""
-        return self._internal.selected_rows
+    def selection(self) -> dict | list[dict] | None:
+        """The selected row(s) — the data bag.
+
+        In `'single'` mode, the selected record `dict` (or `None` when nothing
+        is selected). In `'multi'` mode, a `list` of record dicts (empty when
+        nothing is selected). Each record carries its non-displayed fields too,
+        indexed by key like any record. Read-only.
+        """
+        rows = self._internal.selected_rows
+        if self._selection_mode == "multi":
+            return rows
+        return rows[0] if rows else None
 
     # ----- Scroll -----
 

--- a/src/bootstack/widgets/listview.py
+++ b/src/bootstack/widgets/listview.py
@@ -22,7 +22,7 @@ class ListView(PublicWidgetBase):
 
     Each record dict should have an `'id'` key; one is auto-generated if absent.
     Displayed fields are `'title'`, `'text'`, `'icon'`, and `'badge'`. Other
-    keys are stored and returned by `get_selected()` and events but are not
+    keys are stored and returned by `selection` and events but are not
     rendered.
 
     Args:
@@ -80,6 +80,7 @@ class ListView(PublicWidgetBase):
         **kwargs: Any,
     ) -> None:
         self._parent = self._resolve_parent(parent)
+        self._selection_mode = selection_mode
         layout_kw = self._split_layout_kwargs(kwargs)
         tk_master = self._parent._child_master() if self._parent else None
 
@@ -149,13 +150,42 @@ class ListView(PublicWidgetBase):
 
     # ----- Selection -----
 
-    def get_selected(self) -> list[dict]:
-        """Return currently selected records as a list of dicts."""
-        return self._internal.get_selected()
+    @property
+    def selection(self) -> dict | list[dict] | None:
+        """The selected record(s) — the data bag.
+
+        In `'single'` mode, the selected record `dict` (or `None` when nothing
+        is selected). In `'multi'` mode, a `list` of record dicts (empty when
+        nothing is selected). Each record carries its non-displayed fields too,
+        indexed by key like any record. Read-only.
+        """
+        rows = self._internal.get_selected()
+        if self._selection_mode == "multi":
+            return rows
+        return rows[0] if rows else None
+
+    def select_items(self, record_ids: list) -> None:
+        """Select items by record `id`.
+
+        In `'single'` mode this replaces the current selection; in `'multi'`
+        mode the items are added to it.
+
+        Args:
+            record_ids: Record ids of the items to select.
+        """
+        self._internal.select_items(record_ids)
 
     def select_all(self) -> None:
         """Select all items. Only effective when `selection_mode='multi'`."""
         self._internal.select_all()
+
+    def deselect_items(self, record_ids: list) -> None:
+        """Remove the given items from the selection by record `id`.
+
+        Args:
+            record_ids: Record ids to deselect.
+        """
+        self._internal.deselect_items(record_ids)
 
     def clear_selection(self) -> None:
         """Deselect all items."""
@@ -200,7 +230,7 @@ class ListView(PublicWidgetBase):
 
         Args:
             handler: Called with the curated
-                :class:`~bootstack.events.Event`; call `get_selected()` to read
+                :class:`~bootstack.events.Event`; read `selection` to get
                 the current selection. Omit to get a composable
                 :class:`~bootstack.streams.Stream` instead.
 

--- a/src/bootstack/widgets/tree.py
+++ b/src/bootstack/widgets/tree.py
@@ -115,6 +115,7 @@ class Tree(PublicWidgetBase):
         **kwargs: Any,
     ) -> None:
         self._parent = self._resolve_parent(parent)
+        self._selection_mode = selection_mode
         layout_kw = self._split_layout_kwargs(kwargs)
         tk_master = self._parent._child_master() if self._parent else None
 
@@ -429,9 +430,17 @@ class Tree(PublicWidgetBase):
     # ----- selection -----
 
     @property
-    def selected_nodes(self) -> list[TreeNode]:
-        """The currently selected nodes, in tree order."""
-        return self._internal.get_selected()
+    def selection(self) -> TreeNode | list[TreeNode] | None:
+        """The selected node(s) — node handles, in tree order.
+
+        In `'single'` mode, the selected :class:`TreeNode` (or `None` when
+        nothing is selected). In `'multi'` mode, a `list` of nodes (empty when
+        nothing is selected). Each node's data bag is at `node.data`. Read-only.
+        """
+        nodes = self._internal.get_selected()
+        if self._selection_mode == "multi":
+            return nodes
+        return nodes[0] if nodes else None
 
     def select(self, node: TreeNode) -> None:
         """Select a node (replaces in single mode, adds in multi)."""

--- a/tests/features/data_display_public.py
+++ b/tests/features/data_display_public.py
@@ -47,7 +47,7 @@ with App(title="Data Display", minsize=(900, 620), padding=0, gap=0) as app:
             lbl_sel = Label("Selected: []")
 
             def show_selection(_event=None):
-                selected = lv.get_selected()
+                selected = lv.selection
                 lbl_sel.text = f"Selected: {[r['name'] for r in selected]}"
 
             lv.on_selection_changed(show_selection)

--- a/tests/widgets/public/test_datatable.py
+++ b/tests/widgets/public/test_datatable.py
@@ -90,7 +90,7 @@ def test_memory_source_select_rows_roundtrip(shown_app):
     table.select_rows([10, 30])
     _pump(shown_app)
 
-    selected_ids = sorted(r["id"] for r in table.selected_rows)
+    selected_ids = sorted(r["id"] for r in table.selection)
     assert selected_ids == [10, 30]
 
 
@@ -109,7 +109,7 @@ def test_memory_source_hides_internal_selected_field(shown_app):
 
     for r in table.to_rows("all"):
         assert "selected" not in r
-    for r in table.selected_rows:
+    for r in table.selection:
         assert "selected" not in r
 
 
@@ -123,7 +123,7 @@ def test_sqlite_source_default_still_works(shown_app):
     table.select_rows([20])
     _pump(shown_app)
 
-    assert [r["id"] for r in table.selected_rows] == [20]
+    assert [r["id"] for r in table.selection] == [20]
     for r in table.to_rows("all"):
         assert "_bs_row_id" not in r and "_bs_selected" not in r
 
@@ -209,3 +209,36 @@ def test_density_compact_is_shorter_than_default(shown_app):
     _pump(shown_app)
 
     assert _rowheight(compact_table) < _rowheight(default_table)
+
+
+# --------------------------------------------------------------------------- selection shape
+
+
+@pytest.mark.gui
+def test_selection_single_mode_is_a_record_dict(shown_app):
+    """Single mode: `.selection` is the selected record dict (or None)."""
+    table = bs.DataTable(rows=[dict(r) for r in ROWS], columns=["name", "role"],
+                         selection_mode="single", page_size=10)
+    _pump(shown_app)
+
+    assert table.selection is None
+
+    table.select_rows([20])
+    _pump(shown_app)
+    sel = table.selection
+    assert isinstance(sel, dict)
+    assert sel["id"] == 20 and sel["name"] == "Boole"
+
+
+@pytest.mark.gui
+def test_selection_multi_mode_is_a_list(shown_app):
+    """Multi mode: `.selection` is always a list — empty when none selected."""
+    table = bs.DataTable(rows=[dict(r) for r in ROWS], columns=["name", "role"],
+                         selection_mode="multi", page_size=10)
+    _pump(shown_app)
+
+    assert table.selection == []
+
+    table.select_rows([10, 30])
+    _pump(shown_app)
+    assert sorted(r["id"] for r in table.selection) == [10, 30]

--- a/tests/widgets/public/test_listview.py
+++ b/tests/widgets/public/test_listview.py
@@ -2,7 +2,7 @@
 
 ListView is in-memory (its default source is a ``MemoryDataSource``), so a record
 carries *every* user field — including ones the item template never displays and
-arbitrary live objects — and hands them back from ``get_selected()``.
+arbitrary live objects — and hands them back from ``selection``.
 """
 from __future__ import annotations
 
@@ -53,8 +53,84 @@ def test_undisplayed_fields_survive(shown_app):
     lv.select_all()
     _pump(shown_app)
 
-    selected = {r["id"]: r for r in lv.get_selected()}
+    selected = {r["id"]: r for r in lv.selection}
     assert selected[1]["tags"] == ["vip"]
     # In-memory: an arbitrary live object rides along by reference.
     assert selected[1]["handle"] is payload
     assert selected[2]["title"] == "Bob"
+
+
+@pytest.mark.gui
+def test_selection_shape_by_mode(shown_app):
+    """`.selection` is polymorphic by mode — a record dict (single) vs a list."""
+    single = bs.ListView(
+        items=[{"id": 1, "title": "Alice", "tags": ["vip"]}, {"id": 2, "title": "Bob"}],
+        selection_mode="single",
+    )
+    multi = bs.ListView(items=[{"id": 1, "title": "Alice"}], selection_mode="multi")
+    _pump(shown_app)
+
+    assert single.selection is None       # singular accessor → None, not []
+    assert multi.selection == []          # list accessor → empty list
+
+    single.select_items([1])
+    _pump(shown_app)
+    sel = single.selection
+    assert isinstance(sel, dict) and sel["id"] == 1
+    # The bag carries undisplayed fields through the singular accessor too.
+    assert sel["tags"] == ["vip"]
+
+    # Single mode replaces, never accumulates.
+    single.select_items([2])
+    _pump(shown_app)
+    assert single.selection["id"] == 2
+
+    multi.select_all()
+    _pump(shown_app)
+    sel = multi.selection
+    assert isinstance(sel, list) and sel[0]["id"] == 1
+
+
+@pytest.mark.gui
+def test_select_and_deselect_items_by_id(shown_app):
+    """`select_items`/`deselect_items` drive a multi selection by record id."""
+    lv = bs.ListView(
+        items=[{"id": i, "title": str(i)} for i in (1, 2, 3)],
+        selection_mode="multi",
+    )
+    _pump(shown_app)
+
+    lv.select_items([1, 3])
+    _pump(shown_app)
+    assert sorted(r["id"] for r in lv.selection) == [1, 3]
+
+    lv.deselect_items([1])
+    _pump(shown_app)
+    assert [r["id"] for r in lv.selection] == [3]
+
+
+@pytest.mark.gui
+def test_single_mode_replace_fires_one_event(shown_app):
+    """Single-mode selection fires exactly one change event per selection.
+
+    Replacing a selection internally does `deselect_all()` + `select()` — two
+    source mutations — but they are silenced as a unit and the widget emits a
+    single `<<SelectionChange>>`, so a replace must not double-fire.
+    """
+    lv = bs.ListView(
+        items=[{"id": 1, "title": "A"}, {"id": 2, "title": "B"}],
+        selection_mode="single",
+    )
+    _pump(shown_app)
+
+    fires = []
+    lv.on_selection_changed(lambda e: fires.append(e))
+    _pump(shown_app)
+
+    lv.select_items([1])
+    _pump(shown_app)
+    assert len(fires) == 1 and lv.selection["id"] == 1
+
+    lv.select_items([2])          # replace the existing selection
+    _pump(shown_app)
+    assert len(fires) == 2 and lv.selection["id"] == 2   # one more, not two

--- a/tests/widgets/public/test_tree.py
+++ b/tests/widgets/public/test_tree.py
@@ -340,11 +340,11 @@ def test_single_selection_replaces(shown_app):
 
     tree.select(src)
     _pump(shown_app)
-    assert tree.selected_nodes == [src]
+    assert tree.selection == src
 
     tree.select(readme)
     _pump(shown_app)
-    assert tree.selected_nodes == [readme]
+    assert tree.selection == readme
 
 
 @pytest.mark.gui
@@ -357,15 +357,15 @@ def test_multi_selection_accumulates_and_clears(shown_app):
     tree.select(a)
     tree.select(b)
     _pump(shown_app)
-    assert set(tree.selected_nodes) >= {a, b}
+    assert set(tree.selection) >= {a, b}
 
     tree.deselect(a)
     _pump(shown_app)
-    assert a not in tree.selected_nodes
+    assert a not in tree.selection
 
     tree.clear_selection()
     _pump(shown_app)
-    assert tree.selected_nodes == []
+    assert tree.selection == []
 
 
 @pytest.mark.gui
@@ -376,11 +376,24 @@ def test_multi_select_cascades_to_descendants(shown_app):
 
     tree.select(src)
     _pump(shown_app)
-    selected = set(tree.selected_nodes)
+    selected = set(tree.selection)
     # Parent + all descendants selected by the cascade.
     assert src in selected
     for child in src.children:
         assert child in selected
+
+
+@pytest.mark.gui
+def test_selection_empty_shape_by_mode(shown_app):
+    """`.selection` is None (single/none) or [] (multi) when nothing is selected."""
+    single = bs.Tree(nodes=PROJECT, selection_mode="single")
+    multi = bs.Tree(nodes=PROJECT, selection_mode="multi")
+    none = bs.Tree(nodes=PROJECT, selection_mode="none")
+    _pump(shown_app)
+
+    assert single.selection is None
+    assert multi.selection == []
+    assert none.selection is None
 
 
 # --------------------------------------------------------------------------- events


### PR DESCRIPTION
## Summary

Extends the option family's universal, polymorphic **`.selection`** accessor
(shipped for Select/RadioGroup/ToggleGroup in #114–#118) to the three
record-native widgets. They already carried records but exposed them under three
divergent names of divergent kinds — `ListView.get_selected()` (a method),
`DataTable.selected_rows`, `Tree.selected_nodes`. This unifies the read side and
closes the symmetric write-side gap on ListView.

**Breaking — clean break, no shim** (matches the pre-release namespace-curation
precedent of #104).

## Read side

`.selection` is polymorphic by `selection_mode`:

| mode | ListView / DataTable | Tree |
|---|---|---|
| `single` | `dict \| None` | `TreeNode \| None` |
| `multi` | `list[dict]` | `list[TreeNode]` |
| `none` | `None` | `None` |

ListView/DataTable return record dicts directly (the bag, indexed by key); Tree
returns node **handles** (bag at `node.data`).

Removed: `ListView.get_selected()`, `DataTable.selected_rows`, `Tree.selected_nodes`.

⚠️ **Behavior note:** DataTable defaults to `selection_mode='single'`, so
`table.selection` is now a `dict | None` by default (the old `selected_rows` was
always a list).

## Write side

Adds `ListView.select_items(ids)` / `deselect_items(ids)` by record id, mirroring
`DataTable.select_rows` / `deselect_rows` (single-mode **replace**, multi-mode
**add**). ListView previously had no per-item programmatic selection — only
`select_all`/`clear_selection`. The verb+noun naming stays in each widget's own
vocabulary (rows / items / nodes); that divergence is intentional, not reconciled.

Both methods wrap the source mutations in `_silence_source()` and emit a single
`<<SelectionChange>>`, so a single-mode replace (`deselect_all()` + `select()`)
does **not** double-fire.

## Docs
ListView/DataTable/Tree guides updated for `.selection` (+ data bag / `node.data`)
and the new ListView select/deselect methods.

## Tests
- Migrated existing call sites to `.selection`.
- Per-mode shape coverage (single→dict/handle/None, multi→list, none→None).
- `select_items`/`deselect_items` round-trip by id.
- Regression pinning that a single-mode replace fires **exactly one** change event.

## Verification
- `test_listview.py` 4, `test_datatable.py` 10, `test_tree.py` 40,
  `test_public_surface.py` 141 — all pass in isolation.
- Clean `-W` docs build: build succeeded, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
