### PR TITLE
feat: public Image/Icon API, AppIcon, field signals, and bootstack.toml cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,11 +16,39 @@ Go from nothing to something fast. The user should never need to `import tkinter
 
 ---
 
-## Recently completed (all merged to `main`)
+## Recently completed (merged to `main` unless noted)
 
 Pointers only — these shipped; rationale, detail, and gotchas live in the linked
 memories and git history.
 
+- **Public Image/Icon API + AppIcon + field signals + toml cleanup** (branch
+  **`feat/image-icon-api`** — **committed, NOT yet PR'd/merged**; reviewed) — new public
+  **`bootstack.images`**: a toolkit-free **`Image`** handle (`open`/`from_bytes`/`from_pil`,
+  lazy materialize, theme-following), **`get_icon`/`list_icons`**, and **`AppIcon`** (a
+  glyph on a rounded tile) that **`App`/`Window` accept as `icon=`** and that exports
+  **`.ico`/`.icns`/`.png`** via `save()` for packaging. Live **`icon`/`image` property
+  setters** on Label/Button/MenuButton/SelectButton; the icon **spec** `{name,size,color}`
+  is public via `bootstack.types` (**`Icon`/`IconSpec`**, color resolves theme tokens).
+  **AppIcon render** is the hard-won part: size-aware `shape="auto"` (glyph-only at small
+  title-bar sizes, **tile** from taskbar size up), **integer-ratio tile supersampling**,
+  glyph drawn at **native display size + pixel-aligned** (`_render_icon(align=)`),
+  size-dependent padding, and **DPI-matched sizes baked into the `.ico`** (the small-size
+  crispness fix — true per-size sharpness still needs hand-drawn grid-aligned art).
+  Ships the **`bootstack appicon`** GUI designer and **`[build.icon]`** glyph generation.
+  Also: **`Window(parent=)`** + anchored **`Window.show(anchor_to=, anchor_point=, …)`**;
+  **reveal-after-settle** window show (no open-time shift); **typed `signal=`** on
+  Number/Date/Time fields (binds the parsed value, not text; committed separately);
+  **`bootstack.toml` scoped to a build/scaffold manifest** (runtime **`[settings]`**
+  removed — runtime config is `App()` kwargs + `Store`); framework lifecycle fixes
+  (scheduler descendant-destroy guard, grid prune-on-destroy, clipboard helpers); public
+  **file-dialog verbs** (`ask_save_file`/`ask_open_file`/`ask_open_files`/`ask_directory`).
+  Docs: `reference/images` guide, `api-reference/images`, the **Application Icons** how-to
+  (`tasks/application-icons` — runtime-vs-build-icon distinction + glyph/color tips). A
+  **pre-commit review (5 agents)** found+fixed 2 HIGH (field-Signal leak; Signal type-
+  mismatch crash) + 2 MEDIUM (image-clear theme-binding leak; `show()` alpha-not-in-finally)
+  + nits. Memories `project_image_icon_public_api`, `project_field_value_signal_dtype`,
+  `project_app_settings_flattening`. **REMAINING:** open a PR; follow-up `Picture`
+  display widget (animated GIF / splash) is a separate branch.
 - **Menu bar + command bar** (PR #124, merged) — cross-platform **`app.menubar`**
   (also `window.menubar` / `shell.menubar`): a single-layer menu model with two
   renderers — a themed in-window strip on **Win/Linux** and the **native global menu

--- a/docs/_dev/field-value-dtype.md
+++ b/docs/_dev/field-value-dtype.md
@@ -1,0 +1,79 @@
+# Field value model — a `dtype`/codec on the base field (follow-up initiative)
+
+**Status:** designed 2026-06-12, NOT started. Grew out of the image-icon branch
+(`feat/image-icon-api`) while wiring `NumberField(signal=...)`.
+
+## Motivation
+
+Two value-plumbing bugs surfaced in `NumberField` in one session, both fixed
+surgically:
+
+1. **`.value` returned a string** after a programmatic set (the internal stored
+   the value as text when no `value_format` was set). Fixed by coercing in the
+   public getter (`numberfield.py` `_as_number`).
+2. **Stepping accumulated float error** (`0.05 + 0.05 + … → 0.15000000000000002`).
+   Fixed by quantizing to the increment's decimal precision in
+   `numberentry_part.py` `step()` / `_increment_decimals()`.
+
+Both are the same root problem: **no single owner of "this field holds a `float`
+with step `0.05`."** Set / get / parse / format / step each independently
+re-derive the type and precision, and drift apart — so bugs leak out one
+operation at a time and get patched one at a time. The same fragility lives in
+`DateField`/`TimeField` (date/time parse+format) and any future typed field.
+
+## Proposal
+
+Give the base field a small **codec** keyed off a `dtype`:
+
+```
+dtype = {
+    type:    the Python type of .value (int|float|date|time|str|...)
+    parse:   text  -> value      (raises on invalid)
+    format:  value -> text       (display)
+    quantum: optional step/precision for numeric snapping
+}
+```
+
+The base `Field` owns value↔text using the codec, so:
+
+- `.value` returns the correct type **by construction** (retire `_as_number`).
+- stepping quantizes via `quantum` (retire the ad-hoc `_increment_decimals`).
+- the bound `signal` is typed off the dtype.
+- a new typed field = "declare a dtype," not "re-implement value handling."
+
+Typed subclasses become thin configs: `NumberField` → numeric codec
+(int/float + step), `DateField` → date codec (+ format), `TimeField` → time
+codec, `TextField` → identity (str). `Select` already carries its own value
+map — fold it in or leave it.
+
+## Already shipped on `feat/image-icon-api` (the near-term half)
+
+- **`ValueSignalMixin`** (`widgets/_core/field_mixin.py`): generic, type-agnostic
+  two-way `value ↔ signal` binding (seed, signal→field, field→signal on
+  `on_change`, loop guard) + a `signal` property returning the value signal.
+- **`signal=`** added to `NumberField`, `DateField`, `TimeField` (binding the
+  TYPED value — number/date/time, not text). `Select` already had `signal=`.
+- The two surgical bug fixes above, with regression tests in
+  `tests/widgets/public/test_field_text_value.py`.
+
+So value↔signal **consistency** is done; the codec is the remaining
+**architecture** investment (prevents future drift; retires the two patches).
+
+## Scope / files (when built)
+
+- `widgets/_impl/composites/field.py` (base `Field`) + `_parts/*entry_part.py`
+  (numeric/date/time/text parts) — relocate parse/format/quantize onto the codec.
+- `widgets/numberfield.py`, `datefield.py`, `timefield.py`, `textfield.py` —
+  declare their dtype; drop per-field value coercion.
+- Public contract unchanged (`.value` returns the same types) → can migrate one
+  field at a time behind tests, no big-bang break.
+
+## Open questions
+
+- Is `dtype` a **public** knob (a generic `Field(dtype=...)`) or purely an
+  internal base mechanism the typed subclasses configure? (Lean internal-first.)
+- Naming: `dtype` vs `value_type` vs a `Codec`/`Converter` object.
+- How `value_format` (display format string) relates to the codec's `format`
+  (the codec should own it; `value_format` becomes a codec parameter).
+- Range-mode `DateField` (`value` is a `tuple[date, date]`) — the codec/signal
+  binding currently assumes scalar; decide tuple handling.

--- a/docs/api-reference/dialogs.rst
+++ b/docs/api-reference/dialogs.rst
@@ -24,11 +24,15 @@ blocks until dismissed, and returns the user's choice (or ``None`` on cancel).
    bootstack.ask_color
    bootstack.ask_date
    bootstack.ask_date_range
+   bootstack.ask_directory
    bootstack.ask_filter
    bootstack.ask_float
    bootstack.ask_font
    bootstack.ask_integer
    bootstack.ask_item
+   bootstack.ask_open_file
+   bootstack.ask_open_files
+   bootstack.ask_save_file
    bootstack.ask_string
    bootstack.confirm
    bootstack.toast

--- a/docs/api-reference/images.rst
+++ b/docs/api-reference/images.rst
@@ -1,0 +1,22 @@
+Images
+======
+
+.. currentmodule:: bootstack.images
+
+Toolkit-free image handles and icons. An ``Image`` holds artwork or a deferred
+icon and is rendered only when bound to a widget; ``get_icon`` builds a
+theme-aware icon from a Bootstrap Icons name; ``AppIcon`` generates an
+application icon for ``App`` or ``Window``.
+
+For a task-oriented introduction — displaying artwork, theming icons, and
+generating app icons (including for PyInstaller builds) — see the
+:doc:`/reference/images` guide.
+
+.. autosummary::
+   :toctree: generated
+   :nosignatures:
+
+   Image
+   get_icon
+   list_icons
+   AppIcon

--- a/docs/api-reference/index.rst
+++ b/docs/api-reference/index.rst
@@ -19,6 +19,7 @@ The following submodules are also public; import the names you need from each
 - ``bootstack.events`` — Event objects and the typed payloads ``on_*`` handlers
   receive.
 - ``bootstack.streams`` — Composable event pipelines — debounce, filter, map.
+- ``bootstack.images`` — Image handles, themed icons, and application icons.
 - ``bootstack.style`` — Color themes, runtime theme switching, and fonts.
 - ``bootstack.validation`` — Rules that validate what a user enters.
 - ``bootstack.i18n`` — Translatable text and locale-aware formatting.
@@ -101,6 +102,12 @@ Appearance and locale
 .. grid:: 1 2 2 2
    :gutter: 3
 
+   .. grid-item-card:: Images
+      :link: images
+      :link-type: doc
+
+      Image handles, theme-aware icons, and generated application icons.
+
    .. grid-item-card:: Theming
       :link: theming
       :link-type: doc
@@ -160,6 +167,7 @@ Services and reference
    dialogs
    data
    validation
+   images
    theming
    i18n
    scheduling

--- a/docs/api-reference/types.rst
+++ b/docs/api-reference/types.rst
@@ -152,6 +152,11 @@ Literals for selection behavior and tabular data export.
    `(text, value)` tuple, or an `OptionDict`. Lets an option's displayed label
    differ from its stored value.
 
+.. py:type:: Icon
+
+   An icon as either a Bootstrap Icons name (`'bell-fill'`) or an `IconSpec`
+   mapping for control over size and color.
+
 .. py:type:: SelectionMode
 
    How many rows or items can be selected — `'none'`, `'single'`, or `'multi'`.
@@ -176,6 +181,9 @@ that ``DataTable`` and ``Form`` accept.
    `'spinnerfield'`, `'switch'`, `'checkbox'`, `'slider'`.
 
 .. autoclass:: FormOptions
+   :members:
+
+.. autoclass:: IconSpec
    :members:
 
 .. autoclass:: OptionDict

--- a/docs/examples/appicon.py
+++ b/docs/examples/appicon.py
@@ -1,0 +1,28 @@
+import bootstack as bs
+from bootstack.images import AppIcon
+
+# An AppIcon is a glyph on a rounded, colored tile. Pass it as `icon=` to give a
+# window its title-bar / taskbar icon — no .ico file needed. Colors accept theme
+# tokens ("primary", "info", ...) or hex strings.
+launcher_icon = AppIcon("rocket", background="primary")
+
+with bs.App(title="Launcher", size=(420, 340), icon=launcher_icon, padding=24, gap=12) as app:
+
+    # Show the same icon inside the app (e.g. a header / about panel).
+    bs.Label(image=launcher_icon.to_image(96, tiled=True))
+    bs.Label("Launcher", font="heading-lg")
+    bs.Label("Ready for liftoff.", accent="secondary")
+
+    def open_about():
+        about_icon = AppIcon("info-circle", background="info")
+        # A secondary Window carries its own AppIcon and opens over the app.
+        with bs.Window(title="About", size=(300, 220), parent=app,
+                       icon=about_icon, padding=20, gap=8) as win:
+            bs.Label(image=about_icon.to_image(64, tiled=True))
+            bs.Label("About Launcher", font="heading-md")
+            bs.Label("A tiny demo.", accent="secondary")
+        win.show(anchor_to=app, anchor_point="center", window_point="center")
+
+    bs.Button("About…", accent="primary", on_click=open_about)
+
+app.run()

--- a/docs/reference/images.rst
+++ b/docs/reference/images.rst
@@ -1,0 +1,118 @@
+Images and icons
+================
+
+The :mod:`bootstack.images` module is the framework-native way to show pictures
+and icons. Everything starts with an :class:`Image <bootstack.images.Image>` — a
+lightweight handle that carries image data (or a deferred icon) and is only
+rendered when you hand it to a widget. You can build one before an application
+exists and share it across widgets.
+
+.. currentmodule:: bootstack.images
+
+Displaying artwork
+------------------
+
+Build an :class:`Image` from a file, raw bytes, or an in-memory Pillow image,
+then pass it to any widget that accepts ``image=`` — such as
+:class:`~bootstack.Label` or :class:`~bootstack.Button`::
+
+    import bootstack as bs
+    from bootstack.images import Image
+
+    with bs.App() as app:
+        logo = Image.open("assets/logo.png")
+        bs.Label(image=logo)
+        bs.Label("Profile", image=Image.open("avatar.png"), icon_position="left")
+    app.run()
+
+File and byte sources accept the common raster image formats — **PNG**, **JPEG**,
+**GIF**, **BMP**, **TIFF**, **WebP**, and **ICO**. (Animated formats load their
+first frame; an animated-image widget is a separate feature.)
+
+A handle reports its size without rendering anything::
+
+    logo = Image.open("assets/logo.png")
+    print(logo.width, logo.height)
+
+Theme-aware icons
+-----------------
+
+:func:`get_icon` creates an icon from a `Bootstrap Icons
+<https://icons.getbootstrap.com>`_ name. Give it a theme color token and the
+icon re-renders automatically when the theme changes; give it a hex string and
+it stays fixed::
+
+    from bootstack.images import get_icon
+
+    # Follows the theme — re-colors on light/dark switch.
+    bs.Button("Save", image=get_icon("save", color="primary"))
+
+    # Fixed color, regardless of theme.
+    bs.Label(image=get_icon("star-fill", size=24, color="#ffc107"))
+
+``color`` accepts any theme color token (such as ``'foreground'``, ``'primary'``,
+or ``'danger'``) or a ``#hex`` value; it defaults to ``'foreground'``, the
+standard text color. For a single decorative icon beside text, the widget's own
+``icon=`` parameter is simpler — reach for :func:`get_icon` when you want an
+:class:`Image` handle you can reuse or recolor explicitly.
+
+Use :func:`list_icons` to discover the available names — for example to build a
+picker or validate input::
+
+    from bootstack.images import list_icons
+
+    all_names = list_icons()
+    arrows = list_icons(contains="arrow")
+
+Application icons
+-----------------
+
+:class:`AppIcon` renders a Bootstrap glyph as an application icon — no icon file
+required::
+
+    from bootstack.images import AppIcon
+
+    with bs.App(icon=AppIcon("rocket", background="primary")) as app:
+        bs.Label("Ready for launch")
+    app.run()
+
+``App`` and ``Window`` both accept ``icon=`` as an icon file path, an
+:class:`Image`, or an :class:`AppIcon`.
+
+An app icon renders in one of two shapes:
+
+- a **tile** — the glyph in ``foreground`` on a filled, rounded ``background``
+  (the macOS look); or
+- **glyph-only** — the glyph alone in the ``background`` (brand) color on a
+  transparent field (the typical Windows and Linux look).
+
+By default (``shape="auto"``) the shape follows the platform and the size — a
+tile on macOS, and on Windows and Linux glyph-only at the small title-bar sizes
+with a tile at taskbar sizes and up — so ``AppIcon("rocket", background="primary")``
+looks right everywhere. Pass ``shape="tile"`` or ``shape="glyph"`` to force one.
+
+The runtime ``icon=`` shown here and the **separate** icon embedded in a packaged
+build are covered end to end — along with how to pick a glyph and colors that
+make a good icon, and the designer (``bootstack appicon``) — in
+:doc:`/tasks/application-icons`.
+
+See also
+--------
+
+- :doc:`/reference/theming` — color themes and the tokens icons follow.
+- :doc:`/widgets/button` and :doc:`/widgets/label` — the widgets that take
+  ``image=``.
+
+API reference
+-------------
+
+The complete reference for :mod:`bootstack.images` lives in
+:doc:`/api-reference/images`. At a glance:
+
+.. autosummary::
+   :nosignatures:
+
+   Image
+   get_icon
+   list_icons
+   AppIcon

--- a/docs/tasks/application-icons.rst
+++ b/docs/tasks/application-icons.rst
@@ -1,0 +1,196 @@
+Application Icons
+=================
+
+An application icon identifies your app wherever the operating system shows it:
+the title bar, the taskbar, the task switcher, and — once you package the app —
+the file manager, the Start menu or Dock, and pinned shortcuts. bootstack lets
+you set it from a single Bootstrap glyph, with no image editor required.
+
+There are **two** icons to think about, for two different moments in your app's
+life, and they are set independently.
+
+Two icons, two moments
+----------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 18 41 41
+
+   * -
+     - Runtime icon
+     - Distribution icon
+   * - Set with
+     - ``App(icon=...)`` / ``Window(icon=...)`` in your code
+     - ``[build.icon]`` in ``bootstack.toml`` (embedded by the packager)
+   * - Appears on
+     - The title bar and taskbar button of the *running* window
+     - The packaged file in Explorer, the Start-menu / Dock entry, a pinned
+       shortcut, and the taskbar button *before* your window paints its own icon
+   * - Form
+     - Generated on the fly — no file to manage
+     - A real icon **file** embedded in the executable at build time
+   * - Colors
+     - Theme tokens *or* hex (a theme is active, so tokens resolve)
+     - **Hex only** — no app runs during a build to resolve a token
+
+Setting one does not set the other. For a consistent look everywhere, give both
+the **same artwork** — the simplest way is to build it once and point both at it.
+
+The runtime icon
+----------------
+
+:class:`~bootstack.images.AppIcon` renders a `Bootstrap Icons
+<https://icons.getbootstrap.com>`_ glyph into an application icon with no file
+required. Pass it as the ``icon=`` of an :class:`~bootstack.App` or
+:class:`~bootstack.Window`:
+
+.. code-block:: python
+
+   import bootstack as bs
+   from bootstack.images import AppIcon
+
+   launcher = AppIcon("rocket", background="primary", foreground="white")
+
+   with bs.App(title="Launcher", icon=launcher) as app:
+       bs.Label("Ready for liftoff.")
+   app.run()
+
+``icon=`` also accepts a path to an existing icon file or an
+:class:`~bootstack.images.Image`. Colors may be theme color tokens (such as
+``"primary"``) or hex strings; a token is resolved once, when the icon is
+generated, so the icon does not follow later theme changes.
+
+Shape, and how it adapts to size
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+An app icon takes one of two shapes:
+
+- a **tile** — the glyph in ``foreground`` on a filled, rounded ``background``
+  (the macOS look); or
+- **glyph-only** — the glyph alone in the ``background`` (brand) color on a
+  transparent field (the classic Windows and Linux look).
+
+With the default ``shape="auto"``, bootstack chooses per platform *and* per
+size. macOS icons are always a tile. On Windows and Linux, a single
+multi-resolution icon is **glyph-only at the small title-bar sizes** — a bare
+mark reads more clearly when there are only a handful of pixels — and a **tile
+from taskbar size up**, so it stands out as a branded mark among the other
+taskbar icons. Pass ``shape="tile"`` or ``shape="glyph"`` to force one shape at
+every size. ``radius`` sets the tile's corner rounding, from ``0.0`` (square) to
+``0.5`` (a circle).
+
+Designing it visually
+~~~~~~~~~~~~~~~~~~~~~~~
+
+To experiment without editing code, run the designer:
+
+.. code-block:: console
+
+   $ bootstack appicon
+
+Pick a glyph, choose the background and foreground colors and a corner radius,
+and preview the result live at every size. When it looks right, export an icon
+file or copy a ready-to-paste ``[build.icon]`` snippet for ``bootstack.toml``.
+
+The distribution icon
+---------------------
+
+A packaged executable embeds its icon at build time, so it needs a real file on
+disk. There are two ways to provide one.
+
+**Export a file and point at it.** Render your :class:`~bootstack.images.AppIcon`
+to a file once with :meth:`~bootstack.images.AppIcon.save`. The format follows
+the extension — ``.ico`` (Windows, multi-resolution), ``.icns`` (macOS), or
+``.png`` (a single 256-pixel image):
+
+.. code-block:: python
+
+   from bootstack.images import AppIcon
+
+   AppIcon("rocket", background="#0d6efd", foreground="#ffffff").save("assets/app.ico")
+
+.. code-block:: toml
+
+   [build.icon]
+   path = "assets/app.ico"
+
+**Or describe the glyph and let the build render it** — handy when you do not
+want to keep a generated file in version control:
+
+.. code-block:: toml
+
+   [build.icon]
+   glyph = "rocket"
+   background = "#0d6efd"
+   foreground = "#ffffff"
+   radius = 0.22
+   shape = "auto"
+
+.. note::
+
+   Build-time colors must be **hex values**. Theme color tokens (like
+   ``"primary"``) are resolved against the active theme, which exists only while
+   an application is running — not during a build.
+
+If you set neither ``path`` nor ``glyph``, the build falls back to the bundled
+bootstack icon.
+
+.. tip::
+
+   Keep the two icons in sync. Either export once and point both ``App(icon=)``
+   and ``[build.icon] path`` at the same file, or use the same glyph and hex
+   colors in both places.
+
+Choosing a glyph and colors
+---------------------------
+
+A generated icon is only as good as the glyph and colors you give it. Not every
+glyph or color makes a good app icon — these rules of thumb keep it legible:
+
+- **Pick a simple, bold silhouette.** An app icon is recognized by its shape at
+  a glance, often at 16–24 px. Filled glyphs — the ``-fill`` variants such as
+  ``heart-fill`` or ``lightning-charge-fill`` — hold up far better than thin
+  line glyphs, whose strokes break up when small. Avoid busy or detailed glyphs;
+  they turn to mush at small sizes. Browse names with ``bootstack icons`` or
+  :func:`~bootstack.images.list_icons`.
+- **One idea, centered.** A single clear symbol reads; two marks compete.
+- **Maximize contrast.** The glyph must stand out from its background. On a tile
+  you control both colors, so contrast is easy — a white or near-white glyph on
+  a saturated brand background is a safe default. Glyph-only has no background of
+  its own, so the brand color has to read against **both** light and dark title
+  bars (an icon file cannot follow the system theme); avoid mid-tones that
+  disappear against one or the other.
+- **Give the brand color some weight.** Saturated, mid-to-dark colors make a
+  confident taskbar mark; very pale colors wash out against light window chrome.
+
+The limits of a generated icon
+------------------------------
+
+A generated icon is drawn from a *single* vector glyph and scaled to every size
+your app needs. bootstack works hard to keep that crisp: it chooses the shape
+per size, supersamples at whole-number ratios, snaps the glyph to the pixel
+grid, and bakes the exact DPI sizes the system asks for into the ``.ico``. The
+result is sharp across the sizes most apps use.
+
+There is, however, a ceiling. A single drawing scaled *down* can never be quite
+as crisp at the very smallest sizes (16–24 px) as artwork drawn **for** that
+size. Truly pixel-perfect small icons need a **custom bitmap per size**, with
+every edge placed on the pixel grid so nothing lands on a half-pixel and softens
+under antialiasing. That is exactly how bootstack's own built-in icon was made —
+each small size hand-aligned to the grid.
+
+In practice:
+
+- For most apps, prototypes, and internal tools, a generated
+  :class:`~bootstack.images.AppIcon` is an excellent, zero-effort icon. Ship it.
+- For a polished product where the 16/24 px icon must be razor-sharp, treat the
+  generated icon as your starting point and have a designer draw a per-size,
+  grid-aligned ``.ico``. Point ``[build.icon] path`` at that hand-made file (and
+  pass the same file to ``App(icon=)`` if you want it at runtime too).
+
+See also
+--------
+
+- :doc:`/reference/images` — the images and icons module in full, including
+  displaying artwork and theme-aware :func:`~bootstack.images.get_icon`.
+- :doc:`/reference/theming` — the color tokens an icon's colors can name.

--- a/docs/user-guide/index.rst
+++ b/docs/user-guide/index.rst
@@ -26,6 +26,7 @@ see :doc:`/widgets/index`.
    /tasks/dialogs
    /tasks/navigation
    /tasks/layout
+   /tasks/application-icons
 
 .. toctree::
    :caption: Topics
@@ -33,6 +34,7 @@ see :doc:`/widgets/index`.
 
    /reference/theming
    /reference/typography
+   /reference/images
    /reference/localization
    /reference/signals
    /reference/events

--- a/src/bootstack/__init__.py
+++ b/src/bootstack/__init__.py
@@ -22,6 +22,7 @@ submodules — for example::
     from bootstack.validation import ValidationRule
     from bootstack.style import Theme, get_theme_color
     from bootstack.events import Event, Subscription
+    from bootstack.images import Image, get_icon, AppIcon
     from bootstack.types import AccentToken
 
 See the "API overview" in the documentation for the full map.
@@ -50,6 +51,7 @@ from bootstack.dialogs import (
     alert, confirm, ask_string, ask_integer, ask_float,
     ask_date, ask_date_range, ask_item,
     ask_color, ask_font, ask_filter,
+    ask_save_file, ask_open_file, ask_open_files, ask_directory,
 )
 
 # ── Application & windows ─────────────────────────────────────────────────────
@@ -121,6 +123,7 @@ __all__ = [
     # Dialog verbs
     "alert", "confirm", "ask_string", "ask_integer", "ask_float", "ask_date",
     "ask_date_range", "ask_item", "ask_color", "ask_font", "ask_filter",
+    "ask_save_file", "ask_open_file", "ask_open_files", "ask_directory",
     # Application & windows
     "App", "AppShell", "Window",
     # Layout

--- a/src/bootstack/_core/images.py
+++ b/src/bootstack/_core/images.py
@@ -4,31 +4,34 @@ This module provides a unified image service for loading, caching, and managing
 Tk-compatible PhotoImage objects. It uses Pillow as the backend to support a wide
 variety of image formats beyond what Tk natively supports.
 
-The primary interface is the `Image` class, which provides class methods for
-loading images from various sources while automatically caching them to avoid
+The primary interface is the `_ImageService` class, which provides class methods
+for loading images from various sources while automatically caching them to avoid
 repeated decoding and to prevent garbage collection issues with Tk images.
+
+This is the internal render/cache backend. The public, Tk-free image handle that
+delegates to it lives in `bootstack.images` (`Image`/`get_icon`/`AppIcon`).
 
 Examples:
     Basic usage with file paths:
 
     ```python
-    from bootstack._core.images import Image
+    from bootstack._core.images import _ImageService
 
     # Load an image from disk (cached automatically)
-    photo = Image.open("icons/save.png")
+    photo = _ImageService.open("icons/save.png")
     button = Button(app, image=photo)
     ```
 
     Loading from bytes (e.g., embedded resources):
 
     ```python
-    photo = Image.from_bytes(icon_data)
+    photo = _ImageService.from_bytes(icon_data)
     ```
 
     Creating transparent spacer images:
 
     ```python
-    spacer = Image.transparent(16, 16)
+    spacer = _ImageService.transparent(16, 16)
     ```
 """
 
@@ -60,7 +63,7 @@ class ImageCacheInfo:
     items: int
 
 
-class Image:
+class _ImageService:
     """Platform image service for loading and caching PhotoImage objects.
 
     This class provides a centralized service for working with images in
@@ -76,17 +79,17 @@ class Image:
     Examples:
         ```python
             # From a file path
-            icon = Image.open("path/to/icon.png")
+            icon = _ImageService.open("path/to/icon.png")
 
             # From raw bytes
-            icon = Image.from_bytes(embedded_data)
+            icon = _ImageService.from_bytes(embedded_data)
 
             # From a PIL Image object
             pil_img = PILImage.open("photo.jpg").resize((100, 100))
-            icon = Image.from_pil(pil_img)
+            icon = _ImageService.from_pil(pil_img)
 
             # Create a transparent spacer
-            spacer = Image.transparent(32, 32)
+            spacer = _ImageService.transparent(32, 32)
         ```
 
     Note:
@@ -148,7 +151,7 @@ class Image:
             An ImageCacheInfo object containing cache statistics.
 
         Examples:
-            >>> info = Image.cache_info()
+            >>> info = _ImageService.cache_info()
             >>> print(f"Cached images: {info.items}")
         """
         return ImageCacheInfo(items=len(cls._cache))
@@ -174,11 +177,11 @@ class Image:
             A Tk-compatible PhotoImage that can be used with widgets.
 
         Examples:
-            >>> photo = Image.open("assets/logo.png")
+            >>> photo = _ImageService.open("assets/logo.png")
             >>> label = Label(app, image=photo)
 
             >>> # With custom cache key for versioning
-            >>> photo = Image.open("icon.png", key=("icon", "v2"))
+            >>> photo = _ImageService.open("icon.png", key=("icon", "v2"))
         """
         p = Path(path).expanduser().resolve()
         cache_key = key if key is not None else ("file", str(p))
@@ -200,9 +203,9 @@ class Image:
 
         Args:
             image: A PIL Image object to convert.
-            key: Optional custom cache key. If not provided, the object id
-                of the PIL Image is used (note: this means the same PIL Image
-                object will be cached, but copies won't hit the cache).
+            key: Optional custom cache key. If not provided, a key derived from
+                the image's content is used, so equal images share a photo and a
+                new image can never collide with a freed one's cached photo.
 
         Returns:
             A Tk-compatible PhotoImage that can be used with widgets.
@@ -211,9 +214,23 @@ class Image:
             >>> from PIL import Image as PILImage
             >>> pil_img = PILImage.open("photo.jpg")
             >>> pil_img = pil_img.resize((100, 100))
-            >>> photo = Image.from_pil(pil_img)
+            >>> photo = _ImageService.from_pil(pil_img)
         """
-        cache_key = key if key is not None else ("pil", id(image))
+        if key is not None:
+            cache_key: Hashable = key
+        else:
+            # Content-based key. id(image) is NOT safe: PIL images are short-lived
+            # (e.g. a freshly rendered icon), and once garbage-collected their id
+            # can be reused by a different image — which would then be served the
+            # previous image's cached photo (a stale/duplicated picture).
+            try:
+                cache_key = (
+                    "pil", image.mode, image.size,
+                    hashlib.md5(image.tobytes()).hexdigest(),
+                )
+            except Exception:
+                # Content not byte-serializable — render fresh, uncached.
+                return PILPhotoImage(image=image)
         cached = cls.get_cached(cache_key)
         if cached is not None:
             return cached
@@ -242,10 +259,10 @@ class Image:
             >>> # Load from embedded resource
             >>> with open("icon.png", "rb") as f:
             ...     icon_data = f.read()
-            >>> photo = Image.from_bytes(icon_data)
+            >>> photo = _ImageService.from_bytes(icon_data)
 
             >>> # With custom cache key
-            >>> photo = Image.from_bytes(data, key="my-icon")
+            >>> photo = _ImageService.from_bytes(data, key="my-icon")
         """
         digest = hashlib.md5(data).hexdigest()
         cache_key = key if key is not None else ("bytes", digest)
@@ -276,7 +293,7 @@ class Image:
 
         Examples:
             >>> # Create a 16x16 transparent spacer
-            >>> spacer = Image.transparent(16, 16)
+            >>> spacer = _ImageService.transparent(16, 16)
             >>> label = Label(app, image=spacer)
 
             >>> # Use as compound image padding
@@ -354,7 +371,20 @@ class Image:
         return cls.set_cached(key, photo)
 
     @classmethod
-    def _render_icon(cls, name: str, size: int, color: str) -> PILImage.Image:
+    def _render_icon(
+        cls, name: str, size: int, color: str, *, align: bool = False
+    ) -> PILImage.Image:
+        """Render a named glyph to an RGBA image of `size` x `size`.
+
+        Args:
+            name: Bootstrap Icons glyph name.
+            size: Output edge length in pixels.
+            color: Fill color (hex).
+            align: Snap the glyph's draw origin to the final pixel grid. Crisper
+                for standalone marks (e.g. app icons) where the glyph fills the
+                frame; off by default so glyphs sitting beside text keep their
+                exact optical centering.
+        """
         _, glyphmap = cls._load_icon_assets()
         glyph = glyphmap.get(name)
         if glyph is None:
@@ -366,6 +396,14 @@ class Image:
             oversample = 2
         else:
             oversample = 1
+
+        def _snap(dx: float, dy: float) -> tuple[float, float]:
+            # Round the draw origin to a multiple of `oversample` so that after
+            # the downscale the glyph lands on whole pixels — its edges stay crisp
+            # instead of being antialiased across a sub-pixel offset.
+            if not align:
+                return dx, dy
+            return round(dx / oversample) * oversample, round(dy / oversample) * oversample
 
         canvas_size = size * oversample
         pad = int(canvas_size * _ICON_PAD_FACTOR)
@@ -388,6 +426,7 @@ class Image:
             dy = (canvas_size - ink_h) / 2 - nt * font_size
             if _ICON_Y_BIAS:
                 dy += canvas_size * _ICON_Y_BIAS
+            dx, dy = _snap(dx, dy)
             draw.text((dx, dy), glyph, font=font, fill=color)
         else:
             # Fallback for glyphs absent from icon_metrics.json: measure with
@@ -414,6 +453,7 @@ class Image:
             dy = pad + (inner - full_height) // 2 + (ascent - bbox[3])
             if _ICON_Y_BIAS:
                 dy += int(canvas_size * _ICON_Y_BIAS)
+            dx, dy = _snap(dx, dy)
             draw.text((dx, dy), glyph, font=font, fill=color)
 
         if oversample > 1:

--- a/src/bootstack/_runtime/app.py
+++ b/src/bootstack/_runtime/app.py
@@ -393,7 +393,7 @@ class App(BaseWindow, WidgetCapabilitiesMixin, tkinter.Tk):
             title: str | None = None,
             *,
             theme: str | None = None,
-            icon: tkinter.PhotoImage | None = None,
+            icon: tkinter.PhotoImage | str | None = None,
 
             # theme
             light_theme: str = "bootstrap-light",

--- a/src/bootstack/_runtime/base_window.py
+++ b/src/bootstack/_runtime/base_window.py
@@ -18,6 +18,7 @@ The BaseWindow mixin provides:
 
 from __future__ import annotations
 
+import os
 import sys
 import tkinter
 import warnings
@@ -271,15 +272,19 @@ class BaseWindow:
                     pass
             return
 
-        # User provided a custom icon
+        # User provided a custom icon — a path string or a photo-image object
+        # (Tk's PhotoImage or Pillow's ImageTk.PhotoImage, both accepted by
+        # iconphoto()).
         try:
-            if isinstance(iconphoto, tkinter.PhotoImage):
-                self._icon = iconphoto
-                self.iconphoto(True, self._icon)
-            elif str(iconphoto).lower().endswith('.ico'):
-                self.wm_iconbitmap(str(iconphoto))
+            if isinstance(iconphoto, (str, os.PathLike)):
+                path = str(iconphoto)
+                if path.lower().endswith('.ico'):
+                    self.wm_iconbitmap(path)
+                else:
+                    self._icon = tkinter.PhotoImage(file=path, master=self)
+                    self.iconphoto(True, self._icon)
             else:
-                self._icon = tkinter.PhotoImage(file=iconphoto, master=self)
+                self._icon = iconphoto
                 self.iconphoto(True, self._icon)
         except (tkinter.TclError, Exception) as e:
             print(f'Failed to load icon: {iconphoto} - {e}')
@@ -397,7 +402,34 @@ class BaseWindow:
         self._apply_window_style()
         if getattr(self, 'winsys', None) == 'win32':
             self.update()
-        self.deiconify()
+
+        # Reveal-after-settle: some content can only realize its final size once
+        # the window is mapped (e.g. a ScrollView's canvas filling its viewport).
+        # Map the window invisibly, let it settle, then reveal it — so it never
+        # visibly shifts into place on open. Restores any prior alpha.
+        try:
+            prev_alpha = self.attributes('-alpha')
+        except tkinter.TclError:
+            prev_alpha = None
+        if prev_alpha is not None:
+            try:
+                self.attributes('-alpha', 0.0)
+            except tkinter.TclError:
+                prev_alpha = None
+
+        try:
+            self.deiconify()
+            self.update_idletasks()
+            if getattr(self, 'winsys', None) == 'win32':
+                self.update()
+        finally:
+            # Always restore visibility — if settling raised (e.g. a pending
+            # callback in update()), the window must not stay stuck at alpha 0.
+            if prev_alpha is not None:
+                try:
+                    self.attributes('-alpha', prev_alpha)
+                except tkinter.TclError:
+                    pass
 
     def title(self, value: str | None = None) -> str:
         """Get or set the window title.

--- a/src/bootstack/_runtime/toplevel.py
+++ b/src/bootstack/_runtime/toplevel.py
@@ -31,7 +31,7 @@ class Toplevel(BaseWindow, WidgetCapabilitiesMixin, tkinter.Toplevel):
     def __init__(
             self,
             title: str = "bootstack",
-            icon: tkinter.PhotoImage | None = None,
+            icon: tkinter.PhotoImage | str | None = None,
             size: Optional[Tuple[int, int]] = None,
             position: Optional[Tuple[int, int]] = None,
             minsize: Optional[Tuple[int, int]] = None,

--- a/src/bootstack/cli/__init__.py
+++ b/src/bootstack/cli/__init__.py
@@ -26,7 +26,7 @@ import argparse
 import sys
 from typing import Sequence
 
-from bootstack.cli import add, build, doctor, icons, promote, run, start
+from bootstack.cli import add, appicon, build, doctor, icons, promote, run, start
 from bootstack.cli.demo import run_demo
 
 
@@ -80,6 +80,7 @@ For more information on a command:
     add.add_parser(subparsers)
     doctor.add_parser(subparsers)
     icons.add_parser(subparsers)
+    appicon.add_parser(subparsers)
 
     # Gallery command
     gallery_parser = subparsers.add_parser(

--- a/src/bootstack/cli/appicon.py
+++ b/src/bootstack/cli/appicon.py
@@ -1,0 +1,284 @@
+"""App icon command — a visual designer for application icons.
+
+Launches a small bootstack app that previews an `AppIcon` live as you adjust the
+glyph, colors, and corner radius, then exports it (`.ico`/`.icns`/`.png`) or
+copies a ready-to-paste ``[build.icon]`` snippet for ``bootstack.toml``.
+"""
+from __future__ import annotations
+
+import argparse
+
+from bootstack.widgets.types import IconSpec
+
+
+def add_parser(subparsers: argparse._SubParsersAction) -> None:
+    parser = subparsers.add_parser(
+        "appicon",
+        help="Design an application icon and export it",
+        description=(
+            "Launch the app icon designer.\n\n"
+            "Pick a Bootstrap glyph, choose background and foreground colors and "
+            "a corner radius, and preview the result live at several sizes. Export "
+            "an .ico / .icns / .png for a packaged build, or copy a [build.icon] "
+            "snippet for bootstack.toml. (Find glyph names with `bootstack icons`.)"
+        ),
+    )
+    parser.set_defaults(func=lambda args: run_appicon())
+
+
+# Windows/Linux preview sizes (glyph-only), largest first.
+_PREVIEW_SIZES = [96, 64, 48, 32, 16]
+# macOS preview size (the rounded tile).
+_MACOS_SIZE = 196
+
+_HEX_DIGITS = set("0123456789abcdefABCDEF")
+
+
+def _is_hex(color: str) -> bool:
+    return (
+        color.startswith("#")
+        and len(color) in (4, 7, 9)
+        and all(ch in _HEX_DIGITS for ch in color[1:])
+    )
+
+
+def run_appicon() -> None:
+    import bootstack as bs
+    from bootstack.images import AppIcon, list_icons
+
+    state: dict = {"jobs": {}, "win_imgs": [], "mac_img": None}
+
+    with bs.App(title="App Icon Designer", size=(800, 600)) as app:
+        # Signals require the application root, so create them inside the context.
+        glyph_sig = bs.Signal("rocket")
+        bg_sig = bs.Signal("#0d6efd")
+        fg_sig = bs.Signal("#ffffff")
+        radius_sig = bs.Signal(0.22)
+        dark_sig = bs.Signal(False)
+        status_sig = bs.Signal("Adjust settings to see live preview")
+
+        with bs.HStack(fill='both', anchor="n", expand=True):
+
+            # ── Controls ──────────────────────────────────────────────────────
+            with bs.VStack(padding=16, gap=24, anchor_items="n", anchor="n", fill="y"):
+                bs.Label("App Icon Designer", font="heading-md")
+                bs.Label(textsignal=status_sig, font="caption", accent="muted", wrap_width=225)
+
+                gl = bs.TextField(textsignal=glyph_sig, fill="x", label="Glyph")
+                gl.insert_addon("button", "after", icon="grid-fill", on_click=lambda: _open_picker(gl))
+
+                bg = bs.TextField(textsignal=bg_sig, fill="x", label="Background color")
+                bg.insert_addon("button", "after", icon="palette-fill", on_click=lambda: _pick(bg_sig))
+
+                fg = bs.TextField(textsignal=fg_sig, fill="x", label="Foreground")
+                fg.insert_addon("button", "after", icon="palette-fill", on_click=lambda: _pick(fg_sig))
+
+                bs.NumberField(signal=radius_sig, min_value=0.00, max_value=0.50, step=0.01, fill='x', label="Corner radius (macOS tile)")
+
+                with bs.HStack(fill='x'):
+                    bs.Label("Preview Dark Theme", fill='x', expand=True)
+                    bs.Switch(None, signal=dark_sig, anchor="w")
+
+                with bs.HStack(gap=6, fill="both", fill_items='x', expand_items=True, expand=True, anchor_items="s"):
+                    bs.Button("Export…", accent="primary", on_click=lambda: _export())
+                    bs.Button("Copy TOML", variant="outline", on_click=lambda: _copy_toml())
+
+
+            bs.Separator(orient="vertical", fill="y")
+
+            # ── Preview ───────────────────────────────────────────────────────
+            with bs.VStack(padding=16, fill="both", expand=True, anchor_items="center"):
+                preview = bs.Grid(rows=2, columns=1, gap=10, fill="both", expand=True)
+
+
+    def _current_icon() -> "AppIcon":
+        # shape="auto" — exports glyph-only for .ico/.png, a tile for .icns.
+        return AppIcon(
+            glyph_sig() or "rocket",
+            background=bg_sig(),
+            foreground=fg_sig(),
+            radius=radius_sig(),
+        )
+
+    def _colors_ok() -> bool:
+        return _is_hex(bg_sig()) and _is_hex(fg_sig())
+
+    def _win_tiled(icon: "AppIcon", size: int) -> bool:
+        # Mirror the real shape='auto' .ico: glyph-only at small title-bar frames,
+        # a tile at taskbar sizes and up — so the preview matches the export.
+        return icon._tiled_for_size(size, suffix=".ico")
+
+    def _build_preview() -> None:
+        # Build the preview skeleton ONCE; updates swap images in place so the
+        # screen never flashes from tearing down and rebuilding the widgets.
+        icon = _current_icon()
+        win_imgs: list = []
+
+        with bs.VStack(parent=preview, row=0, column=0, gap=4, anchor_items="center"):
+            bs.Label("Windows / Linux", font="caption", accent="muted")
+            with bs.HStack(gap=12, anchor_items="s"):
+                for size in _PREVIEW_SIZES:
+                    tiled = _win_tiled(icon, size)
+                    with bs.VStack(gap=2):
+                        img = bs.Label(image=icon.to_image(size, tiled=tiled))
+                        bs.Label(f"{size}px", font="caption", accent="muted", anchor="s")
+                        win_imgs.append((size, tiled, img))
+
+        with bs.VStack(parent=preview, row=1, column=0, gap=4, anchor_items="center"):
+            bs.Label("macOS", font="caption", accent="muted")
+            mac_img = bs.Label(image=icon.to_image(_MACOS_SIZE, tiled=True))
+
+        state["win_imgs"] = win_imgs
+        state["mac_img"] = mac_img
+
+    def _colors_ready() -> bool:
+        if not _colors_ok():
+            status_sig.set("Colors must be hex values (e.g. #0d6efd).")
+            return False
+        status_sig.set("Adjust the settings — the preview updates live.")
+        return True
+
+    def _update_tiles() -> None:
+        # Foreground and corner radius only affect TILED frames — the macOS tile
+        # and the larger Windows/Linux frames. The small glyph-only frames are
+        # unchanged, so they are left in place.
+        if state.get("rendering") or not _colors_ready():
+            return
+        state["rendering"] = True
+        try:
+            icon = _current_icon()
+            for size, tiled, img in state["win_imgs"]:
+                if tiled:
+                    img.image = icon.to_image(size, tiled=True)
+            state["mac_img"].image = icon.to_image(_MACOS_SIZE, tiled=True)
+        finally:
+            state["rendering"] = False
+
+    def _update_all() -> None:
+        # Guard against re-entrancy: a scheduled update can fire inside a modal
+        # dialog's nested event loop (e.g. while the color picker is open), which
+        # could otherwise overlap an in-progress swap.
+        if state.get("rendering") or not _colors_ready():
+            return
+        state["rendering"] = True
+        try:
+            icon = _current_icon()
+            # Swap each image in place — no widget rebuild, no flicker. Each frame
+            # keeps the shape it was built with (small = glyph-only, large = tile).
+            for size, tiled, img in state["win_imgs"]:
+                img.image = icon.to_image(size, tiled=tiled)
+            state["mac_img"].image = icon.to_image(_MACOS_SIZE, tiled=True)
+        finally:
+            state["rendering"] = False
+
+    def _schedule(key: str, fn) -> None:
+        # Coalesce rapid signal changes (e.g. dragging the radius slider) into
+        # one update via the framework scheduler (cancelable Job, lifetime-tied).
+        job = state["jobs"].get(key)
+        if job is not None:
+            job.cancel()
+        state["jobs"][key] = app.schedule.delay(80, fn)
+
+    def _pick(target: "bs.Signal") -> None:
+        choice = bs.ask_color()
+        if choice is not None:
+            target.set(choice.hex)
+
+    def _apply_theme(*_) -> None:
+        app.theme = "bootstrap-dark" if dark_sig() else "bootstrap-light"
+
+    def _open_picker(parent) -> None:
+        all_names = list_icons()
+        pick: dict = {"job": None, "grid": None}
+
+        with bs.Window(title="Choose an icon", size=(500, 500), parent=parent) as win:
+            query = bs.Signal("")
+            count = bs.Signal("")
+            with bs.VStack(padding=12, gap=8, fill="both", expand=True):
+                bs.TextField(textsignal=query, placeholder="Search icons…", fill="x")
+                bs.Label(textsignal=count, font="caption", accent="muted")
+                scroller = bs.ScrollView(fill="both", expand=True, height=430)
+
+        def _choose(name: str) -> None:
+            glyph_sig.set(name)
+            win.close()
+
+        def _rebuild_grid(*_) -> None:
+            if pick["grid"] is not None:
+                pick["grid"].destroy()
+            q = (query() or "").strip().lower()
+            matches = [n for n in all_names if q in n] if q else all_names
+            shown = matches[:120]
+            count.set(
+                f"{len(matches):,} icons"
+                + (" — showing first 120, refine to narrow" if len(matches) > 120 else "")
+            )
+            with bs.Grid(parent=scroller, columns=8, gap=2) as grid:
+                for name in shown:
+                    spec: IconSpec = {"name": name, "size": 36}
+                    bs.Button(
+                        icon=spec,
+                        icon_only=True,
+                        variant="ghost",
+                        on_click=lambda n=name: _choose(n),
+                    )
+            pick["grid"] = grid
+
+        def _on_query(*_) -> None:
+            # Debounce search via the window's own scheduler (auto-cancels when
+            # the picker closes).
+            if pick["job"] is not None:
+                pick["job"].cancel()
+            pick["job"] = win.schedule.delay(150, _rebuild_grid)
+
+        query.subscribe(_on_query)
+        _rebuild_grid()
+        # Open beside the trigger — the window's top-left at the field's top-right.
+        win.show(anchor_to=parent, anchor_point="ne", window_point="nw", offset=(8, 0))
+
+    def _export() -> None:
+        if not _colors_ok():
+            status_sig.set("Fix the colors before exporting.")
+            return
+        path = bs.ask_save_file(
+            title="Export app icon",
+            default_extension=".ico",
+            initial_file=f"{glyph_sig() or 'app'}.ico",
+            file_types=[
+                ("Windows icon", "*.ico"),
+                ("macOS icon", "*.icns"),
+                ("PNG image", "*.png"),
+            ],
+        )
+        if not path:
+            return
+        try:
+            _current_icon().save(path)
+            status_sig.set(f"Exported to {path}")
+        except Exception as exc:  # pragma: no cover - surfaced to the user
+            status_sig.set(f"Could not export: {exc}")
+
+    def _copy_toml() -> None:
+        snippet = (
+            "[build.icon]\n"
+            f'glyph = "{glyph_sig() or "rocket"}"\n'
+            f'background = "{bg_sig()}"\n'
+            f'foreground = "{fg_sig()}"\n'
+            f"radius = {round(radius_sig(), 3)}\n"
+        )
+        app.set_clipboard(snippet)
+        status_sig.set("Copied [build.icon] snippet to the clipboard.")
+
+    _build_preview()
+    # Glyph and background affect every frame; foreground and corner radius affect
+    # only the tiled frames (the macOS tile and the larger Windows/Linux frames),
+    # so those re-render just the tiles.
+    glyph_sig.subscribe(lambda *_: _schedule("all", _update_all))
+    bg_sig.subscribe(lambda *_: _schedule("all", _update_all))
+    fg_sig.subscribe(lambda *_: _schedule("tiles", _update_tiles))
+    radius_sig.subscribe(lambda *_: _schedule("tiles", _update_tiles))
+    dark_sig.subscribe(_apply_theme)
+    app.run()
+
+if __name__ == '__main__':
+    run_appicon()

--- a/src/bootstack/cli/config.py
+++ b/src/bootstack/cli/config.py
@@ -24,11 +24,6 @@ id = "{app_id}"
 entry = "{entry}"
 template = "{template}"
 
-[settings]
-theme = "{theme}"
-language = "en"
-appearance = "system"
-
 [layout]
 default_container = "grid"
 """
@@ -41,7 +36,15 @@ windowed = true
 onefile = false
 
 [build.icon]
+# Point at an existing icon file:
 # path = "assets/icon.ico"
+# ...or generate one from a Bootstrap icon glyph. Colors must be hex values
+# (theme tokens cannot be resolved at build time, when no app is running):
+# glyph = "rocket"
+# shape = "auto"          # auto | tile | glyph (auto: glyph-only small, tile large)
+# background = "#0d6efd"
+# foreground = "#ffffff"
+# radius = 0.22
 
 [build.datas]
 include = [
@@ -64,15 +67,6 @@ class AppConfig:
 
 
 @dataclass
-class SettingsConfig:
-    """The [settings] section of bootstack.toml."""
-
-    theme: str = "bootstrap-light"
-    language: str = "en"
-    appearance: str = "system"  # system | light | dark
-
-
-@dataclass
 class LayoutConfig:
     """The [layout] section of bootstack.toml."""
 
@@ -81,9 +75,20 @@ class LayoutConfig:
 
 @dataclass
 class BuildIconConfig:
-    """The [build.icon] section of bootstack.toml."""
+    """The [build.icon] section of bootstack.toml.
+
+    Either point `path` at an existing icon file, or set `glyph` to generate an
+    icon from a Bootstrap icon at build time. Generated-icon colors must be hex
+    values — theme tokens cannot be resolved during a build, when no application
+    is running.
+    """
 
     path: Optional[str] = None
+    glyph: Optional[str] = None
+    shape: str = "auto"
+    background: str = "#0d6efd"
+    foreground: str = "#ffffff"
+    radius: float = 0.22
 
 
 @dataclass
@@ -109,7 +114,6 @@ class TtkbConfig:
     """Complete bootstack.toml configuration."""
 
     app: AppConfig = field(default_factory=AppConfig)
-    settings: SettingsConfig = field(default_factory=SettingsConfig)
     layout: LayoutConfig = field(default_factory=LayoutConfig)
     build: Optional[BuildConfig] = None
 
@@ -117,7 +121,6 @@ class TtkbConfig:
     def from_dict(cls, data: dict[str, Any]) -> TtkbConfig:
         """Create TtkbConfig from a dictionary (parsed TOML)."""
         app_data = data.get("app", {})
-        settings_data = data.get("settings", {})
         layout_data = data.get("layout", {})
         build_data = data.get("build")
 
@@ -126,12 +129,6 @@ class TtkbConfig:
             id=app_data.get("id", "com.example.myapp"),
             entry=app_data.get("entry", "src/myapp/main.py"),
             template=app_data.get("template", "basic"),
-        )
-
-        settings = SettingsConfig(
-            theme=settings_data.get("theme", "bootstrap-light"),
-            language=settings_data.get("language", "en"),
-            appearance=settings_data.get("appearance", "system"),
         )
 
         layout = LayoutConfig(
@@ -147,11 +144,18 @@ class TtkbConfig:
                 backend=build_data.get("backend", "pyinstaller"),
                 windowed=build_data.get("windowed", True),
                 onefile=build_data.get("onefile", False),
-                icon=BuildIconConfig(path=icon_data.get("path")),
+                icon=BuildIconConfig(
+                    path=icon_data.get("path"),
+                    glyph=icon_data.get("glyph"),
+                    shape=icon_data.get("shape", "auto"),
+                    background=icon_data.get("background", "#0d6efd"),
+                    foreground=icon_data.get("foreground", "#ffffff"),
+                    radius=float(icon_data.get("radius", 0.22)),
+                ),
                 datas=BuildDatasConfig(include=datas_data.get("include", [])),
             )
 
-        return cls(app=app, settings=settings, layout=layout, build=build)
+        return cls(app=app, layout=layout, build=build)
 
     @classmethod
     def load(cls, path: Path | str = "bootstack.toml") -> TtkbConfig:
@@ -252,7 +256,6 @@ def generate_config(
         name=name,
         app_id=app_id,
         entry=entry,
-        theme=theme,
         template=template,
     )
 

--- a/src/bootstack/cli/icons.py
+++ b/src/bootstack/cli/icons.py
@@ -30,7 +30,7 @@ _RENDER_BATCH = 200
 def run_icons() -> None:
     import tkinter as tk
     from bootstack.signals import Signal
-    from bootstack._core.images import Image
+    from bootstack._core.images import _ImageService
     from bootstack._runtime.app import App as _App
     from bootstack.widgets._impl.primitives.frame import Frame as _Frame
     from bootstack.widgets._impl.primitives.label import Label as _Label
@@ -77,7 +77,7 @@ def run_icons() -> None:
     _Label(statusbar, textsignal=status_sig, font="caption", accent="muted").pack(side="left")
 
     # ── Data + render state ──────────────────────────────────────────────────
-    _, glyphmap = Image._load_icon_assets()
+    _, glyphmap = _ImageService._load_icon_assets()
     all_names: list[str] = sorted(glyphmap.keys())
 
     _photos: list[Any] = []            # strong refs — prevents Tk GC
@@ -161,7 +161,7 @@ def run_icons() -> None:
             cx = col * cell_w + cell_w // 2
             cy = row * _CELL_H + 6
 
-            photo = Image.get_icon(name, _ICON_SIZE, fg)
+            photo = _ImageService.get_icon(name, _ICON_SIZE, fg)
             _photos.append(photo)
 
             img_id = canvas.create_image(

--- a/src/bootstack/cli/pyinstaller.py
+++ b/src/bootstack/cli/pyinstaller.py
@@ -48,11 +48,36 @@ ONEFILE = config.build.onefile if config.build else False
 
 # Icon handling
 ICON_PATH = None
-if config.build and config.build.icon.path:
-    icon_candidate = PROJECT_ROOT / config.build.icon.path
+_icon_cfg = config.build.icon if config.build else None
+if _icon_cfg and _icon_cfg.path:
+    icon_candidate = PROJECT_ROOT / _icon_cfg.path
     if icon_candidate.exists():
         ICON_PATH = str(icon_candidate)
-else:
+elif _icon_cfg and _icon_cfg.glyph:
+    # Generate an .ico from a glyph. No app runs during a build, so colors must
+    # be hex — a theme token cannot be resolved and would fail to render.
+    if not (_icon_cfg.background.startswith("#") and _icon_cfg.foreground.startswith("#")):
+        print(
+            "[build.icon] background/foreground must be hex colors (e.g. "
+            "'#0d6efd'); theme tokens need a running app. Using the default icon."
+        )
+    else:
+        try:
+            from bootstack.images import AppIcon
+            out = PROJECT_ROOT / "build" / "app-icon.ico"
+            out.parent.mkdir(parents=True, exist_ok=True)
+            AppIcon(
+                _icon_cfg.glyph,
+                background=_icon_cfg.background,
+                foreground=_icon_cfg.foreground,
+                radius=_icon_cfg.radius,
+                shape=_icon_cfg.shape,
+            ).save(str(out))
+            ICON_PATH = str(out)
+        except Exception as exc:
+            print(f"Could not generate app icon from glyph {{_icon_cfg.glyph!r}}: {{exc}}")
+
+if ICON_PATH is None:
     # Fall back to the bundled bootstack launch icon (the same artwork
     # the runtime sets via wm_iconphoto, just rendered as a multi-size
     # .ico for Windows). Users can override by setting [build.icon] path

--- a/src/bootstack/cli/run.py
+++ b/src/bootstack/cli/run.py
@@ -83,10 +83,6 @@ def run_run(args: argparse.Namespace) -> None:
         else:
             env["PYTHONPATH"] = str(src_dir)
 
-    # Pass theme from config so the app can pick it up
-    if config is not None and config.settings.theme:
-        env["BOOTSTACK_THEME"] = config.settings.theme
-
     try:
         result = subprocess.run(
             [sys.executable, str(entry_point)],

--- a/src/bootstack/cli/templates/__init__.py
+++ b/src/bootstack/cli/templates/__init__.py
@@ -20,8 +20,6 @@ MAIN_PY_TEMPLATE = '''\
 Run with: python -m {module_name}
 """
 
-import os
-
 import bootstack as bs
 
 from {module_name}.views.main_view import MainView
@@ -31,7 +29,7 @@ def main() -> None:
     """Application entry point."""
     with bs.App(
         title="{app_name}",
-        theme=os.environ.get("BOOTSTACK_THEME", "{theme}"),
+        theme="{theme}",
         size=(800, 600),
     ) as app:
         MainView()
@@ -293,7 +291,6 @@ bootstack build
 Application settings are defined in `bootstack.toml`:
 
 - `[app]` - Application metadata
-- `[settings]` - Runtime settings (theme, language)
 - `[layout]` - Default layout preferences
 - `[build]` - Build/packaging configuration (after `bootstack promote`)
 '''
@@ -310,8 +307,6 @@ APPSHELL_MAIN_PY_TEMPLATE = '''\
 Run with: python -m {module_name}
 """
 
-import os
-
 import bootstack as bs
 
 from {module_name}.pages.home_page import HomePage
@@ -322,7 +317,7 @@ def main() -> None:
     """Application entry point."""
     with bs.AppShell(
         title="{app_name}",
-        theme=os.environ.get("BOOTSTACK_THEME", "{theme}"),
+        theme="{theme}",
         size=(1000, 650),
     ) as shell:
         shell.commandbar.add_button(icon="sun", on_click=bs.toggle_theme)
@@ -478,7 +473,6 @@ bootstack build
 Application settings are defined in `bootstack.toml`:
 
 - `[app]` - Application metadata
-- `[settings]` - Runtime settings (theme, language)
 - `[layout]` - Default layout preferences
 - `[build]` - Build/packaging configuration (after `bootstack promote`)
 '''

--- a/src/bootstack/dialogs/__init__.py
+++ b/src/bootstack/dialogs/__init__.py
@@ -13,7 +13,7 @@ from bootstack.dialogs._impl.fontdialog import FontDialog as _InternalFontDialog
 from bootstack.dialogs._impl.filterdialog import FilterDialog as _InternalFilterDialog
 from bootstack.widgets._impl.primitives.label import Label as _Label
 from bootstack.widgets._impl.primitives.frame import Frame as _Frame
-from bootstack._core.images import Image as _ImageService
+from bootstack._core.images import _ImageService
 from bootstack.style.style import get_theme_color as _get_theme_color
 
 __all__ = [
@@ -21,6 +21,7 @@ __all__ = [
     "alert", "confirm",
     "ask_string", "ask_integer", "ask_float", "ask_date", "ask_date_range",
     "ask_item", "ask_color", "ask_font", "ask_filter",
+    "ask_save_file", "ask_open_file", "ask_open_files", "ask_directory",
     # dialog classes
     "Dialog", "DialogButton", "FormDialog", "FilterDialog",
     "ColorChooserDialog", "ColorChoice", "FontDialog", "FontChoice",
@@ -806,3 +807,141 @@ def ask_filter(
     )
     dlg.show()
     return dlg.result
+
+
+# File-system dialogs (native OS choosers) ----------------------------------
+
+def _run_file_dialog(_name: str, parent: Any, **options: Any) -> Any:
+    """Call a `tkinter.filedialog` function with cleaned options."""
+    import tkinter
+    from tkinter import filedialog
+
+    opts = {k: v for k, v in options.items() if v not in (None, "")}
+    master = parent if parent is not None else tkinter._default_root
+    if master is not None:
+        opts["parent"] = master
+    return getattr(filedialog, _name)(**opts)
+
+
+def _coerce_file_types(file_types: Any) -> Any:
+    if not file_types:
+        return None
+    return [tuple(ft) for ft in file_types]
+
+
+def ask_save_file(
+    *,
+    title: str = "",
+    initial_file: str = "",
+    initial_dir: str = "",
+    file_types: list[tuple[str, str]] | None = None,
+    default_extension: str = "",
+    parent: Any = None,
+) -> str | None:
+    """Show a native save dialog and return the chosen path.
+
+    Args:
+        title: Dialog window title.
+        initial_file: Suggested file name.
+        initial_dir: Directory to open in. Defaults to the last used location.
+        file_types: Selectable file types as `(label, pattern)` pairs, for
+            example `[('PNG image', '*.png'), ('All files', '*.*')]`.
+        default_extension: Extension appended when the user omits one (for
+            example `'.png'`).
+        parent: Parent widget. Defaults to the active root window.
+
+    Returns:
+        The chosen file path, or `None` if canceled.
+    """
+    path = _run_file_dialog(
+        "asksaveasfilename",
+        parent,
+        title=title,
+        initialfile=initial_file,
+        initialdir=initial_dir,
+        filetypes=_coerce_file_types(file_types),
+        defaultextension=default_extension,
+    )
+    return path or None
+
+
+def ask_open_file(
+    *,
+    title: str = "",
+    initial_dir: str = "",
+    file_types: list[tuple[str, str]] | None = None,
+    parent: Any = None,
+) -> str | None:
+    """Show a native open dialog for a single file and return its path.
+
+    Args:
+        title: Dialog window title.
+        initial_dir: Directory to open in. Defaults to the last used location.
+        file_types: Selectable file types as `(label, pattern)` pairs, for
+            example `[('Images', '*.png *.jpg'), ('All files', '*.*')]`.
+        parent: Parent widget. Defaults to the active root window.
+
+    Returns:
+        The chosen file path, or `None` if canceled.
+    """
+    path = _run_file_dialog(
+        "askopenfilename",
+        parent,
+        title=title,
+        initialdir=initial_dir,
+        filetypes=_coerce_file_types(file_types),
+    )
+    return path or None
+
+
+def ask_open_files(
+    *,
+    title: str = "",
+    initial_dir: str = "",
+    file_types: list[tuple[str, str]] | None = None,
+    parent: Any = None,
+) -> list[str]:
+    """Show a native open dialog allowing several files.
+
+    Args:
+        title: Dialog window title.
+        initial_dir: Directory to open in. Defaults to the last used location.
+        file_types: Selectable file types as `(label, pattern)` pairs.
+        parent: Parent widget. Defaults to the active root window.
+
+    Returns:
+        The chosen file paths, or an empty list if canceled.
+    """
+    paths = _run_file_dialog(
+        "askopenfilenames",
+        parent,
+        title=title,
+        initialdir=initial_dir,
+        filetypes=_coerce_file_types(file_types),
+    )
+    return list(paths) if isinstance(paths, (list, tuple)) else []
+
+
+def ask_directory(
+    *,
+    title: str = "",
+    initial_dir: str = "",
+    parent: Any = None,
+) -> str | None:
+    """Show a native folder chooser and return the chosen directory.
+
+    Args:
+        title: Dialog window title.
+        initial_dir: Directory to open in. Defaults to the last used location.
+        parent: Parent widget. Defaults to the active root window.
+
+    Returns:
+        The chosen directory path, or `None` if canceled.
+    """
+    path = _run_file_dialog(
+        "askdirectory",
+        parent,
+        title=title,
+        initialdir=initial_dir,
+    )
+    return path or None

--- a/src/bootstack/dialogs/_impl/message.py
+++ b/src/bootstack/dialogs/_impl/message.py
@@ -7,7 +7,7 @@ from types import SimpleNamespace
 from typing import Any, Callable, List, Optional
 
 from bootstack.widgets._impl.primitives import Frame, Label
-from bootstack._core.images import Image as _ImageService
+from bootstack._core.images import _ImageService
 from bootstack.constants import *
 from bootstack.i18n import MessageCatalog
 from .dialog import ButtonRole, Dialog, DialogButton

--- a/src/bootstack/images.py
+++ b/src/bootstack/images.py
@@ -1,0 +1,546 @@
+"""Toolkit-free image handles and the icon factory.
+
+This module is the public, framework-native way to work with images and icons:
+
+- `Image` — a lightweight handle that holds image data (or a deferred icon spec)
+  and is only rendered for display when you hand it to a widget. You can build one
+  before an application exists; nothing about the underlying toolkit is exposed.
+- `get_icon` — create a theme-aware `Image` from a Bootstrap Icons name. When the
+  color is given as a theme token, the icon re-renders automatically as the theme
+  changes.
+- `AppIcon` — generate a platform application icon (a glyph on a filled,
+  rounded background) for an `App` or `Window`.
+
+Examples:
+    ```python
+    import bootstack as bs
+    from bootstack.images import Image, get_icon
+
+    with bs.App() as app:
+        bs.Label(image=Image.open("logo.png"))
+        bs.Button("Save", image=get_icon("save", color="primary"))
+    app.run()
+    ```
+"""
+
+from __future__ import annotations
+
+import atexit
+import io
+import math
+import os
+import re
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from bootstack._core.images import _ImageService
+
+if TYPE_CHECKING:
+    from PIL.Image import Image as _PILImage
+    from PIL.ImageTk import PhotoImage as _Photo
+
+__all__ = ["Image", "get_icon", "AppIcon", "list_icons"]
+
+# A color is treated as a literal hex value only when it starts with '#';
+# every other string is a theme color token resolved against the active theme.
+_HEX_RE = re.compile(r"^#[0-9a-fA-F]{3,8}$")
+
+_DEFAULT_ICON_SIZE = 20
+_DEFAULT_ICON_COLOR = "foreground"
+
+# Sizes baked into a Windows multi-resolution `.ico`. Includes the DPI-scaled
+# title-bar/taskbar sizes (20, 40, ...) so Windows finds an exact match at
+# 125%/150%/200% scaling instead of upscaling the nearest one (which blurs).
+_APP_ICON_SIZES = [16, 20, 24, 32, 40, 48, 64, 96, 128, 256]
+
+# With shape='auto' on Windows/Linux, frames below this size are drawn glyph-only
+# (a bare mark reads cleaner than a cramped tile in a tiny title bar) and frames
+# at or above it get the rounded tile (a branded icon for the taskbar, the task
+# switcher, and launchers).
+_AUTO_TILE_MIN_SIZE = 24
+# The rounded tile is supersampled to at least this canvas size before being
+# downscaled, so its curved corners get antialiased (PIL draws them aliased at
+# 1x). The glyph is NOT supersampled with it — it is rendered at its final size.
+_MIN_TILE_CANVAS = 128
+
+# Fraction of the icon edge the glyph box occupies, interpolated by size. Small
+# icons use less padding (a bigger glyph) so the mark stays legible when there are
+# few pixels; large icons get app-icon-style margins. (The glyph renderer adds a
+# little inset of its own, so the visible mark is somewhat smaller than this.)
+# Endpoints are reached at <= 16 px and >= 96 px; sizes between interpolate.
+_GLYPH_FRAC_SMALL_SIZE = 16
+_GLYPH_FRAC_LARGE_SIZE = 96
+# On a tile the glyph sits inside the rounded background; glyph-only icons (no
+# tile) let the mark nearly fill the frame.
+_TILE_GLYPH_FRAC = (0.80, 0.64)        # (small, large)
+_GLYPH_ONLY_FRAC = (0.98, 0.90)
+
+
+def _glyph_frac(size: int, *, tiled: bool) -> float:
+    """Glyph box fraction for `size`, smaller icons getting less padding."""
+    small, large = _TILE_GLYPH_FRAC if tiled else _GLYPH_ONLY_FRAC
+    lo, hi = _GLYPH_FRAC_SMALL_SIZE, _GLYPH_FRAC_LARGE_SIZE
+    if size <= lo:
+        return small
+    if size >= hi:
+        return large
+    t = (size - lo) / (hi - lo)
+    return small + t * (large - small)
+
+
+def _unlink_at_exit(path: str) -> None:
+    """Best-effort removal of a generated runtime icon tempfile at interpreter exit."""
+
+    def _remove() -> None:
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+
+    atexit.register(_remove)
+
+
+def _resolve_color(color: str) -> str:
+    """Resolve a color string to a literal value.
+
+    A `#hex` value is returned unchanged; any other string is treated as a theme
+    color token and resolved against the active theme, falling back to the
+    literal string when there is no theme or the token is unknown.
+    """
+    if _HEX_RE.match(color):
+        return color
+    from bootstack.style import get_theme_color
+
+    try:
+        return get_theme_color(color)
+    except Exception:
+        return color
+
+
+@dataclass(frozen=True)
+class _IconSpec:
+    """A deferred icon: the parameters to render a glyph on demand."""
+
+    name: str
+    size: int
+    color: str
+    is_token: bool
+
+
+class Image:
+    """A toolkit-free image handle, rendered for display only when used.
+
+    An `Image` carries a source — a file, raw bytes, an in-memory picture, or a
+    deferred icon — without creating any display resource up front. The picture
+    is rendered the moment it is handed to a widget (via `image=`), so a handle
+    can be built before an application is running and shared across widgets.
+
+    Build one with `Image.open`, `Image.from_bytes`, or `Image.from_pil`, or use
+    `get_icon` for a Bootstrap icon. Read `width` and `height` at any time.
+
+    File and byte sources accept the common raster image formats — PNG, JPEG,
+    GIF, BMP, TIFF, WebP, and ICO. (Animated formats load their first frame.)
+    """
+
+    __slots__ = ("_pil", "_path", "_data", "_icon", "_photo", "_size")
+
+    def __init__(
+        self,
+        *,
+        pil: "_PILImage | None" = None,
+        path: Path | None = None,
+        data: bytes | None = None,
+        icon: _IconSpec | None = None,
+    ) -> None:
+        self._pil = pil
+        self._path = path
+        self._data = data
+        self._icon = icon
+        self._photo: "_Photo | None" = None
+        self._size: tuple[int, int] | None = None
+
+    # =========================================================================
+    # Constructors
+    # =========================================================================
+
+    @classmethod
+    def open(cls, path: str | Path) -> "Image":
+        """Create an image handle from a file on disk.
+
+        The file is decoded lazily, so the path is not read until the image is
+        displayed or its size is queried.
+
+        Args:
+            path: Path to the image file. Supports `~` expansion. Accepts the
+                common raster formats — PNG, JPEG, GIF, BMP, TIFF, WebP, and ICO.
+
+        Returns:
+            A new image handle.
+        """
+        return cls(path=Path(path).expanduser())
+
+    @classmethod
+    def from_bytes(cls, data: bytes) -> "Image":
+        """Create an image handle from raw, encoded image bytes.
+
+        Args:
+            data: Encoded image bytes in a common raster format — PNG, JPEG,
+                GIF, BMP, TIFF, WebP, or ICO — for example, an embedded resource
+                or a downloaded file.
+
+        Returns:
+            A new image handle.
+        """
+        return cls(data=bytes(data))
+
+    @classmethod
+    def from_pil(cls, image: "_PILImage") -> "Image":
+        """Create an image handle from an in-memory Pillow image.
+
+        Useful when you have already loaded or manipulated a picture with Pillow
+        (resizing, filtering, compositing) and want to display the result.
+
+        Args:
+            image: A Pillow image object to wrap.
+
+        Returns:
+            A new image handle.
+        """
+        return cls(pil=image)
+
+    # =========================================================================
+    # Size
+    # =========================================================================
+
+    @property
+    def width(self) -> int:
+        """The width of the image in pixels."""
+        return self._dimensions()[0]
+
+    @property
+    def height(self) -> int:
+        """The height of the image in pixels."""
+        return self._dimensions()[1]
+
+    def _dimensions(self) -> tuple[int, int]:
+        if self._size is None:
+            if self._icon is not None:
+                self._size = (self._icon.size, self._icon.size)
+            else:
+                pil = self._load_pil()
+                self._size = (pil.width, pil.height)
+        return self._size
+
+    def _load_pil(self) -> "_PILImage":
+        from PIL import Image as PILImage
+
+        if self._pil is not None:
+            return self._pil
+        if self._path is not None:
+            return PILImage.open(self._path)
+        if self._data is not None:
+            return PILImage.open(io.BytesIO(self._data))
+        raise ValueError("image handle has no source")
+
+    # =========================================================================
+    # Internal rendering (called at the widget-binding boundary)
+    # =========================================================================
+
+    @property
+    def _is_theme_following(self) -> bool:
+        """Whether this image must re-render when the theme changes."""
+        return self._icon is not None and self._icon.is_token
+
+    def _invalidate(self) -> None:
+        """Drop the rendered image so the next bind re-renders it."""
+        self._photo = None
+
+    def _materialize(self, master=None) -> "_Photo":
+        """Render the source to a cached display image and return it.
+
+        The ``master`` is accepted for interface symmetry; the backing service
+        renders against the default application root, which exists by the time a
+        handle is bound to a widget.
+        """
+        if self._photo is not None:
+            return self._photo
+        if self._icon is not None:
+            color = self._resolve_icon_color()
+            photo = _ImageService.get_icon(self._icon.name, self._icon.size, color)
+        elif self._path is not None:
+            photo = _ImageService.open(self._path)
+        elif self._data is not None:
+            photo = _ImageService.from_bytes(self._data)
+        elif self._pil is not None:
+            photo = _ImageService.from_pil(self._pil)
+        else:
+            raise ValueError("image handle has no source")
+        self._photo = photo
+        return photo
+
+    def _resolve_icon_color(self) -> str:
+        spec = self._icon
+        assert spec is not None
+        if not spec.is_token:
+            return spec.color
+        return _resolve_color(spec.color)
+
+
+def get_icon(
+    name: str,
+    *,
+    size: int = _DEFAULT_ICON_SIZE,
+    color: str = _DEFAULT_ICON_COLOR,
+) -> Image:
+    """Create a theme-aware icon image from a Bootstrap Icons name.
+
+    The returned handle can be passed to any widget that accepts `image=`. When
+    `color` is a theme color token (the default), the icon re-renders to match
+    whenever the theme changes; a literal hex color stays fixed.
+
+    Args:
+        name: Bootstrap Icons name, for example `'house'` or `'arrow-right'`.
+            Browse the catalog at https://icons.getbootstrap.com.
+        size: Icon size in pixels. Defaults to `20`.
+        color: A theme color token (such as `'foreground'`, `'primary'`, or
+            `'danger'`) or a literal hex string like `'#ff8800'`. Token colors
+            follow the active theme; hex colors are fixed. Defaults to
+            `'foreground'`.
+
+    Returns:
+        A new image handle that renders the icon on demand.
+    """
+    is_hex = bool(_HEX_RE.match(color))
+    spec = _IconSpec(name=name, size=int(size), color=color, is_token=not is_hex)
+    return Image(icon=spec)
+
+
+def list_icons(contains: str | None = None) -> list[str]:
+    """List the available Bootstrap Icons names, sorted.
+
+    Each name can be used as a widget's `icon=` or passed to `get_icon`.
+
+    Args:
+        contains: If given, only names containing this text (case-insensitive)
+            are returned. Defaults to `None` (all names).
+
+    Returns:
+        A sorted list of icon names.
+    """
+    _, glyphmap = _ImageService._load_icon_assets()
+    names = sorted(glyphmap)
+    if contains:
+        needle = contains.lower()
+        names = [n for n in names if needle in n]
+    return names
+
+
+class AppIcon:
+    """A generated application icon.
+
+    Renders a Bootstrap glyph in one of two shapes:
+
+    - a **tile** — the glyph in `foreground` on a filled, rounded `background`
+      (the macOS look); or
+    - **glyph-only** — the glyph alone in the `background` (brand) color on a
+      transparent field (the typical Windows and Linux look).
+
+    By default (`shape='auto'`) the shape follows the platform and the size: a
+    tile for macOS targets (`.icns`, or running on macOS); on Windows and Linux,
+    glyph-only at small sizes (a clean mark in a tiny title bar) and a tile at
+    larger sizes (a branded icon in the taskbar and launchers). A multi-size
+    `.ico` therefore carries both. Set `shape` to `'tile'` or `'glyph'` to force
+    one shape at every size.
+
+    Pass an `AppIcon` as the `icon=` of an `App` or `Window` to set its taskbar
+    and title-bar icon without supplying an icon file, or call `save` to export a
+    packaging asset (for example, an icon for a PyInstaller build).
+
+    Colors may be theme color tokens (such as `'primary'`) or literal hex
+    strings. Tokens are resolved once, when the icon is generated, so the icon
+    does not change as the theme changes; supply a token while an application is
+    active, or use hex values. Generating an icon outside a running application —
+    such as during a build — must use hex values, since no theme is available to
+    resolve a token against.
+    """
+
+    def __init__(
+        self,
+        icon: str,
+        *,
+        background: str = "primary",
+        foreground: str = "white",
+        radius: float = 0.22,
+        shape: str = "auto",
+    ) -> None:
+        """Describe an application icon.
+
+        Args:
+            icon: Bootstrap Icons name to draw, for example `'rocket'`.
+            background: Brand color — fills the rounded background of a tile, or
+                colors the glyph itself when glyph-only. A theme color token or a
+                hex string. Defaults to `'primary'`.
+            foreground: Color of the glyph on a tile (ignored when glyph-only).
+                A theme color token or a hex string. Defaults to `'white'`.
+            radius: Corner radius of the tile background as a fraction of the
+                icon size, from `0.0` (square) to `0.5` (circle). Ignored when
+                glyph-only. Defaults to `0.22`.
+            shape: `'auto'` (default) follows the platform and size — a tile for
+                macOS targets, and on Windows/Linux glyph-only at small sizes with
+                a tile at larger sizes. `'tile'` or `'glyph'` force one shape at
+                every size.
+        """
+        self._icon = icon
+        self._background = background
+        self._foreground = foreground
+        self._radius = max(0.0, min(0.5, float(radius)))
+        self._shape = shape
+        self._cached_path: str | None = None
+
+    def _tiled_for_size(self, size: int, *, suffix: str | None = None) -> bool:
+        """Decide whether to draw a tile for a given target size.
+
+        `shape='tile'`/`'glyph'` force the shape. With `shape='auto'`: macOS
+        targets (an `.icns` file, or — when no suffix is given — running on
+        macOS) are always a tile; Windows and Linux targets are glyph-only below
+        `_AUTO_TILE_MIN_SIZE` and a tile at or above it, so a multi-size `.ico`
+        carries bare marks for the title bar and tiles for the taskbar.
+        """
+        if self._shape == "tile":
+            return True
+        if self._shape == "glyph":
+            return False
+        if suffix == ".icns" or (suffix is None and sys.platform == "darwin"):
+            return True
+        return size >= _AUTO_TILE_MIN_SIZE
+
+    def _render(self, size: int, *, tiled: bool) -> "_PILImage":
+        from PIL import Image as PILImage, ImageDraw
+
+        bg = _resolve_color(self._background)
+        fg = _resolve_color(self._foreground)
+
+        glyph_frac = _glyph_frac(size, tiled=tiled)
+        glyph_color = fg if tiled else bg
+
+        # Render the glyph at its FINAL on-screen size. A font glyph is crispest at
+        # its display size — the glyph renderer grid-fits it there and sharpens
+        # small sizes. If the glyph were supersampled with the tile and the whole
+        # composite downscaled, it would lose that and go soft at 16/24 px.
+        glyph_box = max(1, int(size * glyph_frac))
+        glyph = _ImageService._render_icon(self._icon, glyph_box, glyph_color, align=True)
+
+        def _center(base: "_PILImage") -> "_PILImage":
+            base.alpha_composite(
+                glyph, ((size - glyph.width) // 2, (size - glyph.height) // 2)
+            )
+            return base
+
+        if not tiled:
+            # Glyph-only: the brand-colored mark on a transparent field.
+            return _center(PILImage.new("RGBA", (size, size), (0, 0, 0, 0)))
+
+        # Tile: supersample ONLY the rounded background — its curved corners need
+        # antialiasing PIL won't apply at 1x — then downscale at an integer ratio
+        # for clean edges, and drop the native-size glyph on top.
+        scale = max(2, math.ceil(_MIN_TILE_CANVAS / size))
+        canvas = size * scale
+        tile = PILImage.new("RGBA", (canvas, canvas), (0, 0, 0, 0))
+        ImageDraw.Draw(tile).rounded_rectangle(
+            [0, 0, canvas - 1, canvas - 1],
+            radius=int(canvas * self._radius),
+            fill=bg,
+        )
+        tile = tile.resize((size, size), PILImage.Resampling.LANCZOS)
+        return _center(tile)
+
+    def to_image(self, size: int = 256, *, tiled: bool | None = None) -> "Image":
+        """Render the icon to an `Image` handle for on-screen display.
+
+        Use this to show the application icon inside the app itself — for example
+        on an about screen or a splash panel.
+
+        Args:
+            size: Rendered size in pixels. Defaults to `256`.
+            tiled: Force the tile shape (`True`) or glyph-only (`False`). By
+                default, follows the icon's `shape`.
+
+        Returns:
+            An image handle wrapping the rendered icon.
+        """
+        size = int(size)
+        if tiled is None:
+            tiled = self._tiled_for_size(size)
+        return Image.from_pil(self._render(size, tiled=tiled))
+
+    def save(self, path: str | Path) -> str:
+        """Write the icon to a file, choosing the format by file extension.
+
+        Use this to produce a packaging asset — for example, an icon to point a
+        PyInstaller build at. The format follows the path suffix:
+
+        - `.ico` — a multi-resolution Windows icon.
+        - `.icns` — a macOS icon.
+        - `.png` — a single 256-pixel image.
+
+        Args:
+            path: Destination file path ending in `.ico`, `.icns`, or `.png`.
+
+        Returns:
+            The path that was written, as a string.
+
+        Raises:
+            ValueError: If the file extension is not one of the supported types.
+        """
+        return self._write(Path(path))
+
+    def _write(self, p: Path) -> str:
+        suffix = p.suffix.lower()
+        if suffix == ".ico":
+            # Each frame chooses its own shape: under `auto`, small frames are
+            # glyph-only and larger frames are tiled (see `_tiled_for_size`).
+            imgs = [
+                self._render(s, tiled=self._tiled_for_size(s, suffix=suffix))
+                for s in _APP_ICON_SIZES
+            ]
+            # Largest first — Pillow skips sizes larger than the base image.
+            imgs[-1].save(
+                p,
+                format="ICO",
+                bitmap_format="bmp",
+                sizes=[(s, s) for s in _APP_ICON_SIZES],
+                append_images=imgs[:-1],
+            )
+        elif suffix == ".icns":
+            self._render(1024, tiled=self._tiled_for_size(1024, suffix=suffix)).save(
+                p, format="ICNS"
+            )
+        elif suffix == ".png":
+            self._render(256, tiled=self._tiled_for_size(256, suffix=suffix)).save(
+                p, format="PNG"
+            )
+        else:
+            raise ValueError(
+                f"unsupported app icon format {suffix!r}; use .ico, .icns, or .png"
+            )
+        return str(p)
+
+    def _icon_path(self) -> str:
+        """Generate a runtime icon asset and return its file path.
+
+        On Windows a multi-resolution `.ico` is produced; elsewhere a `.png`.
+        The shape follows the icon's `shape` — under `auto`, a tile on macOS and,
+        on Windows/Linux, glyph-only for the small `.ico` frames and a tile for
+        the larger ones. Generated once per `AppIcon` and cached for reuse.
+        """
+        if self._cached_path is not None:
+            return self._cached_path
+        suffix = ".ico" if sys.platform == "win32" else ".png"
+        fd, tmp = tempfile.mkstemp(suffix=suffix, prefix="bs-appicon-")
+        os.close(fd)
+        self._cached_path = self._write(Path(tmp))
+        _unlink_at_exit(self._cached_path)
+        return self._cached_path

--- a/src/bootstack/scheduling/_schedule.py
+++ b/src/bootstack/scheduling/_schedule.py
@@ -208,5 +208,11 @@ class Schedule:
 
     # ----- internal ----------------------------------------------------------
 
-    def _on_destroy(self, *_: Any) -> None:
+    def _on_destroy(self, event: Any = None) -> None:
+        # `<Destroy>` propagates up from descendants, so this handler fires
+        # whenever any child of the owner is destroyed. Only cancel the owner's
+        # jobs when the owner itself is going away — otherwise destroying a child
+        # widget would wipe out unrelated scheduled work on its ancestors.
+        if event is not None and getattr(event, "widget", None) is not self._owner:
+            return
         self.cancel_all()

--- a/src/bootstack/style/bootstyle_builder_base.py
+++ b/src/bootstack/style/bootstyle_builder_base.py
@@ -484,6 +484,20 @@ class BootstyleBuilderBase:
                 result['size'] = scale_size(result['size'])
             return result
 
+    def _resolve_icon_color(self, color: Any) -> str | None:
+        """Resolve an icon-spec color, turning a theme token into a hex value.
+
+        A hex value passes through; a theme token (such as `'primary'`) is
+        resolved against the active theme; any other string (e.g. a named color
+        like `'white'`) is left for the renderer to interpret.
+        """
+        if not color:
+            return None
+        try:
+            return self.color(color)
+        except Exception:
+            return color
+
     def map_stateful_icons(self, icon: IconSpec, foreground_spec: Sequence[tuple]):
         """
         Build and return a TTK image state map for icons, using the
@@ -526,7 +540,7 @@ class BootstyleBuilderBase:
             return []
 
         base_size: int = int(icon.get('size') or 20)
-        base_color: str | None = icon.get('color')
+        base_color: str | None = self._resolve_icon_color(icon.get('color'))
 
         # Build per-state override lookup: {state_str: {'name':..., 'color':...}}
         state_overrides: dict[str, IconStateMap] = {}
@@ -543,7 +557,7 @@ class BootstyleBuilderBase:
                 if 'name' in ov and ov['name']:
                     override['name'] = ov['name']  # type: ignore[assignment]
                 if 'color' in ov and ov['color']:
-                    override['color'] = ov['color']  # type: ignore[assignment]
+                    override['color'] = self._resolve_icon_color(ov['color'])  # type: ignore[assignment]
                 if override:
                     state_overrides[st] = override
 
@@ -577,8 +591,8 @@ class BootstyleBuilderBase:
                 cache[key] = img
                 return img
 
-            from bootstack._core.images import Image
-            img = Image.get_icon(name, size, color or "black")
+            from bootstack._core.images import _ImageService
+            img = _ImageService.get_icon(name, size, color or "black")
             cache[key] = img
             return img
 

--- a/src/bootstack/style/builders/combobox.py
+++ b/src/bootstack/style/builders/combobox.py
@@ -5,7 +5,7 @@ This module contains style builders for ttk.Combobox widget and variants.
 
 from __future__ import annotations
 
-from bootstack._core.images import Image as _ImageService
+from bootstack._core.images import _ImageService
 from bootstack.style.bootstyle_builder_ttk import BootstyleBuilderTTk
 from bootstack.style.element import Element, ElementImage
 from bootstack.style.utility import recolor_element_image

--- a/src/bootstack/style/builders/contextmenu.py
+++ b/src/bootstack/style/builders/contextmenu.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from bootstack._core.images import Image as _ImageService
+from bootstack._core.images import _ImageService
 
 from bootstack.style.bootstyle_builder_ttk import BootstyleBuilderTTk
 from bootstack.style.builders.utils import apply_icon_mapping, button_font, normalize_button_density

--- a/src/bootstack/style/builders/field.py
+++ b/src/bootstack/style/builders/field.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from typing import Optional
 
-from bootstack._core.images import Image as _ImageService
+from bootstack._core.images import _ImageService
 
 from bootstack.style.bootstyle_builder_ttk import BootstyleBuilderTTk
 from bootstack.style.element import Element, ElementImage

--- a/src/bootstack/style/builders/menubutton.py
+++ b/src/bootstack/style/builders/menubutton.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from typing import Optional
 
-from bootstack._core.images import Image as _ImageService
+from bootstack._core.images import _ImageService
 from bootstack.style.bootstyle_builder_ttk import BootstyleBuilderTTk
 from bootstack.style.element import Element, ElementImage
 from bootstack.style.utility import create_transparent_image, recolor_element_image

--- a/src/bootstack/style/builders/spinbox.py
+++ b/src/bootstack/style/builders/spinbox.py
@@ -5,7 +5,7 @@ This module contains style builders for ttk.Spinbox widget and variants.
 
 from __future__ import annotations
 
-from bootstack._core.images import Image as _ImageService
+from bootstack._core.images import _ImageService
 from bootstack.style.bootstyle_builder_ttk import BootstyleBuilderTTk
 from bootstack.style.element import Element, ElementImage
 from bootstack.style.utility import recolor_element_image

--- a/src/bootstack/style/builders/treeview.py
+++ b/src/bootstack/style/builders/treeview.py
@@ -2,7 +2,7 @@
 import tkinter as tk
 from tkinter import font
 
-from bootstack._core.images import Image as _ImageService
+from bootstack._core.images import _ImageService
 from bootstack.style.bootstyle_builder_ttk import BootstyleBuilderTTk
 from bootstack.style.element import Element, ElementImage
 from bootstack.style.utility import create_transparent_image

--- a/src/bootstack/style/utility.py
+++ b/src/bootstack/style/utility.py
@@ -6,7 +6,7 @@ from typing import Tuple, Union, cast
 from PIL import Image, ImageChops, ImageColor, ImageOps, ImageDraw
 from PIL.ImageTk import PhotoImage
 
-from bootstack._core.images import Image as ImageService
+from bootstack._core.images import _ImageService as ImageService
 from bootstack._runtime.utility import clamp
 from bootstack.style.types import ColorModel
 

--- a/src/bootstack/types.py
+++ b/src/bootstack/types.py
@@ -18,6 +18,7 @@ from bootstack.widgets.types import (
     AccentToken, VariantToken, SurfaceToken, WindowStyle,
     ColumnSpec, EditorType, FormOptions,
     Option, OptionDict,
+    Icon, IconSpec,
 )
 
 __all__ = [
@@ -30,4 +31,5 @@ __all__ = [
     "AccentToken", "VariantToken", "SurfaceToken", "WindowStyle",
     "ColumnSpec", "EditorType", "FormOptions",
     "Option", "OptionDict",
+    "Icon", "IconSpec",
 ]

--- a/src/bootstack/widgets/_core/base.py
+++ b/src/bootstack/widgets/_core/base.py
@@ -109,6 +109,28 @@ class PublicWidgetBase:
             self._schedule = Schedule(self._internal)
         return self._schedule
 
+    # ----- Clipboard ---------------------------------------------------------
+
+    def set_clipboard(self, text: str) -> None:
+        """Replace the system clipboard contents with `text`.
+
+        Args:
+            text: The text to place on the clipboard.
+        """
+        self._internal.clipboard_set(text)
+
+    def get_clipboard(self) -> str:
+        """Return the current text contents of the system clipboard.
+
+        Returns:
+            The clipboard text, or an empty string when the clipboard is empty
+            or holds non-text data.
+        """
+        try:
+            return self._internal.clipboard_get()
+        except Exception:
+            return ""
+
     # ----- on() — overloaded -------------------------------------------------
 
     @overload

--- a/src/bootstack/widgets/_core/field_mixin.py
+++ b/src/bootstack/widgets/_core/field_mixin.py
@@ -125,3 +125,91 @@ class FieldAddonMixin:
             field.add_validation_rule("custom", func=lambda v: v.isdigit())
         """
         self._internal.add_validation_rule(rule_type, **kwargs)
+
+
+class ValueSignalMixin:
+    """Two-way binds a field's typed `.value` to a public `signal`.
+
+    The signal carries the field's **value** (a number, date, time, …) — not its
+    text. The inheriting wrapper must expose a `value` property (get and set) and
+    an `on_change` event; this mixin keeps the two in sync, seeding the field from
+    the signal and updating the signal when the field commits a new value.
+    """
+
+    value: Any
+    on_change: Callable
+
+    def _bind_value_signal(self, signal: "Signal") -> None:
+        """Establish the two-way binding between `self.value` and `signal`."""
+        self._value_signal = signal
+        self._value_syncing = False
+
+        current = signal()
+        if current is not None:
+            self.value = current
+        else:
+            self._push_to_signal(self.value)
+
+        def _from_signal(v: Any) -> None:
+            if self._value_syncing or v is None:
+                return
+            self._value_syncing = True
+            try:
+                self.value = v
+            finally:
+                self._value_syncing = False
+
+        def _to_signal(_event: Any) -> None:
+            if self._value_syncing:
+                return
+            v = self.value
+            if v is None:
+                return
+            self._value_syncing = True
+            try:
+                self._push_to_signal(v)
+            finally:
+                self._value_syncing = False
+
+        # Hold the subscription id so it can be released on destroy. A Signal
+        # usually outlives the widgets bound to it, so a dangling subscription
+        # would pin a destroyed field (and all it references) in memory.
+        self._value_sub = signal.subscribe(_from_signal)
+        self.on_change(_to_signal)
+        self.on_destroy(lambda _e: self._release_value_signal())
+
+    def _push_to_signal(self, value: Any) -> None:
+        """Write `value` to the bound signal, reconciling numeric types.
+
+        `Signal` is strict about value type (it only widens `int` into a
+        `float`-typed signal). A numeric field can produce either an `int` or a
+        `float`, so reconcile the two here. If the signal's type is genuinely
+        incompatible (for example an `int`-typed signal and a fractional value),
+        leave the signal unchanged rather than raising into the Tk event loop.
+        """
+        signal = self._value_signal
+        target = getattr(signal, "_type", None)
+        if target is not None and type(value) is not target:
+            if target is float and type(value) is int:
+                value = float(value)
+            elif target is int and type(value) is float and value.is_integer():
+                value = int(value)
+        try:
+            signal.set(value)
+        except TypeError:
+            pass
+
+    def _release_value_signal(self) -> None:
+        """Drop the value-signal subscription (called on widget destroy)."""
+        sub = getattr(self, "_value_sub", None)
+        if sub is not None:
+            try:
+                self._value_signal.unsubscribe(sub)
+            except Exception:
+                pass
+            self._value_sub = None
+
+    @property
+    def signal(self) -> "Signal | None":
+        """The reactive `Signal` bound to this field's value, or `None`."""
+        return getattr(self, "_value_signal", None)

--- a/src/bootstack/widgets/_core/icon_image_props.py
+++ b/src/bootstack/widgets/_core/icon_image_props.py
@@ -1,0 +1,72 @@
+"""Reusable `icon` / `image` property mixins for widgets that accept them.
+
+Widgets in the button family take a widget-level `icon=` (a Bootstrap icon name)
+and/or `image=` (an `Image` handle) at construction. These mixins expose those as
+live, settable properties so they can be changed after construction — `image`
+updates in place (no rebuild, no flicker).
+"""
+
+from __future__ import annotations
+
+from typing import Any, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from bootstack.widgets.types import IconSpec
+
+
+class IconProperty:
+    """Adds a live `icon` property to a widget whose internal accepts `icon=`."""
+
+    @property
+    def icon(self) -> "str | IconSpec | None":
+        """The icon shown on the widget, or `None` if none is set.
+
+        A Bootstrap Icons name, or an `IconSpec` mapping (`{'name', 'size',
+        'color'}`) for control over size and color.
+        """
+        return self._internal.configure_style_options("icon")
+
+    @icon.setter
+    def icon(self, value: "str | IconSpec | None") -> None:
+        self._internal.configure(icon=value)
+
+
+class ImageProperty:
+    """Adds a live `image` property to a widget whose internal accepts `image=`."""
+
+    @property
+    def image(self) -> Any:
+        """The displayed image handle, or `None`.
+
+        Assigning an `Image` (from `bootstack.images`) updates the picture in
+        place — no rebuild — which avoids the flicker of recreating the widget.
+        """
+        return getattr(self, "_image_handle", None)
+
+    @image.setter
+    def image(self, value: Any) -> None:
+        from bootstack.widgets._core.image_binding import (
+            _release_theme_binding,
+            bind_image,
+        )
+
+        if value is None:
+            # Drop any theme-following binding from a previous Image, otherwise it
+            # keeps re-applying a now-removed image on theme changes (and pins it).
+            _release_theme_binding(self)
+            self._internal.configure(image="")
+            self._image_handle = None
+            self._image_photo = None
+            return
+        from bootstack.images import Image as _ImageHandle
+
+        if isinstance(value, _ImageHandle):
+            bind_image(self, self._internal, value)
+        else:
+            _release_theme_binding(self)
+            self._internal.configure(image=value)
+            self._image_handle = None
+            self._image_photo = value
+
+
+__all__ = ["IconProperty", "ImageProperty"]

--- a/src/bootstack/widgets/_core/image_binding.py
+++ b/src/bootstack/widgets/_core/image_binding.py
@@ -1,0 +1,93 @@
+"""Bind a public image handle onto an internal widget.
+
+The `image=` slot on text widgets accepts a public `bootstack.images.Image`
+handle. Because a handle holds no display resource until it is used, this helper
+renders it against the target widget and, when the handle follows the theme (a
+token-colored icon), re-renders it whenever the theme changes — releasing the
+binding when the widget is destroyed.
+"""
+
+from __future__ import annotations
+
+import tkinter as tk
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from bootstack.images import Image
+
+
+def bind_image(public_widget, internal_widget, image: "Image") -> None:
+    """Render `image` onto `internal_widget`, following the theme if needed.
+
+    Args:
+        public_widget: The public wrapper; strong references to the handle and
+            its rendered image are stored on it so they are not collected.
+        internal_widget: The underlying widget to display the image on.
+        image: The image handle to render and bind.
+    """
+    # Calling this again on the same widget (a live `image=` update) must not
+    # stack theme bindings — release any prior one first.
+    _release_theme_binding(public_widget)
+
+    photo = image._materialize(internal_widget)
+    internal_widget.configure(image=photo)
+    public_widget._image_handle = image
+    public_widget._image_photo = photo
+
+    if not image._is_theme_following:
+        return
+
+    root = internal_widget.winfo_toplevel()
+
+    def _reapply(_event=None) -> None:
+        try:
+            image._invalidate()
+            new_photo = image._materialize(internal_widget)
+            internal_widget.configure(image=new_photo)
+            public_widget._image_photo = new_photo
+        except tk.TclError:
+            pass
+
+    bind_id = root.bind("<<BsThemeChanged>>", _reapply, add="+")
+    public_widget._image_theme_binding = (root, bind_id)
+
+    def _release(event) -> None:
+        if event.widget is not internal_widget:
+            return
+        _release_theme_binding(public_widget)
+
+    internal_widget.bind("<Destroy>", _release, add="+")
+
+
+def _release_theme_binding(public_widget) -> None:
+    """Unbind a previously installed `<<BsThemeChanged>>` handler, if any."""
+    prev = getattr(public_widget, "_image_theme_binding", None)
+    if prev is None:
+        return
+    root, bind_id = prev
+    try:
+        root.unbind("<<BsThemeChanged>>", bind_id)
+    except tk.TclError:
+        pass
+    public_widget._image_theme_binding = None
+
+
+def resolve_window_icon(icon):
+    """Normalize a window `icon=` argument to `(path, deferred_image)`.
+
+    Exactly one of the returned values is non-`None` (or both are, for `None`
+    input). A `path` can be handed to the window at construction; a deferred
+    image must be rendered and applied after the window's root exists.
+
+    Args:
+        icon: An icon file path, an `Image` handle, or an `AppIcon`.
+    """
+    if icon is None:
+        return None, None
+    from bootstack.images import AppIcon, Image
+
+    if isinstance(icon, AppIcon):
+        return icon._icon_path(), None
+    if isinstance(icon, Image):
+        return None, icon
+    return str(icon), None

--- a/src/bootstack/widgets/_impl/_parts/numberentry_part.py
+++ b/src/bootstack/widgets/_impl/_parts/numberentry_part.py
@@ -171,6 +171,20 @@ class NumberEntryPart(TextEntryPart):
             return 'break'
         self.step(-1)
 
+    def _increment_decimals(self) -> int:
+        """Number of decimal places implied by the increment.
+
+        Used to quantize stepped values to the step grid so floating-point
+        error does not accumulate across repeated steps.
+        """
+        from decimal import Decimal
+
+        try:
+            exponent = Decimal(str(self._increment)).as_tuple().exponent
+        except Exception:
+            return 0
+        return max(0, -exponent) if isinstance(exponent, int) else 0
+
     def _apply_bounds(self, x: float) -> float:
         """Apply min/max bounds with optional wrapping."""
         lo = float(self._minvalue) if self._minvalue is not None else None
@@ -216,9 +230,11 @@ class NumberEntryPart(TextEntryPart):
         # Apply bounds/wrapping
         new_value = self._apply_bounds(new_value)
 
-        # Coerce to desired type
+        # Coerce to desired type. Snap floats to the increment's decimal
+        # precision so repeated stepping doesn't accumulate float error (e.g.
+        # 0.05 + 0.05 + 0.05 → 0.15000000000000002).
         if self._num_type is float:
-            coerced = float(new_value)
+            coerced = round(new_value, self._increment_decimals())
         else:
             coerced = int(round(new_value))
 

--- a/src/bootstack/widgets/_impl/composites/tableview/tableview.py
+++ b/src/bootstack/widgets/_impl/composites/tableview/tableview.py
@@ -19,7 +19,7 @@ from typing_extensions import Literal, TypedDict, Unpack
 from bootstack.widgets.types import Master, WidgetDensity
 
 from bootstack.events import RowEvent, RowsEvent, SelectionEvent, ExportEvent
-from bootstack._core.images import Image as _ImageService
+from bootstack._core.images import _ImageService
 from bootstack.style.style import get_style
 # Row identity and the set of hidden internal columns are read through the
 # datasource's protocol-level helpers (`_record_id`, `_public_record`,

--- a/src/bootstack/widgets/_impl/primitives/gridframe.py
+++ b/src/bootstack/widgets/_impl/primitives/gridframe.py
@@ -177,6 +177,35 @@ class GridFrame(Frame):
             for dc in range(colspan):
                 self._occupied.discard((row + dr, col + dc))
 
+    def _prune_destroyed(self) -> None:
+        """Drop managed widgets that have been destroyed, freeing their cells.
+
+        Tk's `destroy()` does not route through `grid_forget()`, so without this
+        the auto-flow cursor and the occupied-cell set would keep stale entries
+        for gone widgets — causing re-added children to fall through to the
+        `(0, 0)` fallback and stack on top of one another.
+        """
+        survivors = []
+        pruned = False
+        for entry in self._managed:
+            widget = entry[0]
+            try:
+                alive = bool(widget.winfo_exists())
+            except Exception:
+                alive = False
+            if alive:
+                survivors.append(entry)
+            else:
+                self._free_area(*entry[2])
+                self._removed.discard(widget)
+                pruned = True
+        if pruned:
+            self._managed = survivors
+            # Restart the flow cursor; `_find_next_position` skips cells still
+            # occupied by survivors, so it lands on the first genuinely free one.
+            self._next_row = 0
+            self._next_col = 0
+
     def _find_next_position(self, rowspan: int = 1, colspan: int = 1) -> tuple[int, int]:
         """Find the next available position using auto-flow rules."""
         if self._auto_flow == "none":
@@ -368,6 +397,11 @@ class GridFrame(Frame):
 
         Applies frame defaults, handles gap spacing, auto-placement, and tracks the widget.
         """
+        # Reclaim cells from any children destroyed since the last placement so
+        # auto-flow positions this widget correctly (Tk destroy() bypasses
+        # grid_forget()).
+        self._prune_destroyed()
+
         # Check if widget was hidden via grid_remove and is being restored
         if widget in self._removed and not options:
             # Restore widget to its original position

--- a/src/bootstack/widgets/app.py
+++ b/src/bootstack/widgets/app.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
-from typing import Any, Callable, Literal, Sequence
+from typing import TYPE_CHECKING, Any, Callable, Literal, Sequence
 
 from bootstack._runtime.app import App as _InternalApp, LocalizeMode
+
+if TYPE_CHECKING:
+    from bootstack.images import AppIcon, Image
 from bootstack.widgets._impl.primitives.packframe import PackFrame
 from bootstack.widgets._core.app_config import AppConfigMixin, APP_CONFIG_KWARGS
 from bootstack.widgets._core.container import PublicContainer, PACK_KEYS, normalize_fill
@@ -23,6 +26,8 @@ class App(AppConfigMixin, WindowControlsMixin, ChromeHostMixin, PublicContainer)
     Args:
         title: Window title bar text and the app's display name.
         size: Initial window size as `(width, height)`.
+        icon: Title-bar and taskbar icon — an icon file path, an `Image` handle,
+            or an `AppIcon`. Defaults to the bootstack icon.
         theme: Theme name to apply on startup (e.g. `'bootstrap-dark'`).
         light_theme: Theme used for the light end of system-appearance
             tracking and `toggle_theme`.
@@ -76,6 +81,7 @@ class App(AppConfigMixin, WindowControlsMixin, ChromeHostMixin, PublicContainer)
         *,
         title: str | None = None,
         size: tuple[int, int] | None = None,
+        icon: "str | Image | AppIcon | None" = None,
         theme: str | None = None,
         # theme
         light_theme: str = "bootstrap-light",
@@ -147,9 +153,25 @@ class App(AppConfigMixin, WindowControlsMixin, ChromeHostMixin, PublicContainer)
             init_kwargs["resizable"] = resizable
         if on_close is not None:
             init_kwargs["on_close"] = on_close
+
         init_kwargs.update(app_kwargs)
 
         self._tk_root = _InternalApp(**init_kwargs)
+
+        # Resolve the icon AFTER the root exists. An `AppIcon` may resolve theme
+        # color tokens (which need the style/root) and a deferred `Image` must be
+        # rendered against the root — doing either before the root would spin up
+        # a stray default root and bind the icon to the wrong interpreter.
+        self._app_icon_photo = None
+        if icon is not None:
+            from bootstack.widgets._core.image_binding import resolve_window_icon
+
+            icon_path, icon_image = resolve_window_icon(icon)
+            if icon_path is not None:
+                self._tk_root._setup_icon(icon_path)
+            elif icon_image is not None:
+                self._app_icon_photo = icon_image._materialize()
+                self._tk_root._setup_icon(self._app_icon_photo)
 
         frame_kwargs: dict[str, Any] = {
             "direction": "vertical",
@@ -217,7 +239,10 @@ class App(AppConfigMixin, WindowControlsMixin, ChromeHostMixin, PublicContainer)
 
     def run(self) -> None:
         """Show the window and start the event loop."""
-        self._tk_root.deiconify()
+        # Let the internal mainloop center and *then* show the window — it
+        # flushes layout and applies the window style while still withdrawn, so
+        # the window is fully drawn and positioned before it becomes visible.
+        # (Deiconifying here first would map it uncentered, then jump on center.)
         self._tk_root.mainloop()
 
     def __exit__(self, exc_type, exc, tb) -> None:

--- a/src/bootstack/widgets/button.py
+++ b/src/bootstack/widgets/button.py
@@ -5,15 +5,16 @@ from typing import Any, Callable, TYPE_CHECKING, overload
 from bootstack.widgets._impl.primitives.button import Button as _InternalButton
 from bootstack.widgets._core.base import PublicWidgetBase
 from bootstack.widgets._core.events import register_widget_events
+from bootstack.widgets._core.icon_image_props import IconProperty, ImageProperty
 from bootstack.events import Event, Subscription
 from bootstack.streams import Stream
-from bootstack.widgets.types import AccentToken, WidgetDensity, IconPosition, ButtonVariant
+from bootstack.widgets.types import AccentToken, WidgetDensity, IconPosition, ButtonVariant, IconSpec
 
 if TYPE_CHECKING:
     from bootstack.signals import Signal
 
 
-class Button(PublicWidgetBase):
+class Button(IconProperty, ImageProperty, PublicWidgetBase):
     """A clickable action trigger.
 
     The button text is the first positional argument. All styling and
@@ -25,16 +26,17 @@ class Button(PublicWidgetBase):
             Equivalent to subscribing to the ``'click'`` event.
         accent: Color intent token. Defaults to the theme's default button color.
         variant: Visual weight token. Default `'solid'`.
-        icon: Bootstrap Icons name (e.g. `'save'`, `'trash'`). See the full
-            catalog at https://icons.getbootstrap.com.
+        icon: Bootstrap Icons name (e.g. `'save'`, `'trash'`) — see the full
+            catalog at https://icons.getbootstrap.com — or an `IconSpec` mapping
+            (`{'name', 'size', 'color'}`) for control over size and color.
         icon_only: If `True`, show only the icon with no text. Inferred
             automatically when `icon=` is set and no text is provided. Set
             meaningful `text` anyway for accessibility.
         icon_position: Position of the icon or image relative to the text.
             Default `'left'`.
-        image: An image handle to display on the button, for custom artwork
-            rather than a Bootstrap Icon name. (The public image-handle API is
-            being finalized for an upcoming release.)
+        image: An `Image` handle (from `bootstack.images`) to display on the
+            button, for custom artwork rather than a Bootstrap Icon name. Also
+            accepts a `get_icon` result.
         width: Button width in character units. Useful for making a row of
             buttons uniform width (e.g. `width=10`).
         textsignal: Reactive `Signal[str]` bound to the button text. Updates
@@ -55,7 +57,7 @@ class Button(PublicWidgetBase):
         on_click: Callable[[], Any] | None = None,
         accent: AccentToken | str | None = None,
         variant: ButtonVariant = "default",
-        icon: str | None = None,
+        icon: str | IconSpec | None = None,
         icon_only: bool = False,
         icon_position: IconPosition = "left",
         image: Any = None,
@@ -86,8 +88,14 @@ class Button(PublicWidgetBase):
             internal_kwargs["icon"] = icon
         if icon_only:
             internal_kwargs["icon_only"] = True
+        deferred_image = None
         if image is not None:
-            internal_kwargs["image"] = image
+            from bootstack.images import Image as _ImageHandle
+
+            if isinstance(image, _ImageHandle):
+                deferred_image = image
+            else:
+                internal_kwargs["image"] = image
         if width is not None:
             internal_kwargs["width"] = width
         if textsignal is not None:
@@ -98,6 +106,10 @@ class Button(PublicWidgetBase):
             internal_kwargs["state"] = "disabled"
 
         self._internal = _InternalButton(tk_master, **internal_kwargs)
+        if deferred_image is not None:
+            from bootstack.widgets._core.image_binding import bind_image
+
+            bind_image(self, self._internal, deferred_image)
         self._attach_to_parent(layout_kw)
 
     # ----- Properties -----
@@ -110,15 +122,6 @@ class Button(PublicWidgetBase):
     @text.setter
     def text(self, value: str) -> None:
         self._internal.configure(text=value)
-
-    @property
-    def icon(self) -> str | None:
-        """Bootstrap Icons name shown on the button, or ``None`` if no icon is set."""
-        return self._internal.configure_style_options("icon")
-
-    @icon.setter
-    def icon(self, value: str | None) -> None:
-        self._internal.configure(icon=value)
 
     @property
     def disabled(self) -> bool:

--- a/src/bootstack/widgets/datefield.py
+++ b/src/bootstack/widgets/datefield.py
@@ -7,7 +7,7 @@ from typing import overload, Any, Callable, Iterable, Literal, TYPE_CHECKING
 from bootstack.widgets._impl.composites.dateentry import DateEntry as _InternalDateEntry
 from bootstack.widgets._core.base import PublicWidgetBase, adapt_handler
 from bootstack.widgets._core.events import resolve_event, register_widget_events
-from bootstack.widgets._core.field_mixin import FieldAddonMixin
+from bootstack.widgets._core.field_mixin import FieldAddonMixin, ValueSignalMixin
 from bootstack.events import ChangeEvent, Subscription, ValidationEvent
 from bootstack.streams import Stream
 from bootstack.validation import RuleType
@@ -28,7 +28,7 @@ _DATEFIELD_EVENTS: dict[str, str] = {
 }
 
 
-class DateField(FieldAddonMixin, PublicWidgetBase):
+class DateField(ValueSignalMixin, FieldAddonMixin, PublicWidgetBase):
     """A date input field with an optional calendar picker button.
 
     In `'single'` mode `value` returns a `date`; in `'range'` mode it returns
@@ -43,8 +43,11 @@ class DateField(FieldAddonMixin, PublicWidgetBase):
             :ref:`format specs <value-formats>`.
         label: Label displayed above the field.
         message: Hint text displayed below the field.
-        textsignal: Reactive `Signal[str]` bound to the field text. The
-            field value and signal stay in sync automatically.
+        signal: Reactive `Signal` two-way bound to the field's `date` value (not
+            its text). When given, it seeds the initial value. This is the usual
+            way to bind a date field.
+        textsignal: Reactive `Signal[str]` bound to the field's raw text rather
+            than its date value. Niche; prefer `signal`.
         show_picker_button: Show the calendar icon button. Default `True`.
         picker_title: Title of the picker dialog.
         picker_first_weekday: First day of week in the picker (0=Mon … 6=Sun).
@@ -72,6 +75,7 @@ class DateField(FieldAddonMixin, PublicWidgetBase):
         self,
         value: str | date | None = None,
         *,
+        signal: "Signal | None" = None,
         value_format: str = "longDate",
         label: str | None = None,
         message: str | None = None,
@@ -138,6 +142,9 @@ class DateField(FieldAddonMixin, PublicWidgetBase):
         self._internal = _InternalDateEntry(tk_master, **internal_kwargs)
         self._attach_to_parent(layout_kw)
 
+        if signal is not None:
+            self._bind_value_signal(signal)
+
     # ----- Event routing -----
 
     def _entry_widget(self) -> tkinter.Misc:
@@ -177,11 +184,6 @@ class DateField(FieldAddonMixin, PublicWidgetBase):
         return Subscription(widget, sequence, bind_id)
 
     # ----- Properties -----
-
-    @property
-    def signal(self) -> "Signal[str] | None":
-        """The reactive signal bound to this field's text, if any."""
-        return getattr(self._internal, 'signal', None)
 
     @property
     def picker_button(self):

--- a/src/bootstack/widgets/label.py
+++ b/src/bootstack/widgets/label.py
@@ -6,18 +6,19 @@ from bootstack.widgets._impl.primitives.label import Label as _InternalLabel
 from bootstack.widgets._impl.primitives.badge import Badge as _InternalBadge
 from bootstack.widgets._core.base import PublicWidgetBase
 from bootstack.widgets._core.events import register_widget_events
+from bootstack.widgets._core.icon_image_props import IconProperty, ImageProperty
 from bootstack.events import Event, Subscription
 from bootstack.streams import Stream
 from bootstack.widgets.types import (
     AccentToken, VariantToken, SurfaceToken,
-    Anchor, Justify, Relief, CompoundMode, Padding, IconPosition,
+    Anchor, Justify, Relief, CompoundMode, Padding, IconPosition, IconSpec,
 )
 
 if TYPE_CHECKING:
     from bootstack.signals import Signal
 
 
-class Label(PublicWidgetBase):
+class Label(IconProperty, ImageProperty, PublicWidgetBase):
     """Static text display with optional icon, semantic styling, and font tokens.
 
     The display text is the first positional argument. All options are
@@ -32,12 +33,12 @@ class Label(PublicWidgetBase):
             a named preset (e.g. `'decimal'`, `'currency'`, `'shortDate'`) or a
             custom pattern (e.g. `'#,##0'`). Requires `textsignal=` and
             localization enabled. See :ref:`format specs <value-formats>`.
-        image: An image handle to display, for custom artwork rather than a
-            Bootstrap Icon name. Use `icon_position=` to control placement
-            relative to text. (The public image-handle API is being finalized
-            for an upcoming release.)
-        icon: Bootstrap Icons name (e.g. `'house'`, `'gear'`). See the
-            full catalog at https://icons.getbootstrap.com.
+        image: An `Image` handle (from `bootstack.images`) to display, for custom
+            artwork rather than a Bootstrap Icon name. Also accepts a `get_icon`
+            result. Use `icon_position=` to control placement relative to text.
+        icon: Bootstrap Icons name (e.g. `'house'`, `'gear'`) — see the full
+            catalog at https://icons.getbootstrap.com — or an `IconSpec` mapping
+            (`{'name', 'size', 'color'}`) for control over size and color.
         icon_only: If `True`, show only the icon. Auto-detected when
             `text` is empty and `icon` is provided.
         icon_position: Position of the icon or image relative to the text.
@@ -67,7 +68,7 @@ class Label(PublicWidgetBase):
         textsignal: "Signal | None" = None,
         value_format: str | None = None,
         image: Any = None,
-        icon: str | None = None,
+        icon: str | IconSpec | None = None,
         icon_only: bool = False,
         icon_position: IconPosition = "left",
         anchor: Anchor | None = None,
@@ -93,8 +94,20 @@ class Label(PublicWidgetBase):
             internal_kwargs["textsignal"] = textsignal
         if value_format is not None:
             internal_kwargs["value_format"] = value_format
+        deferred_image = None
         if image is not None:
-            internal_kwargs["image"] = image
+            from bootstack.images import Image as _ImageHandle
+
+            if isinstance(image, _ImageHandle):
+                deferred_image = image
+                has_text = bool(text) or textsignal is not None
+                if not has_text or icon_only:
+                    internal_kwargs["icon_only"] = True
+                    internal_kwargs["compound"] = "image"
+                else:
+                    internal_kwargs["compound"] = icon_position
+            else:
+                internal_kwargs["image"] = image
         if icon is not None:
             internal_kwargs["icon"] = icon
             has_text = bool(text) or textsignal is not None
@@ -125,6 +138,10 @@ class Label(PublicWidgetBase):
             internal_kwargs["surface"] = surface
 
         self._internal = self._internal_class(tk_master, **internal_kwargs)
+        if deferred_image is not None:
+            from bootstack.widgets._core.image_binding import bind_image
+
+            bind_image(self, self._internal, deferred_image)
         self._attach_to_parent(layout_kw)
 
     # ----- Properties -----

--- a/src/bootstack/widgets/menubutton.py
+++ b/src/bootstack/widgets/menubutton.py
@@ -4,7 +4,8 @@ from typing import Any, Callable, TYPE_CHECKING
 
 from bootstack.widgets._impl.composites.dropdownbutton import DropdownButton as _InternalDropdownButton
 from bootstack.widgets._core.base import PublicWidgetBase
-from bootstack.widgets.types import AccentToken, WidgetDensity, ButtonVariant
+from bootstack.widgets._core.icon_image_props import IconProperty
+from bootstack.widgets.types import AccentToken, WidgetDensity, ButtonVariant, IconSpec
 from bootstack.events import MenuSelectEvent
 
 if TYPE_CHECKING:
@@ -55,7 +56,7 @@ _RESERVED_INTERNAL_KEYS = frozenset({
 })
 
 
-class MenuButton(PublicWidgetBase):
+class MenuButton(IconProperty, PublicWidgetBase):
     """A button that opens a dropdown menu when clicked.
 
     Items are added at construction via ``items=`` or dynamically with
@@ -97,7 +98,7 @@ class MenuButton(PublicWidgetBase):
         *,
         items: list[Any] | None = None,
         on_select: Callable[[MenuSelectEvent], Any] | None = None,
-        icon: str | None = None,
+        icon: str | IconSpec | None = None,
         icon_only: bool = False,
         show_arrow: bool = True,
         menu_options: dict[str, Any] | None = None,

--- a/src/bootstack/widgets/numberfield.py
+++ b/src/bootstack/widgets/numberfield.py
@@ -6,7 +6,7 @@ from typing import overload, Any, Callable, TYPE_CHECKING
 from bootstack.widgets._impl.composites.numericentry import NumericEntry as _InternalNumericEntry
 from bootstack.widgets._core.base import PublicWidgetBase, adapt_handler
 from bootstack.widgets._core.events import resolve_event, register_widget_events
-from bootstack.widgets._core.field_mixin import FieldAddonMixin
+from bootstack.widgets._core.field_mixin import FieldAddonMixin, ValueSignalMixin
 from bootstack.events import ChangeEvent, InputEvent, Subscription, ValidationEvent
 from bootstack.streams import Stream
 from bootstack.widgets.textfield import _INNER_ENTRY_SEQUENCES
@@ -14,6 +14,23 @@ from bootstack.widgets.types import AccentToken, Event, Justify, WidgetDensity
 
 if TYPE_CHECKING:
     from bootstack.signals import Signal
+
+def _as_number(raw: Any) -> int | float | None:
+    """Coerce a field's stored value to a number, regardless of representation.
+
+    The numeric field stores its value as text in some code paths; the public
+    contract is that `value` (and the bound `signal`) is always a number.
+    """
+    if raw is None or raw == "":
+        return None
+    if isinstance(raw, (int, float)):
+        return raw
+    try:
+        f = float(raw)
+    except (TypeError, ValueError):
+        return None
+    return int(f) if f.is_integer() else f
+
 
 _NUMBER_FIELD_EVENTS: dict[str, str] = {
     "input":    "<<Input>>",
@@ -27,7 +44,7 @@ _NUMBER_FIELD_EVENTS: dict[str, str] = {
 }
 
 
-class NumberField(FieldAddonMixin, PublicWidgetBase):
+class NumberField(ValueSignalMixin, FieldAddonMixin, PublicWidgetBase):
     """A numeric input field with optional stepper buttons.
 
     Accepts integer or float values. Up/Down arrow keys and the mouse wheel
@@ -39,10 +56,15 @@ class NumberField(FieldAddonMixin, PublicWidgetBase):
 
     Args:
         value: Initial numeric value. Defaults to `0`.
-        textsignal: Reactive `Signal[str]` bound to the field text. The
-            field and signal stay in sync automatically. Note: the signal
-            must be typed as `str` — initialize with `Signal("0")`,
-            not `Signal(0)`.
+        signal: Reactive `Signal` two-way bound to the field's numeric value.
+            Carries the parsed number (`int`/`float`), not the text. Use a
+            float-typed signal — `Signal(0.0)` — when the field accepts
+            fractional values, so they bind cleanly; an `int`-typed `Signal(0)`
+            holds whole numbers only. When given, it seeds the initial value.
+            This is the usual way to bind a number field.
+        textsignal: Reactive `Signal[str]` bound to the field's raw text (rather
+            than its numeric value). Niche; prefer `signal`. The signal must be
+            typed as `str` — initialize with `Signal("0")`, not `Signal(0)`.
         label: Label displayed above the field.
         message: Hint or helper text displayed below the field.
         min_value: Minimum allowed value (inclusive). No lower bound if omitted.
@@ -79,6 +101,7 @@ class NumberField(FieldAddonMixin, PublicWidgetBase):
         self,
         value: int | float = 0,
         *,
+        signal: "Signal | None" = None,
         textsignal: "Signal | None" = None,
         value_format: str | None = None,
         label: str | None = None,
@@ -142,6 +165,9 @@ class NumberField(FieldAddonMixin, PublicWidgetBase):
         self._internal = _InternalNumericEntry(tk_master, **internal_kwargs)
         self._attach_to_parent(layout_kw)
 
+        if signal is not None:
+            self._bind_value_signal(signal)
+
     # ----- Event routing -----
 
     def _entry_widget(self) -> tkinter.Misc:
@@ -184,16 +210,11 @@ class NumberField(FieldAddonMixin, PublicWidgetBase):
     @property
     def value(self) -> int | float | None:
         """The current numeric value, or `None` if the field is empty."""
-        return self._internal.value
+        return _as_number(self._internal.value)
 
     @value.setter
     def value(self, v: int | float) -> None:
         self._internal.value = v
-
-    @property
-    def signal(self) -> "Signal | None":
-        """The reactive `Signal` bound to this field, or `None`."""
-        return getattr(self._internal, 'signal', None)
 
     @property
     def read_only(self) -> bool:

--- a/src/bootstack/widgets/selectbutton.py
+++ b/src/bootstack/widgets/selectbutton.py
@@ -5,10 +5,11 @@ from typing import overload, Any, Callable, TYPE_CHECKING
 from bootstack.widgets._impl.primitives.optionmenu import OptionMenu as _InternalOptionMenu
 from bootstack.widgets._core.base import PublicWidgetBase
 from bootstack.widgets._core.events import register_widget_events
+from bootstack.widgets._core.icon_image_props import IconProperty
 from bootstack.widgets._core.options import record_to_dict
 from bootstack.events import ChangeEvent, Subscription
 from bootstack.streams import Stream
-from bootstack.widgets.types import AccentToken, Event, Option, OptionDict, WidgetDensity, ButtonVariant
+from bootstack.widgets.types import AccentToken, Event, Option, OptionDict, WidgetDensity, ButtonVariant, IconSpec
 
 if TYPE_CHECKING:
     from bootstack.signals import Signal
@@ -18,7 +19,7 @@ _SELECTBUTTON_EVENTS: dict[str, str] = {
 }
 
 
-class SelectButton(PublicWidgetBase):
+class SelectButton(IconProperty, PublicWidgetBase):
     """A button that opens a dropdown value list — a button-styled alternative to `Select`.
 
     Clicking the button opens a popup list of options. The selected value is
@@ -60,7 +61,7 @@ class SelectButton(PublicWidgetBase):
         accent: AccentToken | str | None = None,
         variant: ButtonVariant = "default",
         density: WidgetDensity | None = None,
-        icon: str | None = None,
+        icon: str | IconSpec | None = None,
         parent: Any = None,
         **kwargs: Any,
     ) -> None:

--- a/src/bootstack/widgets/timefield.py
+++ b/src/bootstack/widgets/timefield.py
@@ -7,7 +7,7 @@ from typing import overload, Any, Callable, TYPE_CHECKING
 from bootstack.widgets._impl.composites.timeentry import TimeEntry as _InternalTimeEntry
 from bootstack.widgets._core.base import PublicWidgetBase, adapt_handler
 from bootstack.widgets._core.events import resolve_event, register_widget_events
-from bootstack.widgets._core.field_mixin import FieldAddonMixin
+from bootstack.widgets._core.field_mixin import FieldAddonMixin, ValueSignalMixin
 from bootstack.events import ChangeEvent, Subscription, ValidationEvent
 from bootstack.streams import Stream
 from bootstack.validation import RuleType
@@ -28,7 +28,7 @@ _TIME_FIELD_EVENTS: dict[str, str] = {
 }
 
 
-class TimeField(FieldAddonMixin, PublicWidgetBase):
+class TimeField(ValueSignalMixin, FieldAddonMixin, PublicWidgetBase):
     """A time-input field with a searchable dropdown of time intervals.
 
     Displays a formatted time value and shows a dropdown list of times at
@@ -48,6 +48,9 @@ class TimeField(FieldAddonMixin, PublicWidgetBase):
         max_time: Latest time shown in the dropdown.
         label: Label displayed above the field.
         message: Hint text displayed below the field.
+        signal: Reactive `Signal` two-way bound to the field's `time` value (not
+            its text). When given, it seeds the initial value. This is the usual
+            way to bind a time field.
         textsignal: Reactive `Signal[str]` bound to the field text. The
             field value and signal stay in sync automatically.
         required: If `True`, field cannot be left empty.
@@ -67,6 +70,7 @@ class TimeField(FieldAddonMixin, PublicWidgetBase):
         self,
         value: datetime.time | str | None = None,
         *,
+        signal: "Signal | None" = None,
         value_format: str = "shortTime",
         interval: int = 30,
         min_time: datetime.time | str | None = None,
@@ -119,6 +123,9 @@ class TimeField(FieldAddonMixin, PublicWidgetBase):
         self._internal = _InternalTimeEntry(tk_master, **internal_kwargs)
         self._attach_to_parent(layout_kw)
 
+        if signal is not None:
+            self._bind_value_signal(signal)
+
     # ----- Event routing -----
 
     def _entry_widget(self) -> tkinter.Misc:
@@ -158,11 +165,6 @@ class TimeField(FieldAddonMixin, PublicWidgetBase):
         return Subscription(widget, sequence, bind_id)
 
     # ----- Properties -----
-
-    @property
-    def signal(self) -> "Signal[str] | None":
-        """The reactive signal bound to this field's text, if any."""
-        return getattr(self._internal, 'signal', None)
 
     @property
     def value(self) -> "datetime.time | None":

--- a/src/bootstack/widgets/types.py
+++ b/src/bootstack/widgets/types.py
@@ -250,3 +250,24 @@ Three interchangeable forms, all normalized to a `(text, value)` pair:
 - a plain `str` — text and value are the same (`'Small'`);
 - a `(text, value)` tuple — decoupled label and value (`('Small', 's')`);
 - an `OptionDict` — `{'text': 'Small', 'value': 's'}`; the extensible form."""
+
+
+class IconSpec(TypedDict, total=False):
+    """A detailed icon specification: a Bootstrap icon name with size and color.
+
+    Use in place of a plain icon name wherever a widget accepts `icon=`, to
+    control the rendered size and color — for example
+    `icon={'name': 'bell-fill', 'size': 24, 'color': 'primary'}`.
+    """
+
+    name: str
+    """Bootstrap Icons name, e.g. `'bell-fill'`."""
+    size: int
+    """Icon size in pixels (automatically DPI-scaled)."""
+    color: str
+    """Icon color — a theme color token (e.g. `'primary'`) or a hex string."""
+
+
+Icon = str | IconSpec
+"""An icon as either a Bootstrap Icons name (`'bell-fill'`) or an `IconSpec`
+mapping for control over size and color."""

--- a/src/bootstack/widgets/window.py
+++ b/src/bootstack/widgets/window.py
@@ -1,12 +1,53 @@
 ﻿from __future__ import annotations
 
-from typing import Any, Callable, Literal
+from typing import TYPE_CHECKING, Any, Callable, Literal
 
 from bootstack.widgets._impl.primitives.packframe import PackFrame
 from bootstack.widgets._core.container import PublicContainer, PACK_KEYS, normalize_fill
 from bootstack.widgets._core.window_controls import WindowControlsMixin
 from bootstack.widgets._core.window_menu import ChromeHostMixin
 from bootstack.widgets.types import Padding, Fill, Anchor, SurfaceToken, WindowStyle
+
+if TYPE_CHECKING:
+    from bootstack.images import AppIcon, Image
+
+
+def _resolve_window_parent(parent: Any) -> Any:
+    """Resolve a public widget (or tk widget) to its containing tk window.
+
+    Accepts an `App`, a `Window`, or any widget inside one, and returns the
+    enclosing toplevel — so centering and transient-parenting act on the window,
+    not on a small child widget.
+    """
+    if parent is None:
+        return None
+    widget = None
+    for attr in ("_tk_root", "_tk_toplevel", "_internal"):
+        widget = getattr(parent, attr, None)
+        if widget is not None:
+            break
+    if widget is None:
+        widget = parent  # assume it is already a tk widget
+    try:
+        return widget.winfo_toplevel()
+    except Exception:
+        return widget
+
+
+def _resolve_anchor_widget(target: Any) -> Any:
+    """Resolve an anchor target to a tk widget (keeping it, not its toplevel).
+
+    A string (`'screen'`/`'cursor'`/`'parent'`) passes through; a public widget
+    resolves to the underlying tk widget so a window can be placed relative to
+    that exact widget (e.g. beside a field).
+    """
+    if isinstance(target, str) or target is None:
+        return target
+    for attr in ("_tk_toplevel", "_tk_root", "_internal"):
+        widget = getattr(target, attr, None)
+        if widget is not None:
+            return widget
+    return target
 
 
 class Window(WindowControlsMixin, ChromeHostMixin, PublicContainer):
@@ -21,6 +62,8 @@ class Window(WindowControlsMixin, ChromeHostMixin, PublicContainer):
     Args:
         title: Window title bar text.
         size: Initial size as `(width, height)`.
+        icon: Title-bar and taskbar icon — an icon file path, an `Image` handle,
+            or an `AppIcon`. Defaults to the bootstack icon.
         position: Initial position as `(x, y)`.
         min_size: Minimum window size as `(width, height)`.
         max_size: Maximum window size as `(width, height)`.
@@ -28,7 +71,12 @@ class Window(WindowControlsMixin, ChromeHostMixin, PublicContainer):
         modal: Modality level. `False` — non-modal (default). `True` or
             `'window'` — grabs input from the parent only. `'app'` — grabs
             input from all windows.
-        center_on_parent: Center over the parent/transient window.
+        parent: The window this one belongs to — an `App`, another `Window`, or
+            any widget inside one. Makes this window transient to it (stacks
+            above it, hides with it) and is the target for `center_on_parent`.
+            Defaults to the main application window.
+        center_on_parent: Center over `parent` (the main window if `parent` is
+            not given).
         center_on_screen: Center on the screen.
         topmost: Keep the window above other windows.
         undecorated: Remove OS window decorations (`overrideredirect`).
@@ -58,11 +106,13 @@ class Window(WindowControlsMixin, ChromeHostMixin, PublicContainer):
         *,
         title: str = "",
         size: tuple[int, int] | None = None,
+        icon: "str | Image | AppIcon | None" = None,
         position: tuple[int, int] | None = None,
         min_size: tuple[int, int] | None = None,
         max_size: tuple[int, int] | None = None,
         resizable: tuple[bool, bool] | None = None,
         modal: Literal[False, True, "window", "app"] = False,
+        parent: Any = None,
         center_on_parent: bool = False,
         center_on_screen: bool = False,
         topmost: bool = False,
@@ -111,9 +161,26 @@ class Window(WindowControlsMixin, ChromeHostMixin, PublicContainer):
             init_kwargs["on_close"] = on_close
         if window_style is not None:
             init_kwargs["window_style"] = window_style
+
+        parent_widget = _resolve_window_parent(parent)
+        self._parent_window = parent_widget
+        if parent_widget is not None:
+            init_kwargs["transient"] = parent_widget
+
+        from bootstack.widgets._core.image_binding import resolve_window_icon
+
+        icon_path, icon_image = resolve_window_icon(icon)
+        if icon_path is not None:
+            init_kwargs["icon"] = icon_path
         init_kwargs.update(kwargs)
 
         self._tk_toplevel = _InternalToplevel(**init_kwargs)
+
+        # An Image handle needs the window to exist before it can be rendered.
+        self._window_icon_photo = None
+        if icon_image is not None:
+            self._window_icon_photo = icon_image._materialize()
+            self._tk_toplevel._setup_icon(self._window_icon_photo)
 
         frame_kwargs: dict[str, Any] = {
             "direction": "vertical",
@@ -144,12 +211,54 @@ class Window(WindowControlsMixin, ChromeHostMixin, PublicContainer):
 
     # ----- Lifecycle -----
 
-    def show(self) -> "Window":
-        """Show the window and apply any modal grab.
+    def show(
+        self,
+        *,
+        anchor_to: Any = None,
+        anchor_point: Anchor = "center",
+        window_point: Anchor = "center",
+        offset: tuple[int, int] = (0, 0),
+        auto_flip: bool = True,
+    ) -> "Window":
+        """Show the window, optionally positioned relative to a widget.
+
+        With no arguments the window appears at its configured position (or
+        centered on its `parent`). Pass `anchor_to` to place it relative to a
+        widget instead — for example, to the right of a field.
+
+        Args:
+            anchor_to: A widget to position this window against, or one of
+                `'screen'`, `'cursor'`, or `'parent'`. When given, this overrides
+                centering.
+            anchor_point: The point on the anchor target to align to — one of
+                `'n'`, `'s'`, `'e'`, `'w'`, `'ne'`, `'nw'`, `'se'`, `'sw'`, or
+                `'center'`. For example, `'e'` is the target's right edge.
+            window_point: The matching point on this window placed at the anchor
+                (same value set). For example, `anchor_point='e'` with
+                `window_point='w'` puts this window's left edge at the target's
+                right edge — i.e. to its right.
+            offset: Extra `(x, y)` pixel offset from the anchored position.
+            auto_flip: Flip to the opposite side if the window would otherwise go
+                off-screen. Defaults to `True`.
 
         Returns:
             `self` — allows chaining: ``win = Window(...).show()``.
         """
+        if anchor_to is not None:
+            from bootstack._runtime.window_utilities import WindowPositioning
+
+            toplevel = self._tk_toplevel
+            toplevel.update_idletasks()
+            WindowPositioning.position_anchored(
+                window=toplevel,
+                anchor_to=_resolve_anchor_widget(anchor_to),
+                parent=self._parent_window,
+                anchor_point=anchor_point,
+                window_point=window_point,
+                offset=offset,
+                auto_flip=auto_flip,
+                ensure_visible=True,
+            )
         self._tk_toplevel.show()
         return self
 

--- a/tests/cli/test_appicon.py
+++ b/tests/cli/test_appicon.py
@@ -1,0 +1,33 @@
+"""Tests for the `bootstack appicon` designer command (non-GUI parts)."""
+
+from __future__ import annotations
+
+import argparse
+
+import pytest
+
+from bootstack.cli import appicon
+
+
+def test_parser_registers():
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers()
+    appicon.add_parser(sub)
+    args = parser.parse_args(["appicon"])
+    assert callable(args.func)
+
+
+@pytest.mark.parametrize(
+    "color, ok",
+    [
+        ("#fff", True),
+        ("#0d6efd", True),
+        ("#0d6efdff", True),
+        ("primary", False),
+        ("0d6efd", False),
+        ("#xyz", False),
+        ("#0d6ef", False),
+    ],
+)
+def test_is_hex(color, ok):
+    assert appicon._is_hex(color) is ok

--- a/tests/cli/test_templates.py
+++ b/tests/cli/test_templates.py
@@ -86,13 +86,13 @@ def test_create_basic_project(tmp_path: Path, container: str, simple: bool) -> N
     assert cfg["app"]["name"] == "MyApp"
     assert cfg["app"]["template"] == "basic"
     assert cfg["app"]["entry"] == "src/myapp/main.py"
-    assert cfg["settings"]["theme"] == "cosmo"
+    assert "settings" not in cfg  # runtime config is not a toml concern
     assert "build" not in cfg  # promote adds it later
 
-    # main.py respects BOOTSTACK_THEME (env override path) and references the
-    # right view subclass for the chosen container.
+    # main.py bakes the chosen theme as a literal and references the right view
+    # subclass for the chosen container.
     main_src = (target / "src" / "myapp" / "main.py").read_text(encoding="utf-8")
-    assert 'os.environ.get("BOOTSTACK_THEME", "cosmo")' in main_src
+    assert 'theme="cosmo"' in main_src
     assert "from myapp.views.main_view import MainView" in main_src
 
     view_src = (target / "src" / "myapp" / "views" / "main_view.py").read_text(encoding="utf-8")
@@ -131,11 +131,11 @@ def test_create_appshell_project(tmp_path: Path, simple: bool) -> None:
 
     cfg = _load_toml(target / "bootstack.toml")
     assert cfg["app"]["template"] == "appshell"
-    assert cfg["settings"]["theme"] == "superhero"
+    assert "settings" not in cfg  # runtime config is not a toml concern
 
     main_src = (target / "src" / "myshell" / "main.py").read_text(encoding="utf-8")
     assert "bs.AppShell" in main_src
-    assert 'os.environ.get("BOOTSTACK_THEME", "superhero")' in main_src
+    assert 'theme="superhero"' in main_src
     assert "HomePage" in main_src and "SettingsPage" in main_src
 
 

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -1,0 +1,112 @@
+"""Headless tests for the public image handles and icon factory.
+
+These exercise `bootstack.images` without creating an application, proving that a
+handle carries no toolkit resource until it is bound to a widget.
+"""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+from PIL import Image as PILImage
+
+from bootstack.images import AppIcon, Image, get_icon
+
+
+def _png_bytes(size=(7, 11), color=(10, 20, 30, 255)) -> bytes:
+    buf = io.BytesIO()
+    PILImage.new("RGBA", size, color).save(buf, "PNG")
+    return buf.getvalue()
+
+
+def test_open_reports_size_without_an_app(tmp_path):
+    p = tmp_path / "a.png"
+    p.write_bytes(_png_bytes((13, 17)))
+    img = Image.open(p)
+    assert (img.width, img.height) == (13, 17)
+    assert img._photo is None  # nothing rendered yet
+
+
+def test_from_bytes_reports_size():
+    img = Image.from_bytes(_png_bytes((5, 9)))
+    assert (img.width, img.height) == (5, 9)
+
+
+def test_from_pil_reports_size():
+    img = Image.from_pil(PILImage.new("RGB", (4, 6)))
+    assert (img.width, img.height) == (4, 6)
+
+
+def test_get_icon_builds_no_toolkit_object():
+    icon = get_icon("house")
+    assert (icon.width, icon.height) == (20, 20)
+    assert icon._photo is None
+
+
+def test_get_icon_size_override():
+    assert get_icon("gear", size=32).width == 32
+
+
+def test_token_color_is_theme_following():
+    assert get_icon("house", color="primary")._is_theme_following is True
+
+
+def test_hex_color_is_static():
+    assert get_icon("house", color="#ff8800")._is_theme_following is False
+
+
+@pytest.mark.parametrize("ext", [".ico", ".png", ".icns"])
+def test_appicon_save_exports_each_format(tmp_path, ext):
+    out = tmp_path / f"app{ext}"
+    AppIcon("rocket", background="#0d6efd", foreground="#ffffff").save(out)
+    assert out.exists() and out.stat().st_size > 0
+
+
+def test_appicon_rejects_unknown_format(tmp_path):
+    with pytest.raises(ValueError):
+        AppIcon("rocket").save(tmp_path / "app.bmp")
+
+
+def test_appicon_hex_render_needs_no_app(tmp_path):
+    # Hex colors resolve without a running application (the build-time path).
+    out = AppIcon("rocket", background="#222222", foreground="#ffffff").save(
+        tmp_path / "build.ico"
+    )
+    assert PILImage.open(out).size == (256, 256)
+
+
+def _edge_alpha(path) -> int:
+    # Top-edge midpoint: opaque on a tile (filled background), transparent on a
+    # glyph-only mark.
+    im = PILImage.open(path).convert("RGBA")
+    w, _ = im.size
+    return im.getpixel((w // 2, 2))[3]
+
+
+def _ico_edge_alpha(path, size: int) -> int:
+    # Same probe, but for a specific frame inside a multi-size `.ico`.
+    frame = PILImage.open(path).ico.getimage((size, size)).convert("RGBA")
+    return frame.getpixel((size // 2, max(1, size // 16)))[3]
+
+
+def test_auto_shape_is_mixed_for_ico(tmp_path):
+    # auto on Windows/Linux: small frames glyph-only, large frames tiled.
+    out = AppIcon("rocket", background="#0d6efd").save(tmp_path / "a.ico")
+    assert _ico_edge_alpha(out, 16) == 0      # title-bar frame — bare mark
+    assert _ico_edge_alpha(out, 256) == 255   # large frame — filled tile
+
+
+def test_auto_shape_is_tiled_for_icns(tmp_path):
+    out = AppIcon("rocket", background="#0d6efd").save(tmp_path / "a.icns")
+    assert _edge_alpha(out) == 255  # filled tile
+
+
+def test_forced_tile_on_ico(tmp_path):
+    out = AppIcon("rocket", background="#0d6efd", shape="tile").save(tmp_path / "t.ico")
+    assert _edge_alpha(out) == 255
+
+
+def test_forced_glyph_on_icns(tmp_path):
+    out = AppIcon("rocket", background="#0d6efd", shape="glyph").save(tmp_path / "g.icns")
+    assert _edge_alpha(out) == 0

--- a/tests/test_images_gui.py
+++ b/tests/test_images_gui.py
@@ -1,0 +1,72 @@
+"""GUI tests for image binding, theme-following, and window icons.
+
+One `App` per process: these all run under a single module-scoped application
+(creating a second `App` in the same process crashes Tk on Windows).
+"""
+
+from __future__ import annotations
+
+import pytest
+from PIL import Image as PILImage
+
+import bootstack as bs
+from bootstack.images import AppIcon, Image, get_icon
+
+
+@pytest.fixture(scope="module")
+def app():
+    with bs.App(theme="bootstrap-light") as a:
+        yield a
+
+
+@pytest.fixture(scope="module")
+def png(tmp_path_factory):
+    p = tmp_path_factory.mktemp("img") / "a.png"
+    PILImage.new("RGBA", (24, 24), (200, 50, 50, 255)).save(p)
+    return str(p)
+
+
+def test_label_renders_image_handle(app, png):
+    lbl = bs.Label("Hi", image=Image.open(png))
+    app.tk.update()
+    assert lbl._internal.cget("image")  # a real image is set
+    assert lbl._image_photo is not None
+
+
+def test_button_renders_icon_handle(app):
+    btn = bs.Button("Save", image=get_icon("save", color="foreground"))
+    app.tk.update()
+    assert btn._internal.cget("image")
+
+
+def test_token_icon_rerenders_on_theme_change(app):
+    lbl = bs.Label("X", image=get_icon("house", color="foreground"))
+    app.tk.update()
+    before = lbl._image_photo
+    app.theme = "bootstrap-dark"
+    app.tk.update()
+    assert lbl._image_photo is not before  # re-rendered for the new theme
+    app.theme = "bootstrap-light"
+    app.tk.update()
+
+
+def test_hex_icon_does_not_rerender_on_theme_change(app):
+    lbl = bs.Label("X", image=get_icon("gear", color="#ff8800"))
+    app.tk.update()
+    before = lbl._image_photo
+    app.theme = "bootstrap-dark"
+    app.tk.update()
+    assert lbl._image_photo is before
+    app.theme = "bootstrap-light"
+    app.tk.update()
+
+
+def test_window_accepts_each_icon_type(app, png):
+    w_path = bs.Window(title="p", icon=png)
+    w_image = bs.Window(title="i", icon=Image.open(png))
+    w_appicon = bs.Window(title="a", icon=AppIcon("gear", background="#333333"))
+    app.tk.update()
+    assert w_image._window_icon_photo is not None
+    # path / AppIcon routes go through the file path, not a retained photo
+    assert w_path._window_icon_photo is None
+    assert w_appicon._window_icon_photo is None

--- a/tests/test_public_surface.py
+++ b/tests/test_public_surface.py
@@ -29,6 +29,7 @@ EXPECTED_TOPLEVEL = {
     # dialog verbs
     "alert", "confirm", "ask_string", "ask_integer", "ask_float", "ask_date",
     "ask_date_range", "ask_item", "ask_color", "ask_font", "ask_filter",
+    "ask_save_file", "ask_open_file", "ask_open_files", "ask_directory",
     # application & windows
     "App", "AppShell", "Window",
     # layout
@@ -69,6 +70,7 @@ MOVED = {
     "bootstack.scheduling": ["Schedule", "Job"],
     "bootstack.shortcuts": ["Shortcuts", "Shortcut", "get_shortcuts"],
     "bootstack.store": ["Store"],
+    "bootstack.images": ["Image", "get_icon", "AppIcon", "list_icons"],
     "bootstack.errors": [
         "BootstackError", "UnknownEventError", "ParentResolutionError",
         "DuplicateIdError", "SerializationError",
@@ -82,6 +84,7 @@ MOVED = {
         "BaseWidgetKwargs", "StyledKwargs", "Anchor", "Fill", "Side", "Sticky",
         "Padding", "WindowStyle", "LayoutKind", "AutoFlow",
         "ColumnSpec", "EditorType", "FormOptions", "Option", "OptionDict",
+        "Icon", "IconSpec",
     ],
     # EditFilter demoted from top-level (Tk-coupled CodeEditor extension hook);
     # stays importable here for power users. See project_editfilter_public_api.

--- a/tests/widgets/public/test_field_text_value.py
+++ b/tests/widgets/public/test_field_text_value.py
@@ -45,6 +45,95 @@ FIELD_FACTORIES = [
 ]
 
 
+def test_numberfield_signal_is_numeric_and_two_way(app):
+    sig = bs.Signal(0.22)
+    nf = bs.NumberField(signal=sig, min_value=0.0, max_value=0.5, step=0.1)
+    app._tk_root.update_idletasks()
+
+    # Seeds the field from the signal's numeric value.
+    assert nf.value == 0.22
+
+    # signal -> field
+    sig.set(0.4)
+    app._tk_root.update_idletasks()
+    assert nf.value == 0.4
+
+    # field commit -> signal, as a number (not text)
+    entry = nf._internal._entry
+    entry.delete(0, "end")
+    entry.insert(0, "0.3")
+    entry.event_generate("<FocusOut>")
+    app._tk_root.update_idletasks()
+    assert sig() == 0.3
+    assert isinstance(sig(), float)
+
+
+def test_typed_fields_signal_binds_value_not_text(app):
+    import datetime
+
+    # DateField: signal carries a date.
+    dsig = bs.Signal(datetime.date(2024, 1, 2))
+    df = bs.DateField(signal=dsig)
+    app._tk_root.update_idletasks()
+    assert df.value == datetime.date(2024, 1, 2)
+    assert df.signal is dsig
+    dsig.set(datetime.date(2025, 6, 15))
+    app._tk_root.update_idletasks()
+    assert df.value == datetime.date(2025, 6, 15)
+
+    # TimeField: signal carries a time.
+    tsig = bs.Signal(datetime.time(8, 30))
+    tf = bs.TimeField(signal=tsig)
+    app._tk_root.update_idletasks()
+    assert tf.value == datetime.time(8, 30)
+    assert isinstance(tf.value, datetime.time)
+
+
+def test_value_signal_unsubscribes_on_destroy(app):
+    # A Signal usually outlives the widgets bound to it; destroying a bound field
+    # must release its subscription so the field is not pinned in memory.
+    sig = bs.Signal(0.0)
+    before = len(sig._subscribers)
+    nf = bs.NumberField(signal=sig, step=0.1)
+    app._tk_root.update_idletasks()
+    assert len(sig._subscribers) == before + 1  # bound
+
+    nf.destroy()
+    app._tk_root.update_idletasks()
+    assert len(sig._subscribers) == before  # released
+
+
+def test_push_to_signal_reconciles_numeric_types(app):
+    # int field value -> float-typed signal widens cleanly.
+    fsig = bs.Signal(0.0)
+    nf = bs.NumberField(signal=fsig, step=1)
+    nf._push_to_signal(5)
+    assert fsig() == 5.0 and isinstance(fsig(), float)
+
+    # Fractional value -> int-typed signal is incompatible: it must NOT raise
+    # into the Tk loop; the signal simply keeps its prior value.
+    isig = bs.Signal(2)
+    nf2 = bs.NumberField(signal=isig, step=1)
+    nf2._push_to_signal(0.3)
+    assert isig() == 2
+
+    # An integral float -> int-typed signal coerces back to int.
+    nf2._push_to_signal(7.0)
+    assert isig() == 7 and isinstance(isig(), int)
+
+
+def test_numberfield_stepping_stays_on_step_grid(app):
+    nf = bs.NumberField(value=0.0, min_value=0.0, max_value=1.0, step=0.05)
+    entry = nf._internal._entry
+    values = []
+    for _ in range(8):
+        entry.event_generate("<<Increment>>")
+        app._tk_root.update_idletasks()
+        values.append(nf.value)
+    # No accumulated float error — every value is a clean multiple of 0.05.
+    assert values == [0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4]
+
+
 @pytest.mark.parametrize("name, make", FIELD_FACTORIES, ids=[f[0] for f in FIELD_FACTORIES])
 def test_field_exposes_text_as_str(app, name, make):
     w = make()

--- a/tests/widgets/test_icon_image_props.py
+++ b/tests/widgets/test_icon_image_props.py
@@ -1,0 +1,71 @@
+"""Live `icon` / `image` properties and the icon-spec form (one App/process)."""
+
+from __future__ import annotations
+
+import pytest
+
+import bootstack as bs
+from bootstack.images import get_icon
+
+
+@pytest.fixture(scope="module")
+def app():
+    a = bs.App()
+    a._tk_root.withdraw()
+    try:
+        yield a
+    finally:
+        try:
+            a._tk_root.destroy()
+        except Exception:
+            pass
+
+
+def test_label_icon_and_image_settable(app):
+    lbl = bs.Label("Hi", icon="house")
+    lbl.icon = "gear"
+    assert lbl.icon == "gear"
+    lbl.image = get_icon("star", size=20)
+    assert lbl.image is not None
+
+
+def test_button_icon_and_image_settable(app):
+    btn = bs.Button("Go", icon="house")
+    btn.icon = "gear"
+    assert btn.icon == "gear"
+    btn.image = get_icon("star", size=20)
+    assert btn.image is not None
+
+
+def test_menubutton_and_selectbutton_icon_settable(app):
+    mb = bs.MenuButton("M", icon="house")
+    mb.icon = "gear"
+    assert mb.icon == "gear"
+    sb = bs.SelectButton(options=["a", "b"], icon="house")
+    sb.icon = "gear"
+    assert sb.icon == "gear"
+
+
+def test_clearing_image_releases_theme_binding(app):
+    lbl = bs.Label("Hi")
+    # A token-colored icon follows the theme, installing a <<BsThemeChanged>>
+    # binding that re-renders it on theme change.
+    lbl.image = get_icon("star", size=20, color="primary")
+    app._tk_root.update_idletasks()
+    assert getattr(lbl, "_image_theme_binding", None) is not None
+
+    # Clearing the image must release that binding — otherwise it keeps pinning
+    # the old handle and re-applying a removed image on theme changes.
+    lbl.image = None
+    assert getattr(lbl, "_image_theme_binding", None) is None
+    assert lbl.image is None
+
+
+def test_icon_spec_with_size_and_token_color(app):
+    spec = {"name": "bell-fill", "size": 24, "color": "primary"}
+    btn = bs.Button("Go", icon=spec)
+    app._tk_root.update_idletasks()
+    assert btn.icon == spec  # accepted and round-trips
+    # and assignable as a spec
+    btn.icon = {"name": "gear", "size": 18, "color": "#ff8800"}
+    assert btn.icon["name"] == "gear"

--- a/tests/widgets/test_rebuild_regressions.py
+++ b/tests/widgets/test_rebuild_regressions.py
@@ -1,0 +1,71 @@
+"""Regression tests for dynamic rebuild bugs (one App per process).
+
+Both bugs were surfaced by a UI that destroys and recreates child widgets on
+every update (a live preview):
+
+1. ``Grid`` auto-flow placed re-added children on top of one another because
+   ``destroy()`` bypasses ``grid_forget()``, leaving stale occupied cells.
+2. ``Schedule`` cancelled an owner's jobs whenever *any* descendant was
+   destroyed, because ``<Destroy>`` propagates up to the owner's binding.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import bootstack as bs
+
+
+@pytest.fixture(scope="module")
+def app():
+    a = bs.App()
+    a._tk_root.withdraw()
+    try:
+        yield a
+    finally:
+        try:
+            a._tk_root.destroy()
+        except Exception:
+            pass
+
+
+def test_grid_autoflow_survives_destroy_recreate(app):
+    grid = bs.Grid(rows=2, columns=1, parent=app)
+    tiles: list = []
+
+    def rebuild() -> None:
+        for w in tiles:
+            w.destroy()
+        tiles.clear()
+        tiles.append(bs.Label("a", parent=grid))
+        tiles.append(bs.Label("b", parent=grid))
+
+    rebuild()
+    rebuild()  # the re-add that used to collide both children at row 0
+    rebuild()
+
+    rows = sorted(int(t._internal.grid_info()["row"]) for t in tiles)
+    assert rows == [0, 1], f"auto-flow collided after rebuild: rows={rows}"
+    grid.destroy()
+
+
+def test_child_destroy_does_not_cancel_ancestor_schedule(app):
+    job = app.schedule.delay(10_000, lambda: None)
+    assert job in app.schedule._jobs
+
+    child = bs.Label("x", parent=app)
+    child.destroy()  # before the fix this wiped the app's scheduler
+
+    assert job in app.schedule._jobs, "destroying a child cancelled an ancestor job"
+    assert job._active
+    job.cancel()
+
+
+def test_owner_destroy_still_cancels_its_jobs(app):
+    # The guard must not break the intended behavior: a widget's own jobs are
+    # cancelled when that widget is destroyed.
+    panel = bs.VStack(parent=app)
+    job = panel.schedule.delay(10_000, lambda: None)
+    assert job in panel.schedule._jobs
+    panel.destroy()
+    assert job._active is False


### PR DESCRIPTION
## Summary

Three logical commits on `feat/image-icon-api`:

- **`feat(fields)`** — typed `signal=` on `NumberField`/`DateField`/`TimeField` via a shared `ValueSignalMixin` that two-way binds the field's **parsed value** (int/float, date, time), not its formatted text; plus step quantization so increments stay on the step grid.
- **`feat(images)`** — the public **`bootstack.images`** module: a toolkit-free **`Image`** handle, theme-following **`get_icon`/`list_icons`**, and **`AppIcon`** (a glyph on a rounded tile) that `App`/`Window` accept as `icon=` and that exports `.ico`/`.icns`/`.png` for packaging. Live `icon`/`image` setters on the button family; public `Icon`/`IconSpec`. Size-aware AppIcon rendering (integer-ratio tile supersampling, native-size pixel-aligned glyph, DPI-matched `.ico` sizes; `shape="auto"` = glyph-only small / tile large). The `bootstack appicon` GUI designer + `[build.icon]` glyph generation. `Window(parent=)` + anchored `show()`; reveal-after-settle window show. `bootstack.toml` scoped to a build/scaffold manifest (runtime `[settings]` removed). Framework lifecycle fixes (scheduler descendant-destroy guard, grid prune-on-destroy, clipboard helpers) and public file-dialog verbs.
- **`docs(claude)`** — handoff entry.

## Review

A pre-commit review (5 parallel reviewers + verification) found and fixed: **2 HIGH** (a `signal=` field-Signal subscription leak; a `Signal.set` type-mismatch crash on a documented-recommended usage), **2 MEDIUM** (theme-binding leak when clearing `image=`; window `show()` alpha restore not in `finally`), and minor nits. Regression tests added.

## Tests

Headless + GUI suites pass (GUI modules run one-App-per-process); clean docs build under `-W`.

## Notes

- Pre-release: clean breaking changes (no shims). `bootstack.toml` `[settings]` removal is backward-tolerant (a legacy section is ignored, not an error).
- Follow-up (separate branch): a `Picture` display widget (animated GIF / splash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
