### PR TITLE
docs(claude): handoff — universal `.selection` (PR #120); refresh next-up

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,29 @@ Go from nothing to something fast. The user should never need to `import tkinter
 Pointers only — these shipped; rationale, detail, and gotchas live in the linked
 memories and git history.
 
+- **Universal `.selection` on the record-native widgets** (PR #120, merged) —
+  extends the option family's polymorphic `.selection` accessor (PRs #114–#118) to
+  **ListView / DataTable / Tree**, which carried records but exposed them under
+  divergent names of divergent kinds (`get_selected()` method / `selected_rows` /
+  `selected_nodes`). **Breaking, clean break (no shim):** those three are GONE;
+  `.selection` is now universal and **polymorphic by `selection_mode`** — single →
+  `dict | None` (Tree: `TreeNode | None`), multi → `list[dict]` (Tree:
+  `list[TreeNode]`), none → `None`. ListView/DataTable return record dicts (the
+  bag, indexed by key); Tree returns node **handles** (bag at `node.data`). Each
+  wrapper stores `self._selection_mode` and collapses the internal's always-list to
+  the singular shape. **Behavior note:** DataTable defaults to
+  `selection_mode='single'`, so `table.selection` is a `dict | None` by default (the
+  old `selected_rows` was always a list). Also closed the symmetric **write-side
+  gap**: new **`ListView.select_items(ids)` / `deselect_items(ids)`** (by record id,
+  single-mode replace / multi-mode add) mirroring `DataTable.select_rows` /
+  `deselect_rows` — ListView previously had only `select_all`/`clear_selection`.
+  Both wrap source mutations in `_silence_source()` and emit ONE `<<SelectionChange>>`
+  (a single-mode replace does `deselect_all()` + `select()` but must not double-fire
+  — regression-tested). Verb+noun naming stays per-widget vocabulary (rows/items/
+  nodes) **by design** — not a divergence to reconcile. Tree needed nothing
+  (`select(node)`/`deselect(node)` is the right node-handle primitive). Tests in
+  `test_listview.py`/`test_datatable.py`/`test_tree.py`; guides updated. Memory
+  `project_option_databag`; brief `docs/_dev/option-databag.md`.
 - **Field value/text/label contract + selection data bag** (PRs #113–#116, all
   merged) — a framework-wide field-widget contract and a shared, extensible option
   shape, built across four PRs:
@@ -145,18 +168,6 @@ memories and git history.
 
 ## Next up — candidates (pick one)
 
-- **Selection `.selection` naming alignment** (follow-on from the option-databag PR
-  #116) — extend the universal `.selection` accessor to the record-native widgets
-  **ListView/DataTable/Tree**, which already carry records but expose them under
-  divergent names: `get_selected()` (ListView, method), `selected_rows` (DataTable),
-  `selected_nodes` (Tree). Add the singular/`selection` form and reconcile the
-  plural names; Tree's `selection` returns node handles (bag at `node.data`).
-  **Breaking** (renames shipped API) — its own PR. Brief: `docs/_dev/option-databag.md`.
-- **Option `icon` + per-item `disabled` behavior** — wire up the two reserved
-  `OptionDict` keys (currently carried but inert): render `icon` beside each option's
-  label, and make a single option non-selectable via `disabled` — across the entry-
-  backed Select popup, the menu-backed SelectButton, and the button-backed groups.
-  Touches the icon renderer. Memory `project_option_databag`.
 - **Select grouping** (optgroup-style) — cluster options under group headers in the
   Select popup (and maybe the family). Maintainer-requested; **discuss shape before
   building** (composes with the `Option` shape + data bag). Memory

--- a/docs/_dev/option-databag.md
+++ b/docs/_dev/option-databag.md
@@ -1,6 +1,13 @@
 # Initiative — Option data bag + the universal `selection` accessor
 
-**Status:** IN PROGRESS. Branch `feat/option-databag` off `main`. Started 2026-06-11.
+**Status:** SHIPPED (fully). The bag + universal `.selection` accessor for the
+option family merged in **PR #116**; the reserved `icon`/`disabled` keys were
+wired up (icon-only inferred from blank text) in **PR #118** (which also flipped
+`ToggleGroup`'s default accent to `'default'` and fixed its disabled-background
+builder); the naming-alignment follow-on — extending `.selection` to
+ListView/DataTable/Tree + the ListView write-side methods — merged in **PR #120**
+(see "Naming-alignment follow-on (PR #120)" below). The design sections below are
+kept as the historical record.
 **Builds on:** the field value/text/label model (`project_field_value_text_model`)
 and the shared `Option` shape shipped in PRs #114/#115.
 
@@ -73,12 +80,36 @@ selection), Tabs/SideNav/PageStack (navigation).
 
 ## This branch vs follow-up
 
-- **This branch (foundation):** parts 1+2 for the **option family only**
-  (Select, SelectButton, RadioGroup, ToggleGroup). The four already expose
-  `value`/`text`; add `selection` returning the full record.
-- **Follow-up PR (naming alignment):** add `.selection` to ListView/DataTable/
-  Tree, mapping/replacing their existing `get_selected()` / `selected_rows` /
-  `selected_nodes`. Separate because it renames shipped API.
+- **Foundation (PR #116):** parts 1+2 for the **option family only** (Select,
+  SelectButton, RadioGroup, ToggleGroup). The four already expose `value`/`text`;
+  added `selection` returning the full record.
+- **Follow-up (PR #120, shipped):** see "Naming-alignment follow-on" below.
+
+## Naming-alignment follow-on (PR #120, shipped)
+
+Extended `.selection` to the record-native **ListView / DataTable / Tree**, which
+carried records but exposed them under divergent names of divergent kinds —
+`ListView.get_selected()` (a method), `DataTable.selected_rows`,
+`Tree.selected_nodes`. **Breaking, clean break (no shim):** those three are GONE.
+
+- `.selection` is **polymorphic by `selection_mode`** (mirrors ToggleGroup):
+  single → `dict | None` (Tree: `TreeNode | None`), multi → `list[dict]` (Tree:
+  `list[TreeNode]`), none → `None`. Each wrapper stores `self._selection_mode` and
+  collapses the internal's always-list to the singular shape.
+- ListView/DataTable return record dicts directly; Tree returns node **handles**
+  (bag at `node.data`) — the principled exception.
+- **Behavior note:** DataTable defaults to `selection_mode='single'`, so
+  `table.selection` is a `dict | None` by default (the old `selected_rows` was
+  always a list).
+- **Write-side gap closed:** new `ListView.select_items(ids)` /
+  `deselect_items(ids)` (by record id; single-mode replace, multi-mode add)
+  mirroring `DataTable.select_rows` / `deselect_rows` — ListView previously had
+  only `select_all`/`clear_selection`. Both wrap source mutations in
+  `_silence_source()` and emit ONE `<<SelectionChange>>` (single-mode replace does
+  `deselect_all()` + `select()` but must not double-fire — regression-tested).
+- Verb+noun naming stays in each widget's own vocabulary (rows / items / nodes)
+  **by design** — not a divergence to reconcile. Tree needed no new method:
+  `select(node)` / `deselect(node)` is the right node-handle primitive.
 
 ## Work surface (option family)
 
@@ -105,7 +136,9 @@ selection), Tabs/SideNav/PageStack (navigation).
 - Clean `-W` docs build; run the select/group examples.
 
 ## Deferred / future
-- Wire up `icon` (render beside each option) and per-item `disabled` — separate
-  PRs once the carry ships.
+- ✅ DONE (PR #118) — `icon` rendered beside each option, per-item `disabled`,
+  and icon-only inferred from blank text.
+- ✅ DONE (PR #120) — `.selection` extended to ListView/DataTable/Tree (see the
+  naming-alignment follow-on above).
 - **Select grouping** (optgroup-style) — see `project_select_grouping`; discuss
-  after this lands.
+  before building. The only remaining piece of this initiative's orbit.


### PR DESCRIPTION
## Summary

Handoff docs following the merge of #120 (universal `.selection` accessor on the
record-native widgets). Docs/notes only — no code changes.

## Changes

**`CLAUDE.md`**
- Add a "Recently completed" entry for **PR #120**: universal polymorphic
  `.selection` on ListView/DataTable/Tree (clean-break removal of
  `get_selected()`/`selected_rows`/`selected_nodes`), the DataTable single-mode
  default behavior note, and ListView's new write-side `select_items`/`deselect_items`
  (by id; one-event discipline). Records that per-widget noun naming
  (rows/items/nodes) is intentional, not a divergence.
- Drop two now-shipped "Next up" candidates — the `.selection` alignment (→ #120)
  and "Option icon + per-item disabled" (→ #118). **Select grouping** is now the
  front-runner.

**`docs/_dev/option-databag.md`** — this `main` copy was stale (predated
#116/#118/#120 actually landing). Status → fully SHIPPED; added a
"Naming-alignment follow-on (PR #120)" section; marked icon/disabled (#118) and the
naming alignment (#120) done under Deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
