### PR TITLE
feat(widgets): public detach()/attach() + on_attach/on_detach

### DIFF
--- a/docs/_templates/autosummary/toplevel.rst
+++ b/docs/_templates/autosummary/toplevel.rst
@@ -1,0 +1,10 @@
+{{ fullname | escape | underline }}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}
+   :members:
+   :special-members: __call__
+   :exclude-members: tk, var, attach, detach, is_attached, on_attach, on_detach
+   :inherited-members:
+   :show-inheritance:

--- a/docs/api-reference/application.rst
+++ b/docs/api-reference/application.rst
@@ -10,6 +10,7 @@ opens a secondary top-level window.
 .. autosummary::
    :toctree: generated
    :nosignatures:
+   :template: toplevel
 
    App
    AppShell

--- a/docs/reference/events.rst
+++ b/docs/reference/events.rst
@@ -353,6 +353,63 @@ the native events above. Unlike them, ``on_destroy`` fires exactly once and
 cannot be canceled. For a *window's* close button — which a handler can veto —
 use ``on_close`` instead (see :doc:`/getting-started/app-structures`).
 
+Detaching and reattaching
+-------------------------
+
+Destroying a widget is permanent. To pull a widget out of the layout *without*
+tearing it down — and put it back later in the same spot — use ``detach`` and
+``attach``. A detached widget stops taking up space but keeps its state,
+children, and bindings.
+
+.. code-block:: python
+
+   panel = bs.VStack()
+   ...
+   panel.detach()            # hide it — frees its space
+   panel.attach()            # bring it back exactly where it was
+
+``attach`` accepts the same layout options as the constructor, so you can move a
+widget as you bring it back. For stacked widgets, ``index=`` sets the position
+among the currently attached siblings (or pass an explicit ``before=`` /
+``after=`` sibling):
+
+.. code-block:: python
+
+   row.detach()
+   row.attach(index=0)       # back at the top of its stack
+
+The ``is_attached`` property reports the current state, and a plain ``detach()``
+on an already-detached widget (or ``attach()`` after a no-argument ``detach``)
+round-trips cleanly.
+
+To build a widget that starts hidden, pass ``attached=False`` to its
+constructor. It is created and parented in place — so a later ``attach()``
+drops it into the slot it was declared in — but takes up no space until shown,
+with no startup flicker:
+
+.. code-block:: python
+
+   with bs.VStack():
+       bs.Label("Account")
+       banner = bs.Label("Saved!", accent="success", attached=False)
+       bs.TextField()
+
+   ...
+   banner.attach()           # reveal it between the label and the field
+
+Two events bracket this. ``on_attach`` fires whenever the widget enters the
+layout — on its initial placement and on every ``attach`` — and ``on_detach``
+fires when it leaves, including when an ancestor hides it. They are the place to
+start and stop work that should only run while the widget is on screen:
+
+.. code-block:: python
+
+   chart = bs.Card()
+   chart.on_attach(lambda e: feed.subscribe(chart.refresh))
+   chart.on_detach(lambda e: feed.unsubscribe(chart.refresh))
+
+Each hands the handler a curated :class:`Event <bootstack.events.Event>`.
+
 Filtering native events
 -----------------------
 

--- a/src/bootstack/widgets/_core/base.py
+++ b/src/bootstack/widgets/_core/base.py
@@ -43,6 +43,7 @@ class PublicWidgetBase:
 
     _internal: tkinter.Misc
     _parent: "PublicWidgetBase | None"
+    _placement: Any  # container.Placement — set when first placed in a layout
 
     @staticmethod
     def _resolve_parent(
@@ -63,7 +64,11 @@ class PublicWidgetBase:
             layout_keys = (PLACE_KEYS - {"width", "height", "anchor"}) | PLACE_TRIGGER_KEYS
         else:
             layout_keys = PACK_KEYS | GRID_KEYS
-        return {k: kwargs.pop(k) for k in list(kwargs) if k in layout_keys}
+        layout = {k: kwargs.pop(k) for k in list(kwargs) if k in layout_keys}
+        # `attached` is geometry-manager-agnostic — capture it in every mode.
+        if "attached" in kwargs:
+            layout["attached"] = kwargs.pop("attached")
+        return layout
 
     def _attach_to_parent(self, layout_kw: dict) -> None:
         if not self._auto_place:
@@ -188,6 +193,106 @@ class PublicWidgetBase:
         """
         self._internal.destroy()
 
+    @property
+    def is_attached(self) -> bool:
+        """Whether the widget is currently placed in its layout.
+
+        `True` while the widget occupies space in its parent; `False` after
+        `detach` (or before it has ever been placed). A detached widget keeps
+        its state and can be returned to the layout with `attach`.
+        """
+        try:
+            return bool(self._internal.winfo_manager())
+        except tkinter.TclError:
+            return False
+
+    def detach(self) -> None:
+        """Remove the widget from its layout without destroying it.
+
+        The widget stops occupying space but keeps its state, children, and
+        event bindings, ready to be returned with `attach`. The current
+        position is snapshotted so a plain `attach()` restores it exactly —
+        for stacked siblings this is the index among the *currently attached*
+        siblings, so detaching other siblings first shifts that index.
+
+        Calling `detach` on a widget that is already detached, or one that was
+        never placed in a layout, does nothing. Fires `on_detach`.
+        """
+        placement = getattr(self, "_placement", None)
+        if placement is None or not self.is_attached:
+            return
+        if placement.method == "pack":
+            slaves = list(placement.master.pack_slaves())
+            try:
+                placement.index = slaves.index(self._internal)
+            except ValueError:
+                placement.index = None
+            self._internal.pack_forget()
+        elif placement.method == "grid":
+            # grid_forget (not grid_remove): the "remembered" state left by
+            # grid_remove rejects an explicit re-grid; we reconstruct fully
+            # from the stored cell options instead.
+            self._internal.grid_forget()
+        else:
+            self._internal.place_forget()
+
+    def attach(self, **kwargs: Any) -> None:
+        """Return a detached widget to its layout, optionally moving it.
+
+        With no arguments, restores the widget to exactly where `detach` took
+        it from. Any layout kwargs accepted by the original placement (e.g.
+        `fill`, `expand`, `anchor`, `sticky`, `margin`) override the stored
+        options. For stacked widgets, `index=` sets the position among the
+        currently attached siblings (or pass an explicit `before=`/`after=`
+        sibling); without one, the snapshotted position is used.
+
+        Calling `attach` on a widget that is already attached moves it (the
+        kwargs are re-applied). Fires `on_attach`.
+
+        Args:
+            **kwargs: Layout placement options to override for this placement.
+
+        Raises:
+            ParentResolutionError: If the widget was never placed in a layout.
+        """
+        from bootstack.widgets._core.container import (
+            PACK_KEYS, GRID_KEYS, PLACE_KEYS,
+            normalize_fill, _expand_margin, resolve_pack_order,
+        )
+
+        placement = getattr(self, "_placement", None)
+        if placement is None:
+            raise ParentResolutionError(
+                f"{type(self).__name__} was never placed in a layout; "
+                f"nothing to attach()."
+            )
+        # Re-applying to an attached widget is a move: clear it first so the
+        # placement (and any index math) starts from a clean slate.
+        if self.is_attached:
+            self.detach()
+
+        master = placement.master
+        options = dict(placement.options)
+        if kwargs:
+            if "fill" in kwargs:
+                kwargs["fill"] = normalize_fill(kwargs["fill"])
+            _expand_margin(kwargs)
+
+        if placement.method == "pack":
+            order = {k: kwargs.pop(k) for k in ("index", "before", "after") if k in kwargs}
+            options.update({k: v for k, v in kwargs.items() if k in PACK_KEYS})
+            if not order and placement.index is not None:
+                order["index"] = placement.index
+            order_kw = resolve_pack_order(order, master)
+            self._internal.pack(in_=master, **options, **order_kw)
+        elif placement.method == "grid":
+            options.update({k: v for k, v in kwargs.items() if k in GRID_KEYS})
+            self._internal.grid(in_=master, **options)
+        else:
+            options.update({k: v for k, v in kwargs.items() if k in PLACE_KEYS})
+            self._internal.place(in_=master, **options)
+        placement.options = options
+
     @overload
     def on_destroy(self) -> "Stream": ...
     @overload
@@ -212,6 +317,57 @@ class PublicWidgetBase:
             is given, otherwise a :class:`~bootstack.streams.Stream`.
         """
         return self.on("destroy", handler)
+
+    @overload
+    def on_attach(self) -> "Stream": ...
+    @overload
+    def on_attach(self, handler: Callable[[Event], Any]) -> Subscription: ...
+    def on_attach(
+        self,
+        handler: Callable[[Event], Any] | None = None,
+    ) -> "Stream | Subscription":
+        """Register a callback fired when the widget enters the layout.
+
+        Fires each time the widget becomes visible in its parent — on initial
+        placement and on every `attach`. Pair it with `on_detach` to keep
+        per-visibility resources (timers, observers) tied to the widget's
+        presence on screen. The handler receives a curated
+        :class:`~bootstack.events.Event`.
+
+        Args:
+            handler: Called when the widget is attached. Omit to get a
+                composable :class:`~bootstack.streams.Stream`.
+
+        Returns:
+            A cancellable :class:`~bootstack.events.Subscription` when a handler
+            is given, otherwise a :class:`~bootstack.streams.Stream`.
+        """
+        return self.on("attach", handler)
+
+    @overload
+    def on_detach(self) -> "Stream": ...
+    @overload
+    def on_detach(self, handler: Callable[[Event], Any]) -> Subscription: ...
+    def on_detach(
+        self,
+        handler: Callable[[Event], Any] | None = None,
+    ) -> "Stream | Subscription":
+        """Register a callback fired when the widget leaves the layout.
+
+        Fires each time the widget stops occupying space in its parent — on
+        `detach` and when an ancestor hides it. Pair it with `on_attach` to
+        release per-visibility resources. The handler receives a curated
+        :class:`~bootstack.events.Event`.
+
+        Args:
+            handler: Called when the widget is detached. Omit to get a
+                composable :class:`~bootstack.streams.Stream`.
+
+        Returns:
+            A cancellable :class:`~bootstack.events.Subscription` when a handler
+            is given, otherwise a :class:`~bootstack.streams.Stream`.
+        """
+        return self.on("detach", handler)
 
     def __repr__(self) -> str:
         try:

--- a/src/bootstack/widgets/_core/container.py
+++ b/src/bootstack/widgets/_core/container.py
@@ -7,7 +7,7 @@ PACK_KEYS = frozenset({
     "side", "fill", "expand", "anchor",
     "padx", "pady", "ipadx", "ipady",
     "margin", "margin_x", "margin_y",
-    "before", "after", "in_",
+    "index", "before", "after", "in_",
 })
 
 GRID_KEYS = frozenset({
@@ -82,6 +82,54 @@ from bootstack.widgets._core.base import PublicWidgetBase  # noqa: E402
 from bootstack.widgets._core.context import push_container, pop_container  # noqa: E402
 
 
+class Placement:
+    """Snapshot of how a widget was placed, enabling `detach`/`attach`.
+
+    Recorded on the child at layout time by `guide_layout`; consumed by
+    `PublicWidgetBase.detach`/`attach` to remove and re-insert the widget
+    without re-running its constructor. `options` holds the resolved Tk
+    geometry-manager options (no ordering refs); `index` is the pack position
+    among siblings, snapshotted afresh on each `detach`.
+    """
+
+    __slots__ = ("method", "master", "options", "index")
+
+    def __init__(
+        self,
+        method: str,
+        master: tkinter.Misc,
+        options: dict,
+        index: int | None = None,
+    ) -> None:
+        self.method = method      # "pack" | "grid" | "place"
+        self.master = master      # the Tk master the child is placed in
+        self.options = options    # resolved Tk options (no before/after/index)
+        self.index = index        # pack order among siblings (snapshot at detach)
+
+
+def resolve_pack_order(order: dict, master: tkinter.Misc) -> dict:
+    """Translate public `index`/`before`/`after` into a Tk pack-order kwarg.
+
+    Pops the ordering keys from `order` and returns the corresponding Tk
+    `pack()` kwarg dict. `index=` is the position among the master's currently
+    packed children, translated to `before=<that child>` (appended when the
+    index is past the end). Explicit `before=`/`after=` accept either a public
+    widget or a raw Tk widget. `before` wins over `after` wins over `index`.
+    """
+    index = order.pop("index", None)
+    before = order.pop("before", None)
+    after = order.pop("after", None)
+    if before is not None:
+        return {"before": getattr(before, "_internal", before)}
+    if after is not None:
+        return {"after": getattr(after, "_internal", after)}
+    if index is not None:
+        slaves = master.pack_slaves()
+        if 0 <= index < len(slaves):
+            return {"before": slaves[index]}
+    return {}
+
+
 class PublicContainer(PublicWidgetBase):
     """Base for public containers (HStack, VStack, Grid, App).
 
@@ -102,23 +150,46 @@ class PublicContainer(PublicWidgetBase):
         raise NotImplementedError
 
     def guide_layout(self, child: PublicWidgetBase, **layout_kw: Any) -> None:
-        """Place `child._internal` under this container."""
+        """Place `child._internal` under this container.
+
+        Records a `Placement` snapshot on the child so it can later be
+        `detach`-ed and `attach`-ed. When `attached=False` is passed, the
+        snapshot is recorded but the widget is NOT mapped — it starts hidden,
+        ready to be shown with `attach`.
+        """
+        attached = layout_kw.pop("attached", True)
         if "fill" in layout_kw:
             layout_kw["fill"] = normalize_fill(layout_kw["fill"])
         _expand_margin(layout_kw)
         place_mode = any(k in layout_kw for k in PLACE_TRIGGER_KEYS)
         tk_widget = child._internal
+        master = self._child_master()
 
         if place_mode:
             options = {k: v for k, v in layout_kw.items() if k in PLACE_KEYS}
-            tk_widget.place(in_=self._child_master(), **options)
+            if attached:
+                tk_widget.place(in_=master, **options)
+            child._placement = Placement("place", master, options)
             return
 
         method, options = self._merge_layout_options(child, layout_kw)
         if method == "pack":
-            tk_widget.pack(in_=self._child_master(), **options)
+            # Capture an explicit index before resolve_pack_order strips it.
+            explicit_index = options.get("index")
+            order_kw = resolve_pack_order(options, master)  # mutates options
+            if attached:
+                tk_widget.pack(in_=master, **options, **order_kw)
+                child._placement = Placement("pack", master, dict(options))
+            else:
+                # Remember the slot a later attach() should restore: an
+                # explicit index if given, else the natural append position
+                # (the count of siblings already packed at this point).
+                index = explicit_index if explicit_index is not None else len(master.pack_slaves())
+                child._placement = Placement("pack", master, dict(options), index=index)
         elif method == "grid":
-            tk_widget.grid(in_=self._child_master(), **options)
+            if attached:
+                tk_widget.grid(in_=master, **options)
+            child._placement = Placement("grid", master, dict(options))
         else:
             raise ValueError(f"Unknown layout method: {method!r}")
 

--- a/src/bootstack/widgets/_core/events.py
+++ b/src/bootstack/widgets/_core/events.py
@@ -18,6 +18,8 @@ class _Widget(_EventCategory):
     BLUR         = "blur"
     RESIZE       = "resize"
     DESTROY      = "destroy"
+    ATTACH       = "attach"
+    DETACH       = "detach"
     EXPAND       = "expand"
     COLLAPSE     = "collapse"
     ACTIVATE     = "activate"
@@ -74,6 +76,8 @@ GLOBAL_EVENT_MAP: dict[str, str] = {
     "blur":         "<FocusOut>",
     "resize":       "<Configure>",
     "destroy":      "<Destroy>",
+    "attach":       "<Map>",
+    "detach":       "<Unmap>",
     # Input
     "input":        "<KeyRelease>",
     "submit":       "<Return>",

--- a/tests/widgets/public/test_attach_detach.py
+++ b/tests/widgets/public/test_attach_detach.py
@@ -1,0 +1,344 @@
+"""Tests for the public ``detach`` / ``attach`` widget API and its events.
+
+A widget placed in a layout can be pulled out (`detach`) and put back
+(`attach`) without being destroyed, across all three geometry managers
+(pack / grid / place). `attach` round-trips the original position and accepts
+layout overrides; `on_attach` / `on_detach` fire as the widget enters and
+leaves the layout.
+
+All GUI work shares ONE module-scoped `App` — creating a second `App` in the
+same process crashes the ttk style engine.
+"""
+from __future__ import annotations
+
+import pytest
+
+import bootstack as bs
+from bootstack.errors import ParentResolutionError
+
+pytestmark = pytest.mark.gui
+
+
+@pytest.fixture(scope="module")
+def app():
+    """A single shown App shared by every test in this module."""
+    a = bs.App()
+    a._tk_root.deiconify()
+    a._tk_root.update_idletasks()
+    a._tk_root.update()
+    try:
+        yield a
+    finally:
+        try:
+            a._tk_root.destroy()
+        except Exception:
+            pass
+
+
+@pytest.fixture
+def pump(app):
+    """Flush pending Tk events so map/unmap and geometry settle."""
+    def _pump():
+        app._tk_root.update_idletasks()
+        app._tk_root.update()
+    return _pump
+
+
+def _order(container, widgets):
+    """Return the labels of `widgets` in current pack order under `container`."""
+    by_tk = {w._internal: name for name, w in widgets.items()}
+    return [by_tk[s] for s in container._internal.pack_slaves() if s in by_tk]
+
+
+# ---------------------------------------------------------------------------
+# is_attached
+# ---------------------------------------------------------------------------
+
+def test_is_attached_reflects_placement(app, pump):
+    col = bs.VStack(parent=app)
+    btn = bs.Button("X", parent=col)
+    pump()
+    assert btn.is_attached is True
+    btn.detach()
+    pump()
+    assert btn.is_attached is False
+    btn.attach()
+    pump()
+    assert btn.is_attached is True
+
+
+def test_detach_without_placement_is_noop(app):
+    # The App has no stored placement (it is a root, never placed in a parent).
+    # detach() must be a safe no-op rather than raising.
+    assert not hasattr(app, "_placement")
+    app.detach()  # no error
+    assert not hasattr(app, "_placement")
+
+
+# ---------------------------------------------------------------------------
+# pack — order round-trips
+# ---------------------------------------------------------------------------
+
+def test_pack_detach_attach_restores_order(app, pump):
+    col = bs.VStack(parent=app)
+    a = bs.Button("A", parent=col)
+    b = bs.Button("B", parent=col)
+    c = bs.Button("C", parent=col)
+    widgets = {"A": a, "B": b, "C": c}
+    pump()
+    assert _order(col, widgets) == ["A", "B", "C"]
+
+    b.detach()
+    pump()
+    assert _order(col, widgets) == ["A", "C"]
+
+    b.attach()
+    pump()
+    assert _order(col, widgets) == ["A", "B", "C"]
+
+
+def test_pack_attach_index_moves(app, pump):
+    col = bs.VStack(parent=app)
+    a = bs.Button("A", parent=col)
+    b = bs.Button("B", parent=col)
+    c = bs.Button("C", parent=col)
+    widgets = {"A": a, "B": b, "C": c}
+    pump()
+
+    a.detach()
+    a.attach(index=2)
+    pump()
+    assert _order(col, widgets) == ["B", "C", "A"]
+
+
+def test_pack_attach_before_after(app, pump):
+    col = bs.VStack(parent=app)
+    a = bs.Button("A", parent=col)
+    b = bs.Button("B", parent=col)
+    c = bs.Button("C", parent=col)
+    widgets = {"A": a, "B": b, "C": c}
+    pump()
+
+    c.detach()
+    c.attach(before=a)
+    pump()
+    assert _order(col, widgets) == ["C", "A", "B"]
+
+    c.detach()
+    c.attach(after=a)
+    pump()
+    assert _order(col, widgets) == ["A", "C", "B"]
+
+
+def test_pack_index_at_construction(app, pump):
+    col = bs.VStack(parent=app)
+    a = bs.Button("A", parent=col)
+    b = bs.Button("B", parent=col)
+    # Insert C at the front via the public index= knob.
+    c = bs.Button("C", parent=col, index=0)
+    widgets = {"A": a, "B": b, "C": c}
+    pump()
+    assert _order(col, widgets) == ["C", "A", "B"]
+
+
+def test_attach_on_attached_widget_moves(app, pump):
+    col = bs.VStack(parent=app)
+    a = bs.Button("A", parent=col)
+    b = bs.Button("B", parent=col)
+    c = bs.Button("C", parent=col)
+    widgets = {"A": a, "B": b, "C": c}
+    pump()
+
+    # Move without an explicit detach first.
+    a.attach(index=2)
+    pump()
+    assert a.is_attached is True
+    assert _order(col, widgets) == ["B", "C", "A"]
+
+
+# ---------------------------------------------------------------------------
+# pack — overrides + idempotency
+# ---------------------------------------------------------------------------
+
+def test_attach_applies_layout_override(app, pump):
+    col = bs.VStack(parent=app)
+    btn = bs.Button("X", parent=col)
+    pump()
+    btn.detach()
+    btn.attach(fill="x", expand=True)
+    pump()
+    info = btn._internal.pack_info()
+    assert info["fill"] == "x"
+    assert bool(int(info["expand"])) is True
+
+
+def test_detach_is_idempotent(app, pump):
+    col = bs.VStack(parent=app)
+    btn = bs.Button("X", parent=col)
+    pump()
+    btn.detach()
+    btn.detach()  # no error, still detached
+    pump()
+    assert btn.is_attached is False
+    btn.attach()
+    pump()
+    assert btn.is_attached is True
+
+
+def test_attach_without_placement_raises(app):
+    # The App is a container that was never placed in a parent layout.
+    with pytest.raises(ParentResolutionError):
+        app.attach()
+
+
+# ---------------------------------------------------------------------------
+# grid
+# ---------------------------------------------------------------------------
+
+def test_grid_detach_attach_restores_cell(app, pump):
+    grid = bs.Grid(parent=app, columns=2)
+    ga = bs.Button("GA", parent=grid, row=0, column=0)
+    gb = bs.Button("GB", parent=grid, row=0, column=1)
+    pump()
+    assert gb.is_attached is True
+
+    gb.detach()
+    pump()
+    assert gb.is_attached is False
+
+    gb.attach()
+    pump()
+    info = gb._internal.grid_info()
+    assert int(info["row"]) == 0
+    assert int(info["column"]) == 1
+
+
+def test_grid_attach_override(app, pump):
+    grid = bs.Grid(parent=app, columns=2)
+    gb = bs.Button("GB", parent=grid, row=0, column=0)
+    pump()
+    gb.detach()
+    gb.attach(sticky="ew")
+    pump()
+    assert gb._internal.grid_info()["sticky"] == "ew"
+
+
+# ---------------------------------------------------------------------------
+# place
+# ---------------------------------------------------------------------------
+
+def test_place_detach_attach_restores_coords(app, pump):
+    col = bs.VStack(parent=app)
+    p = bs.Button("P", parent=col, x=30, y=40)
+    pump()
+    assert p._internal.winfo_manager() == "place"
+
+    p.detach()
+    pump()
+    assert p.is_attached is False
+
+    p.attach()
+    pump()
+    info = p._internal.place_info()
+    assert int(info["x"]) == 30
+    assert int(info["y"]) == 40
+
+
+# ---------------------------------------------------------------------------
+# attached=False — start hidden
+# ---------------------------------------------------------------------------
+
+def test_attached_false_starts_detached(app, pump):
+    col = bs.VStack(parent=app)
+    btn = bs.Button("X", parent=col, attached=False)
+    pump()
+    assert btn.is_attached is False
+
+
+def test_attached_false_attaches_in_natural_slot(app, pump):
+    col = bs.VStack(parent=app)
+    a = bs.Button("A", parent=col)
+    b = bs.Button("B", parent=col, attached=False)
+    c = bs.Button("C", parent=col)
+    widgets = {"A": a, "B": b, "C": c}
+    pump()
+    assert _order(col, widgets) == ["A", "C"]
+
+    b.attach()
+    pump()
+    assert _order(col, widgets) == ["A", "B", "C"]
+
+
+def test_attached_false_grid_restores_cell(app, pump):
+    grid = bs.Grid(parent=app, columns=2)
+    gb = bs.Button("GB", parent=grid, row=0, column=1, attached=False)
+    pump()
+    assert gb.is_attached is False
+    gb.attach()
+    pump()
+    info = gb._internal.grid_info()
+    assert int(info["row"]) == 0 and int(info["column"]) == 1
+
+
+def test_attached_false_place_restores(app, pump):
+    col = bs.VStack(parent=app)
+    p = bs.Button("P", parent=col, x=10, y=20, attached=False)
+    pump()
+    assert p.is_attached is False
+    p.attach()
+    pump()
+    assert p._internal.winfo_manager() == "place"
+
+
+def test_attached_false_fires_no_spurious_events(app, pump):
+    col = bs.VStack(parent=app)
+    btn = bs.Button("X", parent=col, attached=False)
+    events: list[str] = []
+    btn.on_attach(lambda e: events.append("attach"))
+    btn.on_detach(lambda e: events.append("detach"))
+    pump()
+    assert events == []  # nothing fires while it sits detached
+    btn.attach()
+    pump()
+    assert events == ["attach"]
+
+
+# ---------------------------------------------------------------------------
+# events
+# ---------------------------------------------------------------------------
+
+def test_on_attach_on_detach_fire(app, pump):
+    col = bs.VStack(parent=app)
+    btn = bs.Button("X", parent=col)
+    pump()
+
+    events: list[str] = []
+    btn.on_attach(lambda e: events.append("attach"))
+    btn.on_detach(lambda e: events.append("detach"))
+
+    btn.detach()
+    pump()
+    btn.attach()
+    pump()
+
+    assert events == ["detach", "attach"]
+
+
+def test_on_detach_returns_subscription(app, pump):
+    col = bs.VStack(parent=app)
+    btn = bs.Button("X", parent=col)
+    pump()
+
+    events: list[str] = []
+    sub = btn.on_detach(lambda e: events.append("detach"))
+
+    btn.detach()
+    pump()
+    assert events == ["detach"]
+
+    sub.cancel()
+    btn.attach()
+    pump()
+    btn.detach()
+    pump()
+    assert events == ["detach"], "cancelled subscription must not fire again"


### PR DESCRIPTION
## Summary

Gives every widget a public **`detach()` / `attach()`** pair so a placed widget can be pulled out of its layout and put back **without being destroyed**, across all three geometry managers (pack / grid / place). Revives the deferred `<Map>` / `<Unmap>` lifecycle as **`on_attach` / `on_detach`** — the names are now earned by a real control pair.

## API

- **`detach()`** — removes the widget (`pack_forget` / `grid_forget` / `place_forget`) while keeping its state, children, and bindings. No-op if already detached or never placed.
- **`attach(**kwargs)`** — puts it back. No args restores the exact prior position; layout kwargs (`fill`, `sticky`, `index=`, `before=` / `after=`, …) override. Re-attaching an attached widget moves it.
- **`is_attached`** — property backed by `winfo_manager()` (single source of truth, no flag to drift).
- **`on_attach` / `on_detach`** — events wired to `<Map>` / `<Unmap>`; propagate through ancestors (detaching a container fires them on nested children).
- **`attached=False`** constructor arg — build a widget hidden *in place*: records the placement but skips mapping (no flicker, no spurious events); a later `attach()` lands it in its declared slot.

## Notable mechanics

- `guide_layout` now records a `Placement(method, master, options, index)` snapshot on each child so detach/attach reconstruct without re-running the constructor.
- **pack ordering:** `pack_forget` loses order, so `detach()` snapshots the index among *currently-attached* siblings and `attach()` translates it to `before=slaves[index]`. New public **`index=`** pack knob (also at construction); `before=` / `after=` accept public widget refs.
- **grid:** uses `grid_forget` + full reconstruct from stored cell options — `grid_remove`'s "remembered" state rejects an explicit re-`grid`.

## Tests / docs

- `tests/widgets/public/test_attach_detach.py` — 20 cases (pack/grid/place round-trips, index/before/after, overrides, idempotency, `attached=False`, events, subscription cancel). All pass.
- New **"Detaching and reattaching"** section in `docs/reference/events.rst`; clean `-W` docs build.
- No regressions in existing base-layer / selection tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
