### PR TITLE
fix(media): image-subsystem review — leak, theme, parity, and edge-case fixes

### DIFF
--- a/src/bootstack/widgets/_impl/composites/carousel.py
+++ b/src/bootstack/widgets/_impl/composites/carousel.py
@@ -128,7 +128,43 @@ class Carousel(Frame):
         self._stage.bind("<Right>", lambda e: self.next())
         self.bind("<<BsThemeChanged>>", self._on_theme, add="+")
 
+        # Auto-refresh when the data source changes externally (parity with the
+        # other record-native widgets); the subscription is released on destroy.
+        self._change_sub = None
+        on_change = getattr(self._datasource, "on_change", None)
+        if callable(on_change):
+            try:
+                self._change_sub = on_change(self._on_source_change)
+            except Exception:
+                self._change_sub = None
+        self.bind("<Destroy>", self._on_destroy, add="+")
+
     # ----- theme / data ------------------------------------------------------
+
+    def _on_source_change(self, _event: Any = None) -> None:
+        try:
+            self.reload()
+        except Exception:
+            pass
+
+    def _on_destroy(self, event: Any = None) -> None:
+        if event is not None and getattr(event, "widget", None) is not self:
+            return
+        sub, self._change_sub = self._change_sub, None
+        if sub is not None:
+            try:
+                sub.cancel()
+            except Exception:
+                pass
+
+    def reload(self) -> None:
+        """Reload from the data source and refresh the current slide."""
+        n = self._count()
+        self._index = max(0, min(self._index, n - 1)) if n else 0
+        if self._box[0] > 1 and self._box[1] > 1:
+            self._set_current(self._compose(self._pil_at(self._index), *self._box))
+            self._ensure_frame(*self._box)
+            self._draw_overlays(*self._box)
 
     def _surface_color(self) -> str:
         token = getattr(self, "_surface", None) or "background"
@@ -242,6 +278,9 @@ class Carousel(Frame):
         self._box = box
         if box[0] <= 1 or box[1] <= 1:
             return
+        # Don't fight an in-flight transition; it recomposes at the settled box.
+        if self._transitioning:
+            return
         self._set_current(self._compose(self._pil_at(self._index), *box))
         self._ensure_frame(*box)
         self._draw_overlays(*box)
@@ -261,7 +300,12 @@ class Carousel(Frame):
             return
         w, h = self._box
         if w <= 1 or h <= 1:
+            # Not laid out yet — record the index and announce the change; the
+            # first <Configure> will render it.
             self._index = index
+            record = self._public_at(index)
+            if record is not None:
+                self.event_generate("<<Change>>", data=record)
             return
         next_pil = self._compose(self._pil_at(index), w, h)
         self._index = index
@@ -338,7 +382,14 @@ class Carousel(Frame):
         step(1)
 
     def _after_change(self) -> None:
-        self._draw_overlays(*self._box)
+        bw, bh = self._box
+        if bw > 1 and bh > 1:
+            # A resize deferred during the transition leaves the settled image at
+            # the old size — recompose if it no longer matches the live box.
+            if self._cur_pil is None or self._cur_pil.size != (bw, bh):
+                self._set_current(self._compose(self._pil_at(self._index), bw, bh))
+            self._ensure_frame(bw, bh)
+            self._draw_overlays(bw, bh)
         record = self._public_at(self._index)
         if record is not None:
             self.event_generate("<<Change>>", data=record)
@@ -442,6 +493,11 @@ class Carousel(Frame):
         self._autoplay = False
         self._cancel_autoplay()
 
+    def stop(self) -> None:
+        """Stop autoplay and return to the first slide."""
+        self.pause()
+        self.go_to(0)
+
     def _arm_autoplay(self) -> None:
         self._cancel_autoplay()
         if self._autoplay:
@@ -454,6 +510,12 @@ class Carousel(Frame):
 
     def _autoplay_tick(self) -> None:
         self._autoplay_job = None
+        if self._transitioning:
+            # A tick landed mid-transition; next() would no-op and autoplay would
+            # die (no _after_change to re-arm). Retry shortly instead.
+            if self._autoplay:
+                self._autoplay_job = self._schedule.delay(_FRAME_MS * 8, self._autoplay_tick)
+            return
         self.next()   # _after_change re-arms
 
     # ----- events / accessors ------------------------------------------------

--- a/src/bootstack/widgets/_impl/composites/gallery.py
+++ b/src/bootstack/widgets/_impl/composites/gallery.py
@@ -13,7 +13,6 @@ of `columns` tiles — the 1D list recycle generalized one axis, not a 2D recycl
 from __future__ import annotations
 
 import contextlib
-from pathlib import Path
 from tkinter import Canvas, TclError
 from typing import Any, Literal
 
@@ -21,10 +20,11 @@ from PIL import Image as PILImage, ImageDraw
 from PIL.Image import Resampling
 from PIL.ImageTk import PhotoImage
 
-from bootstack._core.images import _ImageService
 from bootstack.data import MemoryDataSource, DataSourceProtocol
 from bootstack.style.style import get_style
-from bootstack.widgets._impl.composites._image_fit import FitMode, fit_image, round_corners
+from bootstack.widgets._impl.composites._image_fit import (
+    FitMode, fit_image, resolve_pil, round_corners,
+)
 from bootstack.widgets._impl.primitives.frame import Frame
 from bootstack.widgets._impl.primitives.label import Label
 from bootstack.widgets._impl.primitives.scrollbar import Scrollbar
@@ -35,26 +35,6 @@ _RING_THICKNESS = 3
 _RING_GAP = 3                       # separation between the image and the ring
 _RING_PAD = _RING_GAP + _RING_THICKNESS   # margin reserved around the image
 EMPTY = {"__empty__": True, "id": "__empty__"}
-
-
-def _resolve_pil(source: Any) -> "PILImage.Image | None":
-    """Resolve a record's image field to a PIL image (first frame), or None."""
-    if source is None:
-        return None
-    from bootstack.images import Image as _ImageHandle
-
-    try:
-        if isinstance(source, _ImageHandle):
-            return source._load_pil()
-        if isinstance(source, (str, Path)):
-            return PILImage.open(Path(source).expanduser())
-        from PIL.Image import Image as _PILImage
-
-        if isinstance(source, _PILImage):
-            return source
-    except Exception:
-        return None
-    return None
 
 
 class GalleryTile(Frame):
@@ -130,7 +110,7 @@ class GalleryTile(Frame):
         )
 
     def _render_thumb(self, source: Any) -> None:
-        pil = _resolve_pil(source)
+        pil = resolve_pil(source)
         if pil is None:
             self._canvas.itemconfigure(self._img_id, image="")
             self._photo = None
@@ -138,8 +118,18 @@ class GalleryTile(Frame):
         composed = fit_image(pil.convert("RGBA"), self._tw, self._th, self._fit)
         if self._radius > 0:
             composed = round_corners(composed, self._radius)
-        self._photo = _ImageService.from_pil(composed)
+        # A plain PhotoImage (kept alive by self._photo, GC'd when replaced) — do
+        # NOT route through the global _ImageService cache, which never evicts and
+        # would accumulate one entry per distinct thumbnail as the grid scrolls.
+        self._photo = PhotoImage(composed)
         self._canvas.itemconfigure(self._img_id, image=self._photo)
+
+    def refresh_surface(self) -> None:
+        """Re-resolve the canvas background after a theme change."""
+        try:
+            self._canvas.configure(background=self._surface_color())
+        except TclError:
+            pass
 
     def _on_click(self, _event) -> None:
         # Call the gallery directly: virtual events do NOT bubble from a child
@@ -220,10 +210,22 @@ class Gallery(Frame):
             except Exception:
                 self._change_sub = None
         self.bind("<Destroy>", self._on_destroy, add="+")
+        self.bind("<<BsThemeChanged>>", self._on_theme, add="+")
+        # First render is driven by the container's <Configure> (bound above);
+        # no init timer needed.
 
-        self.after(10, self._relayout)
+    # ----- theme / silence / source change ----------------------------------
 
-    # ----- silence / source change ------------------------------------------
+    def _on_theme(self, _event=None) -> None:
+        """Re-apply theme-dependent colors after a theme switch.
+
+        The tile surface backgrounds and the accent selection ring are resolved
+        from theme tokens; rebuild them so they track the new theme.
+        """
+        for tile in self._tiles:
+            tile.refresh_surface()
+        if self._tiles:
+            self._build_ring()   # new accent color, re-shared to every tile
 
     def _silence_source(self):
         silence = getattr(self._datasource, "_silence", None)

--- a/src/bootstack/widgets/carousel.py
+++ b/src/bootstack/widgets/carousel.py
@@ -163,6 +163,21 @@ class Carousel(PublicWidgetBase):
         """Stop auto-advancing."""
         self._internal.pause()
 
+    def stop(self) -> None:
+        """Stop auto-advancing and return to the first slide."""
+        self._internal.stop()
+
+    # ----- Data -----
+
+    @property
+    def data_source(self) -> "DataSourceProtocol":
+        """The underlying data source instance."""
+        return self._internal.get_datasource()
+
+    def reload(self) -> None:
+        """Reload from the data source and refresh the current slide."""
+        self._internal.reload()
+
     # ----- Events -----
 
     @overload


### PR DESCRIPTION
## Summary

Fixes from a direct review of the image subsystem (Image/Icon API + Picture/Gallery/Carousel) — memory leak, theme handling, API/naming parity, and edge cases. No new features; cleanup and correctness only.

## Gallery

- **Leak fix (H1):** tiles now use a plain `PhotoImage` (kept alive by the tile, GC'd when replaced) instead of routing every composed thumbnail through the global `_ImageService` cache, which never evicts — scrolling a large gallery no longer accumulates one cached photo per distinct thumbnail. Matches Picture/Carousel.
- **Theme (M2):** handle `<<BsThemeChanged>>` — refresh tile surface backgrounds and rebuild the accent selection ring (previously stale after a theme switch).
- **Cleanup (L1):** dropped the raw `self.after(10, _relayout)` init timer; first render is driven by the container `<Configure>` (verified tiles still build).
- **DRY (N5):** removed the duplicate `_resolve_pil`; uses the shared `_image_fit.resolve_pil`.

## Carousel

- **Parity (N2):** added `data_source` property + `reload()` + a data-source `on_change` subscription with `<Destroy>` cleanup — matches Gallery's record-native handling.
- **Parity (N1):** added `stop()` (pause + return to the first slide) to match `Picture.stop()`.
- **Autoplay (L2):** a tick that lands during an in-flight transition reschedules instead of silently dropping autoplay.
- **Resize (L3):** resize during a transition is deferred and recomposed at the settled box instead of fighting the animation.
- **Pre-layout (L4):** `go_to`/`next` before the first layout now fires `on_change`.

## Deferred (tracked, not in this PR)

- Global `_ImageService._cache` eviction/LRU cap (broader than the suite).
- `ListView.on_selection_changed → on_select` rename (verbose/past-tense; outside the image subsystem) — folds into a future event-naming pass with the other stragglers. The image suite itself is convention-compliant (Gallery `on_select`, Carousel `on_change`).

## Verification

Per-fix smoke tests (leak path, theme refresh, reload/stop, autoplay-during-transition, pre-layout event); Gallery hero renders unchanged; `tests/test_public_surface.py` 153 passed; strict `-W` docs build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
