### PR TITLE
feat(appshell): internal clean-slate shell rewrite — grouped-static nav + styling (not yet public)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -318,9 +318,20 @@ custom `panel()`. **Scrollable static nav**: `NavPanel` item area in a `ScrollVi
 footer divider (`'never'`↔`'scroll'`, hysteresis, no flicker); canvas bg painted
 to the sidebar surface. **`nav-quiet` square under a rail, `nav-pill` standalone**
 (mixed-provider workspaces must share one row language). Test `test_shell_groups`
-rewritten for grouped-static. Deferred: thin/overlay nav scrollbar (17px classic
-now — step-9 styling); `Workspace` context-manager support (two-tier examples use
-`with`). **NEXT: the deferred public-AppShell swap (spec step 11) + step-9 styling.**
+rewritten for grouped-static. **Sidebar styling round shipped** (committed): a
+reusable **`'thin'` 4px square scrollbar variant** (Pillow `create_box_image`;
+`ScrollView` threads surface), `NavPanel` scrollable item area (footer pinned,
+overflow-gated bar + footer divider, gutter absorbed into the right inset so the
+margin stays even + footer re-aligns), and **empty-state placeholders** for
+`tree_nav`/empty `list_nav` (`placeholder=`). The current step is DONE.
+**NEXT = step 11 (the public-AppShell swap)**, which now also owns: **drop the
+standalone `bs.SideNav`** (decided — coupled to removing the old sidenav-based
+AppShell that `bs.AppShell` still points at; `SideNavHeader`/`SideNavSeparator`
+stay, used by `NavPanel`); **wire + style the statusbar + menubar/command bar**
+into the new shell (chrome band is an empty Frame, statusbar a bare Toolbar);
+`Workspace` context-manager support; the public façade (`commandbar`/`nav`/`pages`
++ window controls). Separate initiative: thin-scrollbar public exposure + audit
+other scrollable widgets (memory `project_thin_scrollbar_initiative`).
 
 **Throwaway demos `development/shell_*_demo.py` stay UNTRACKED** (scratch, not
 framework code). Side note logged: a future `Tabs` `variant='secondary'` (top

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -284,28 +284,47 @@ memories and git history.
 
 ## Next up
 
-### ★ ACTIVE — AppShell + SideNav refactor (START HERE, fresh session)
+### ★ ACTIVE — AppShell + navigation clean-slate rewrite (START HERE, fresh session)
 
-The chosen next initiative (maintainer, 2026-06-12). A combined rework of
-**AppShell** and **SideNav** — make AppShell expose real public widget handles,
-and refactor SideNav's API/internals (its event renames have been intentionally
-deferred to this). **Scope, goals, and known issues: `docs/_dev/appshell-sidenav-refactor.md`**
-(seed brief). Memory `project_appshell_sidenav_refactor`. Pulls together:
+A clean-slate VS Code-style **rail + swappable sidebar + content** rewrite of the
+shell's navigation (supersedes the original combined-refactor framing below).
+**Live spec: `docs/_dev/appshell-navigation-spec.md` — read Revision 2 (model
+finalization) + Revision 3 (accordion sections vs static groups).** Memory
+`project_appshell_sidenav_refactor`. Seed brief (`docs/_dev/appshell-sidenav-refactor.md`)
+is now background-only.
 
-- **AppShell public façades** — `shell.commandbar` today returns the INTERNAL
-  composite with the old `command=` API, not a public `CommandBar`; same for
-  nav/pages. Expose public handles (`commandbar`/`nav`/`pages`), return public
-  widgets from `add_*` (the `_adopt`-classmethod pattern), `CommandBar.content` /
-  make-it-a-container, window-control accessors, and fold `menu_layout` /
-  `chrome_surface` into AppShell. Detail in `docs/_dev/widget-api-audit.md`.
-- **SideNav refactor** — fold in the deferred event renames
-  `on_pane_toggled → on_toggle`, `on_display_mode_changed → on_display_change`
-  (present-tense convention, `project_event_naming_revisit`); plus the long-standing
-  SideNav/AppShell deferred improvements (see Carryover): `nav_pane_width=` not wired
-  to `SideNav(pane_width=)`, hardcoded nav density/font, group active-child highlight +
-  indentation, footer non-page widgets.
-- Related context: `project_menu_redesign` (the PR #124 menu/command-bar redesign
-  this builds on), `project_macos_window_chrome` (native chrome follow-up, separate).
+**Branch `feat/appshell-navigation`. Steps 1–9 DONE & committed:** NavModel →
+region layout → single-tier wiring → provider seam → all 3 providers + live refresh
+→ two-tier rail + VS Code gesture → sidebar collapse/visibility/nav-state persistence
+→ 1-level groups (now being redesigned, see below) → **full step-9 styling**: dark
+rail/chrome surface (rail/status tier sits clearly below the neutral selection
+wash), neutral selection by default + `accent_selection` opt-in, subtle `raised`
+sidebar elevation, `list_nav` on the real recycling `ListView` with **pixel-ellipsis
+title/text truncation** (labels `width=1` so they never push the icon/chevron off;
+`_elide` via `get_font().measure`; re-elides on the center frame's `<Configure>`),
+density + chevron exposed on `list_nav`/`tree_nav`.
+
+**NEXT = the step-8 REDESIGN per Revision 3** (the flat header+run "collapsible
+group" was the wrong model — it can't hold "an accordion containing a list"). Five
+steps in the spec: (1) revert the flat-run hack so `add_header()` is a pure label
+again; (2) `NavGroup` — an `Expander`-backed content host exposing the workspace
+content verbs (`add_page`/`list_nav`/`tree_nav`/`panel`/`@detail`) via context
+manager; (3) workspace accordion mode (`add_group()`, key/selection aggregation
+across sections, navigate-to-reveal, nested content deck); (4) style the `Expander`
+header to the workspace nav language; (5) rewrite `test_shell_groups` + add
+accordion/heterogeneous-body/reveal cases. Three sidebar archetypes are locked:
+flat-static (compactable) · grouped-static (`add_header` labels, flush button-style
+items) · accordion (`add_group` sections, hidden↔expanded, no icon-compact).
+
+**Throwaway demos `development/shell_*_demo.py` stay UNTRACKED** (scratch, not
+framework code). Side note logged: a future `Tabs` `variant='secondary'` (top
+indicator) — `project_secondary_tab_variant`, NOT part of this work.
+
+- Related context: `project_menu_redesign` (PR #124 menu/command-bar this builds
+  on), `project_macos_window_chrome` (native chrome follow-up, separate). Deferred
+  AppShell-public-façade items (public `commandbar`/`nav`/`pages` handles,
+  window-control accessors) land when the rewritten internals are swapped onto the
+  public `AppShell` in the spec's step 11.
 
 ### Other candidates
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -288,15 +288,15 @@ memories and git history.
 
 A clean-slate VS Code-style **rail + swappable sidebar + content** rewrite of the
 shell's navigation (supersedes the original combined-refactor framing below).
-**Live spec: `docs/_dev/appshell-navigation-spec.md` — read Revision 2 (model
-finalization) + Revision 3 (accordion sections vs static groups).** Memory
-`project_appshell_sidenav_refactor`. Seed brief (`docs/_dev/appshell-sidenav-refactor.md`)
-is now background-only.
+**Live spec: `docs/_dev/appshell-navigation-spec.md` — read Revision 4 (the
+accordion CUT — current decision) first, then Revision 2/3 for the superseded
+arc.** Memory `project_appshell_sidenav_refactor`. Seed brief
+(`docs/_dev/appshell-sidenav-refactor.md`) is now background-only.
 
 **Branch `feat/appshell-navigation`. Steps 1–9 DONE & committed:** NavModel →
 region layout → single-tier wiring → provider seam → all 3 providers + live refresh
 → two-tier rail + VS Code gesture → sidebar collapse/visibility/nav-state persistence
-→ 1-level groups (now being redesigned, see below) → **full step-9 styling**: dark
+→ grouped-static (`add_header`; accordion tried then cut, see below) → **step-9 styling**: dark
 rail/chrome surface (rail/status tier sits clearly below the neutral selection
 wash), neutral selection by default + `accent_selection` opt-in, subtle `raised`
 sidebar elevation, `list_nav` on the real recycling `ListView` with **pixel-ellipsis
@@ -304,17 +304,23 @@ title/text truncation** (labels `width=1` so they never push the icon/chevron of
 `_elide` via `get_font().measure`; re-elides on the center frame's `<Configure>`),
 density + chevron exposed on `list_nav`/`tree_nav`.
 
-**NEXT = the step-8 REDESIGN per Revision 3** (the flat header+run "collapsible
-group" was the wrong model — it can't hold "an accordion containing a list"). Five
-steps in the spec: (1) revert the flat-run hack so `add_header()` is a pure label
-again; (2) `NavGroup` — an `Expander`-backed content host exposing the workspace
-content verbs (`add_page`/`list_nav`/`tree_nav`/`panel`/`@detail`) via context
-manager; (3) workspace accordion mode (`add_group()`, key/selection aggregation
-across sections, navigate-to-reveal, nested content deck); (4) style the `Expander`
-header to the workspace nav language; (5) rewrite `test_shell_groups` + add
-accordion/heterogeneous-body/reveal cases. Three sidebar archetypes are locked:
-flat-static (compactable) · grouped-static (`add_header` labels, flush button-style
-items) · accordion (`add_group` sections, hidden↔expanded, no icon-compact).
+**DONE — accordion CUT + grouped-static finished (committed `580e0218`, Revision
+4).** The Revision-3 accordion was built then **dropped** (maintainer: not worth
+the trouble — the "section that IS a list/tree" carried all the complexity/bugs
+and conflated content-hierarchy with nav). `NavGroup`/`ProviderHost` deleted;
+`Workspace` back to a single provider; `add_group`/`expand_all`/`collapse_all`
+gone; `SideNavHeader` is a plain label. **Sidebar = three shapes only:**
+flat-static (`add_page`, compactable) · grouped-static (`add_header` = a plain
+**muted** label, flush items, `10→16` top-gap group break) · data-bound
+(`list_nav`/`tree_nav`). A collapsible sub-list → compose `bs.Accordion` in a
+custom `panel()`. **Scrollable static nav**: `NavPanel` item area in a `ScrollView`
+(wheel + auto-hiding bar), footer pinned outside; overflow-gated gutter/bar +
+footer divider (`'never'`↔`'scroll'`, hysteresis, no flicker); canvas bg painted
+to the sidebar surface. **`nav-quiet` square under a rail, `nav-pill` standalone**
+(mixed-provider workspaces must share one row language). Test `test_shell_groups`
+rewritten for grouped-static. Deferred: thin/overlay nav scrollbar (17px classic
+now — step-9 styling); `Workspace` context-manager support (two-tier examples use
+`with`). **NEXT: the deferred public-AppShell swap (spec step 11) + step-9 styling.**
 
 **Throwaway demos `development/shell_*_demo.py` stay UNTRACKED** (scratch, not
 framework code). Side note logged: a future `Tabs` `variant='secondary'` (top

--- a/docs/_dev/appshell-navigation-spec.md
+++ b/docs/_dev/appshell-navigation-spec.md
@@ -352,6 +352,7 @@ placement/window-state/etc. via `AppConfigMixin`), plus navigation options.
 | `rail_width` | `int \| None` | token | rail / compact width (shared token — collapse is seamless) |
 | `collapsible` | `bool` | `True` | show the in-sidebar chevron + bind Ctrl/Cmd-B (collapse: compact for a standalone static sidebar, else hide — see R6) |
 | `nav_accent` | `AccentToken \| str` | `'primary'` | active-item accent |
+| `rail_labels` | `bool` | `False` | show a caption under each rail icon (widens the rail); icon-only otherwise |
 | `remember_nav_state` | `bool` | `False` | persist sidebar_mode + per-workspace page across sessions |
 | `show_statusbar` | `bool` | `False` | force the status band on (else content-driven) |
 | `show_dock` *(reserved)* | `bool` | `False` | render the detail/inspector dock |

--- a/docs/_dev/appshell-navigation-spec.md
+++ b/docs/_dev/appshell-navigation-spec.md
@@ -439,7 +439,15 @@ with shell.add_workspace("tools", text="Tools", icon="tools") as ws:
    two-tier rail look identical; `remember_nav_state` persistence.
 8. **Custom panel mode** — `ws.panel()`; `supports_compact = False`.
 9. **Elevation tokens** — rail/sidebar/content as named elevation tokens
-   (light/dark flip).
+   (light/dark flip). Also align selection COLOR across providers (decision #12):
+   the selected-wash hue already matches (`tree_nav`'s `Tree` rows and the
+   `NavPanel` items both use `subtle(accent)`), but two items remain — (a) compute
+   the tree's wash against the *sidebar* surface so the shade matches exactly, and
+   (b) settle ONE selected-label foreground convention across `add_page`/`list_nav`/
+   `tree_nav` (accent text vs plain `on_surface` — sidebars go both ways; today nav
+   items flip to accent, the tree stays plain). If accent text is chosen, keep the
+   tree's flip **role-scoped** (nav-role only) so content-area data grids stay
+   `on_surface`. The left bar stays a flat-list affordance (no bar on the tree).
 10. **Detail dock** *(reserved — likely a follow-on)* — wire the slot + axis.
 11. **Polish** — window-control accessors, fold `menu_layout`/`chrome_surface`,
     `bootstack.events` additions, docs (clean `-W` build), `test_public_surface`.

--- a/docs/_dev/appshell-navigation-spec.md
+++ b/docs/_dev/appshell-navigation-spec.md
@@ -112,6 +112,14 @@ chevron and Ctrl-B agree for the static case.
     why a mixed sidebar jars); style the chevron (size/weight/placement) and the
     collapsible-header treatment (distinct from a plain static label); quiet the
     per-item accent fg/icon coloring per R3.
+  - **Sidebar nav-item style variants (native Toolbutton variants):** the items
+    are `RadioToggle`s styled by native variants — `nav-quiet` (under-rail: square
+    `navitem` wash + neutral fg), `nav-pill`/`nav-pill-compact` (standalone:
+    rounded `card` pill + accent fg). The pill is currently a **ghost** treatment
+    (subtle accent tint + accent fg). **FOLLOW-UP:** add a **`solid`** pill variant
+    — fill the pill with the solid accent token and use the on-color foreground
+    (e.g. white-on-accent); ghost stays the default. This generalizes to offering
+    the button-family variants (ghost/solid/outline) for sidebar items.
   - **Composition guideline (docs, not enforced):** use grouping *consistently* —
     a flat list, or everything under collapsible sections (VS Code Explorer); a
     single primary item *above* groups is acceptable, but don't sprinkle loose

--- a/docs/_dev/appshell-navigation-spec.md
+++ b/docs/_dev/appshell-navigation-spec.md
@@ -136,6 +136,111 @@ chevron and Ctrl-B agree for the static case.
 
 ---
 
+## Revision 3 — accordion sections vs. static groups (2026-06-13, with maintainer)
+
+Step 8 shipped "1-level collapsible groups" as a **flat run** — a header plus the
+sibling items following it, where collapse just *hides the run*. That model
+conflated two different primitives and can't express "an accordion containing a
+list" (the body isn't a container, just later siblings). Revision 3 corrects the
+model. **Supersedes Revision 2 / R2** (the flat-accordion restoration).
+
+### The three sidebar archetypes
+
+The grouping element is the tell. A static **header is a label**; an accordion
+**header is a control**. They look different by design.
+
+| archetype | grouping element | items | collapse |
+|---|---|---|---|
+| **Flat static** | none | quiet/pill nav rows | compact → icons |
+| **Grouped static** | `add_header()` — a quiet label | quiet nav rows | hidden ↔ expanded |
+| **Accordion** | `add_group()` — an interactive bar (`Expander`) | *anything* (rows / list / tree / custom) | hidden ↔ expanded |
+
+### Accordion — `add_group()` returns a `NavGroup` (context manager + content host)
+
+A `NavGroup` exposes the **same content verbs as the workspace** (`add_page`,
+`list_nav`, `tree_nav`, `panel()`, `@detail`) plus `expand`/`collapse`/`toggle`/
+`expanded`/`title`. Each section owns its content; selecting anything in any
+section drives the **one shared content/detail region** (the VS Code editor-area
+model). Backed by the existing `Expander` (header is a `CompositeFrame` with
+hover/press/selected — *configured*, not hand-styled); reuses the existing
+providers mounted into the section body (sidebar side) + the shared content region
+(detail side).
+
+```python
+ws = shell.add_workspace("explorer", text="Explorer", icon="files")
+
+with ws.add_group("Folders", icon="folder") as g:   # section of nav pages
+    g.add_page("src",   text="src",   icon="folder")
+    g.add_page("tests", text="tests", icon="folder")
+
+with ws.add_group("Outline") as g:                   # section that IS a tree
+    g.tree_nav(nodes=outline_nodes)
+    @g.detail
+    def show(node): ...
+
+with ws.add_group("Timeline", expanded=False) as g:  # section that IS a list
+    g.list_nav(source=timeline)
+    @g.detail
+    def show(record): ...
+```
+
+- `ws.add_group(title, *, icon=None, expanded=True)` → `NavGroup`.
+- Detail is **per-section** for data-bound sections (`@g.detail`); `add_page`
+  sections render their page. All feed the shared content region (one active at a
+  time, via a content deck keyed by active item).
+- `ws.expand_all()`/`collapse_all()` retarget to the sections.
+
+### Grouped-static — `add_header()` is now a pure label
+
+`collapsible=` is **removed** from `add_header` (and from `SideNavHeader`). A
+static header is a non-interactive small-caps secondary label; the items after it
+are ordinary quiet nav rows, **flush** under the label (the label's color + top
+margin carry the hierarchy — no indentation). *Decision: grouped-static items keep
+the button/quiet-row language, NOT list-item rows* — row style encodes what the
+row is (nav rows = pages; list rows = records). The header label is what makes
+grouped-static "its own thing"; the items don't diverge. Genuinely list-dense
+grouped rows are the signal to use an accordion section containing a `list_nav`.
+
+### Model implications
+
+1. **Workspace = a container of content-hosts.** Today one `_provider`. New: a
+   workspace is *either* a single provider (flat/grouped static, list, tree,
+   custom) *or* a set of accordion sections. First `add_group()` claims accordion
+   mode; mixing top-level `add_page` with groups is disallowed (the consistency
+   guideline).
+2. **Key aggregation.** Each section reports its keys up; the workspace aggregates
+   (keys unique within a workspace). `NavModel` still holds one `(workspace,
+   page)` truth.
+3. **Navigate-to-reveal.** `navigate(ws, key)` finds the owning section, expands
+   it, shows + visually selects there, and clears the visual selection in sibling
+   sections.
+4. **Compact.** Flat-static stays compactable; grouped-static and accordion are
+   `supports_compact=False` (hidden ↔ expanded) — VS Code "collapses completely":
+   Ctrl-B hides the whole sidebar, only the rail remains. No icon-flattened
+   accordion.
+
+### Implementation steps (step 8 redesign)
+
+1. **Revert the flat-run hack** — drop `collapsible=`/chevron/`_toggle_group` from
+   `SideNavHeader` + `NavPanel` + `add_header`; header is a label again.
+2. **`NavGroup`** — an `Expander`-backed content host exposing the workspace
+   content verbs; mounts its provider into the `Expander.content` (sidebar) +
+   shared content region (detail). Context manager.
+3. **Workspace accordion mode** — `add_group()`; aggregate keys/selection across
+   sections; route `show`/`select_visual` to the owning section; nested content
+   deck. `expand_all`/`collapse_all` retarget.
+4. **Styling** — configure the `Expander` header to the workspace nav language
+   (quiet vs pill); section body inherits the sidebar surface.
+5. **Tests** — rewrite `test_shell_groups`; add accordion-section + heterogeneous-
+   body + navigate-to-reveal cases.
+
+### Side note (unrelated, logged for later)
+
+Create a **`'secondary'` Tabs variant** that draws the selection indicator at the
+**top** of the tab instead of the bottom. Not part of the appshell work.
+
+---
+
 ## 1. Locked decisions (from discussion)
 
 1. **Single-tier is two-tier with one workspace.** The rail (workspace switcher)

--- a/docs/_dev/appshell-navigation-spec.md
+++ b/docs/_dev/appshell-navigation-spec.md
@@ -76,26 +76,38 @@ clean breaking changes, no compat shims.
     - **Elevation:** rail = 0, sidebar = 1, content = 2 — **named elevation
       tokens** (light themes darken with depth; dark themes often lighten — the
       token lets it flip correctly per theme).
-    - **Active markers differ by tier — the bar is sidebar-only:**
-      - **Rail active** = a **subtle accent-tinted wash** (`b.subtle(accent,
-        surface)`, resolved against the *rail* surface — it must be tuned against
-        elevation 0, not the sidebar's surface) + glyph at **full neutral
-        foreground**; inactive glyphs **muted**; **no bar, no accent on the glyph**
-        (accent appears once, as the wash tint — accent-wash + accent-glyph is "too
-        much"). The rail must carry its active state independently because the hide
-        gesture can remove the sidebar entirely.
-      - **Sidebar active** = subtle wash + **accent foreground** + **left indicator
-        bar** (decision #12); the wash carries selection through compact mode where
-        the bar matches the fill and disappears.
+    - **Active markers (REVISED 2026-06-13 to the maintainer's VS Code model —
+      this supersedes the earlier "bar is sidebar-only" of decision #12):**
+      - **Rail (workspace) = the STRONG tier.** Unselected glyphs **muted**;
+        selected glyph **full color** (the **toggle-button** muted→full-color
+        treatment — *reuse the existing ToggleButton/toggle styling + rounded
+        `button` asset*, NOT the flat `navitem` asset), **plus the indicator bar**
+        (accent OR just foreground). The rail owns the bar.
+      - **Sidebar list (page) = the QUIET tier.** **Subtle wash only** —
+        `subtle(accent)`, **no bar, no muted/full-color, no accent text**. Just a
+        quiet selection wash.
+      - Rationale: one bar (on the rail) + a quiet list resolves the accent-overload
+        the maintainer flagged (rail accent + sidebar bar + sidebar accent text was
+        "too much"). VS Code: activity bar = bar + muted/full-color; side list =
+        subtle wash.
     - **Icon scale — two tokens:** `inline_icon_size` (small, ~16–18px
       density-scaled — expanded item beside a label) vs `rail_icon_size` (larger,
-      ~20–24px — standalone categorical glyph). Size alone signals the tier.
-    - **The seam rule (load-bearing):** a compacted *single* sidebar adopts the
-      **rail paradigm wholesale** — `rail_icon_size`, the rail wash+neutral-glyph
-      marker (NOT the bar), and `rail_width` — so collapsing a one-workspace
-      sidebar is visually identical to a two-tier rail (collapse never reveals a
-      seam). Net: only two icon sizes system-wide (inline, rail/compact), and
-      "compact" ≡ "rail".
+      ~28px — standalone categorical glyph). Size alone signals the tier.
+    - **List rendering:** `list_nav` should use the **real `ListView` widget**
+      (recycling for large/live lists + the subtle-wash selection it already does);
+      static `add_page` keeps `NavPanel` (ListView is overkill — can't do
+      interspersed headers/separators/footer, and recycling is wasted on a few
+      authored items). The `tree` uses the `Tree` widget; align its selected wash
+      to the sidebar's subtle wash (no accent text), per decision #12.
+    - **The seam rule:** a compacted *single* sidebar adopts the rail paradigm
+      (rail treatment + `rail_width`), so collapsing a one-workspace sidebar looks
+      like a two-tier rail. With the revised model the rail = toggle-button +
+      muted/full-color + bar, so the compacted sidebar shows that.
+    - **Interim state (step 6):** the rail is built from compact `SideNavItem`
+      (flat navitem asset, ~28px icon, no bar, accent-glyph-on-select) — a
+      placeholder; step 9 rebuilds it on the toggle-button treatment above. The
+      tree opens **unselected** by default (correct for a hierarchy); add an
+      empty-state placeholder in the content area so a fresh tree isn't blank.
 
 ---
 
@@ -438,17 +450,19 @@ with shell.add_workspace("tools", text="Tools", icon="tools") as ws:
    (visibility); shared `rail_width`/`sidebar_width` tokens so single-collapse and
    two-tier rail look identical; `remember_nav_state` persistence.
 8. **Custom panel mode** — `ws.panel()`; `supports_compact = False`.
-9. **Elevation tokens** — rail/sidebar/content as named elevation tokens
-   (light/dark flip). Also align selection COLOR across providers (decision #12):
-   the selected-wash hue already matches (`tree_nav`'s `Tree` rows and the
-   `NavPanel` items both use `subtle(accent)`), but two items remain — (a) compute
-   the tree's wash against the *sidebar* surface so the shade matches exactly, and
-   (b) settle ONE selected-label foreground convention across `add_page`/`list_nav`/
-   `tree_nav` (accent text vs plain `on_surface` — sidebars go both ways; today nav
-   items flip to accent, the tree stays plain). If accent text is chosen, keep the
-   tree's flip **role-scoped** (nav-role only) so content-area data grids stay
-   `on_surface`. The left bar stays a flat-list affordance (no bar on the tree).
-10. **Detail dock** *(reserved — likely a follow-on)* — wire the slot + axis.
+9. **Elevation + selection tokens** — the visual hierarchy per the REVISED
+   decision #13 (the authoritative model). Concretely:
+   - **Rail:** rebuild on the **toggle-button treatment** (muted unselected →
+     full-color selected, rounded `button` asset) **+ the indicator bar** (accent
+     or foreground); replace the interim compact-`SideNavItem` rail. ~28px glyph.
+   - **Sidebar list:** reduce to **subtle wash only** — strip the bar + accent
+     text from the `NavPanel` nav items (currently flat `navitem` asset has the
+     bar).
+   - **`list_nav` → real `ListView`** (recycling + subtle wash); static keeps
+     `NavPanel`. **Tree** selected wash → align to the sidebar subtle wash
+     (role-scoped; don't touch content-area grids), no accent text.
+   - Rail/sidebar/content as named **elevation tokens** (light/dark flip).
+   - **Tree empty-state placeholder** in the content area (tree opens unselected).
 11. **Polish** — window-control accessors, fold `menu_layout`/`chrome_surface`,
     `bootstack.events` additions, docs (clean `-W` build), `test_public_surface`.
 

--- a/docs/_dev/appshell-navigation-spec.md
+++ b/docs/_dev/appshell-navigation-spec.md
@@ -241,6 +241,56 @@ Create a **`'secondary'` Tabs variant** that draws the selection indicator at th
 
 ---
 
+## Revision 4 — accordion CUT (2026-06-13, with maintainer)
+
+After building the Revision-3 accordion (`add_group` → `NavGroup` over `Expander`,
+heterogeneous list/tree/page section bodies, shared content region, navigate-to-
+reveal), the maintainer pulled the plug: **the accordion is not worth the
+trouble.** The heavy, bug-prone part was "a section that *is* a list/tree" — the
+shared content deck across sections, reveal into a collapsed data view, sibling-
+selection clearing, the no-intrinsic-height fix, the header highlight wash. It also
+conflated content-hierarchy with navigation, exactly what the design doc warns
+against. **Supersedes Revision 2 / R2 and Revision 3.**
+
+**Decision: drop the built-in accordion.** The sidebar has three authored shapes:
+
+| shape | how | scroll |
+|---|---|---|
+| **flat-static** | `add_page` | compact → icons; item area scrolls |
+| **grouped-static** | `add_page` + `add_header` (a plain **muted** label, flush items, larger top gap for the group break) | item area scrolls |
+| **data-bound** | `list_nav` / `tree_nav` | the recycling widget scrolls itself |
+
+A collapsible section that hides/reveals a sub-list is a **content** concern —
+compose `bs.Accordion` inside a custom `panel()`. `NavGroup` / `ProviderHost` were
+deleted; `Workspace` is back to a single provider; `add_group` / `expand_all` /
+`collapse_all` are gone from `Shell`/`Workspace`; `SideNavHeader` is a plain label.
+
+**Also shipped this pass (the grouped-static finish):**
+- **Muted section headers** — `SideNavHeader.DEFAULT_ACCENT='muted'` (was full-
+  strength); a header is quiet chrome, the clickable rows carry the contrast.
+- **Bigger group break** — `NavPanel.add_header` top padding `10→16` (bottom stays
+  `4`, so the header still hugs its own items).
+- **Scrollable static nav** — `NavPanel` wraps its item area in a `ScrollView`
+  (mousewheel + auto-hiding bar) with the **footer pinned** outside it. Overflow-
+  gated: when content fits → `scrollbar_visibility='never'` (no gutter, no bar,
+  no footer divider, items full-width); when it overflows → `'scroll'` (gutter +
+  bar) and a `SideNavSeparator` divider appears above the footer. The 8px-vs-bar-
+  width difference + a 4px epsilon gives stable hysteresis (no flicker). Canvas
+  background is painted to the sidebar surface (repaint on `<<BsThemeChanged>>`).
+- **Square (`nav-quiet`) under a rail, `nav-pill` standalone stays** — confirmed:
+  under a rail you have mixed-provider workspaces (static + list + tree) that must
+  share one row language, so the pill is single-tier-only.
+
+**Deferred (noted, not done):** thin/overlay nav scrollbar (the bar is the 17px
+classic width — a step-9 styling item); `Workspace` is not yet a context manager
+though the two-tier examples use `with shell.add_workspace(...) as ws:` (close
+when the public `AppShell` is swapped on, step 11).
+
+Tests: `test_shell_groups` rewritten for grouped-static. Throwaway demos
+`development/shell_*_demo.py` stay untracked.
+
+---
+
 ## 1. Locked decisions (from discussion)
 
 1. **Single-tier is two-tier with one workspace.** The rail (workspace switcher)

--- a/docs/_dev/appshell-navigation-spec.md
+++ b/docs/_dev/appshell-navigation-spec.md
@@ -1,0 +1,462 @@
+# AppShell + Navigation — implementation spec
+
+Status: **DRAFT for review** (2026-06-13). Actionable spec derived from
+`appshell-design.md` (the rationale/north-star) + the locked decisions from the
+2026-06-13 design discussion. This supersedes the *API shapes* in the design doc
+where they conflict (e.g. `shell.toolbar` → `shell.commandbar`); the design doc
+remains the source for *why*.
+
+Clean-slate rewrite of `AppShell` + the shell's navigation. Pre-release →
+clean breaking changes, no compat shims.
+
+---
+
+## 1. Locked decisions (from discussion)
+
+1. **Single-tier is two-tier with one workspace.** The rail (workspace switcher)
+   is always in the *model*; it only *renders* when `len(workspaces) > 1`. The
+   switcher is therefore optional with zero app-code branching.
+2. **Nested page-stack cascade.** `rail selection → sidebar panel` and
+   `sidebar selection → content page` are both page-stack swaps. Off-screen
+   panels stay alive (per-workspace memory: selection + scroll survive).
+3. **One provider per workspace, mutually exclusive.** A workspace's sidebar is
+   filled by exactly one of `add_page` (static), `list_nav`, `tree_nav`, or a
+   custom panel. Mixing is an error, not a merge.
+4. **Two modes per workspace.** *Provider mode* (blessed: cascade +
+   collapse-to-rail + per-workspace memory) vs *custom mode* (blank container,
+   user owns content-switching, **hides but does not compact to a rail**).
+5. **Collapse-to-rail requires icon-representable content.** Inherent constraint,
+   not a bug — only provider-mode panels compact; custom panels only hide.
+6. **VS Code rail gesture.** Click the **active** rail icon → hide the sidebar.
+   Click a **different** rail icon → switch workspace + show the sidebar.
+7. **Three independent layout axes; rail→sidebar content-coupled.** Visibility of
+   rail / sidebar / detail-dock toggle independently. Rail *drives* sidebar
+   content (the cascade); the detail dock answers to neither.
+8. **Detail/inspector dock reserved, not built this round.** Right-side region +
+   independent `dock_visible` axis are reserved in the layout and the nav model;
+   no rendering work now.
+8b. **Status bar built minimal this round.** Full-width bottom band, shell-global,
+    home for *passive* status; reuses the CommandBar strip primitive; left/right
+    clusters; content-driven presence. Per-view status segments deferred.
+9. **§3 of the design doc ("menubar is a toolbar") is dead.** Use the shipped
+   two-surface split (`menubar` + `commandbar`, PR #124). The rail/sidebar sit
+   *below* that chrome row.
+10. **Detail payload normalized to one shape** (resolves design-doc open
+    decision #2): both `list_nav` and `tree_nav` detail builders receive the
+    universal `.selection` **record dict**, not dict-vs-node.
+11. **`SideNav` stays standalone, and is simplified.** It remains a public widget
+    usable outside a shell (the seed-brief renames land on it: `on_toggle`/
+    `on_display_change`), and the AppShell static (`add_page`) provider renders
+    the *same* primitive. **Collapsible groups (`SideNavGroup` expandability) are
+    removed** — accordions in the primary nav break collapse-to-rail and conflate
+    content-hierarchy with navigation (design doc §4). What survives: single-select
+    nav items (radio semantics, nav rendering), **static** group headers (inline
+    markers that chunk the list and hide on collapse), separators, footer items,
+    and the `hidden → compact → expanded` axis. Grouping survives *without*
+    collapsibility — a header + its items may indent and highlight the active child.
+12. **The sidebar owns ONE selection language; providers adopt it by role.** The
+    nav-item visual treatment — subtle accent wash (`b.subtle(accent, surface)`) +
+    an optional **left indicator bar** + accent foreground, **no hover-when-selected**
+    — is a *sidebar* affordance, theme-token driven (flips light/dark). All three
+    providers (`add_page`/`list_nav`/`tree_nav`) render rows in this language, so
+    switching a workspace's provider never makes the rows jump. This is independent
+    of ListView's *content-area* selection style (which dropped the bar for a
+    simpler wash) — a ListView in `list_nav` *role* takes the sidebar language, not
+    its data-grid styling ("a widget exposes capabilities; a provider exposes a
+    role"). Implementation reuses the existing pattern: the `navitem_{density}`
+    nine-patch (with the baked indicator-bar channel) + the shared **button-family
+    sizing helpers** (`toolbutton_layout`/`button_padding`/`button_font`/
+    `icon_size`/`normalize_button_density`) — exactly how `ToggleGroup` reuses
+    `ButtonGroup`'s baked shapes with a role-specific builder. Cleanup: drop the
+    unused `variant`/`VariantToken` kwarg from `SideNavItem`
+    (`project_variant_type_revisit`).
+13. **Per-tier visual hierarchy (rail vs sidebar vs content).** Three reinforcing
+    axes of distinction so two icon columns never compete and *"the eye lands on
+    exactly one high-contrast item per tier"* (design doc §6):
+    - **Elevation:** rail = 0, sidebar = 1, content = 2 — **named elevation
+      tokens** (light themes darken with depth; dark themes often lighten — the
+      token lets it flip correctly per theme).
+    - **Active markers differ by tier — the bar is sidebar-only:**
+      - **Rail active** = a **subtle accent-tinted wash** (`b.subtle(accent,
+        surface)`, resolved against the *rail* surface — it must be tuned against
+        elevation 0, not the sidebar's surface) + glyph at **full neutral
+        foreground**; inactive glyphs **muted**; **no bar, no accent on the glyph**
+        (accent appears once, as the wash tint — accent-wash + accent-glyph is "too
+        much"). The rail must carry its active state independently because the hide
+        gesture can remove the sidebar entirely.
+      - **Sidebar active** = subtle wash + **accent foreground** + **left indicator
+        bar** (decision #12); the wash carries selection through compact mode where
+        the bar matches the fill and disappears.
+    - **Icon scale — two tokens:** `inline_icon_size` (small, ~16–18px
+      density-scaled — expanded item beside a label) vs `rail_icon_size` (larger,
+      ~20–24px — standalone categorical glyph). Size alone signals the tier.
+    - **The seam rule (load-bearing):** a compacted *single* sidebar adopts the
+      **rail paradigm wholesale** — `rail_icon_size`, the rail wash+neutral-glyph
+      marker (NOT the bar), and `rail_width` — so collapsing a one-workspace
+      sidebar is visually identical to a two-tier rail (collapse never reveals a
+      seam). Net: only two icon sizes system-wide (inline, rail/compact), and
+      "compact" ≡ "rail".
+
+---
+
+## 2. Three-layer architecture
+
+Layout, navigation logic, and content-population are separated so they don't bleed
+into each other (today's `AppShell` mixes all three).
+
+### Layer 1 — Region layout (dumb)
+The band layout. Full-width top (`menubar`/`commandbar`) and bottom (`statusbar`)
+bands; a body row that is a paned arrangement of `rail · sidebar · content · dock`.
+Each region is a **toggleable slot**. Knows nothing about navigation — just
+shows/hides/sizes regions. The `dock` slot is reserved (not rendered this round);
+the `statusbar` band is built minimal.
+
+```
+┌─────────────────────────────────────────────┐
+│ menubar / commandbar  (full width)           │
+├──┬──────────────┬──────────────────┬─────────┤
+│r │ sidebar      │                  │  dock   │
+│a │ (swaps per   │     content      │ (resv'd)│
+│i │  workspace)  │                  │         │
+│l │              │                  │         │
+├──┴──────────────┴──────────────────┴─────────┤
+│ statusbar  (full width, minimal — passive)   │
+└─────────────────────────────────────────────┘
+```
+
+### Layer 2 — `NavModel` (the brain): single observable state
+**Tk-free, headless-testable.** One source of truth; controls dispatch into it,
+regions subscribe.
+
+```python
+SidebarMode = Literal["hidden", "compact", "expanded"]
+
+@dataclass
+class WorkspaceState:
+    key: str
+    text: str = ""
+    icon: str | dict | None = None
+    is_footer: bool = False          # pinned to rail bottom
+    provider: ProviderKind = "pages" # pages | list | tree | custom
+
+class NavModel:
+    workspaces: list[WorkspaceState]      # insertion order
+    active_workspace: str | None
+    active_page: dict[str, str]           # workspace_key -> page_key (per-ws memory)
+    sidebar_mode: SidebarMode             # the ONE linear axis
+    dock_visible: bool                    # independent axis (reserved)
+
+    # transitions (the only ways state changes)
+    def add_workspace(self, key, **meta) -> WorkspaceState: ...
+    def select_workspace(self, key) -> None: ...      # rail click (different icon)
+    def select_page(self, key, *, workspace=None) -> None:
+    def activate_rail(self, key) -> None:             # VS Code gesture dispatcher:
+        # if key == active_workspace and sidebar visible -> hide
+        # else -> select_workspace(key) + show
+    def toggle_sidebar(self) -> None:                 # hamburger/shortcut: visibility
+    def set_sidebar_mode(self, mode) -> None:         # chevron: compact<->expanded
+    def toggle_dock(self) -> None:
+
+    def subscribe(self, listener) -> Subscription: ...  # regions observe
+```
+
+Invariant: `sidebar_mode` is a single linear axis (`hidden → compact → expanded`),
+so "hidden but expanded" is unrepresentable. In two-tier the rail is the
+always-present tier-1, so the secondary panel uses only `hidden ↔ expanded`
+(no own compact — two icon-rails side by side is noise).
+
+`rail_renders == len([w for w in workspaces if not w.is_footer]) + footers > 1`
+(i.e. more than one workspace total). Pure function of workspace count.
+
+### Layer 3 — Providers (Strategy + Adapter)
+What *fills* a workspace panel, behind one contract: **emit a selection → swap
+content**. The sidebar region holds *a provider* and doesn't know which kind.
+
+```python
+class NavProvider(Protocol):
+    def mount(self, panel: Container) -> None: ...   # build the sidebar widget
+    def on_select(self, handler) -> Subscription: ...# emits the selected record
+    def selection: dict | None                        # universal record shape
+    def supports_compact: bool                        # pages/list/tree True; custom False
+```
+
+- `add_page` → **static** provider (authored items + authored bodies).
+- `list_nav(source=)` → **flat data-bound** (a `ListView` in nav role: single-select,
+  no multi/export). Adapts `DataSourceProtocol` (pagination/`where`/`order`).
+- `tree_nav(...)` → **hierarchical data-bound** (a `Tree` in nav role; same source
+  viewed through a parent column).
+- custom → no provider; raw container, `supports_compact = False`.
+
+Providers *consume* the widget/source; they don't subclass it, so widgets keep
+gaining capability without it leaking into the narrow nav contract.
+
+---
+
+## 3. Public API surface
+
+### 3.1 `AppShell` (the shell == the implicit default workspace)
+
+Constructor keeps the existing flat-kwargs path (`theme`/`size`/`locale`/window
+placement/window-state/etc. via `AppConfigMixin`), plus navigation options.
+**New/changed nav kwargs:**
+
+| kwarg | type | default | meaning |
+|---|---|---|---|
+| `show_sidebar` | `bool` | `True` | render the sidebar region |
+| `sidebar_mode` | `'expanded'\|'compact'\|'hidden'` | `'expanded'` | initial sidebar state |
+| `sidebar_width` | `int \| None` | token | expanded width |
+| `rail_width` | `int \| None` | token | rail / compact width (shared token — collapse is seamless) |
+| `collapsible` | `bool` | `True` | show the in-sidebar chevron + bind Ctrl/Cmd-B |
+| `nav_accent` | `AccentToken \| str` | `'primary'` | active-item accent |
+| `remember_nav_state` | `bool` | `False` | persist sidebar_mode + per-workspace page across sessions |
+| `show_statusbar` | `bool` | `False` | force the status band on (else content-driven) |
+| `show_dock` *(reserved)* | `bool` | `False` | render the detail/inspector dock |
+
+**Region accessors (public handles — NOT internal composites):**
+
+| accessor | returns | notes |
+|---|---|---|
+| `shell.commandbar` | `CommandBar` | public handle (fixes today's leak) |
+| `shell.menubar` | menubar handle | already public (PR #124) |
+| `shell.rail` | `Rail` | workspace switcher; methods no-op when not rendered |
+| `shell.content` | content region handle | active page container |
+| `shell.statusbar` | `StatusBar` | full-width bottom band (see §3.5) |
+| `shell.dock` *(reserved)* | dock handle | right-side detail/inspector region |
+
+**Workspace API on the shell** — sugar that targets the **implicit default
+workspace**:
+
+| method | returns | effect |
+|---|---|---|
+| `add_page(key, *, text, icon, group, scrollable)` | `Page` (context mgr) | static authored page |
+| `add_footer_page(key, ...)` | `Page` | page pinned to sidebar bottom |
+| `add_header(text)` | `NavHeader` | static (non-collapsible) group label |
+| `add_separator()` | `NavSeparator` | divider |
+| `list_nav(source=, *, image_field=, caption_field=, where=, order=)` | `ListNav` | claim default ws as flat data-bound |
+| `tree_nav(source=None, *, parent_field=, ...)` | `TreeNav` | claim default ws as hierarchical |
+| `detail` | decorator | the parameterized body for a data-bound provider |
+| `panel()` | `Container` (context mgr) | claim default ws as **custom mode** |
+
+**Two-tier API:**
+
+| method | returns | effect |
+|---|---|---|
+| `add_workspace(key, *, text, icon)` | `Workspace` (context mgr) | adds a rail icon → a sidebar panel |
+| `add_footer_workspace(key, ...)` | `Workspace` | rail icon pinned to rail bottom |
+
+**Navigation + lifecycle:**
+
+| method/prop | meaning |
+|---|---|
+| `navigate(page)` / `navigate(workspace, page)` | set active workspace and/or page |
+| `current` | active page key (single-tier) |
+| `current_workspace` | active workspace key (two-tier) |
+| `toggle_sidebar()` / `show_sidebar()` / `hide_sidebar()` | visibility (hamburger) |
+| `sidebar_mode` (rw prop) | `'hidden'\|'compact'\|'expanded'` |
+| window controls | `close`/`minimize`/`maximize`/… via `WindowControlsMixin` |
+| `run()` | show + mainloop |
+
+**Mutual-exclusivity rule (locked):** shell-level page methods
+(`add_page`/`list_nav`/`tree_nav`/`panel`) are sugar for the implicit default
+workspace and are **mutually exclusive with `add_workspace`**. Call one style or
+the other. Calling `add_workspace` after a shell-level page method (or vice-versa)
+raises — this keeps "simple stays simple" and "complex is explicit" without an
+implicit workspace that has no rail icon/text.
+
+### 3.2 `Workspace` (returned by `add_workspace`; the shell *is* the default one)
+
+Exposes the **same page API the shell has** — `add_page`, `add_footer_page`,
+`add_header`, `add_separator`, `list_nav`, `tree_nav`, `detail`, `panel`,
+`navigate(page)`, `current`, and `content` (the workspace's content-region handle,
+for hand-driven swapping in custom mode). This literal symmetry is what makes
+single→two-tier purely additive.
+
+### 3.3 `Rail` (the workspace switcher)
+Mostly framework-driven (built from workspaces). Public surface is small:
+`rail.select(key)`, `rail.current`, `rail.on_change(handler)` (→ a workspace-change
+event). Footer workspaces render at the rail bottom.
+
+### 3.5 `StatusBar` (full-width bottom band)
+
+Shell-global, the home for **passive** status (indicators, counts, sync state) —
+*interactive* controls stay on the `commandbar`. Reuses the CommandBar strip
+primitive with a `statusbar` style role (thinner, muted surface), so the
+left/right-cluster mental model carries over.
+
+| method | effect |
+|---|---|
+| `add_widget(widget, *, side='left')` | add a passive widget to the left/right cluster |
+| `add_spacer()` | push subsequent items to the right cluster |
+| `add_text(text, *, side='left')` | convenience label segment |
+| `clear()` | remove all segments |
+
+**Content-driven presence:** the band renders only if items were added *or*
+`show_statusbar=True`. A one-screen utility never sees an empty strip.
+Shell-global only this round — per-workspace/per-view status segments are deferred
+(the band itself is global; segments can be added later without re-cutting it).
+
+### 3.4 Events (`bootstack.events`)
+
+| shorthand | payload | fires |
+|---|---|---|
+| `shell.on_page_change(h)` | `PageChangeEvent(key, prev_key, data)` | active page changes |
+| `shell.on_workspace_change(h)` | `WorkspaceChangeEvent(key, prev_key)` *(new)* | rail switches workspace |
+| `shell.on_sidebar_toggle(h)` | `PaneToggleEvent(is_open)` | sidebar shown/hidden |
+| `shell.on_sidebar_mode_change(h)` | `DisplayModeEvent(mode)` | compact ↔ expanded |
+
+All follow the `@overload` no-arg→`Stream` / handler→`Subscription` convention.
+Present-tense names throughout (`project_event_naming_revisit`).
+
+---
+
+## 4. Usage patterns
+
+### 4.1 Single-tier, static pages (the default — rail never appears)
+
+```python
+import bootstack as bs
+
+with bs.AppShell(title="My App", size=(800, 540)) as shell:
+    shell.commandbar.add_spacer()
+    shell.commandbar.add_button(icon="circle-half", on_click=bs.toggle_theme)
+
+    with shell.add_page("dashboard", text="Dashboard", icon="speedometer2"):
+        with bs.VStack(fill="x", gap=12, padding=24):
+            bs.Label("Dashboard", font="heading-lg")
+            bs.Label("Welcome back.")
+
+    with shell.add_page("inbox", text="Inbox", icon="inbox"):
+        bs.Label("Inbox", font="heading-lg")
+
+    shell.add_separator()
+    shell.add_header("Documents")
+
+    with shell.add_page("files", text="Files", icon="folder"):
+        bs.Label("Files", font="heading-lg")
+
+    with shell.add_footer_page("settings", text="Settings", icon="gear"):
+        bs.Label("Settings", font="heading-lg")
+
+    shell.navigate("dashboard")
+shell.run()
+```
+
+### 4.2 Single-tier, data-bound list (master–detail, still no rail)
+
+```python
+from bootstack.data import MemoryDataSource
+
+devices = MemoryDataSource().load([...])
+
+with bs.AppShell(title="Devices") as shell:
+    shell.list_nav(source=devices)          # claims the implicit workspace
+
+    @shell.detail
+    def show(record):                        # re-rendered per selection
+        with bs.VStack(fill="both", gap=12, padding=24):
+            bs.Label(record["title"], font="heading-lg")
+            bs.Label(record["text"])
+    # no navigate() needed — first record auto-selected
+shell.run()
+```
+
+### 4.3 Two-tier (rail appears — one provider per workspace)
+
+```python
+with bs.AppShell(title="Instrument Console", size=(960, 600)) as shell:
+    shell.commandbar.add_spacer()
+    shell.commandbar.add_button(icon="circle-half", on_click=bs.toggle_theme)
+
+    # WS 1 — static authored pages
+    with shell.add_workspace("acquire", text="Acquire", icon="cpu") as ws:
+        with ws.add_page("sensors", text="Sensors", icon="thermometer-half"):
+            bs.Label("Sensors", font="heading-lg")
+        ws.add_separator()
+        ws.add_header("Hardware")
+        with ws.add_page("ports", text="Ports", icon="usb-symbol"):
+            bs.Label("Ports", font="heading-lg")
+
+    # WS 2 — flat data-bound master–detail
+    with shell.add_workspace("devices", text="Devices", icon="hdd-stack") as ws:
+        ws.list_nav(source=devices)
+        @ws.detail
+        def show_device(record):
+            bs.Label(record["title"], font="heading-lg")
+
+    # WS 3 — hierarchical data-bound
+    with shell.add_workspace("library", text="Library", icon="folder") as ws:
+        with ws.tree_nav() as tree:
+            tree.add_nodes([...])
+        @ws.detail
+        def show_node(record):               # normalized: record dict, not node obj
+            bs.Label(record["text"], font="heading-lg")
+
+    # global Settings pinned to the rail bottom
+    with shell.add_footer_workspace("settings", text="Settings", icon="gear") as ws:
+        with ws.add_page("general", text="General", icon="sliders"):
+            bs.Label("Settings", font="heading-lg")
+
+    # passive global status in the bottom band (interactive controls stay on the
+    # commandbar). Renders because items were added.
+    shell.statusbar.add_widget(bs.Badge("0 devices", accent="primary"))
+    shell.statusbar.add_spacer()
+    shell.statusbar.add_text("Ready")
+
+    shell.navigate("acquire", "sensors")     # workspace first, then page
+shell.run()
+```
+
+### 4.4 Custom panel (escape hatch — hides but does not compact)
+
+```python
+with shell.add_workspace("tools", text="Tools", icon="tools") as ws:
+    with ws.panel():                         # blank sidebar container; custom mode
+        bs.Label("Filters", font="heading-md")
+        with bs.Accordion():                 # allowed here (not in provider mode)
+            ...
+    # you drive the content region yourself (register pages + navigate, or swap frames)
+```
+
+---
+
+## 5. Implementation plan (each step leaves a working shell)
+
+1. **`NavModel` (headless)** — state machine, transitions, per-workspace memory,
+   the VS Code `activate_rail` gesture, `subscribe`. Full unit tests, no Tk.
+2. **Region layout (Layer 1)** — band grid + body paned slots + show/hide/size.
+   Dumb, no nav semantics. Build the `statusbar` band (minimal, reusing the
+   CommandBar strip primitive); reserve the `dock` slot.
+3. **Wire model ↔ regions, single-tier path** — rail hidden; `add_page` works;
+   `navigate`/`on_page_change`. Public handles for `commandbar`/`content`.
+4. **Provider abstraction + static provider** — `NavProvider` Protocol;
+   `add_page` as the first provider; selection→content swap.
+5. **Data-bound providers** — `list_nav` then `tree_nav`; `@detail` master-detail;
+   normalize payload to the record dict (open-decision #2).
+6. **Two-tier rail** — `add_workspace`/`add_footer_workspace`; `Rail` widget; VS
+   Code gesture; per-workspace panel deck; `on_workspace_change`.
+7. **Sidebar collapse** — chevron (compact↔expanded) + hamburger/Ctrl-B
+   (visibility); shared `rail_width`/`sidebar_width` tokens so single-collapse and
+   two-tier rail look identical; `remember_nav_state` persistence.
+8. **Custom panel mode** — `ws.panel()`; `supports_compact = False`.
+9. **Elevation tokens** — rail/sidebar/content as named elevation tokens
+   (light/dark flip).
+10. **Detail dock** *(reserved — likely a follow-on)* — wire the slot + axis.
+11. **Polish** — window-control accessors, fold `menu_layout`/`chrome_surface`,
+    `bootstack.events` additions, docs (clean `-W` build), `test_public_surface`.
+
+---
+
+## 6. Open questions — RESOLVED (2026-06-13)
+
+1. **SideNav standalone vs absorbed.** **Resolved:** stays standalone *and*
+   simplified — collapsible groups removed. See locked decision #11.
+2. **Custom-mode content wiring.** **Resolved:** expose **both** — `ws.panel()`
+   for the sidebar container and `ws.content` for hand-driven content swapping.
+3. **Status bar scope.** **Resolved:** build minimal, shell-global, reusing the
+   CommandBar primitive (see §3.5). Per-view segments deferred.
+4. **`navigate` signature overload.** **Resolved:** positional overload —
+   `navigate(page)` (single-tier) / `navigate(workspace, page)` (two-tier).
+5. **Auto-select first item** for data-bound providers. **Resolved:** on by
+   default — `list_nav`/`tree_nav` auto-select the first item so the detail body
+   renders without an explicit `navigate`.
+```

--- a/docs/_dev/appshell-navigation-spec.md
+++ b/docs/_dev/appshell-navigation-spec.md
@@ -11,6 +11,102 @@ clean breaking changes, no compat shims.
 
 ---
 
+## Revision 2 — model finalization (2026-06-13, with maintainer)
+
+A design conversation (driven by VS Code pattern analysis) refined the navigation
+model. The decisions below **supersede** parts of §1 where they conflict (marked
+inline). Net: the model is *simpler* — one strong icon tier (the rail), one quiet
+panel tier (the sidebar), **tier-relative** styling, and collapsible groups
+restored.
+
+**R1 — Drop the *seam rule*, not `compact` itself.** Compact (icon-only) stays a
+real sidebar state, but **only for a standalone static sidebar** (no rail) — the
+primary nav narrowing to an icon strip (Gmail / admin-dashboard style). What is
+removed is the **seam rule**: the mandate that a compacted single sidebar adopt the
+rail's exact paradigm + `rail_width` so it looks indistinguishable from a two-tier
+rail (decisions #1/#5/#13). Compact is just the static pills rendered icon-only at
+an icon-fitting width — it is *not* pretending to be a workspace rail (there is no
+rail when it's standalone, so no confusion). Specifics:
+- **Sidebar axis stays `hidden ↔ compact ↔ expanded`** — NavModel `SidebarMode`
+  is unchanged (`compact` retained).
+- **Compact is static-only.** `list_nav` / `tree_nav` are **`hidden ↔ expanded`**
+  only — a label-less data list / icon-only hierarchy is meaningless ("a list nav
+  can be hidden, but not compact, whatever that even means"). So
+  `supports_compact` = `True` for the static provider, `False` for list/tree.
+- **Under a rail, every tier-2 sidebar is `hidden ↔ expanded`** regardless of
+  provider — an icon-only panel beside the icon rail is two icon columns = noise
+  (the §2.2 invariant). So compact applies only to the *standalone* static case.
+
+Icon-compaction-into-a-rail-lookalike is what's gone; "want a real rail" → add
+workspaces (the rail is a first-class tier you opt into, not an emergent state of a
+collapsed sidebar).
+
+**R2 — Collapsible accordion groups are restored (reverses decision #11's
+removal).** "A static sidenav with collapsible section headers" and "a 1-level
+accordion" are the *same widget* — a non-collapsible header is just a group pinned
+open. So this is **folded into the static provider** (optional `collapsible`
+groups), not a 4th provider. Hard rule: **accordions are 1 level** (collapsible
+section → flat items, no nesting). Depth → `tree_nav`. This is what fills real
+two-tier sidebars (VS Code Explorer/Extensions, Slack/Discord channels).
+
+**R3 — Sidebar styling is tier-relative, not provider-absolute.** Prominence
+tracks whether a rail outranks the sidebar:
+- **Static, standalone (no rail) = the primary nav** → **button-like, rounded
+  "pill" items** (macOS System Settings vibe). Reuses the rounded `button` asset
+  family.
+- **Static, under a rail = tier-2** → **quiet flat full-width list rows** (the
+  rail is now the strong tier; the sidebar recedes).
+- **`list_nav` / `tree_nav` keep their list/tree row language in *all* contexts**
+  — a data list reads as a list (Mail's sidebar), never as pills. *("You'd never
+  see a pill sidebar next to a list nav — that's the wrong navigation structure.")*
+- **Rail** → strong rounded toggle-button (muted→full-color) + indicator bar, on
+  its **own chrome/elevation color**.
+
+Because shell-level `add_page` (no rail) and workspace `add_page` (rail present)
+are mutually exclusive, a provider always knows its tier at mount — no runtime
+flipping between pills and flat rows.
+
+**R4 — Static `add_page` stays on both shell and workspace.** It is the
+single-tier idiom, but valid under a rail (e.g. a footer "Settings" workspace with
+General/Appearance sub-pages), rendered in the tier-2 quiet language per R3.
+
+**R5 — One sidebar selection language *per tier*.** All providers in the same tier
+render rows alike (decision #12's spirit): tier-2 (under-rail) = quiet wash, no
+bar, no accent text; tier-1 standalone static = rounded pill. The rail owns the
+bar.
+
+**R6 — Ctrl-B collapses the sidebar as far as is *useful*, context-dependently.**
+VS Code's Ctrl-B fully hides the side panel because the activity bar (rail) stays
+as a fallback nav. A **standalone static sidebar is the only nav**, so hiding it
+strands the user — there, Ctrl-B = **expanded ↔ compact** (shrink to icons, never
+strand). For a **data-bound** sidebar (can't compact) or **any sidebar under a
+rail** (rail remains as nav), Ctrl-B = **expanded ↔ hidden** (VS Code behavior).
+So: compact-toggle when `not rail_visible and provider.supports_compact`, else
+visibility-toggle. The explicit verbs `toggle_sidebar()`/`show_sidebar()`/
+`hide_sidebar()` stay **pure visibility** (the hamburger primitive); only the
+keyboard shortcut is context-smart. The step-9 chevron does expanded↔compact, so
+chevron and Ctrl-B agree for the static case.
+
+**Re-scoped build order** (supersedes §5 steps 7–11):
+- **7 — Sidebar visibility/compaction + persistence** (slimmed): wire
+  `hidden ↔ compact ↔ expanded` → view, where **compact = icon-only + narrower
+  width, gated to the standalone static case** (no rail, `supports_compact`);
+  `toggle_sidebar`/`show_sidebar`/`hide_sidebar` (pure visibility) + `sidebar_mode`
+  rw prop + context-smart **Ctrl/Cmd-B** (compact-toggle for standalone static,
+  else hide — R6); `remember_nav_state` (sidebar_mode + per-workspace page). **No
+  visible chevron control** (the trigger for compact↔expanded is folded into step
+  9). **No PanedWindow sash** (deferred to a separate 7b follow-up).
+- **8 — Collapsible groups (accordion) + custom panel.** 1-level collapsible
+  groups in the static provider; `ws.panel()` custom mode.
+- **9 — Visual hierarchy (the big styling pass — discuss before implementing).**
+  Tier-relative styling per R3: rail strong toggle-button + bar + own chrome
+  color; tier-2 sidebar quiet list rows; tier-1 standalone static rounded pills;
+  `list_nav` → real `ListView`, tree aligned to the quiet wash; named elevation
+  tokens (rail/sidebar/content); tree empty-state placeholder.
+- **10 — Dock** (reserved, deferred). **11 — Polish** + swap public AppShell.
+
+---
+
 ## 1. Locked decisions (from discussion)
 
 1. **Single-tier is two-tier with one workspace.** The rail (workspace switcher)
@@ -25,8 +121,11 @@ clean breaking changes, no compat shims.
 4. **Two modes per workspace.** *Provider mode* (blessed: cascade +
    collapse-to-rail + per-workspace memory) vs *custom mode* (blank container,
    user owns content-switching, **hides but does not compact to a rail**).
-5. **Collapse-to-rail requires icon-representable content.** Inherent constraint,
-   not a bug — only provider-mode panels compact; custom panels only hide.
+5. **Collapse-to-rail requires icon-representable content.** *(REVISED by Revision
+   2 / R1 — `compact` (icon-only) is retained but applies ONLY to a standalone
+   static sidebar; the seam rule "compact looks like the rail" is removed. Nothing
+   compacts *into a rail*.)* Inherent constraint, not a bug — only the static
+   provider compacts (icon-only); list/tree and custom panels only hide.
 6. **VS Code rail gesture.** Click the **active** rail icon → hide the sidebar.
    Click a **different** rail icon → switch workspace + show the sidebar.
 7. **Three independent layout axes; rail→sidebar content-coupled.** Visibility of
@@ -44,7 +143,9 @@ clean breaking changes, no compat shims.
 10. **Detail payload normalized to one shape** (resolves design-doc open
     decision #2): both `list_nav` and `tree_nav` detail builders receive the
     universal `.selection` **record dict**, not dict-vs-node.
-11. **`SideNav` stays standalone, and is simplified.** It remains a public widget
+11. **`SideNav` stays standalone, and is simplified.** *(PARTLY SUPERSEDED by
+    Revision 2 / R2 — collapsible groups are RESTORED as 1-level accordions folded
+    into the static provider. The rest of this decision stands.)* It remains a public widget
     usable outside a shell (the seed-brief renames land on it: `on_toggle`/
     `on_display_change`), and the AppShell static (`add_page`) provider renders
     the *same* primitive. **Collapsible groups (`SideNavGroup` expandability) are
@@ -70,7 +171,10 @@ clean breaking changes, no compat shims.
     `ButtonGroup`'s baked shapes with a role-specific builder. Cleanup: drop the
     unused `variant`/`VariantToken` kwarg from `SideNavItem`
     (`project_variant_type_revisit`).
-13. **Per-tier visual hierarchy (rail vs sidebar vs content).** Three reinforcing
+13. **Per-tier visual hierarchy (rail vs sidebar vs content).** *(REVISED by
+    Revision 2 / R3 — the per-tier hierarchy stands; the seam rule is removed and
+    sidebar styling is now tier-relative: standalone static = rounded pills
+    (compact = those pills icon-only), under-rail static = quiet list rows.)* Three reinforcing
     axes of distinction so two icon columns never compete and *"the eye lands on
     exactly one high-contrast item per tier"* (design doc §6):
     - **Elevation:** rail = 0, sidebar = 1, content = 2 — **named elevation
@@ -141,7 +245,7 @@ the `statusbar` band is built minimal.
 regions subscribe.
 
 ```python
-SidebarMode = Literal["hidden", "compact", "expanded"]
+SidebarMode = Literal["hidden", "compact", "expanded"]  # compact = static-only (R1)
 
 @dataclass
 class WorkspaceState:
@@ -173,9 +277,12 @@ class NavModel:
 ```
 
 Invariant: `sidebar_mode` is a single linear axis (`hidden → compact → expanded`),
-so "hidden but expanded" is unrepresentable. In two-tier the rail is the
-always-present tier-1, so the secondary panel uses only `hidden ↔ expanded`
-(no own compact — two icon-rails side by side is noise).
+so "hidden but expanded" is unrepresentable. *(Revision 2 / R1: `compact` is
+retained but applies ONLY to a standalone static sidebar — `list_nav`/`tree_nav`
+and any under-rail tier-2 sidebar use `hidden ↔ expanded` only. A single sidebar
+never morphs into a rail-lookalike; "want a rail" → add workspaces.)* In two-tier
+the rail is the always-present tier-1, so the secondary panel uses only
+`hidden ↔ expanded` (no own compact — two icon-rails side by side is noise).
 
 `rail_renders == len([w for w in workspaces if not w.is_footer]) + footers > 1`
 (i.e. more than one workspace total). Pure function of workspace count.
@@ -218,7 +325,7 @@ placement/window-state/etc. via `AppConfigMixin`), plus navigation options.
 | `sidebar_mode` | `'expanded'\|'compact'\|'hidden'` | `'expanded'` | initial sidebar state |
 | `sidebar_width` | `int \| None` | token | expanded width |
 | `rail_width` | `int \| None` | token | rail / compact width (shared token — collapse is seamless) |
-| `collapsible` | `bool` | `True` | show the in-sidebar chevron + bind Ctrl/Cmd-B |
+| `collapsible` | `bool` | `True` | show the in-sidebar chevron + bind Ctrl/Cmd-B (collapse: compact for a standalone static sidebar, else hide — see R6) |
 | `nav_accent` | `AccentToken \| str` | `'primary'` | active-item accent |
 | `remember_nav_state` | `bool` | `False` | persist sidebar_mode + per-workspace page across sessions |
 | `show_statusbar` | `bool` | `False` | force the status band on (else content-driven) |

--- a/docs/_dev/appshell-navigation-spec.md
+++ b/docs/_dev/appshell-navigation-spec.md
@@ -103,6 +103,17 @@ chevron and Ctrl-B agree for the static case.
   color; tier-2 sidebar quiet list rows; tier-1 standalone static rounded pills;
   `list_nav` → real `ListView`, tree aligned to the quiet wash; named elevation
   tokens (rail/sidebar/content); tree empty-state placeholder.
+  - **Collapsible groups (step 8):** **indent/nest** grouped items under their
+    header so grouped vs ungrouped reads clearly (the unindented look in step 8 is
+    why a mixed sidebar jars); style the chevron (size/weight/placement) and the
+    collapsible-header treatment (distinct from a plain static label); quiet the
+    per-item accent fg/icon coloring per R3.
+  - **Composition guideline (docs, not enforced):** use grouping *consistently* —
+    a flat list, or everything under collapsible sections (VS Code Explorer); a
+    single primary item *above* groups is acceptable, but don't sprinkle loose
+    top-level items among collapsible groups. The pinned footer is conventionally
+    standalone and exempt. The API allows the mix (flexibility); examples/docs
+    model the consistent idiom.
 - **10 — Dock** (reserved, deferred). **11 — Polish** + swap public AppShell.
 
 ---

--- a/docs/_dev/appshell-navigation-spec.md
+++ b/docs/_dev/appshell-navigation-spec.md
@@ -59,8 +59,11 @@ tracks whether a rail outranks the sidebar:
 - **`list_nav` / `tree_nav` keep their list/tree row language in *all* contexts**
   — a data list reads as a list (Mail's sidebar), never as pills. *("You'd never
   see a pill sidebar next to a list nav — that's the wrong navigation structure.")*
-- **Rail** → strong rounded toggle-button (muted→full-color) + indicator bar, on
-  its **own chrome/elevation color**.
+- **Rail** → the VS Code **activity-bar** treatment: muted unselected glyph →
+  **full-strength glyph + accent indicator bar**, **FLAT (not rounded)**, on its
+  **own chrome/elevation color**. The rail is built on the `navitem` **bar** asset,
+  **not** the rounded `button` asset. The rounded "pill" is the *standalone-static*
+  look ONLY — do not give it to the rail (a previous draft conflated the two).
 
 Because shell-level `add_page` (no rail) and workspace `add_page` (rail present)
 are mutually exclusive, a provider always knows its tier at mount — no runtime
@@ -99,8 +102,9 @@ chevron and Ctrl-B agree for the static case.
 - **8 — Collapsible groups (accordion) + custom panel.** 1-level collapsible
   groups in the static provider; `ws.panel()` custom mode.
 - **9 — Visual hierarchy (the big styling pass — discuss before implementing).**
-  Tier-relative styling per R3: rail strong toggle-button + bar + own chrome
-  color; tier-2 sidebar quiet list rows; tier-1 standalone static rounded pills;
+  Tier-relative styling per R3: rail = FLAT VS Code bar treatment (`navitem`
+  asset: muted→full-strength glyph + accent bar, NOT rounded) + own chrome color;
+  tier-2 sidebar quiet list rows; tier-1 standalone static rounded pills;
   `list_nav` → real `ListView`, tree aligned to the quiet wash; named elevation
   tokens (rail/sidebar/content); tree empty-state placeholder.
   - **Collapsible groups (step 8):** **indent/nest** grouped items under their
@@ -115,6 +119,12 @@ chevron and Ctrl-B agree for the static case.
     standalone and exempt. The API allows the mix (flexibility); examples/docs
     model the consistent idiom.
 - **10 — Dock** (reserved, deferred). **11 — Polish** + swap public AppShell.
+  Includes the deferred **rail follow-ups**: (a) **footer actions/menus** — a
+  non-radio path for plain icon buttons + icon menu buttons pinned to the rail
+  footer (VS Code's gear/accounts), styled to match the rail (muted→hover, no
+  selection bar); (b) **rail item tooltips** — the rail is icon-only, so each
+  item wants a tooltip (built into the per-item `RadioToggle`). Both designed
+  with the `shell.rail` public façade in this step.
 
 ---
 
@@ -185,7 +195,11 @@ chevron and Ctrl-B agree for the static case.
 13. **Per-tier visual hierarchy (rail vs sidebar vs content).** *(REVISED by
     Revision 2 / R3 — the per-tier hierarchy stands; the seam rule is removed and
     sidebar styling is now tier-relative: standalone static = rounded pills
-    (compact = those pills icon-only), under-rail static = quiet list rows.)* Three reinforcing
+    (compact = those pills icon-only), under-rail static = quiet list rows. The
+    RAIL uses the FLAT `navitem` bar treatment (muted→full-strength glyph + accent
+    bar), NOT the rounded `button` asset — rounded is the standalone-static pill
+    ONLY. The "reuse ToggleButton + rounded button asset for the rail" wording
+    below is the conflation R3 corrects.)* Three reinforcing
     axes of distinction so two icon columns never compete and *"the eye lands on
     exactly one high-contrast item per tier"* (design doc §6):
     - **Elevation:** rail = 0, sidebar = 1, content = 2 — **named elevation

--- a/docs/_dev/appshell-navigation-spec.md
+++ b/docs/_dev/appshell-navigation-spec.md
@@ -281,10 +281,37 @@ deleted; `Workspace` is back to a single provider; `add_group` / `expand_all` /
   under a rail you have mixed-provider workspaces (static + list + tree) that must
   share one row language, so the pill is single-tier-only.
 
-**Deferred (noted, not done):** thin/overlay nav scrollbar (the bar is the 17px
-classic width — a step-9 styling item); `Workspace` is not yet a context manager
-though the two-tier examples use `with shell.add_workspace(...) as ws:` (close
-when the public `AppShell` is swapped on, step 11).
+**Also shipped after the cut (sidebar styling round, committed):**
+- **Scrollable static nav** — `NavPanel` item area in a `ScrollView`; footer
+  pinned outside. Overflow-gated: fits → no gutter/bar/divider, items full-width;
+  overflows → bar + footer divider. The scrollbar gutter is **absorbed into the
+  right inset** (right margin stays even, not inset+gutter) and the footer
+  re-aligns to the scrolled rows — both adapt to the live bar width.
+- **Thin scrollbar** — new reusable **`'thin'`** scrollbar variant (4px solid
+  square thumb via `create_box_image`, track painted to the surface); `ScrollView`
+  threads its surface to its scrollbars. `NavPanel` uses it. (The 8/17px confusion
+  earlier was a stale-read artifact — the bar was always thin; it's now 4px.)
+- **Muted section headers** (`SideNavHeader.DEFAULT_ACCENT='muted'`) + a larger
+  group break (header top padding `10→16`).
+- **Empty-state placeholders** — `tree_nav` (opens unselected) and an empty
+  `list_nav` show a centered muted placeholder until a row is picked
+  (`placeholder=` on both).
+
+**Deferred → step 11 (the public-AppShell swap):**
+- **Drop the standalone `bs.SideNav`.** Decided (its unique value is thin — app
+  nav = AppShell, in-dialog nav = vertical `Tabs`; and it duplicates `NavPanel`).
+  Coupled to removing the old AppShell: the current public `bs.AppShell` is still
+  the OLD sidenav-based one, so SideNav can't be removed until the new `Shell` is
+  swapped on. `SideNavHeader`/`SideNavSeparator` stay (used by `NavPanel`).
+- **Wire + style the statusbar and menubar/command bar** into the new shell — the
+  `chrome` band is an empty `Frame` and the `statusbar` is a bare `Toolbar`; the
+  public `commandbar`/`menubar`/`statusbar` APIs aren't on the new `Shell` yet.
+- **`Workspace` context-manager support** (`with shell.add_workspace(...) as ws:`).
+- Public AppShell façade (`commandbar`/`nav`/`pages` + window-control accessors).
+
+**Separate initiative:** expose/document the `'thin'` scrollbar variant publicly +
+audit other scrollable widgets for narrow bars (memory
+`project_thin_scrollbar_initiative`).
 
 Tests: `test_shell_groups` rewritten for grouped-static. Throwaway demos
 `development/shell_*_demo.py` stay untracked.

--- a/src/bootstack/style/builders/listview.py
+++ b/src/bootstack/style/builders/listview.py
@@ -12,6 +12,21 @@ from bootstack.style.builders.utils import (
 )
 
 
+def _selection_wash(b: BootstyleBuilderTTk, accent: str, background: str, options: dict) -> str:
+    """Row selection background — NEUTRAL by default; accent only when opted in.
+
+    Governs the row's background wash only. The selection control's glyph still
+    follows the accent (it reads as the accent indicator regardless). `wash=False`
+    drops the wash entirely (selection shown via the control); `accent_selection`
+    requests the old accent-tinted wash.
+    """
+    if not options.get('wash', True):
+        return background
+    if options.get('accent_selection', False):
+        return b.subtle(accent or 'primary', background)
+    return b.active(background)
+
+
 @BootstyleBuilderTTk.register_builder('container', 'ListView.TFrame')
 def build_list_container_style(b: BootstyleBuilderTTk, ttk_style: str, accent: str = None, **options):
     """List container frame style - no hover state (only items should have hover)."""
@@ -28,11 +43,8 @@ def build_list_frame_style(b: BootstyleBuilderTTk, ttk_style: str, accent: str =
     surface_token = options.get('surface', 'content')
     base_token = surface_token.split('[')[0]
     background = b.color(surface_token)
-    active = b.elevate(b.color(base_token), 2)
     pressed = b.pressed(background)
-    selected = b.subtle(accent_token, background)
-    if not options.get('wash', True):
-        selected = background  # selection shown via the control, not a row wash
+    selected = _selection_wash(b, accent, background, options)
     b.configure_style(ttk_style, background=background, relief='flat')
 
     # No hover wash and no 'focus' wash: rows show selection only (keyboard focus
@@ -72,11 +84,8 @@ def build_list_item_style(
     accent_token = accent or 'primary'
 
     background = b.color(surface_token)
-    active = b.elevate(b.color(base_token), 2)
     pressed = b.pressed(background)
-    selected = b.subtle(accent_token, background)
-    if not options.get('wash', True):
-        selected = background  # selection shown via the control, not a row wash
+    selected = _selection_wash(b, accent, background, options)
 
     # Use separated image for separated variant, otherwise use standard list_item
     is_separated = 'separated' in variant
@@ -147,9 +156,8 @@ def build_list_item_button_style(b: BootstyleBuilderTTk, ttk_style: str, accent:
     density = normalize_button_density(options.get('density', 'default'))
 
     background = b.color(surface_token)
-    active = b.elevate(b.color(base_token), 2)
     pressed = b.pressed(background)
-    selected = b.subtle(accent or 'primary', background)
+    selected = _selection_wash(b, accent, background, options)
 
     b.create_style_layout(
         ttk_style,
@@ -214,15 +222,11 @@ def build_list_icon(b: BootstyleBuilderTTk, ttk_style: str, accent: str = None, 
     density = normalize_button_density(options.get('density', 'default'))
 
     background = b.color(surface_token)
-    active = b.elevate(b.color(base_token), 2)
     pressed = b.pressed(background)
-    selected = b.subtle(accent or 'primary', background)
+    selected = _selection_wash(b, accent, background, options)
     on_background = b.on_color(background)
     on_selected = b.on_color(selected)
     on_disabled = b.disabled('text', background)
-    if not options.get('wash', True):
-        selected = background      # icon/chevron don't wash when row wash is off
-        on_selected = on_background
 
     # Create layout (remove focus border)
     b.create_style_layout(
@@ -285,16 +289,13 @@ def build_list_selection_icon(b: BootstyleBuilderTTk, ttk_style: str, accent: st
     density = normalize_button_density(options.get('density', 'default'))
 
     background = b.color(surface_token)
-    active = b.elevate(b.color(base_token), 2)
     pressed = b.pressed(background)
-    selected = b.subtle(accent or 'primary', background)
+    # Neutral row wash by default; the GLYPH foreground below stays accent so the
+    # checked control is the accent indicator regardless of the wash.
+    selected = _selection_wash(b, accent, background, options)
     accent_color = b.color(accent or 'primary')
     muted = b.color('muted')
     on_disabled = b.disabled('text', background)
-    if not options.get('wash', True):
-        # Row wash is off: the control keeps its accent GLYPH fill (foreground)
-        # but drops its own selected BACKGROUND box so it matches the row.
-        selected = background
 
     b.create_style_layout(
         ttk_style,
@@ -349,16 +350,10 @@ def build_list_item_label(b: BootstyleBuilderTTk, ttk_style: str, accent: str = 
     foreground_token = options.get('foreground', None)
 
     background = b.color(surface_token)
-    active = b.elevate(b.color(base_token), 2)
     pressed = b.pressed(background)
-    selected = b.subtle(accent or 'primary', background)
-    on_selected = b.on_color(selected)
+    selected = _selection_wash(b, accent, background, options)
     on_background = b.color(foreground_token) if foreground_token else b.on_color(background)
-    if not options.get('wash', True):
-        # No row wash: text keeps its normal background and color (selection is
-        # shown by the control instead).
-        selected = background
-        on_selected = on_background
+    on_selected = b.on_color(selected)
 
     # Selection only — no hover wash, no 'focus' wash (keyboard focus = row bar).
     # Row hover was removed (competed with stripe/selection washes).

--- a/src/bootstack/style/builders/scrollbar.py
+++ b/src/bootstack/style/builders/scrollbar.py
@@ -6,7 +6,11 @@ from typing import Optional
 
 from bootstack.style.bootstyle_builder_ttk import BootstyleBuilderTTk
 from bootstack.style.element import Element, ElementImage
-from bootstack.style.utility import recolor_element_image
+from bootstack.style.utility import recolor_element_image, create_box_image
+
+
+# A few-pixel thumb for the 'thin' variant — suits narrow lists/navs.
+_THIN_SCROLLBAR_THICKNESS = 4
 
 
 def build_horizontal_scrollbar(b: BootstyleBuilderTTk, ttk_style: str, accent: Optional[str] = None, **options):
@@ -87,6 +91,56 @@ def build_rounded_scrollbar_style(b: BootstyleBuilderTTk, ttk_style: str, accent
         _build_rounded_vertical_scrollbar(b, ttk_style, accent, **options)
     else:
         _build_rounded_horizontal_scrollbar(b, ttk_style, accent, **options)
+
+
+@BootstyleBuilderTTk.register_builder('thin', 'TScrollbar')
+def build_thin_scrollbar_style(b: BootstyleBuilderTTk, ttk_style: str, accent: str = None, **options):
+    """A thin, square scrollbar — a few-pixel solid thumb on a surface-matched track.
+
+    Suited to narrow lists and navs. The thumb is neutral (the surface border
+    color) by default, or the accent when one is given; the track matches the
+    surface so an auto-hiding bar leaves no visible gutter tint. The thumb image
+    is a flat box generated on demand (it stretches uniformly along the track —
+    no rounding), so the bar reads as a clean square sliver.
+    """
+    orient = options.get('orient', 'vertical')
+    surface = b.color(options.get('surface', 'content'))
+    thumb = b.color(accent) if accent is not None else b.border(surface)
+    thumb_active = b.active(thumb)
+    thumb_pressed = b.pressed(thumb)
+    t = _THIN_SCROLLBAR_THICKNESS
+
+    if orient == 'vertical':
+        size = (t, 8)
+        trough_el = 'Vertical.Scrollbar.trough'
+        sticky = 'ns'
+    else:
+        size = (8, t)
+        trough_el = 'Horizontal.Scrollbar.trough'
+        sticky = 'ew'
+
+    normal_img = create_box_image(size[0], size[1], thumb)
+    active_img = create_box_image(size[0], size[1], thumb_active)
+    pressed_img = create_box_image(size[0], size[1], thumb_pressed)
+
+    b.create_style_element_image(
+        ElementImage(
+            f'{ttk_style}.thumb', normal_img, border=0, width=size[0], height=size[1],
+        ).state_specs([
+            ('pressed', pressed_img),
+            ('active', active_img),
+            ('', normal_img),
+        ]))
+
+    b.create_style_layout(
+        ttk_style,
+        Element(trough_el, sticky=sticky).children([
+            Element(f'{ttk_style}.thumb', sticky=sticky),
+        ]))
+
+    b.configure_style(
+        ttk_style, troughcolor=surface, bordercolor=surface, relief='flat', arrowsize=0,
+    )
 
 
 def _build_rounded_vertical_scrollbar(b: BootstyleBuilderTTk, ttk_style: str, accent: Optional[str] = None, **options):

--- a/src/bootstack/style/builders/sidenav.py
+++ b/src/bootstack/style/builders/sidenav.py
@@ -9,7 +9,7 @@ from typing import Optional
 
 from bootstack.style.bootstyle_builder_ttk import BootstyleBuilderTTk
 from bootstack.style.element import Element, ElementImage
-from bootstack.style.utility import recolor_element_image, mix_colors, create_transparent_image
+from bootstack.style.utility import recolor_element_image, create_transparent_image
 from bootstack.style.builders.utils import apply_icon_mapping, resolve_icon_spec
 from bootstack.style.builders.toolbutton import (
     toolbutton_layout, button_padding, button_font, icon_size, normalize_button_density
@@ -432,16 +432,18 @@ def _build_nav_compact(b, ttk_style, *, accent_token, options, image_key, select
 
 
 def _quiet_colors(b, accent_token, options):
-    # Subtle wash + neutral foreground (the wash alone marks selection).
+    # Neutral default: a light neutral wash (the active/hover level) marks the
+    # selection — no accent — with a neutral foreground, like the buttons. Accent
+    # is opt-in via a future variant.
     surface = b.color(options.get('surface', 'card'))
-    return b.subtle(accent_token, surface), b.on_color(surface)
+    return b.active(surface), b.on_color(surface)
 
 
 def _pill_colors(b, accent_token, options):
-    # Stronger accent tint + accent foreground (the prominent macOS-style pill).
+    # Neutral default: a light neutral pill (active/hover level, no accent tint) +
+    # neutral foreground; the rounded pill shape carries the prominence.
     surface = b.color(options.get('surface', 'card'))
-    ratio = 0.14 if b.provider.mode == 'light' else 0.18
-    return mix_colors(b.color(accent_token), surface, ratio), b.color(accent_token)
+    return b.active(surface), b.on_color(surface)
 
 
 @BootstyleBuilderTTk.register_builder('nav-quiet', 'Toolbutton')

--- a/src/bootstack/style/builders/sidenav.py
+++ b/src/bootstack/style/builders/sidenav.py
@@ -202,9 +202,10 @@ def build_rail_toolbutton_style(b: BootstyleBuilderTTk, ttk_style: str, accent: 
 
     A radio toggle (single-select) rendered icon-only on the chrome surface:
     the glyph is muted when idle and full-strength when selected (or hovered),
-    and the `navitem` asset's left indicator bar shows the accent color when
-    selected. The background stays flat in every state (no wash / no fill) — the
-    bar carries the selection. The accent lives in the bar, not the glyph.
+    and the `navitem` asset's left indicator bar shows the **foreground** color
+    when selected (neutral by default — accent is opt-in, like the buttons). The
+    background stays flat in every state (no wash / no fill) — the bar carries the
+    selection.
     """
     accent_token = accent or 'primary'
     surface_token = options.get('surface', 'chrome')
@@ -220,7 +221,8 @@ def build_rail_toolbutton_style(b: BootstyleBuilderTTk, ttk_style: str, accent: 
     surface_pressed = b.pressed(surface_hover)
     on_surface = b.on_color(surface)
     muted = b.muted_foreground(surface)
-    accent_color = b.color(accent_token)
+    # Neutral indicator bar by default (the foreground); accent is opt-in.
+    bar_color = on_surface
     disabled = b.disabled()
     on_disabled = b.disabled('text', disabled)
 
@@ -228,10 +230,10 @@ def build_rail_toolbutton_style(b: BootstyleBuilderTTk, ttk_style: str, accent: 
     normal_img  = recolor_element_image(image_key, surface, surface, surface, surface)
     hover_img   = recolor_element_image(image_key, surface_hover, surface_hover, surface_hover, surface)
     pressed_img = recolor_element_image(image_key, surface_pressed, surface_pressed, surface_pressed, surface)
-    # Selected: accent bar visible, background still flat (no wash).
-    selected_img         = recolor_element_image(image_key, surface,         surface,         accent_color, surface)
-    selected_hover_img   = recolor_element_image(image_key, surface_hover,   surface_hover,   accent_color, surface)
-    selected_pressed_img = recolor_element_image(image_key, surface_pressed, surface_pressed, accent_color, surface)
+    # Selected: foreground bar visible, background still flat (no wash).
+    selected_img         = recolor_element_image(image_key, surface,         surface,         bar_color, surface)
+    selected_hover_img   = recolor_element_image(image_key, surface_hover,   surface_hover,   bar_color, surface)
+    selected_pressed_img = recolor_element_image(image_key, surface_pressed, surface_pressed, bar_color, surface)
     disabled_img = recolor_element_image(image_key, disabled, disabled, surface, surface)
 
     b.create_style_element_image(

--- a/src/bootstack/style/builders/sidenav.py
+++ b/src/bootstack/style/builders/sidenav.py
@@ -285,6 +285,83 @@ def build_rail_toolbutton_style(b: BootstyleBuilderTTk, ttk_style: str, accent: 
     b.map_style(ttk_style, **state_spec)
 
 
+@BootstyleBuilderTTk.register_builder('nav-quiet', 'Toolbutton')
+def build_nav_quiet_toolbutton_style(b: BootstyleBuilderTTk, ttk_style: str, accent: str = None, **options):
+    """Build the quiet sidebar nav item (the under-a-rail / tier-2 treatment).
+
+    A flat full-width row: the selected row gets a **subtle accent wash** only —
+    **no indicator bar** and a **neutral foreground** (no accent text/icon), so
+    the wash alone marks selection (VS Code's Explorer / a settings list). This
+    is a `RadioToggle` (single-select) styled via the native engine; compaction
+    to icon-only is a `-compound` toggle on the widget, not a style concern.
+    """
+    accent_token = accent or 'primary'
+    surface_token = options.get('surface', 'card')
+    density = options.get('density', 'default')
+    icon_only = options.get('icon_only', False)
+    anchor = options.get('anchor', 'w')
+    image_key = f'navitem_{normalize_button_density(density)}'
+
+    surface = b.color(surface_token)
+    surface_hover = b.color(f'{surface_token}_hover') if b.colors.get(f'{surface_token}_hover') else b.active(surface)
+    surface_pressed = b.pressed(surface_hover)
+    on_surface = b.on_color(surface)
+    active = b.subtle(accent_token, surface)
+    active_pressed = b.pressed(active)
+    disabled = b.disabled()
+    on_disabled = b.disabled('text', disabled)
+
+    # The bar channel (3rd) always matches the fill, so no bar ever shows. The
+    # subtle wash appears only on the selected state.
+    normal_img  = recolor_element_image(image_key, surface, surface, surface, surface)
+    hover_img   = recolor_element_image(image_key, surface_hover, surface_hover, surface_hover, surface)
+    pressed_img = recolor_element_image(image_key, surface_pressed, surface_pressed, surface_pressed, surface)
+    selected_img         = recolor_element_image(image_key, active,         active,         active,         surface)
+    selected_hover_img   = recolor_element_image(image_key, active,         active,         active,         surface)
+    selected_pressed_img = recolor_element_image(image_key, active_pressed, active_pressed, active_pressed, surface)
+    disabled_img = recolor_element_image(image_key, disabled, disabled, disabled, surface)
+
+    b.create_style_element_image(
+        ElementImage(
+            f'{ttk_style}.border', normal_img.image, sticky="nsew",
+            border=normal_img.meta.border, padding=normal_img.meta.border
+        ).state_specs(
+            [
+                ('disabled', disabled_img.image),
+                ('selected pressed', selected_pressed_img.image),
+                ('selected hover', selected_hover_img.image),
+                ('selected', selected_img.image),
+                ('pressed', pressed_img.image),
+                ('hover', hover_img.image),
+                ('', normal_img.image)
+            ]))
+
+    b.create_style_layout(ttk_style, toolbutton_layout(ttk_style))
+
+    nav_padding = options.get('padding') or b.scale((12, 6, 12, 6))
+
+    b.configure_style(
+        ttk_style,
+        background=surface,
+        foreground=on_surface,
+        relief='flat',
+        padding=nav_padding,
+        anchor=anchor,
+        font=button_font(density),
+    )
+
+    # Neutral foreground in every state — the wash is the only selection marker.
+    state_spec = dict(
+        foreground=[
+            ('disabled', on_disabled),
+            ('', on_surface),
+        ]
+    )
+    state_spec = apply_icon_mapping(b, options, state_spec, icon_size(icon_only, density))
+
+    b.map_style(ttk_style, **state_spec)
+
+
 @BootstyleBuilderTTk.register_builder('default', 'NavigationButton.TFrame')
 def build_navigationbutton_frame_style(b: BootstyleBuilderTTk, ttk_style: str, accent: str = None, **options):
     """Build NavigationButton frame style with selection indicator.

--- a/src/bootstack/style/builders/sidenav.py
+++ b/src/bootstack/style/builders/sidenav.py
@@ -210,6 +210,9 @@ def build_rail_toolbutton_style(b: BootstyleBuilderTTk, ttk_style: str, accent: 
     surface_token = options.get('surface', 'chrome')
     density = options.get('density', 'default')
     icon_only = options.get('icon_only', True)
+    # Labeled rail: a small caption under the icon (compound='top' on the widget)
+    # instead of icon-only + tooltips. Dedicated variant, so we just flip the font.
+    labeled = options.get('labeled', False)
     image_key = f'navitem_{normalize_button_density(density)}'
 
     surface = b.color(surface_token)
@@ -250,8 +253,14 @@ def build_rail_toolbutton_style(b: BootstyleBuilderTTk, ttk_style: str, accent: 
 
     # Rail items are tall, near-square tap targets (VS Code activity bar), not the
     # icon-height of a normal icon-only toolbutton. Generous vertical padding +
-    # anchor center gives the larger hit area and vertical rhythm.
-    rail_padding = options.get('padding') or b.scale((0, 7, 0, 7))
+    # anchor center gives the larger hit area and vertical rhythm. Labeled rails
+    # use a smaller caption font and a touch more room for the stacked label.
+    if labeled:
+        rail_font = 'caption'
+        rail_padding = options.get('padding') or b.scale((2, 8, 2, 8))
+    else:
+        rail_font = button_font(density)
+        rail_padding = options.get('padding') or b.scale((0, 7, 0, 7))
 
     b.configure_style(
         ttk_style,
@@ -260,7 +269,7 @@ def build_rail_toolbutton_style(b: BootstyleBuilderTTk, ttk_style: str, accent: 
         relief='flat',
         padding=rail_padding,
         anchor='center',
-        font=button_font(density),
+        font=rail_font,
     )
 
     state_spec = dict(

--- a/src/bootstack/style/builders/sidenav.py
+++ b/src/bootstack/style/builders/sidenav.py
@@ -196,6 +196,86 @@ def build_navigation_toolbutton_style(b: BootstyleBuilderTTk, ttk_style: str, ac
     b.map_style(ttk_style, **state_spec)
 
 
+@BootstyleBuilderTTk.register_builder('rail', 'Toolbutton')
+def build_rail_toolbutton_style(b: BootstyleBuilderTTk, ttk_style: str, accent: str = None, **options):
+    """Build the workspace-rail item — the VS Code activity-bar treatment.
+
+    A radio toggle (single-select) rendered icon-only on the chrome surface:
+    the glyph is muted when idle and full-strength when selected (or hovered),
+    and the `navitem` asset's left indicator bar shows the accent color when
+    selected. The background stays flat in every state (no wash / no fill) — the
+    bar carries the selection. The accent lives in the bar, not the glyph.
+    """
+    accent_token = accent or 'primary'
+    surface_token = options.get('surface', 'chrome')
+    density = options.get('density', 'default')
+    icon_only = options.get('icon_only', True)
+    image_key = f'navitem_{normalize_button_density(density)}'
+
+    surface = b.color(surface_token)
+    surface_hover = b.color(f'{surface_token}_hover') if b.colors.get(f'{surface_token}_hover') else b.active(surface)
+    surface_pressed = b.pressed(surface_hover)
+    on_surface = b.on_color(surface)
+    muted = b.muted_foreground(surface)
+    accent_color = b.color(accent_token)
+    disabled = b.disabled()
+    on_disabled = b.disabled('text', disabled)
+
+    # Flat background throughout; the left bar is hidden (== fill) unless selected.
+    normal_img  = recolor_element_image(image_key, surface, surface, surface, surface)
+    hover_img   = recolor_element_image(image_key, surface_hover, surface_hover, surface_hover, surface)
+    pressed_img = recolor_element_image(image_key, surface_pressed, surface_pressed, surface_pressed, surface)
+    # Selected: accent bar visible, background still flat (no wash).
+    selected_img         = recolor_element_image(image_key, surface,         surface,         accent_color, surface)
+    selected_hover_img   = recolor_element_image(image_key, surface_hover,   surface_hover,   accent_color, surface)
+    selected_pressed_img = recolor_element_image(image_key, surface_pressed, surface_pressed, accent_color, surface)
+    disabled_img = recolor_element_image(image_key, disabled, disabled, surface, surface)
+
+    b.create_style_element_image(
+        ElementImage(
+            f'{ttk_style}.border', normal_img.image, sticky="nsew",
+            border=normal_img.meta.border, padding=normal_img.meta.border
+        ).state_specs(
+            [
+                ('disabled', disabled_img.image),
+                ('selected pressed', selected_pressed_img.image),
+                ('selected hover', selected_hover_img.image),
+                ('selected', selected_img.image),
+                ('pressed', pressed_img.image),
+                ('hover', hover_img.image),
+                ('', normal_img.image)
+            ]))
+
+    b.create_style_layout(ttk_style, toolbutton_layout(ttk_style))
+
+    # Rail items are tall, near-square tap targets (VS Code activity bar), not the
+    # icon-height of a normal icon-only toolbutton. Generous vertical padding +
+    # anchor center gives the larger hit area and vertical rhythm.
+    rail_padding = options.get('padding') or b.scale((0, 7, 0, 7))
+
+    b.configure_style(
+        ttk_style,
+        background=surface,
+        foreground=muted,
+        relief='flat',
+        padding=rail_padding,
+        anchor='center',
+        font=button_font(density),
+    )
+
+    state_spec = dict(
+        foreground=[
+            ('disabled', on_disabled),
+            ('selected', on_surface),
+            ('hover', on_surface),
+            ('', muted),
+        ]
+    )
+    state_spec = apply_icon_mapping(b, options, state_spec, icon_size(icon_only, density))
+
+    b.map_style(ttk_style, **state_spec)
+
+
 @BootstyleBuilderTTk.register_builder('default', 'NavigationButton.TFrame')
 def build_navigationbutton_frame_style(b: BootstyleBuilderTTk, ttk_style: str, accent: str = None, **options):
     """Build NavigationButton frame style with selection indicator.

--- a/src/bootstack/style/builders/sidenav.py
+++ b/src/bootstack/style/builders/sidenav.py
@@ -9,8 +9,8 @@ from typing import Optional
 
 from bootstack.style.bootstyle_builder_ttk import BootstyleBuilderTTk
 from bootstack.style.element import Element, ElementImage
-from bootstack.style.utility import recolor_element_image
-from bootstack.style.builders.utils import apply_icon_mapping
+from bootstack.style.utility import recolor_element_image, mix_colors, create_transparent_image
+from bootstack.style.builders.utils import apply_icon_mapping, resolve_icon_spec
 from bootstack.style.builders.toolbutton import (
     toolbutton_layout, button_padding, button_font, icon_size, normalize_button_density
 )
@@ -285,46 +285,68 @@ def build_rail_toolbutton_style(b: BootstyleBuilderTTk, ttk_style: str, accent: 
     b.map_style(ttk_style, **state_spec)
 
 
-@BootstyleBuilderTTk.register_builder('nav-quiet', 'Toolbutton')
-def build_nav_quiet_toolbutton_style(b: BootstyleBuilderTTk, ttk_style: str, accent: str = None, **options):
-    """Build the quiet sidebar nav item (the under-a-rail / tier-2 treatment).
+# Sidebar nav item geometry. The icon is its OWN layout element so a real spacer
+# can sit between it and the label — ttk gives no control over the compound
+# image<->text gap, so the icon must be separated out (like the radio indicator).
+_NAV_ICON_SIZE = 20
+# Icon-only (compact) buttons read better with a slightly larger glyph and a
+# taller, squarer footprint than the labeled rows.
+_NAV_COMPACT_ICON_SIZE = 24
+_NAV_GAP = 10
+# Nine-patch content inset for nav items. Kept well below the asset border (the
+# slice) so items don't carry the asset's full built-in padding as dead space
+# between buttons.
+_NAV_CONTENT_PAD = 4
 
-    A flat full-width row: the selected row gets a **subtle accent wash** only —
-    **no indicator bar** and a **neutral foreground** (no accent text/icon), so
-    the wash alone marks selection (VS Code's Explorer / a settings list). This
-    is a `RadioToggle` (single-select) styled via the native engine; compaction
-    to icon-only is a `-compound` toggle on the widget, not a style concern.
-    """
-    accent_token = accent or 'primary'
+
+def _nav_colors(b, accent_token, options):
     surface_token = options.get('surface', 'card')
-    density = options.get('density', 'default')
-    icon_only = options.get('icon_only', False)
-    anchor = options.get('anchor', 'w')
-    image_key = f'navitem_{normalize_button_density(density)}'
-
     surface = b.color(surface_token)
     surface_hover = b.color(f'{surface_token}_hover') if b.colors.get(f'{surface_token}_hover') else b.active(surface)
     surface_pressed = b.pressed(surface_hover)
     on_surface = b.on_color(surface)
-    active = b.subtle(accent_token, surface)
-    active_pressed = b.pressed(active)
     disabled = b.disabled()
     on_disabled = b.disabled('text', disabled)
+    return surface, surface_hover, surface_pressed, on_surface, disabled, on_disabled
 
-    # The bar channel (3rd) always matches the fill, so no bar ever shows. The
-    # subtle wash appears only on the selected state.
-    normal_img  = recolor_element_image(image_key, surface, surface, surface, surface)
-    hover_img   = recolor_element_image(image_key, surface_hover, surface_hover, surface_hover, surface)
-    pressed_img = recolor_element_image(image_key, surface_pressed, surface_pressed, surface_pressed, surface)
-    selected_img         = recolor_element_image(image_key, active,         active,         active,         surface)
-    selected_hover_img   = recolor_element_image(image_key, active,         active,         active,         surface)
-    selected_pressed_img = recolor_element_image(image_key, active_pressed, active_pressed, active_pressed, surface)
-    disabled_img = recolor_element_image(image_key, disabled, disabled, disabled, surface)
 
+def _nav_border_element(b, ttk_style, image_key, *, surface, surface_hover, surface_pressed,
+                        selected_bg, selected_pressed, disabled):
+    """Create a nav item's flat background nine-patch (no indicator bar).
+
+    Channels are `(white=fill, black, magenta, transparent=surface)`. The edge
+    channels (black/magenta) must blend correctly per asset:
+
+    - the rounded `button` asset (pill) uses black=border / magenta=focus-ring,
+      so both must match the **background** (surface) or the rounded edge fails to
+      anti-alias and the pill reads square/haloed;
+    - the square `navitem` asset (quiet) uses black as part of the fill and
+      magenta as the (here hidden) indicator bar, so both must match the **fill**.
+
+    The 4th channel (surface-behind) is always the surface so rounded corners
+    blend into the region.
+    """
+    rounded = image_key.startswith('button')
+
+    def img(fill):
+        edge = surface if rounded else fill
+        return recolor_element_image(image_key, fill, edge, edge, surface)
+
+    normal_img   = img(surface)
+    hover_img    = img(surface_hover)
+    pressed_img  = img(surface_pressed)
+    selected_img = img(selected_bg)
+    selected_hover_img   = img(selected_bg)
+    selected_pressed_img = img(selected_pressed)
+    disabled_img = img(disabled)
+    # `border` is the nine-patch slice (for the rounded corners); `padding` is the
+    # asset's intended content inset (0 for navitem/card — no built-in dead space).
+    # The button's height therefore comes from the configure padding only; spacing
+    # BETWEEN items is the container's job (NavPanel pack).
     b.create_style_element_image(
         ElementImage(
             f'{ttk_style}.border', normal_img.image, sticky="nsew",
-            border=normal_img.meta.border, padding=normal_img.meta.border
+            border=normal_img.meta.border, padding=normal_img.meta.padding
         ).state_specs(
             [
                 ('disabled', disabled_img.image),
@@ -336,30 +358,136 @@ def build_nav_quiet_toolbutton_style(b: BootstyleBuilderTTk, ttk_style: str, acc
                 ('', normal_img.image)
             ]))
 
-    b.create_style_layout(ttk_style, toolbutton_layout(ttk_style))
 
-    nav_padding = options.get('padding') or b.scale((12, 6, 12, 6))
+def _build_nav_expanded(b, ttk_style, *, accent_token, options, image_key, selected_bg, selected_fg):
+    """Expanded nav item: icon element + spacer + text label (a real icon/text gap)."""
+    density = options.get('density', 'default')
+    surface, surface_hover, surface_pressed, on_surface, disabled, on_disabled = _nav_colors(b, accent_token, options)
+    _nav_border_element(
+        b, ttk_style, image_key, surface=surface, surface_hover=surface_hover,
+        surface_pressed=surface_pressed, selected_bg=selected_bg,
+        selected_pressed=b.pressed(selected_bg), disabled=disabled,
+    )
+
+    fg_spec = [('disabled', on_disabled), ('selected', selected_fg), ('', on_surface)]
+
+    # Icon as its own stateful element (recolored to follow the text foreground).
+    icon_spec = resolve_icon_spec(options)
+    has_icon = False
+    if icon_spec:
+        spec = b.normalize_icon_spec(icon_spec, _NAV_ICON_SIZE)
+        icon_map = b.map_stateful_icons(spec, fg_spec)
+        if icon_map:
+            has_icon = True
+            b.create_style_element_image(
+                ElementImage(f'{ttk_style}.icon', icon_map[-1][1], sticky="").state_specs(icon_map))
+
+    # Spacer between icon and text; collapses to ~0 in icon-only (the 'alternate'
+    # state) so the same layout also serves the compacted item.
+    gap = create_transparent_image(_NAV_GAP, 1)
+    gap0 = create_transparent_image(1, 1)
+    b.create_style_element_image(
+        ElementImage(f'{ttk_style}.spacer', gap, sticky="").state_specs([('alternate', gap0), ('', gap)]))
+
+    row = []
+    if has_icon:
+        row.append(Element(f'{ttk_style}.icon', side="left", sticky=""))
+        row.append(Element(f'{ttk_style}.spacer', side="left", sticky=""))
+    row.append(Element('Toolbutton.label', side="left", sticky="nsew"))
+    b.create_style_layout(
+        ttk_style,
+        Element(f'{ttk_style}.border', sticky="nsew").children(
+            [Element('Toolbutton.padding', sticky="nsew").children(row)]))
 
     b.configure_style(
-        ttk_style,
-        background=surface,
-        foreground=on_surface,
-        relief='flat',
-        padding=nav_padding,
-        anchor=anchor,
+        ttk_style, background=surface, foreground=on_surface, relief='flat',
+        padding=options.get('padding') or b.scale((10, 8, 10, 8)),
+        anchor=options.get('anchor', 'w'), font=button_font(density),
+    )
+    # Only the text label's foreground here — the icon element carries its own.
+    b.map_style(ttk_style, foreground=[('disabled', on_disabled), ('selected', selected_fg), ('', on_surface)])
+
+
+def _build_nav_compact(b, ttk_style, *, accent_token, options, image_key, selected_bg, selected_fg):
+    """Compact nav item: a single centered icon (icon-only)."""
+    density = options.get('density', 'default')
+    surface, surface_hover, surface_pressed, on_surface, disabled, on_disabled = _nav_colors(b, accent_token, options)
+    _nav_border_element(
+        b, ttk_style, image_key, surface=surface, surface_hover=surface_hover,
+        surface_pressed=surface_pressed, selected_bg=selected_bg,
+        selected_pressed=b.pressed(selected_bg), disabled=disabled,
+    )
+    b.create_style_layout(ttk_style, toolbutton_layout(ttk_style))
+    b.configure_style(
+        ttk_style, background=surface, foreground=on_surface, relief='flat',
+        # No horizontal padding: the compact sidebar is only the rail width, and
+        # the icon centers via anchor; a bit more vertical padding makes the
+        # icon-only buttons taller/squarer.
+        padding=options.get('padding') or b.scale((0, 10, 0, 10)), anchor='center',
         font=button_font(density),
     )
-
-    # Neutral foreground in every state — the wash is the only selection marker.
-    state_spec = dict(
-        foreground=[
-            ('disabled', on_disabled),
-            ('', on_surface),
-        ]
-    )
-    state_spec = apply_icon_mapping(b, options, state_spec, icon_size(icon_only, density))
-
+    state_spec = dict(foreground=[('disabled', on_disabled), ('selected', selected_fg), ('', on_surface)])
+    state_spec = apply_icon_mapping(b, options, state_spec, _NAV_COMPACT_ICON_SIZE)
     b.map_style(ttk_style, **state_spec)
+
+
+def _quiet_colors(b, accent_token, options):
+    # Subtle wash + neutral foreground (the wash alone marks selection).
+    surface = b.color(options.get('surface', 'card'))
+    return b.subtle(accent_token, surface), b.on_color(surface)
+
+
+def _pill_colors(b, accent_token, options):
+    # Stronger accent tint + accent foreground (the prominent macOS-style pill).
+    surface = b.color(options.get('surface', 'card'))
+    ratio = 0.14 if b.provider.mode == 'light' else 0.18
+    return mix_colors(b.color(accent_token), surface, ratio), b.color(accent_token)
+
+
+@BootstyleBuilderTTk.register_builder('nav-quiet', 'Toolbutton')
+def build_nav_quiet_toolbutton_style(b: BootstyleBuilderTTk, ttk_style: str, accent: str = None, **options):
+    """Quiet sidebar nav item (under a rail): subtle wash, neutral fg, no bar."""
+    accent_token = accent or 'primary'
+    image_key = f'navitem_{normalize_button_density(options.get("density", "default"))}'
+    sel_bg, sel_fg = _quiet_colors(b, accent_token, options)
+    _build_nav_expanded(b, ttk_style, accent_token=accent_token, options=options,
+                        image_key=image_key, selected_bg=sel_bg, selected_fg=sel_fg)
+
+
+@BootstyleBuilderTTk.register_builder('nav-quiet-compact', 'Toolbutton')
+def build_nav_quiet_compact_toolbutton_style(b: BootstyleBuilderTTk, ttk_style: str, accent: str = None, **options):
+    """Quiet nav item compacted to a centered icon."""
+    accent_token = accent or 'primary'
+    image_key = f'navitem_{normalize_button_density(options.get("density", "default"))}'
+    sel_bg, sel_fg = _quiet_colors(b, accent_token, options)
+    _build_nav_compact(b, ttk_style, accent_token=accent_token, options=options,
+                       image_key=image_key, selected_bg=sel_bg, selected_fg=sel_fg)
+
+
+@BootstyleBuilderTTk.register_builder('nav-pill', 'Toolbutton')
+def build_nav_pill_toolbutton_style(b: BootstyleBuilderTTk, ttk_style: str, accent: str = None, **options):
+    """Standalone sidebar nav item: a rounded accent pill + accent fg (macOS vibe).
+
+    The primary nav (no rail): the selected row gets a rounded accent-tinted pill
+    (the `card` asset — black/white only, no focus-ring band) with accent
+    foreground. Distinct from the quiet under-a-rail treatment (square wash +
+    neutral fg).
+    """
+    accent_token = accent or 'primary'
+    image_key = 'card'
+    sel_bg, sel_fg = _pill_colors(b, accent_token, options)
+    _build_nav_expanded(b, ttk_style, accent_token=accent_token, options=options,
+                        image_key=image_key, selected_bg=sel_bg, selected_fg=sel_fg)
+
+
+@BootstyleBuilderTTk.register_builder('nav-pill-compact', 'Toolbutton')
+def build_nav_pill_compact_toolbutton_style(b: BootstyleBuilderTTk, ttk_style: str, accent: str = None, **options):
+    """Standalone nav item compacted to a centered icon (rounded pill on select)."""
+    accent_token = accent or 'primary'
+    image_key = 'card'
+    sel_bg, sel_fg = _pill_colors(b, accent_token, options)
+    _build_nav_compact(b, ttk_style, accent_token=accent_token, options=options,
+                       image_key=image_key, selected_bg=sel_bg, selected_fg=sel_fg)
 
 
 @BootstyleBuilderTTk.register_builder('default', 'NavigationButton.TFrame')

--- a/src/bootstack/style/theme_provider.py
+++ b/src/bootstack/style/theme_provider.py
@@ -316,6 +316,7 @@ class ThemeProvider:
             surfaces = {
                 'chrome': tinted_surface(max(bg_lightness - 3, 3)),    # Darker than content
                 'content': bg,                                          # Theme background
+                'raised': tinted_surface(min(bg_lightness + 2, 18)),   # Subtle elevation (half of card)
                 'card': tinted_surface(min(bg_lightness + 4, 20)),     # First card elevation
                 'card_raised': tinted_surface(min(bg_lightness + 8, 25)), # Second card elevation
                 'overlay': tinted_surface(min(bg_lightness + 7, 25)),  # Menus, dialogs
@@ -329,6 +330,7 @@ class ThemeProvider:
             surfaces = {
                 'chrome': tinted_surface(max(bg_lightness - 8, 88)),     # Noticeably darker
                 'content': bg,                                            # Theme background
+                'raised': tinted_surface(max(bg_lightness - 2, 94)),     # Subtle elevation (half of card)
                 'card': tinted_surface(max(bg_lightness - 4, 92)),       # First card elevation
                 'card_raised': tinted_surface(max(bg_lightness - 7, 88)),# Second card elevation
                 'overlay': tinted_surface(max(bg_lightness - 2, 96)),    # Subtle for popups

--- a/src/bootstack/style/theme_provider.py
+++ b/src/bootstack/style/theme_provider.py
@@ -314,7 +314,7 @@ class ThemeProvider:
         if is_dark:
             # Dark mode: lower lightness = darker/recessed
             surfaces = {
-                'chrome': tinted_surface(max(bg_lightness - 3, 3)),    # Darker than content
+                'chrome': tinted_surface(max(bg_lightness - 7, 3)),    # Darkest shell chrome (rail/status)
                 'content': bg,                                          # Theme background
                 'raised': tinted_surface(min(bg_lightness + 2, 18)),   # Subtle elevation (half of card)
                 'card': tinted_surface(min(bg_lightness + 4, 20)),     # First card elevation
@@ -328,7 +328,7 @@ class ThemeProvider:
         else:
             # Light mode: use subtle darkening for elevation (since bg is often near-white)
             surfaces = {
-                'chrome': tinted_surface(max(bg_lightness - 8, 88)),     # Noticeably darker
+                'chrome': tinted_surface(max(bg_lightness - 14, 80)),    # Darkest shell chrome (rail/status)
                 'content': bg,                                            # Theme background
                 'raised': tinted_surface(max(bg_lightness - 2, 94)),     # Subtle elevation (half of card)
                 'card': tinted_surface(max(bg_lightness - 4, 92)),       # First card elevation

--- a/src/bootstack/widgets/_core/navmodel.py
+++ b/src/bootstack/widgets/_core/navmodel.py
@@ -1,0 +1,341 @@
+"""Headless navigation state for the application shell.
+
+`NavModel` is the single source of truth for shell navigation: the ordered set
+of workspaces, which workspace is active, the active page *per* workspace
+(persistent memory), the sidebar's `hidden -> compact -> expanded` axis, and the
+detail-dock visibility. It is deliberately **Tk-free and testable headless** —
+controls dispatch into it via the transition methods, and view regions subscribe
+to it via `subscribe()`.
+
+The model encodes two design invariants:
+
+- The sidebar is a single linear axis `hidden -> compact -> expanded`, so an
+  incoherent state such as "hidden but expanded" is unrepresentable.
+- The rail (workspace switcher) renders only when there is more than one
+  workspace, so a single-tier app is the degenerate one-workspace case with no
+  branching in the consumer.
+
+See `development/appshell-navigation-spec.md` for the full design.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Literal
+
+from bootstack.streams import Handle
+
+
+SidebarMode = Literal["hidden", "compact", "expanded"]
+"""The sidebar's position on its single linear visibility/compaction axis."""
+
+ProviderKind = Literal["pages", "list", "tree", "custom"]
+"""Which navigation provider fills a workspace's sidebar panel."""
+
+NavFacet = Literal["workspace", "page", "sidebar", "dock", "structure"]
+"""Which part of the navigation state a `NavChange` describes."""
+
+
+@dataclass
+class WorkspaceState:
+    """A workspace registered in the navigation model.
+
+    A workspace owns one sidebar panel (filled by a single provider) and
+    remembers its own active page. The rail renders one icon per workspace.
+    """
+
+    key: str
+    """Unique identifier for the workspace."""
+    text: str = ""
+    """Rail label / tooltip text."""
+    icon: str | dict | None = None
+    """Rail glyph — an icon name or icon-spec dict."""
+    is_footer: bool = False
+    """Whether the rail icon is pinned to the bottom of the rail."""
+    provider: ProviderKind = "pages"
+    """The provider that fills this workspace's sidebar panel."""
+
+
+@dataclass(frozen=True)
+class NavChange:
+    """A notification emitted to subscribers when the model changes.
+
+    Only the field(s) relevant to `facet` are populated; subscribers filter on
+    `facet` and read the corresponding field (or the model itself).
+    """
+
+    facet: NavFacet
+    """Which part of the state changed."""
+    workspace: str | None = None
+    """The affected workspace key, for `'workspace'`/`'page'`/`'structure'`."""
+    page: str | None = None
+    """The newly active page key, for `'page'`."""
+    sidebar_mode: SidebarMode | None = None
+    """The new sidebar mode, for `'sidebar'`."""
+    dock_visible: bool | None = None
+    """The new dock visibility, for `'dock'`."""
+
+
+class NavModel:
+    """Observable, Tk-free navigation state for the shell.
+
+    Construct empty, register workspaces with `add_workspace()`, then drive
+    selection and visibility through the transition methods. Subscribe with
+    `subscribe()` to react to changes.
+
+    Args:
+        sidebar_mode: Initial sidebar mode. Default `'expanded'`.
+        dock_visible: Initial detail-dock visibility. Default `False`.
+    """
+
+    def __init__(
+        self,
+        *,
+        sidebar_mode: SidebarMode = "expanded",
+        dock_visible: bool = False,
+    ) -> None:
+        self._workspaces: list[WorkspaceState] = []
+        self._index: dict[str, WorkspaceState] = {}
+        self._active_workspace: str | None = None
+        self._active_page: dict[str, str] = {}
+        self._sidebar_mode: SidebarMode = sidebar_mode
+        # The mode to restore when un-hiding; never 'hidden'.
+        self._restore_mode: SidebarMode = (
+            sidebar_mode if sidebar_mode != "hidden" else "expanded"
+        )
+        self._dock_visible: bool = dock_visible
+        self._listeners: list[Callable[[NavChange], None]] = []
+
+    # ----- Read state -----
+
+    @property
+    def workspaces(self) -> tuple[WorkspaceState, ...]:
+        """All workspaces in insertion order (footers included)."""
+        return tuple(self._workspaces)
+
+    @property
+    def active_workspace(self) -> str | None:
+        """Key of the active workspace, or `None` if none is active."""
+        return self._active_workspace
+
+    @property
+    def sidebar_mode(self) -> SidebarMode:
+        """The sidebar's current position on the `hidden/compact/expanded` axis."""
+        return self._sidebar_mode
+
+    @property
+    def sidebar_visible(self) -> bool:
+        """Whether the sidebar is shown (i.e. not `'hidden'`)."""
+        return self._sidebar_mode != "hidden"
+
+    @property
+    def dock_visible(self) -> bool:
+        """Whether the detail/inspector dock is shown."""
+        return self._dock_visible
+
+    @property
+    def rail_visible(self) -> bool:
+        """Whether the workspace rail renders — true with more than one workspace.
+
+        A single-tier app has one workspace, so the rail is hidden; the switcher
+        is therefore optional with no branching in the consumer.
+        """
+        return len(self._workspaces) > 1
+
+    def workspace(self, key: str) -> WorkspaceState:
+        """Return the workspace registered under `key`.
+
+        Raises:
+            KeyError: If no workspace with that key exists.
+        """
+        return self._index[key]
+
+    def has_workspace(self, key: str) -> bool:
+        """Return whether a workspace is registered under `key`."""
+        return key in self._index
+
+    def active_page(self, workspace: str | None = None) -> str | None:
+        """Return the remembered active page for a workspace.
+
+        Args:
+            workspace: Workspace key; defaults to the active workspace.
+
+        Returns:
+            The remembered page key, or `None` if the workspace has none yet.
+        """
+        ws_key = workspace if workspace is not None else self._active_workspace
+        if ws_key is None:
+            return None
+        return self._active_page.get(ws_key)
+
+    # ----- Transitions -----
+
+    def add_workspace(
+        self,
+        key: str,
+        *,
+        text: str = "",
+        icon: str | dict | None = None,
+        is_footer: bool = False,
+        provider: ProviderKind = "pages",
+    ) -> WorkspaceState:
+        """Register a workspace and return its state.
+
+        The first non-footer workspace added becomes active automatically, so a
+        single-tier app shows content without an explicit `select_workspace()`.
+
+        Args:
+            key: Unique workspace identifier.
+            text: Rail label / tooltip.
+            icon: Rail glyph (icon name or icon-spec dict).
+            is_footer: Pin the rail icon to the rail bottom.
+            provider: Provider kind filling the workspace's sidebar.
+
+        Returns:
+            The created `WorkspaceState`.
+
+        Raises:
+            ValueError: If `key` is empty or already registered.
+        """
+        if not key:
+            raise ValueError("workspace key must be non-empty")
+        if key in self._index:
+            raise ValueError(f"duplicate workspace key: {key!r}")
+
+        ws = WorkspaceState(
+            key=key, text=text, icon=icon, is_footer=is_footer, provider=provider
+        )
+        self._workspaces.append(ws)
+        self._index[key] = ws
+
+        if self._active_workspace is None and not is_footer:
+            self._active_workspace = key
+
+        self._notify(NavChange(facet="structure", workspace=key))
+        return ws
+
+    def select_workspace(self, key: str) -> None:
+        """Make `key` the active workspace (no effect on sidebar visibility).
+
+        This is the lower-level primitive; `activate_rail()` layers the VS Code
+        rail gesture on top.
+
+        Raises:
+            KeyError: If no workspace with that key exists.
+        """
+        if key not in self._index:
+            raise KeyError(key)
+        if key == self._active_workspace:
+            return
+        self._active_workspace = key
+        self._notify(NavChange(facet="workspace", workspace=key))
+
+    def select_page(self, key: str, *, workspace: str | None = None) -> None:
+        """Set the active page for a workspace (its remembered page).
+
+        Args:
+            key: Page key.
+            workspace: Workspace to set it on; defaults to the active workspace.
+
+        Raises:
+            KeyError: If the target workspace does not exist.
+            ValueError: If there is no active workspace and none is given.
+        """
+        ws_key = workspace if workspace is not None else self._active_workspace
+        if ws_key is None:
+            raise ValueError("no active workspace to select a page on")
+        if ws_key not in self._index:
+            raise KeyError(ws_key)
+        if self._active_page.get(ws_key) == key:
+            return
+        self._active_page[ws_key] = key
+        self._notify(NavChange(facet="page", workspace=ws_key, page=key))
+
+    def activate_rail(self, key: str) -> None:
+        """Handle a rail icon click — the VS Code workspace-switch gesture.
+
+        Clicking the **active** workspace's icon hides the sidebar (or shows it
+        again if already hidden); clicking a **different** workspace's icon
+        switches to it and shows the sidebar.
+
+        Raises:
+            KeyError: If no workspace with that key exists.
+        """
+        if key not in self._index:
+            raise KeyError(key)
+        if key == self._active_workspace:
+            self.toggle_sidebar()
+        else:
+            self.select_workspace(key)
+            self.show_sidebar()
+
+    def set_sidebar_mode(self, mode: SidebarMode) -> None:
+        """Set the sidebar mode directly.
+
+        Setting a non-hidden mode records it as the mode to restore when the
+        sidebar is next un-hidden.
+
+        Args:
+            mode: `'hidden'`, `'compact'`, or `'expanded'`.
+
+        Raises:
+            ValueError: If `mode` is not a valid sidebar mode.
+        """
+        if mode not in ("hidden", "compact", "expanded"):
+            raise ValueError(f"invalid sidebar mode: {mode!r}")
+        if mode == self._sidebar_mode:
+            return
+        if mode == "hidden":
+            self._restore_mode = self._sidebar_mode  # current is non-hidden here
+        else:
+            self._restore_mode = mode
+        self._sidebar_mode = mode
+        self._notify(NavChange(facet="sidebar", sidebar_mode=mode))
+
+    def show_sidebar(self) -> None:
+        """Show the sidebar, restoring the last non-hidden mode."""
+        if self._sidebar_mode == "hidden":
+            self.set_sidebar_mode(self._restore_mode)
+
+    def hide_sidebar(self) -> None:
+        """Hide the sidebar entirely (the visibility axis)."""
+        self.set_sidebar_mode("hidden")
+
+    def toggle_sidebar(self) -> None:
+        """Toggle sidebar visibility — the hamburger / shortcut action."""
+        if self._sidebar_mode == "hidden":
+            self.show_sidebar()
+        else:
+            self.hide_sidebar()
+
+    def toggle_dock(self) -> None:
+        """Toggle the detail/inspector dock visibility (its own axis)."""
+        self._dock_visible = not self._dock_visible
+        self._notify(NavChange(facet="dock", dock_visible=self._dock_visible))
+
+    # ----- Subscription -----
+
+    def subscribe(self, listener: Callable[[NavChange], None]) -> Handle:
+        """Register `listener` for change notifications.
+
+        Args:
+            listener: Called with a `NavChange` on every state transition.
+
+        Returns:
+            A cancellable `Handle` (call `.cancel()`, or use as a context
+            manager) that unsubscribes the listener.
+        """
+        self._listeners.append(listener)
+
+        def unsubscribe() -> None:
+            try:
+                self._listeners.remove(listener)
+            except ValueError:
+                pass
+
+        return Handle(unsubscribe)
+
+    def _notify(self, change: NavChange) -> None:
+        # Iterate a copy so a listener may unsubscribe during dispatch.
+        for listener in list(self._listeners):
+            listener(change)

--- a/src/bootstack/widgets/_impl/composites/list/listitem.py
+++ b/src/bootstack/widgets/_impl/composites/list/listitem.py
@@ -10,6 +10,7 @@ from bootstack.widgets._impl.primitives.frame import Frame
 from bootstack.widgets._impl.primitives.label import Label
 from bootstack.widgets._impl.primitives.separator import Separator
 from bootstack.widgets.types import Master, StyledKwargs, WidgetDensity
+from bootstack.style.typography import get_font
 
 
 class ListItemKwargs(StyledKwargs, total=False):
@@ -72,6 +73,11 @@ class ListItem(CompositeFrame):
         self._item_index = 0
         self._selection_icon = None
         self._drag_state = None
+        # Full (untruncated) title/text — the labels render an ellipsized copy
+        # sized to the row's available width (see _retruncate).
+        self._full_title = None
+        self._full_text = None
+        self._last_avail = -1
 
         # configuration properties
         self._show_separator = kwargs.pop('show_separator', False)
@@ -175,6 +181,11 @@ class ListItem(CompositeFrame):
 
         # row-level keyboard events
         self.bind('<space>', self._on_space, add='+')
+
+        # Re-ellipsize the title/text whenever the center frame's allotment
+        # changes (sidebar resize, or the icon/chevron settling) so a long value
+        # can never push the icon/chevron out of the row.
+        self._center_frame.bind('<Configure>', self._on_configure_truncate, add='+')
 
     @property
     def selected(self):
@@ -331,22 +342,28 @@ class ListItem(CompositeFrame):
     def _update_title(self, text=None):
         """Update title widget."""
         title_font = 'caption[bold]' if self._density == 'compact' else 'body[bold]'
+        self._full_title = text
         if text is not None:
+            shown = self._elide(text, get_font(title_font), self._avail_text_px())
             if not self._title_widget:
                 self._title_widget = Label(
                     self._center_frame,
-                    text=text,
+                    text=shown,
                     font=title_font,
                     variant='list',
                     ttk_class='ListView.TLabel',
                     takefocus=False,
                     accent=self._accent,
+                    # width=1 so the label never drives the center frame wider
+                    # than its allotment — fill='x' stretches it back out, and
+                    # the elided text is sized to that allotment (see _retruncate).
+                    width=1,
                     style_options=self._li_style_opts(),
                 )
                 self._title_widget.pack(side='top', fill='x', anchor='w', padx=(0, 3))
                 self.register_composite(self._title_widget)
             else:
-                self._title_widget.configure(text=text)
+                self._title_widget.configure(text=shown)
         else:
             if self._title_widget:
                 try:
@@ -361,22 +378,25 @@ class ListItem(CompositeFrame):
         """Update text widget."""
         # Use caption font for compact density
         text_font = 'caption' if self._density == 'compact' else 'body'
+        self._full_text = text
         if text is not None:
+            shown = self._elide(text, get_font(text_font), self._avail_text_px())
             if not self._text_widget:
                 self._text_widget = Label(
                     self._center_frame,
-                    text=text,
+                    text=shown,
                     font=text_font,
                     variant='list',
                     ttk_class='ListView.TLabel',
                     takefocus=False,
                     accent=self._accent,
+                    width=1,
                     style_options=self._li_style_opts(),
                 )
                 self._text_widget.pack(side='top', fill='x', padx=(0, 3))
                 self.register_composite(self._text_widget)
             else:
-                self._text_widget.configure(text=text)
+                self._text_widget.configure(text=shown)
         else:
             if self._text_widget:
                 try:
@@ -386,6 +406,68 @@ class ListItem(CompositeFrame):
                     pass
                 finally:
                     self._text_widget = None
+
+    # ----- Title/text ellipsis -----
+
+    def _avail_text_px(self) -> int:
+        """Pixels available to the center title/text before they must elide.
+
+        Read straight off the center frame's own allotted width. Because the
+        labels carry `width=1`, the center frame never inflates past its
+        allotment, so this is the true available width and it re-fires its
+        `<Configure>` whenever the icon/chevron settle or the sidebar resizes.
+        """
+        try:
+            w = self._center_frame.winfo_width()
+            if w <= 1:
+                return 0
+            # 3px = the label's own right padx.
+            return max(0, w - 3)
+        except TclError:
+            return 0
+
+    @staticmethod
+    def _elide(text, font, avail: int):
+        """Return `text` shortened with a trailing ellipsis to fit `avail` px."""
+        if not text or avail <= 0:
+            return text
+        try:
+            if font.measure(text) <= avail:
+                return text
+            ell = '…'
+            if font.measure(ell) > avail:
+                return ''
+            lo, hi = 0, len(text)
+            while lo < hi:
+                mid = (lo + hi + 1) // 2
+                if font.measure(text[:mid].rstrip() + ell) <= avail:
+                    lo = mid
+                else:
+                    hi = mid - 1
+            return (text[:lo].rstrip() + ell) if lo > 0 else ell
+        except TclError:
+            return text
+
+    def _on_configure_truncate(self, event=None):
+        """Re-ellipsize when the row's available width changes."""
+        avail = self._avail_text_px()
+        if avail <= 0 or avail == self._last_avail:
+            return
+        self._last_avail = avail
+        self._retruncate(avail)
+
+    def _retruncate(self, avail: int | None = None):
+        """Re-apply ellipsis to the title/text against the current width."""
+        if avail is None:
+            avail = self._avail_text_px()
+        if avail <= 0:
+            return
+        if self._title_widget and self._full_title is not None:
+            font = get_font('caption[bold]' if self._density == 'compact' else 'body[bold]')
+            self._title_widget.configure(text=self._elide(self._full_title, font, avail))
+        if self._text_widget and self._full_text is not None:
+            font = get_font('caption' if self._density == 'compact' else 'body')
+            self._text_widget.configure(text=self._elide(self._full_text, font, avail))
 
     def _update_badge(self, text=None):
         """Update badge widget."""
@@ -429,6 +511,15 @@ class ListItem(CompositeFrame):
                 )
                 self._chevron_widget.pack(side='right', padx=6)
                 self.register_composite(self._chevron_widget)
+                # The chevron is created lazily (after_idle), so it misses the
+                # <<CompositeSelect>> broadcast that ran when selection was first
+                # applied. Sync it to the row's current selection now, otherwise
+                # a row selected on first load shows an unselected chevron color.
+                if self._data.get('selected'):
+                    try:
+                        self._chevron_widget.event_generate('<<CompositeSelect>>')
+                    except TclError:
+                        pass
         else:
             if self._chevron_widget:
                 try:

--- a/src/bootstack/widgets/_impl/composites/scrollview.py
+++ b/src/bootstack/widgets/_impl/composites/scrollview.py
@@ -89,18 +89,23 @@ class ScrollView(Frame):
         self.canvas = Canvas(self, **canvas_kw)
         self.canvas.bind("<Configure>", self._on_canvas_configure)
 
-        # Create scrollbars
+        # Create scrollbars. Thread our own surface through so the scrollbar track
+        # matches the container (an auto-hiding bar then leaves no tinted gutter).
+        sb_surface = getattr(self, "_surface", None)
+        sb_kw: dict[str, Any] = {"surface": sb_surface} if sb_surface else {}
         self.vertical_scrollbar = Scrollbar(
             master=self,
             orient='vertical',
             command=self.canvas.yview,
-            variant=self._scrollbar_variant
+            variant=self._scrollbar_variant,
+            **sb_kw,
         )
         self.horizontal_scrollbar = Scrollbar(
             master=self,
             orient='horizontal',
             command=self.canvas.xview,
-            variant=self._scrollbar_variant
+            variant=self._scrollbar_variant,
+            **sb_kw,
         )
 
         # Configure canvas scrolling

--- a/src/bootstack/widgets/_impl/composites/shell/__init__.py
+++ b/src/bootstack/widgets/_impl/composites/shell/__init__.py
@@ -18,6 +18,7 @@ from bootstack.widgets._impl.composites.shell.providers import (
     ListNavProvider,
     NavProvider,
     StaticProvider,
+    TreeNavProvider,
 )
 from bootstack.widgets._impl.composites.shell.shell import Shell
 
@@ -28,5 +29,6 @@ __all__ = [
     "NavProvider",
     "StaticProvider",
     "ListNavProvider",
+    "TreeNavProvider",
     "Shell",
 ]

--- a/src/bootstack/widgets/_impl/composites/shell/__init__.py
+++ b/src/bootstack/widgets/_impl/composites/shell/__init__.py
@@ -14,6 +14,7 @@ Later layers (rail, tree provider, collapse) build on top of these.
 from bootstack.widgets._impl.composites.shell.content_host import ContentHost
 from bootstack.widgets._impl.composites.shell.layout import ShellLayout
 from bootstack.widgets._impl.composites.shell.nav_panel import NavPanel
+from bootstack.widgets._impl.composites.shell.rail import Rail
 from bootstack.widgets._impl.composites.shell.providers import (
     ListNavProvider,
     NavProvider,
@@ -21,14 +22,17 @@ from bootstack.widgets._impl.composites.shell.providers import (
     TreeNavProvider,
 )
 from bootstack.widgets._impl.composites.shell.shell import Shell
+from bootstack.widgets._impl.composites.shell.workspace import Workspace
 
 __all__ = [
     "ShellLayout",
     "NavPanel",
+    "Rail",
     "ContentHost",
     "NavProvider",
     "StaticProvider",
     "ListNavProvider",
     "TreeNavProvider",
+    "Workspace",
     "Shell",
 ]

--- a/src/bootstack/widgets/_impl/composites/shell/__init__.py
+++ b/src/bootstack/widgets/_impl/composites/shell/__init__.py
@@ -1,0 +1,12 @@
+"""Internal composites for the clean-slate application shell.
+
+Layered per `docs/_dev/appshell-navigation-spec.md`:
+
+- `layout.ShellLayout` — Layer 1, the dumb region/slot band layout.
+
+Later layers (wiring to `NavModel`, providers, rail) build on top of this.
+"""
+
+from bootstack.widgets._impl.composites.shell.layout import ShellLayout
+
+__all__ = ["ShellLayout"]

--- a/src/bootstack/widgets/_impl/composites/shell/__init__.py
+++ b/src/bootstack/widgets/_impl/composites/shell/__init__.py
@@ -16,6 +16,7 @@ from bootstack.widgets._impl.composites.shell.layout import ShellLayout
 from bootstack.widgets._impl.composites.shell.nav_panel import NavPanel
 from bootstack.widgets._impl.composites.shell.rail import Rail
 from bootstack.widgets._impl.composites.shell.providers import (
+    CustomProvider,
     ListNavProvider,
     NavProvider,
     StaticProvider,
@@ -33,6 +34,7 @@ __all__ = [
     "StaticProvider",
     "ListNavProvider",
     "TreeNavProvider",
+    "CustomProvider",
     "Workspace",
     "Shell",
 ]

--- a/src/bootstack/widgets/_impl/composites/shell/__init__.py
+++ b/src/bootstack/widgets/_impl/composites/shell/__init__.py
@@ -4,13 +4,15 @@ Layered per `docs/_dev/appshell-navigation-spec.md`:
 
 - `layout.ShellLayout` — Layer 1, the dumb region/slot band layout.
 - `nav_panel.NavPanel` — the static single-select nav list (sidebar).
+- `providers.NavProvider` / `StaticProvider` — Layer 3, what fills a workspace.
 - `shell.Shell` — wires `NavModel` to the regions (single-tier path).
 
-Later layers (providers, rail, collapse) build on top of these.
+Later layers (rail, data-bound providers, collapse) build on top of these.
 """
 
 from bootstack.widgets._impl.composites.shell.layout import ShellLayout
 from bootstack.widgets._impl.composites.shell.nav_panel import NavPanel
+from bootstack.widgets._impl.composites.shell.providers import NavProvider, StaticProvider
 from bootstack.widgets._impl.composites.shell.shell import Shell
 
-__all__ = ["ShellLayout", "NavPanel", "Shell"]
+__all__ = ["ShellLayout", "NavPanel", "NavProvider", "StaticProvider", "Shell"]

--- a/src/bootstack/widgets/_impl/composites/shell/__init__.py
+++ b/src/bootstack/widgets/_impl/composites/shell/__init__.py
@@ -3,10 +3,14 @@
 Layered per `docs/_dev/appshell-navigation-spec.md`:
 
 - `layout.ShellLayout` — Layer 1, the dumb region/slot band layout.
+- `nav_panel.NavPanel` — the static single-select nav list (sidebar).
+- `shell.Shell` — wires `NavModel` to the regions (single-tier path).
 
-Later layers (wiring to `NavModel`, providers, rail) build on top of this.
+Later layers (providers, rail, collapse) build on top of these.
 """
 
 from bootstack.widgets._impl.composites.shell.layout import ShellLayout
+from bootstack.widgets._impl.composites.shell.nav_panel import NavPanel
+from bootstack.widgets._impl.composites.shell.shell import Shell
 
-__all__ = ["ShellLayout"]
+__all__ = ["ShellLayout", "NavPanel", "Shell"]

--- a/src/bootstack/widgets/_impl/composites/shell/__init__.py
+++ b/src/bootstack/widgets/_impl/composites/shell/__init__.py
@@ -4,15 +4,29 @@ Layered per `docs/_dev/appshell-navigation-spec.md`:
 
 - `layout.ShellLayout` — Layer 1, the dumb region/slot band layout.
 - `nav_panel.NavPanel` — the static single-select nav list (sidebar).
-- `providers.NavProvider` / `StaticProvider` — Layer 3, what fills a workspace.
+- `content_host.ContentHost` — context container for rendering detail bodies.
+- `providers.NavProvider` / `StaticProvider` / `ListNavProvider` — Layer 3.
 - `shell.Shell` — wires `NavModel` to the regions (single-tier path).
 
-Later layers (rail, data-bound providers, collapse) build on top of these.
+Later layers (rail, tree provider, collapse) build on top of these.
 """
 
+from bootstack.widgets._impl.composites.shell.content_host import ContentHost
 from bootstack.widgets._impl.composites.shell.layout import ShellLayout
 from bootstack.widgets._impl.composites.shell.nav_panel import NavPanel
-from bootstack.widgets._impl.composites.shell.providers import NavProvider, StaticProvider
+from bootstack.widgets._impl.composites.shell.providers import (
+    ListNavProvider,
+    NavProvider,
+    StaticProvider,
+)
 from bootstack.widgets._impl.composites.shell.shell import Shell
 
-__all__ = ["ShellLayout", "NavPanel", "NavProvider", "StaticProvider", "Shell"]
+__all__ = [
+    "ShellLayout",
+    "NavPanel",
+    "ContentHost",
+    "NavProvider",
+    "StaticProvider",
+    "ListNavProvider",
+    "Shell",
+]

--- a/src/bootstack/widgets/_impl/composites/shell/content_host.py
+++ b/src/bootstack/widgets/_impl/composites/shell/content_host.py
@@ -1,0 +1,46 @@
+"""Context container for rendering a provider's content into a region frame.
+
+A data-bound provider's `@detail` body is authored with public widgets
+(`with bs.VStack(...): ...`), which parent to whatever container is on top of
+the context stack. `ContentHost` wraps a plain region frame as such a container,
+so the framework can push it, call the detail builder, and pop it — landing the
+built widgets inside the content region.
+
+Mirrors the public `_PageFrame` container protocol (`_child_master` /
+`guide_layout`).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from bootstack.widgets._core.container import PACK_KEYS, normalize_fill
+from bootstack.widgets._core.context import push_container, pop_container
+
+
+class ContentHost:
+    """A context-stack container that parents public widgets into `frame`."""
+
+    def __init__(self, frame: Any) -> None:
+        self._internal = frame
+
+    def _child_master(self) -> Any:
+        return self._internal
+
+    def guide_layout(self, child: Any, **layout_kw: Any) -> None:
+        if "fill" in layout_kw:
+            layout_kw["fill"] = normalize_fill(layout_kw["fill"])
+        options = {k: v for k, v in layout_kw.items() if k in PACK_KEYS}
+        child._internal.pack(in_=self._internal, **options)
+
+    def __enter__(self) -> "ContentHost":
+        push_container(self)
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        pop_container(self)
+
+    def clear(self) -> None:
+        """Destroy all children currently in the frame."""
+        for child in self._internal.winfo_children():
+            child.destroy()

--- a/src/bootstack/widgets/_impl/composites/shell/layout.py
+++ b/src/bootstack/widgets/_impl/composites/shell/layout.py
@@ -135,6 +135,9 @@ class ShellLayout(App):
         # boundary (shown only when the rail renders).
         self._rail_sep = Separator(self._body, orient="vertical")
         self._sidebar = Frame(self._body, surface=SIDEBAR_SURFACE)
+        # A matching divider on the sidebar's right edge defines the sidebar/
+        # content boundary (shown only when the sidebar is visible).
+        self._sidebar_sep = Separator(self._body, orient="vertical")
         self._content = Frame(self._body)
         self._dock = Frame(self._body, surface=DOCK_SURFACE)
 
@@ -163,13 +166,15 @@ class ShellLayout(App):
 
     def _relayout_body(self) -> None:
         """Re-pack the body slots left-to-right in canonical order."""
-        for child in (self._rail, self._rail_sep, self._sidebar, self._content, self._dock):
+        for child in (self._rail, self._rail_sep, self._sidebar, self._sidebar_sep,
+                      self._content, self._dock):
             child.pack_forget()
         if self._show_rail:
             self._rail.pack(side="left", fill="y")
             self._rail_sep.pack(side="left", fill="y")
         if self._show_sidebar:
             self._sidebar.pack(side="left", fill="y")
+            self._sidebar_sep.pack(side="left", fill="y")
         self._content.pack(side="left", fill="both", expand=True)
         if self._show_dock:
             self._dock.pack(side="right", fill="y")

--- a/src/bootstack/widgets/_impl/composites/shell/layout.py
+++ b/src/bootstack/widgets/_impl/composites/shell/layout.py
@@ -1,0 +1,269 @@
+"""Layer 1 — the region/slot band layout for the application shell.
+
+`ShellLayout` owns the window (it subclasses the internal `App`) and arranges
+the shell's bands as independently toggleable slots:
+
+    +-------------------------------------------------+
+    | chrome   (top, full width)                      |
+    +----+--------------+------------------+----------+
+    | r  | sidebar      |     content      |   dock   |
+    | a  |              |                  | (resv'd) |
+    | i  |              |                  |          |
+    | l  |              |                  |          |
+    +----+--------------+------------------+----------+
+    | statusbar   (full width)                        |
+    +-------------------------------------------------+
+
+This layer is deliberately **dumb about navigation** — it exposes region frames
+and show/hide/size operations only. Wiring the regions to `NavModel` (which
+workspace/page is active, the rail gesture, etc.) happens in a higher layer.
+
+The top (`chrome`) and bottom (`statusbar`) bands span the full window width;
+only the body row knows whether the rail/sidebar/dock exist. That invariant lets
+"sidebar + chrome", "chrome only", and "sidebar only" be the same layout with
+slots toggled rather than separate code paths.
+
+Note: the resizable sidebar/content sash (a `PanedWindow`) is deferred to the
+collapse step — for now the body uses fixed-width pack slots. See the build order
+in `docs/_dev/appshell-navigation-spec.md`.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Any
+
+from bootstack._runtime.app import App
+from bootstack.widgets._impl.composites.toolbar import Toolbar
+from bootstack.widgets._impl.primitives.frame import Frame
+
+
+# Default region sizing (pixels). Rail and compact sidebar share a width so a
+# collapsed single sidebar matches the two-tier rail (the seam rule).
+DEFAULT_RAIL_WIDTH = 52
+DEFAULT_SIDEBAR_WIDTH = 240
+DEFAULT_DOCK_WIDTH = 280
+
+
+class ShellLayout(App):
+    """The shell's band layout — a window of toggleable region slots.
+
+    Args:
+        title: Window title.
+        theme: Theme name, or None for the default.
+        size: Initial window size as `(width, height)`.
+        undecorated: Remove OS chrome and draw a custom border (ignored on
+            macOS). Enables window controls + dragging on the chrome row.
+        rail_width: Width of the workspace rail (and compact sidebar) in pixels.
+        sidebar_width: Width of the expanded sidebar in pixels.
+        dock_width: Width of the detail/inspector dock in pixels.
+        **kwargs: Forwarded to `App` (position, minsize, locale, etc.).
+    """
+
+    def __init__(
+        self,
+        *,
+        title: str = "",
+        theme: str | None = None,
+        size: tuple[int, int] | None = None,
+        undecorated: bool = False,
+        rail_width: int = DEFAULT_RAIL_WIDTH,
+        sidebar_width: int = DEFAULT_SIDEBAR_WIDTH,
+        dock_width: int = DEFAULT_DOCK_WIDTH,
+        **kwargs: Any,
+    ) -> None:
+        # overrideredirect has no effect on macOS — disable undecorated there.
+        if sys.platform == "darwin":
+            undecorated = False
+
+        app_kwargs: dict[str, Any] = {"title": title, "override_redirect": undecorated}
+        if theme is not None:
+            app_kwargs["theme"] = theme
+        if size is not None:
+            app_kwargs["size"] = size
+        app_kwargs.update(kwargs)
+        super().__init__(**app_kwargs)
+
+        self._undecorated = undecorated
+        self._rail_width = rail_width
+        self._sidebar_width = sidebar_width
+        self._dock_width = dock_width
+
+        # Visibility flags. Content is always shown; the rest are slots.
+        self._show_chrome = False
+        self._show_statusbar = False
+        self._show_rail = False
+        self._show_sidebar = True
+        self._show_dock = False
+
+        self._build_regions()
+        self._relayout_window()
+        self._relayout_body()
+
+    # ----- Construction -----
+
+    def _build_regions(self) -> None:
+        # In undecorated mode the OS border is gone; a bordered frame substitutes
+        # it (padding is required or the border is obscured by children).
+        if self._undecorated:
+            root = Frame(self, show_border=True, padding=1)
+            root.pack(fill="both", expand=True)
+        else:
+            root = self
+        # NB: do not name this `self._root` — tkinter's `Misc._root()` is a
+        # method; shadowing it with an attribute breaks event dispatch.
+        self._region_root = root
+
+        # Full-width bands.
+        self._chrome = Frame(root)
+        self._statusbar = Toolbar(root, surface="chrome", draggable=False)
+
+        # Body row + its slots.
+        self._body = Frame(root)
+        self._rail = Frame(self._body, surface="chrome")
+        self._sidebar = Frame(self._body, surface="card")
+        self._content = Frame(self._body)
+        self._dock = Frame(self._body, surface="card")
+
+        # Fixed-width slots keep their requested width instead of shrinking to
+        # fit their children.
+        for frame, width in (
+            (self._rail, self._rail_width),
+            (self._sidebar, self._sidebar_width),
+            (self._dock, self._dock_width),
+        ):
+            frame.configure(width=width)
+            frame.pack_propagate(False)
+
+    # ----- Layout (re-pack in canonical order on every visibility change) -----
+
+    def _relayout_window(self) -> None:
+        """Re-pack the full-width bands and the body in canonical order."""
+        for child in (self._chrome, self._statusbar, self._body):
+            child.pack_forget()
+        if self._show_chrome:
+            self._chrome.pack(side="top", fill="x")
+        if self._show_statusbar:
+            self._statusbar.pack(side="bottom", fill="x")
+        # Body fills whatever the bands leave; packed last so it claims the middle.
+        self._body.pack(side="top", fill="both", expand=True)
+
+    def _relayout_body(self) -> None:
+        """Re-pack the body slots left-to-right in canonical order."""
+        for child in (self._rail, self._sidebar, self._content, self._dock):
+            child.pack_forget()
+        if self._show_rail:
+            self._rail.pack(side="left", fill="y")
+        if self._show_sidebar:
+            self._sidebar.pack(side="left", fill="y")
+        self._content.pack(side="left", fill="both", expand=True)
+        if self._show_dock:
+            self._dock.pack(side="right", fill="y")
+
+    # ----- Region visibility -----
+
+    def set_chrome_visible(self, visible: bool) -> None:
+        """Show or hide the top chrome band."""
+        if self._show_chrome != visible:
+            self._show_chrome = visible
+            self._relayout_window()
+
+    def set_statusbar_visible(self, visible: bool) -> None:
+        """Show or hide the bottom status band."""
+        if self._show_statusbar != visible:
+            self._show_statusbar = visible
+            self._relayout_window()
+
+    def set_rail_visible(self, visible: bool) -> None:
+        """Show or hide the workspace rail."""
+        if self._show_rail != visible:
+            self._show_rail = visible
+            self._relayout_body()
+
+    def set_sidebar_visible(self, visible: bool) -> None:
+        """Show or hide the sidebar slot."""
+        if self._show_sidebar != visible:
+            self._show_sidebar = visible
+            self._relayout_body()
+
+    def set_dock_visible(self, visible: bool) -> None:
+        """Show or hide the detail/inspector dock."""
+        if self._show_dock != visible:
+            self._show_dock = visible
+            self._relayout_body()
+
+    # ----- Region sizing -----
+
+    def set_rail_width(self, width: int) -> None:
+        """Set the rail width in pixels."""
+        self._rail_width = width
+        self._rail.configure(width=width)
+
+    def set_sidebar_width(self, width: int) -> None:
+        """Set the expanded-sidebar width in pixels."""
+        self._sidebar_width = width
+        self._sidebar.configure(width=width)
+
+    def set_dock_width(self, width: int) -> None:
+        """Set the dock width in pixels."""
+        self._dock_width = width
+        self._dock.configure(width=width)
+
+    # ----- Region accessors -----
+
+    @property
+    def chrome(self) -> Frame:
+        """The top chrome band (host for the menubar / command bar)."""
+        return self._chrome
+
+    @property
+    def statusbar(self) -> Toolbar:
+        """The bottom status band (a command-bar strip; passive content)."""
+        return self._statusbar
+
+    @property
+    def rail(self) -> Frame:
+        """The workspace rail slot."""
+        return self._rail
+
+    @property
+    def sidebar(self) -> Frame:
+        """The sidebar slot (the active workspace's panel)."""
+        return self._sidebar
+
+    @property
+    def content(self) -> Frame:
+        """The content slot (the active page)."""
+        return self._content
+
+    @property
+    def dock(self) -> Frame:
+        """The detail/inspector dock slot (reserved)."""
+        return self._dock
+
+    # ----- Visibility state (read-only) -----
+
+    @property
+    def chrome_visible(self) -> bool:
+        """Whether the chrome band is shown."""
+        return self._show_chrome
+
+    @property
+    def statusbar_visible(self) -> bool:
+        """Whether the status band is shown."""
+        return self._show_statusbar
+
+    @property
+    def rail_visible(self) -> bool:
+        """Whether the rail is shown."""
+        return self._show_rail
+
+    @property
+    def sidebar_visible(self) -> bool:
+        """Whether the sidebar slot is shown."""
+        return self._show_sidebar
+
+    @property
+    def dock_visible(self) -> bool:
+        """Whether the dock slot is shown."""
+        return self._show_dock

--- a/src/bootstack/widgets/_impl/composites/shell/layout.py
+++ b/src/bootstack/widgets/_impl/composites/shell/layout.py
@@ -36,6 +36,7 @@ from typing import Any
 from bootstack._runtime.app import App
 from bootstack.widgets._impl.composites.toolbar import Toolbar
 from bootstack.widgets._impl.primitives.frame import Frame
+from bootstack.widgets._impl.primitives.separator import Separator
 
 
 # Default region sizing (pixels). Rail and compact sidebar share a width so a
@@ -121,6 +122,9 @@ class ShellLayout(App):
         # Body row + its slots.
         self._body = Frame(root)
         self._rail = Frame(self._body, surface="chrome")
+        # A thin divider between the rail and the sidebar reinforces the tier
+        # boundary (shown only when the rail renders).
+        self._rail_sep = Separator(self._body, orient="vertical")
         self._sidebar = Frame(self._body, surface="card")
         self._content = Frame(self._body)
         self._dock = Frame(self._body, surface="card")
@@ -150,10 +154,11 @@ class ShellLayout(App):
 
     def _relayout_body(self) -> None:
         """Re-pack the body slots left-to-right in canonical order."""
-        for child in (self._rail, self._sidebar, self._content, self._dock):
+        for child in (self._rail, self._rail_sep, self._sidebar, self._content, self._dock):
             child.pack_forget()
         if self._show_rail:
             self._rail.pack(side="left", fill="y")
+            self._rail_sep.pack(side="left", fill="y")
         if self._show_sidebar:
             self._sidebar.pack(side="left", fill="y")
         self._content.pack(side="left", fill="both", expand=True)

--- a/src/bootstack/widgets/_impl/composites/shell/layout.py
+++ b/src/bootstack/widgets/_impl/composites/shell/layout.py
@@ -45,6 +45,15 @@ DEFAULT_RAIL_WIDTH = 52
 DEFAULT_SIDEBAR_WIDTH = 240
 DEFAULT_DOCK_WIDTH = 280
 
+# Region surfaces — the single source of truth. Nav items blend their selection
+# tint (and round their corners) against the SAME surface they render on, so the
+# color can never mismatch the background; callers thread these down rather than
+# hardcoding a surface token independently.
+RAIL_SURFACE = "chrome"
+SIDEBAR_SURFACE = "card"
+DOCK_SURFACE = "card"
+STATUSBAR_SURFACE = "chrome"
+
 
 class ShellLayout(App):
     """The shell's band layout — a window of toggleable region slots.
@@ -117,17 +126,17 @@ class ShellLayout(App):
 
         # Full-width bands.
         self._chrome = Frame(root)
-        self._statusbar = Toolbar(root, surface="chrome", draggable=False)
+        self._statusbar = Toolbar(root, surface=STATUSBAR_SURFACE, draggable=False)
 
         # Body row + its slots.
         self._body = Frame(root)
-        self._rail = Frame(self._body, surface="chrome")
+        self._rail = Frame(self._body, surface=RAIL_SURFACE)
         # A thin divider between the rail and the sidebar reinforces the tier
         # boundary (shown only when the rail renders).
         self._rail_sep = Separator(self._body, orient="vertical")
-        self._sidebar = Frame(self._body, surface="card")
+        self._sidebar = Frame(self._body, surface=SIDEBAR_SURFACE)
         self._content = Frame(self._body)
-        self._dock = Frame(self._body, surface="card")
+        self._dock = Frame(self._body, surface=DOCK_SURFACE)
 
         # Fixed-width slots keep their requested width instead of shrinking to
         # fit their children.
@@ -240,6 +249,16 @@ class ShellLayout(App):
     def content(self) -> Frame:
         """The content slot (the active page)."""
         return self._content
+
+    @property
+    def sidebar_surface(self) -> str:
+        """Surface token the sidebar region renders on (for matched nav tints)."""
+        return SIDEBAR_SURFACE
+
+    @property
+    def rail_surface(self) -> str:
+        """Surface token the rail region renders on."""
+        return RAIL_SURFACE
 
     @property
     def dock(self) -> Frame:

--- a/src/bootstack/widgets/_impl/composites/shell/layout.py
+++ b/src/bootstack/widgets/_impl/composites/shell/layout.py
@@ -49,9 +49,14 @@ DEFAULT_DOCK_WIDTH = 280
 # tint (and round their corners) against the SAME surface they render on, so the
 # color can never mismatch the background; callers thread these down rather than
 # hardcoding a surface token independently.
+#
+# Elevation tiers: the rail is the chrome tier; the sidebar (and dock) sit on a
+# SUBTLE `raised` elevation (half the `card` step) — gentle, not a big ramp, and
+# reinforced by the dividers. Selection is neutral, so a subtle elevation no
+# longer washes it out. content < raised < chrome.
 RAIL_SURFACE = "chrome"
-SIDEBAR_SURFACE = "card"
-DOCK_SURFACE = "card"
+SIDEBAR_SURFACE = "raised"
+DOCK_SURFACE = "raised"
 STATUSBAR_SURFACE = "chrome"
 
 
@@ -132,12 +137,14 @@ class ShellLayout(App):
         self._body = Frame(root)
         self._rail = Frame(self._body, surface=RAIL_SURFACE)
         # A thin divider between the rail and the sidebar reinforces the tier
-        # boundary (shown only when the rail renders).
-        self._rail_sep = Separator(self._body, orient="vertical")
+        # boundary (shown only when the rail renders). Each divider takes the
+        # surface of the region it edges so its stroke is derived against that
+        # surface, not the default content surface.
+        self._rail_sep = Separator(self._body, orient="vertical", surface=RAIL_SURFACE)
         self._sidebar = Frame(self._body, surface=SIDEBAR_SURFACE)
         # A matching divider on the sidebar's right edge defines the sidebar/
         # content boundary (shown only when the sidebar is visible).
-        self._sidebar_sep = Separator(self._body, orient="vertical")
+        self._sidebar_sep = Separator(self._body, orient="vertical", surface=SIDEBAR_SURFACE)
         self._content = Frame(self._body)
         self._dock = Frame(self._body, surface=DOCK_SURFACE)
 

--- a/src/bootstack/widgets/_impl/composites/shell/nav_panel.py
+++ b/src/bootstack/widgets/_impl/composites/shell/nav_panel.py
@@ -76,6 +76,7 @@ class NavPanel(Frame):
         # Pill items are inset from the sidebar edges (the rounded pill needs
         # breathing room from the container); quiet rows run full-width.
         self._inset = 8 if variant == "nav-pill" else 0
+        self._current_inset = self._inset
 
         # Footer pinned to the bottom; the item area scrolls in the space above it
         # (a wheel-scrollable canvas with an auto-hiding bar — the footer itself
@@ -85,14 +86,17 @@ class NavPanel(Frame):
         self._footer.pack(side="bottom", fill="x")
         # A divider above the footer, shown ONLY when the item area scrolls — so a
         # pinned footer reads as its own band instead of abutting a clipped row.
-        # When everything fits it stays hidden (no needless chrome).
-        self._footer_divider = SideNavSeparator(self, surface=surface, padding=(0, 0, 0, 0))
+        # When everything fits it stays hidden (no needless chrome). The vertical
+        # padding gives the line breathing room from the last scrolled row above
+        # and the footer item below (a flush line reads as cramped).
+        self._footer_divider = SideNavSeparator(self, surface=surface, padding=(0, 8, 0, 8))
         # Start with no gutter/bar; overflow detection switches it on only when the
         # content is actually tall enough to scroll (see _update_overflow_state).
         self._scroll = ScrollView(
             self,
             scroll_direction="vertical",
             scrollbar_visibility="never",
+            scrollbar_variant="thin",
             surface=surface,
         )
         self._scroll.pack(side="top", fill="both", expand=True)
@@ -215,8 +219,32 @@ class NavPanel(Frame):
         Pills need breathing room; quiet rows run flush (inset 0). The item area
         is a canvas window (not pack-managed), so its inset is its own padding.
         """
-        self._main.configure(padding=(inset, inset, inset, 0))
-        self._footer.pack_configure(padx=inset, pady=(0, inset))
+        self._current_inset = inset
+        self._apply_insets()
+
+    def _gutter(self) -> int:
+        """Width reserved for the scrollbar while the content overflows (else 0)."""
+        if not self._content_overflows():
+            return 0
+        try:
+            w = self._scroll.vertical_scrollbar.winfo_reqwidth()
+            return w if w > 1 else 0
+        except Exception:
+            return 0
+
+    def _apply_insets(self) -> None:
+        """Apply the content + footer insets, accounting for the scrollbar gutter.
+
+        The gutter sits WITHIN the right inset rather than adding to it, so the
+        right margin stays about the left inset (not inset + gutter). The content's
+        right padding is reduced by the gutter; the footer (not scrolled) reserves
+        max(inset, gutter) so a footer item's right edge still lines up with the
+        scrolled rows.
+        """
+        inset = self._current_inset
+        gutter = self._gutter()
+        self._main.configure(padding=(inset, inset, max(inset - gutter, 0), 0))
+        self._footer.pack_configure(padx=(inset, max(inset, gutter)), pady=(0, inset))
 
     def _paint_canvas_surface(self) -> None:
         """Match the scroll canvas background to the sidebar surface token."""
@@ -263,6 +291,9 @@ class NavPanel(Frame):
                 self._footer_divider.pack(side="bottom", fill="x")
             elif not show_divider and mapped:
                 self._footer_divider.pack_forget()
+            # Keep the content + footer insets in sync with the gutter so the
+            # right margin stays even and footer items align with the scrolled rows.
+            self._apply_insets()
         finally:
             self._updating_overflow = False
 

--- a/src/bootstack/widgets/_impl/composites/shell/nav_panel.py
+++ b/src/bootstack/widgets/_impl/composites/shell/nav_panel.py
@@ -27,6 +27,11 @@ from bootstack.widgets._impl.composites.sidenav.header import SideNavHeader
 from bootstack.widgets._impl.composites.sidenav.separator import SideNavSeparator
 
 
+# Container-controlled spacing (the button's own size is the style's job).
+_ITEM_GAP = 3       # vertical gap between nav buttons
+_COMPACT_INSET = 6  # horizontal inset of the compact (rail-width) sidebar
+
+
 class NavPanel(Frame):
     """A flat, single-select list of navigation items with a pinned footer.
 
@@ -64,11 +69,18 @@ class NavPanel(Frame):
         self._main_children: list = []
         self._footer_items: list = []
 
-        # Footer pinned to the bottom; main area fills the rest above it.
+        # Pill items are inset from the sidebar edges (the rounded pill needs
+        # breathing room from the container); quiet rows run full-width.
+        self._inset = 8 if variant == "nav-pill" else 0
+
+        # Footer pinned to the bottom; main area fills the rest above it. The top
+        # gap matches the horizontal inset so the first pill has even breathing
+        # room from the container.
         self._footer = Frame(self, surface=surface)
         self._footer.pack(side="bottom", fill="x")
         self._main = Frame(self, surface=surface)
         self._main.pack(side="top", fill="both", expand=True)
+        self._apply_inset(self._inset)
 
     def add_item(self, key: str, *, text: str = "", icon=None) -> RadioToggle:
         """Add a selectable item to the main area; wire its click to `on_select`."""
@@ -90,9 +102,9 @@ class NavPanel(Frame):
             compound="image" if self._compact else "left",
             accent=self._accent,
             surface=self._surface,
-            variant=self._variant,
+            variant=self._item_variant(),
         )
-        item.pack(fill="x")
+        item.pack(fill="x", pady=(0, _ITEM_GAP))
         # Click reports the key to the shell (which drives NavModel). The radio
         # also updates the shared signal on click; the shell reconciles via select().
         item.bind("<Button-1>", lambda _e, k=key: self._on_select(k), add="+")
@@ -198,21 +210,36 @@ class NavPanel(Frame):
                 if not self._compact:
                     child.pack(fill="x")
             else:  # RadioToggle nav item
-                child.configure(compound="image" if self._compact else "left")
                 if self._compact or not group_collapsed:
-                    child.pack(fill="x")
+                    child.pack(fill="x", pady=(0, _ITEM_GAP))
+
+    def _item_variant(self) -> str:
+        """The Toolbutton style variant for items in the current mode."""
+        return f"{self._variant}-compact" if self._compact else self._variant
+
+    def _apply_inset(self, inset: int) -> None:
+        """Re-pad the main/footer containers (the pill inset from the edges)."""
+        self._main.pack_configure(padx=inset, pady=(inset, 0))
+        self._footer.pack_configure(padx=inset, pady=(0, inset))
 
     def set_compact(self, compact: bool) -> None:
         """Render items icon-only (compact) or with labels (expanded).
 
-        Compaction is a native `-compound` toggle on each item, not a style state.
+        Compaction swaps each item to the matching `-compact` style variant (a
+        centered icon-only layout) and flips `-compound` to hide the label — both
+        native, no custom composite state.
         """
         if self._compact == compact:
             return
         self._compact = compact
+        # Compact shrinks the sidebar to the rail width; use a small inset so the
+        # pills don't touch the edges (the card pill is narrow enough to fit).
+        self._apply_inset(_COMPACT_INSET if compact else self._inset)
+        variant = self._item_variant()
+        compound = "image" if compact else "left"
+        for item in self._items.values():
+            item.configure(variant=variant, compound=compound)
         self._relayout_main()
-        for item in self._footer_items:
-            item.configure(compound="image" if compact else "left")
 
     @property
     def compact(self) -> bool:

--- a/src/bootstack/widgets/_impl/composites/shell/nav_panel.py
+++ b/src/bootstack/widgets/_impl/composites/shell/nav_panel.py
@@ -101,8 +101,24 @@ class NavPanel(Frame):
         header alone carries enough separation, so a roomy top gap reads as
         excess (especially when it follows an item).
         """
+    def add_header(self, text: str, *, collapsible: bool = False) -> SideNavHeader:
+        """Add a section header to the main area.
+
+        With `collapsible=True` the header gains a chevron and toggles the run of
+        items that follows it (up to the next header or separator) — a 1-level
+        accordion group. `collapsible=False` is a plain static section label (a
+        group "pinned open").
+
+        Uses a tighter top margin than the stock `SideNavHeader` default — the
+        header alone carries enough separation, so a roomy top gap reads as
+        excess (especially when it follows an item).
+        """
         # (left, top, right, bottom) — aligned to the item icon column.
-        header = SideNavHeader(self._main, text=text, padding=(12, 10, 12, 4))
+        header = SideNavHeader(
+            self._main, text=text, padding=(12, 10, 12, 4), collapsible=collapsible
+        )
+        if collapsible:
+            header._on_toggle = lambda h=header: self._toggle_group(h)
         if not self._compact:
             header.pack(fill="x")
         self._main_children.append(header)
@@ -116,25 +132,62 @@ class NavPanel(Frame):
         self._main_children.append(sep)
         return sep
 
-    def set_compact(self, compact: bool) -> None:
-        """Render items icon-only (compact) or with labels (expanded).
+    def _toggle_group(self, header: SideNavHeader) -> None:
+        """Collapse/expand a collapsible header's item run."""
+        header.set_collapsed(not header.collapsed)
+        self._relayout_main()
 
-        Section headers and separators are meaningless without labels, so they
-        hide in compact mode and restore — in their original positions — on
-        expand. The main area is re-packed in insertion order to keep that
-        ordering stable across toggles.
+    def expand_all(self) -> None:
+        """Expand every collapsible group."""
+        self._set_all_groups_collapsed(False)
+
+    def collapse_all(self) -> None:
+        """Collapse every collapsible group."""
+        self._set_all_groups_collapsed(True)
+
+    def _set_all_groups_collapsed(self, collapsed: bool) -> None:
+        changed = False
+        for child in self._main_children:
+            if isinstance(child, SideNavHeader) and child.collapsible:
+                if child.collapsed != collapsed:
+                    child.set_collapsed(collapsed)
+                    changed = True
+        if changed:
+            self._relayout_main()
+
+    def _relayout_main(self) -> None:
+        """Re-pack the main area in insertion order, honoring compact + groups.
+
+        - Compact: items render icon-only; headers and separators hide; collapsed
+          groups are *flattened* (their items still show as icons) — collapse
+          state is preserved and restored on expand.
+        - Expanded: headers/separators show; an item is hidden when it belongs to
+          a collapsed group (the run of items after a collapsed collapsible
+          header, up to the next header or separator).
         """
+        for child in self._main_children:
+            child.pack_forget()
+        group_collapsed = False  # whether the current item run is collapsed
+        for child in self._main_children:
+            if isinstance(child, SideNavHeader):
+                group_collapsed = child.collapsible and child.collapsed
+                if not self._compact:
+                    child.pack(fill="x")
+            elif isinstance(child, SideNavSeparator):
+                group_collapsed = False
+                if not self._compact:
+                    child.pack(fill="x")
+            else:  # SideNavItem
+                child.set_compact(self._compact)
+                if self._compact or not group_collapsed:
+                    child.pack(fill="x")
+
+    def set_compact(self, compact: bool) -> None:
+        """Render items icon-only (compact) or with labels (expanded)."""
         if self._compact == compact:
             return
         self._compact = compact
-        for child in self._main_children:
-            child.pack_forget()
-        for child in self._main_children:
-            if isinstance(child, SideNavItem):
-                child.set_compact(compact)
-                child.pack(fill="x")
-            elif not compact:
-                child.pack(fill="x")
+        self._relayout_main()
         for item in self._footer_items:
             item.set_compact(compact)
 

--- a/src/bootstack/widgets/_impl/composites/shell/nav_panel.py
+++ b/src/bootstack/widgets/_impl/composites/shell/nav_panel.py
@@ -1,0 +1,73 @@
+"""The static navigation panel — single-select nav items in the sidebar.
+
+`NavPanel` is the seed of the static (`add_page`) provider: it renders a flat,
+single-select list of `SideNavItem`s into a sidebar region. Selection is driven
+externally (by the shell, from `NavModel`) — clicking an item reports the key via
+the `on_select` callback; the shell decides what becomes active and calls
+`select()` back to update the visual state. The panel never owns selection truth.
+
+Collapsible groups are deliberately absent (see `docs/_dev/appshell-navigation-spec.md`,
+decision #11): the primary nav is a flat list of items plus static headers.
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+from bootstack.widgets._impl.primitives.frame import Frame
+from bootstack.widgets._impl.composites.sidenav.item import SideNavItem
+
+
+class NavPanel(Frame):
+    """A flat, single-select list of navigation items.
+
+    Args:
+        master: Parent widget (a sidebar region).
+        on_select: Called with an item key when that item is clicked.
+        accent: Accent token for the active-item indicator.
+    """
+
+    def __init__(
+        self,
+        master,
+        *,
+        on_select: Callable[[str], None],
+        accent: str = "primary",
+    ) -> None:
+        super().__init__(master)
+        self._on_select = on_select
+        self._accent = accent
+        self._items: dict[str, SideNavItem] = {}
+        self._selected: str | None = None
+
+    def add_item(self, key: str, *, text: str = "", icon=None) -> SideNavItem:
+        """Add a navigation item and wire its click to `on_select`.
+
+        Args:
+            key: Unique item key (also the page key).
+            text: Display label.
+            icon: Icon name or icon-spec dict.
+
+        Returns:
+            The created `SideNavItem`.
+        """
+        item = SideNavItem(self, key=key, text=text, icon=icon, accent=self._accent)
+        item.pack(fill="x")
+        item.on_invoked(lambda _event, k=key: self._on_select(k))
+        self._items[key] = item
+        return item
+
+    def select(self, key: str | None) -> None:
+        """Set the visual selection to `key` (or clear it with `None`)."""
+        for k, item in self._items.items():
+            item.set_selected(k == key)
+        self._selected = key
+
+    @property
+    def selected(self) -> str | None:
+        """The currently selected item key, or `None`."""
+        return self._selected
+
+    def item_keys(self) -> tuple[str, ...]:
+        """All item keys in insertion order."""
+        return tuple(self._items)

--- a/src/bootstack/widgets/_impl/composites/shell/nav_panel.py
+++ b/src/bootstack/widgets/_impl/composites/shell/nav_panel.py
@@ -41,6 +41,11 @@ class NavPanel(Frame):
         self._accent = accent
         self._items: dict[str, SideNavItem] = {}
         self._selected: str | None = None
+        self._compact = False
+        # Insertion-ordered main-area children (items, headers, separators) so
+        # compaction can re-pack them in order; footer items tracked separately.
+        self._main_children: list[Frame] = []
+        self._footer_items: list[SideNavItem] = []
 
         # Footer pinned to the bottom; main area fills the rest above it.
         self._footer = Frame(self)
@@ -50,25 +55,31 @@ class NavPanel(Frame):
 
     def add_item(self, key: str, *, text: str = "", icon=None) -> SideNavItem:
         """Add a selectable item to the main area; wire its click to `on_select`."""
-        return self._add_item(self._main, key, text=text, icon=icon)
+        return self._add_item(self._main, key, text=text, icon=icon, footer=False)
 
     def add_footer_item(self, key: str, *, text: str = "", icon=None) -> SideNavItem:
         """Add a selectable item pinned to the footer."""
-        return self._add_item(self._footer, key, text=text, icon=icon)
+        return self._add_item(self._footer, key, text=text, icon=icon, footer=True)
 
-    def _add_item(self, parent: Frame, key: str, *, text: str, icon) -> SideNavItem:
+    def _add_item(self, parent: Frame, key: str, *, text: str, icon, footer: bool) -> SideNavItem:
         if key in self._items:
             raise ValueError(f"duplicate nav item key: {key!r}")
         item = SideNavItem(parent, key=key, text=text, icon=icon, accent=self._accent)
+        if self._compact:
+            item.set_compact(True)
         item.pack(fill="x")
         item.on_invoked(lambda _event, k=key: self._on_select(k))
         self._items[key] = item
+        (self._footer_items if footer else self._main_children).append(item)
         return item
 
     def remove_item(self, key: str) -> None:
         """Remove and destroy an item by key (no error if absent)."""
         item = self._items.pop(key, None)
         if item is not None:
+            for tracker in (self._main_children, self._footer_items):
+                if item in tracker:
+                    tracker.remove(item)
             item.destroy()
             if self._selected == key:
                 self._selected = None
@@ -92,14 +103,45 @@ class NavPanel(Frame):
         """
         # (left, top, right, bottom) — aligned to the item icon column.
         header = SideNavHeader(self._main, text=text, padding=(12, 10, 12, 4))
-        header.pack(fill="x")
+        if not self._compact:
+            header.pack(fill="x")
+        self._main_children.append(header)
         return header
 
     def add_separator(self) -> SideNavSeparator:
         """Add a separator to the main area."""
         sep = SideNavSeparator(self._main)
-        sep.pack(fill="x")
+        if not self._compact:
+            sep.pack(fill="x")
+        self._main_children.append(sep)
         return sep
+
+    def set_compact(self, compact: bool) -> None:
+        """Render items icon-only (compact) or with labels (expanded).
+
+        Section headers and separators are meaningless without labels, so they
+        hide in compact mode and restore — in their original positions — on
+        expand. The main area is re-packed in insertion order to keep that
+        ordering stable across toggles.
+        """
+        if self._compact == compact:
+            return
+        self._compact = compact
+        for child in self._main_children:
+            child.pack_forget()
+        for child in self._main_children:
+            if isinstance(child, SideNavItem):
+                child.set_compact(compact)
+                child.pack(fill="x")
+            elif not compact:
+                child.pack(fill="x")
+        for item in self._footer_items:
+            item.set_compact(compact)
+
+    @property
+    def compact(self) -> bool:
+        """Whether the panel is rendering items icon-only."""
+        return self._compact
 
     def select(self, key: str | None) -> None:
         """Set the visual selection to `key` (or clear it with `None`)."""

--- a/src/bootstack/widgets/_impl/composites/shell/nav_panel.py
+++ b/src/bootstack/widgets/_impl/composites/shell/nav_panel.py
@@ -65,6 +65,24 @@ class NavPanel(Frame):
         self._items[key] = item
         return item
 
+    def remove_item(self, key: str) -> None:
+        """Remove and destroy an item by key (no error if absent)."""
+        item = self._items.pop(key, None)
+        if item is not None:
+            item.destroy()
+            if self._selected == key:
+                self._selected = None
+
+    def update_item(self, key: str, *, text: str | None = None, icon=None) -> None:
+        """Update an existing item's label and/or icon in place."""
+        item = self._items.get(key)
+        if item is None:
+            return
+        if text is not None:
+            item.configure(text=text)
+        if icon is not None:
+            item.configure(icon=icon)
+
     def add_header(self, text: str) -> SideNavHeader:
         """Add a static (non-collapsible) section header to the main area.
 

--- a/src/bootstack/widgets/_impl/composites/shell/nav_panel.py
+++ b/src/bootstack/widgets/_impl/composites/shell/nav_panel.py
@@ -1,21 +1,28 @@
 """The static navigation panel — single-select items, headers, separators, footer.
 
 `NavPanel` renders a flat, single-select list into a sidebar region: items in a
-scrolling main area plus a pinned footer area. Selection is driven externally
-(by the shell, from `NavModel`) — clicking an item reports the key via the
-`on_select` callback; the shell decides what becomes active and calls `select()`
-back to update the visual state. The panel never owns selection truth.
+scrolling main area plus a pinned footer area. Each item is a `RadioToggle`
+sharing one `Signal`, so single-select is the radio machinery itself — no
+hand-rolled selection state. The items are styled via a native Toolbutton
+**variant** (`nav-quiet` under a rail; `nav-pill` standalone is added later), so
+the look is driven by the style engine, not custom composite state.
 
-Collapsible groups are deliberately absent (see `docs/_dev/appshell-navigation-spec.md`,
-decision #11): the primary nav is a flat list of items plus *static* headers.
+Selection truth still lives in the shell's `NavModel`: clicking an item reports
+the key via the `on_select` callback; the shell decides what becomes active and
+calls `select()` back (setting the shared signal) to reflect it.
+
+Section headers may be **1-level collapsible groups** (a header + the run of
+items after it, up to the next header/separator). Compaction to icon-only is a
+native `-compound` toggle on each item (`'left'` <-> `'image'`).
 """
 
 from __future__ import annotations
 
 from typing import Callable
 
+from bootstack.signals import Signal
 from bootstack.widgets._impl.primitives.frame import Frame
-from bootstack.widgets._impl.composites.sidenav.item import SideNavItem
+from bootstack.widgets._impl.primitives.radiotoggle import RadioToggle
 from bootstack.widgets._impl.composites.sidenav.header import SideNavHeader
 from bootstack.widgets._impl.composites.sidenav.separator import SideNavSeparator
 
@@ -26,7 +33,10 @@ class NavPanel(Frame):
     Args:
         master: Parent widget (a sidebar region).
         on_select: Called with an item key when that item is clicked.
-        accent: Accent token for the active-item indicator.
+        accent: Accent token for the active item.
+        variant: Toolbutton style variant for the items (the tier treatment) —
+            `'nav-quiet'` under a rail, `'nav-pill'` standalone.
+        surface: Surface token the items sit on (the sidebar region surface).
     """
 
     def __init__(
@@ -35,40 +45,57 @@ class NavPanel(Frame):
         *,
         on_select: Callable[[str], None],
         accent: str = "primary",
+        variant: str = "nav-quiet",
+        surface: str = "card",
     ) -> None:
-        super().__init__(master)
+        super().__init__(master, surface=surface)
         self._on_select = on_select
         self._accent = accent
-        self._items: dict[str, SideNavItem] = {}
-        self._selected: str | None = None
+        self._variant = variant
+        self._surface = surface
+        self._items: dict[str, RadioToggle] = {}
         self._compact = False
+        # Shared selection signal: value is the selected item key (radio
+        # single-select). "" is the sentinel for "nothing selected" (a Signal is
+        # typed by its initial value, so it can't hold None here).
+        self._signal: Signal = Signal("")
         # Insertion-ordered main-area children (items, headers, separators) so
         # compaction can re-pack them in order; footer items tracked separately.
-        self._main_children: list[Frame] = []
-        self._footer_items: list[SideNavItem] = []
+        self._main_children: list = []
+        self._footer_items: list = []
 
         # Footer pinned to the bottom; main area fills the rest above it.
-        self._footer = Frame(self)
+        self._footer = Frame(self, surface=surface)
         self._footer.pack(side="bottom", fill="x")
-        self._main = Frame(self)
+        self._main = Frame(self, surface=surface)
         self._main.pack(side="top", fill="both", expand=True)
 
-    def add_item(self, key: str, *, text: str = "", icon=None) -> SideNavItem:
+    def add_item(self, key: str, *, text: str = "", icon=None) -> RadioToggle:
         """Add a selectable item to the main area; wire its click to `on_select`."""
         return self._add_item(self._main, key, text=text, icon=icon, footer=False)
 
-    def add_footer_item(self, key: str, *, text: str = "", icon=None) -> SideNavItem:
+    def add_footer_item(self, key: str, *, text: str = "", icon=None) -> RadioToggle:
         """Add a selectable item pinned to the footer."""
         return self._add_item(self._footer, key, text=text, icon=icon, footer=True)
 
-    def _add_item(self, parent: Frame, key: str, *, text: str, icon, footer: bool) -> SideNavItem:
+    def _add_item(self, parent: Frame, key: str, *, text: str, icon, footer: bool) -> RadioToggle:
         if key in self._items:
             raise ValueError(f"duplicate nav item key: {key!r}")
-        item = SideNavItem(parent, key=key, text=text, icon=icon, accent=self._accent)
-        if self._compact:
-            item.set_compact(True)
+        item = RadioToggle(
+            parent,
+            value=key,
+            signal=self._signal,
+            text=text,
+            icon=icon,
+            compound="image" if self._compact else "left",
+            accent=self._accent,
+            surface=self._surface,
+            variant=self._variant,
+        )
         item.pack(fill="x")
-        item.on_invoked(lambda _event, k=key: self._on_select(k))
+        # Click reports the key to the shell (which drives NavModel). The radio
+        # also updates the shared signal on click; the shell reconciles via select().
+        item.bind("<Button-1>", lambda _e, k=key: self._on_select(k), add="+")
         self._items[key] = item
         (self._footer_items if footer else self._main_children).append(item)
         return item
@@ -81,8 +108,8 @@ class NavPanel(Frame):
                 if item in tracker:
                     tracker.remove(item)
             item.destroy()
-            if self._selected == key:
-                self._selected = None
+            if self._signal() == key:
+                self._signal.set("")
 
     def update_item(self, key: str, *, text: str | None = None, icon=None) -> None:
         """Update an existing item's label and/or icon in place."""
@@ -94,13 +121,6 @@ class NavPanel(Frame):
         if icon is not None:
             item.configure(icon=icon)
 
-    def add_header(self, text: str) -> SideNavHeader:
-        """Add a static (non-collapsible) section header to the main area.
-
-        Uses a tighter top margin than the stock `SideNavHeader` default — the
-        header alone carries enough separation, so a roomy top gap reads as
-        excess (especially when it follows an item).
-        """
     def add_header(self, text: str, *, collapsible: bool = False) -> SideNavHeader:
         """Add a section header to the main area.
 
@@ -158,9 +178,9 @@ class NavPanel(Frame):
     def _relayout_main(self) -> None:
         """Re-pack the main area in insertion order, honoring compact + groups.
 
-        - Compact: items render icon-only; headers and separators hide; collapsed
-          groups are *flattened* (their items still show as icons) — collapse
-          state is preserved and restored on expand.
+        - Compact: items render icon-only (`-compound='image'`); headers and
+          separators hide; collapsed groups are *flattened* (their items still
+          show as icons) — collapse state is preserved and restored on expand.
         - Expanded: headers/separators show; an item is hidden when it belongs to
           a collapsed group (the run of items after a collapsed collapsible
           header, up to the next header or separator).
@@ -177,19 +197,22 @@ class NavPanel(Frame):
                 group_collapsed = False
                 if not self._compact:
                     child.pack(fill="x")
-            else:  # SideNavItem
-                child.set_compact(self._compact)
+            else:  # RadioToggle nav item
+                child.configure(compound="image" if self._compact else "left")
                 if self._compact or not group_collapsed:
                     child.pack(fill="x")
 
     def set_compact(self, compact: bool) -> None:
-        """Render items icon-only (compact) or with labels (expanded)."""
+        """Render items icon-only (compact) or with labels (expanded).
+
+        Compaction is a native `-compound` toggle on each item, not a style state.
+        """
         if self._compact == compact:
             return
         self._compact = compact
         self._relayout_main()
         for item in self._footer_items:
-            item.set_compact(compact)
+            item.configure(compound="image" if compact else "left")
 
     @property
     def compact(self) -> bool:
@@ -198,14 +221,12 @@ class NavPanel(Frame):
 
     def select(self, key: str | None) -> None:
         """Set the visual selection to `key` (or clear it with `None`)."""
-        for k, item in self._items.items():
-            item.set_selected(k == key)
-        self._selected = key
+        self._signal.set(key if key is not None else "")
 
     @property
     def selected(self) -> str | None:
         """The currently selected item key, or `None`."""
-        return self._selected
+        return self._signal() or None
 
     def item_keys(self) -> tuple[str, ...]:
         """All item keys (main + footer) in insertion order."""

--- a/src/bootstack/widgets/_impl/composites/shell/nav_panel.py
+++ b/src/bootstack/widgets/_impl/composites/shell/nav_panel.py
@@ -11,9 +11,11 @@ Selection truth still lives in the shell's `NavModel`: clicking an item reports
 the key via the `on_select` callback; the shell decides what becomes active and
 calls `select()` back (setting the shared signal) to reflect it.
 
-Section headers may be **1-level collapsible groups** (a header + the run of
-items after it, up to the next header/separator). Compaction to icon-only is a
-native `-compound` toggle on each item (`'left'` <-> `'image'`).
+Section headers are plain, non-interactive labels (they chunk a flat list and
+hide on compaction). There is no built-in collapsible section — hiding/revealing
+a sub-list is a content concern (compose `bs.Accordion` in a custom panel).
+Compaction to icon-only is a native `-compound` toggle on each item
+(`'left'` <-> `'image'`); headers and separators hide while compact.
 """
 
 from __future__ import annotations
@@ -21,8 +23,10 @@ from __future__ import annotations
 from typing import Callable
 
 from bootstack.signals import Signal
+from bootstack.style.style import get_style
 from bootstack.widgets._impl.primitives.frame import Frame
 from bootstack.widgets._impl.primitives.radiotoggle import RadioToggle
+from bootstack.widgets._impl.composites.scrollview import ScrollView
 from bootstack.widgets._impl.composites.sidenav.header import SideNavHeader
 from bootstack.widgets._impl.composites.sidenav.separator import SideNavSeparator
 
@@ -73,13 +77,33 @@ class NavPanel(Frame):
         # breathing room from the container); quiet rows run full-width.
         self._inset = 8 if variant == "nav-pill" else 0
 
-        # Footer pinned to the bottom; main area fills the rest above it. The top
-        # gap matches the horizontal inset so the first pill has even breathing
-        # room from the container.
+        # Footer pinned to the bottom; the item area scrolls in the space above it
+        # (a wheel-scrollable canvas with an auto-hiding bar — the footer itself
+        # never scrolls). The canvas background is painted to the sidebar surface
+        # so the area below short content doesn't flash the default canvas color.
         self._footer = Frame(self, surface=surface)
         self._footer.pack(side="bottom", fill="x")
-        self._main = Frame(self, surface=surface)
-        self._main.pack(side="top", fill="both", expand=True)
+        # A divider above the footer, shown ONLY when the item area scrolls — so a
+        # pinned footer reads as its own band instead of abutting a clipped row.
+        # When everything fits it stays hidden (no needless chrome).
+        self._footer_divider = SideNavSeparator(self, surface=surface, padding=(0, 0, 0, 0))
+        # Start with no gutter/bar; overflow detection switches it on only when the
+        # content is actually tall enough to scroll (see _update_overflow_state).
+        self._scroll = ScrollView(
+            self,
+            scroll_direction="vertical",
+            scrollbar_visibility="never",
+            surface=surface,
+        )
+        self._scroll.pack(side="top", fill="both", expand=True)
+        self._main = self._scroll.add(surface=surface)
+        self._updating_overflow = False
+        self._paint_canvas_surface()
+        self.bind("<<BsThemeChanged>>", lambda _e: self._paint_canvas_surface(), add="+")
+        # Re-evaluate the gutter/bar + footer divider whenever the content height
+        # or viewport changes (items added/removed, sidebar resized, compaction).
+        self._scroll.canvas.bind("<Configure>", lambda _e: self._update_overflow_state(), add="+")
+        self._main.bind("<Configure>", lambda _e: self._update_overflow_state(), add="+")
         self._apply_inset(self._inset)
 
     def add_item(self, key: str, *, text: str = "", icon=None) -> RadioToggle:
@@ -110,6 +134,10 @@ class NavPanel(Frame):
         item.bind("<Button-1>", lambda _e, k=key: self._on_select(k), add="+")
         self._items[key] = item
         (self._footer_items if footer else self._main_children).append(item)
+        if footer:
+            # A footer item may appear after the content is laid out; the divider
+            # gate depends on footer presence, so re-evaluate now.
+            self._update_overflow_state()
         return item
 
     def remove_item(self, key: str) -> None:
@@ -122,6 +150,7 @@ class NavPanel(Frame):
             item.destroy()
             if self._signal() == key:
                 self._signal.set("")
+            self._update_overflow_state()
 
     def update_item(self, key: str, *, text: str | None = None, icon=None) -> None:
         """Update an existing item's label and/or icon in place."""
@@ -133,24 +162,21 @@ class NavPanel(Frame):
         if icon is not None:
             item.configure(icon=icon)
 
-    def add_header(self, text: str, *, collapsible: bool = False) -> SideNavHeader:
-        """Add a section header to the main area.
+    def add_header(self, text: str) -> SideNavHeader:
+        """Add a plain section-label header to the main area.
 
-        With `collapsible=True` the header gains a chevron and toggles the run of
-        items that follows it (up to the next header or separator) — a 1-level
-        accordion group. `collapsible=False` is a plain static section label (a
-        group "pinned open").
+        A header is a quiet, non-interactive label that chunks the flat list; it
+        hides while the panel is compacted. (There is no collapsible-header
+        primitive — a collapsible sub-list is a content concern.)
 
         Uses a tighter top margin than the stock `SideNavHeader` default — the
         header alone carries enough separation, so a roomy top gap reads as
         excess (especially when it follows an item).
         """
-        # (left, top, right, bottom) — aligned to the item icon column.
-        header = SideNavHeader(
-            self._main, text=text, padding=(12, 10, 12, 4), collapsible=collapsible
-        )
-        if collapsible:
-            header._on_toggle = lambda h=header: self._toggle_group(h)
+        # (left, top, right, bottom) — aligned to the item icon column. A roomier
+        # top gap separates the new group from the one above; the small bottom gap
+        # keeps the header bound to its own items.
+        header = SideNavHeader(self._main, text=text, padding=(12, 16, 12, 4))
         if not self._compact:
             header.pack(fill="x")
         self._main_children.append(header)
@@ -164,63 +190,81 @@ class NavPanel(Frame):
         self._main_children.append(sep)
         return sep
 
-    def _toggle_group(self, header: SideNavHeader) -> None:
-        """Collapse/expand a collapsible header's item run."""
-        header.set_collapsed(not header.collapsed)
-        self._relayout_main()
-
-    def expand_all(self) -> None:
-        """Expand every collapsible group."""
-        self._set_all_groups_collapsed(False)
-
-    def collapse_all(self) -> None:
-        """Collapse every collapsible group."""
-        self._set_all_groups_collapsed(True)
-
-    def _set_all_groups_collapsed(self, collapsed: bool) -> None:
-        changed = False
-        for child in self._main_children:
-            if isinstance(child, SideNavHeader) and child.collapsible:
-                if child.collapsed != collapsed:
-                    child.set_collapsed(collapsed)
-                    changed = True
-        if changed:
-            self._relayout_main()
-
     def _relayout_main(self) -> None:
-        """Re-pack the main area in insertion order, honoring compact + groups.
+        """Re-pack the main area in insertion order, honoring compact.
 
-        - Compact: items render icon-only (`-compound='image'`); headers and
-          separators hide; collapsed groups are *flattened* (their items still
-          show as icons) — collapse state is preserved and restored on expand.
-        - Expanded: headers/separators show; an item is hidden when it belongs to
-          a collapsed group (the run of items after a collapsed collapsible
-          header, up to the next header or separator).
+        Compact renders items icon-only (`-compound='image'`) and hides headers
+        and separators (a label-less icon strip); expanded shows everything.
         """
         for child in self._main_children:
             child.pack_forget()
-        group_collapsed = False  # whether the current item run is collapsed
         for child in self._main_children:
-            if isinstance(child, SideNavHeader):
-                group_collapsed = child.collapsible and child.collapsed
-                if not self._compact:
-                    child.pack(fill="x")
-            elif isinstance(child, SideNavSeparator):
-                group_collapsed = False
+            if isinstance(child, (SideNavHeader, SideNavSeparator)):
                 if not self._compact:
                     child.pack(fill="x")
             else:  # RadioToggle nav item
-                if self._compact or not group_collapsed:
-                    child.pack(fill="x", pady=(0, _ITEM_GAP))
+                child.pack(fill="x", pady=(0, _ITEM_GAP))
 
     def _item_variant(self) -> str:
         """The Toolbutton style variant for items in the current mode."""
         return f"{self._variant}-compact" if self._compact else self._variant
 
     def _apply_inset(self, inset: int) -> None:
-        """Re-pad the main/footer containers (the pill inset from the edges)."""
-        self._main.pack_configure(padx=inset, pady=(inset, 0))
+        """Inset the scrolled item area + footer from the sidebar edges.
+
+        Pills need breathing room; quiet rows run flush (inset 0). The item area
+        is a canvas window (not pack-managed), so its inset is its own padding.
+        """
+        self._main.configure(padding=(inset, inset, inset, 0))
         self._footer.pack_configure(padx=inset, pady=(0, inset))
+
+    def _paint_canvas_surface(self) -> None:
+        """Match the scroll canvas background to the sidebar surface token."""
+        try:
+            color = get_style().style_builder.color(self._surface)
+            self._scroll.canvas.configure(background=color)
+        except Exception:
+            pass
+
+    def _content_overflows(self) -> bool:
+        """Whether the item content is taller than the scroll viewport.
+
+        Uses a small epsilon so a 1–4px overhang doesn't toggle the gutter — and,
+        with the gutter's own width, gives stable hysteresis (no flicker).
+        """
+        try:
+            bbox = self._scroll.canvas.bbox("all")
+            if not bbox:
+                return False
+            viewport_h = self._scroll.canvas.winfo_height()
+            return viewport_h > 1 and (bbox[3] - bbox[1]) > viewport_h + 4
+        except Exception:
+            return False
+
+    def _update_overflow_state(self) -> None:
+        """Reserve the scrollbar gutter + show the footer divider only on overflow.
+
+        When the content fits, the bar/gutter is off (`'never'`) so items run
+        full-width and there's no footer divider; when it overflows, the gutter +
+        auto-hiding bar turn on (`'scroll'`) and a divider separates the pinned
+        footer from the scrolling rows.
+        """
+        if self._updating_overflow:
+            return
+        self._updating_overflow = True
+        try:
+            overflow = self._content_overflows()
+            desired = "scroll" if overflow else "never"
+            if self._scroll.cget("scrollbar_visibility") != desired:
+                self._scroll.configure(scrollbar_visibility=desired)
+            show_divider = overflow and bool(self._footer_items)
+            mapped = self._footer_divider.winfo_manager() != ""
+            if show_divider and not mapped:
+                self._footer_divider.pack(side="bottom", fill="x")
+            elif not show_divider and mapped:
+                self._footer_divider.pack_forget()
+        finally:
+            self._updating_overflow = False
 
     def set_compact(self, compact: bool) -> None:
         """Render items icon-only (compact) or with labels (expanded).

--- a/src/bootstack/widgets/_impl/composites/shell/nav_panel.py
+++ b/src/bootstack/widgets/_impl/composites/shell/nav_panel.py
@@ -1,13 +1,13 @@
-"""The static navigation panel — single-select nav items in the sidebar.
+"""The static navigation panel — single-select items, headers, separators, footer.
 
-`NavPanel` is the seed of the static (`add_page`) provider: it renders a flat,
-single-select list of `SideNavItem`s into a sidebar region. Selection is driven
-externally (by the shell, from `NavModel`) — clicking an item reports the key via
-the `on_select` callback; the shell decides what becomes active and calls
-`select()` back to update the visual state. The panel never owns selection truth.
+`NavPanel` renders a flat, single-select list into a sidebar region: items in a
+scrolling main area plus a pinned footer area. Selection is driven externally
+(by the shell, from `NavModel`) — clicking an item reports the key via the
+`on_select` callback; the shell decides what becomes active and calls `select()`
+back to update the visual state. The panel never owns selection truth.
 
 Collapsible groups are deliberately absent (see `docs/_dev/appshell-navigation-spec.md`,
-decision #11): the primary nav is a flat list of items plus static headers.
+decision #11): the primary nav is a flat list of items plus *static* headers.
 """
 
 from __future__ import annotations
@@ -16,10 +16,12 @@ from typing import Callable
 
 from bootstack.widgets._impl.primitives.frame import Frame
 from bootstack.widgets._impl.composites.sidenav.item import SideNavItem
+from bootstack.widgets._impl.composites.sidenav.header import SideNavHeader
+from bootstack.widgets._impl.composites.sidenav.separator import SideNavSeparator
 
 
 class NavPanel(Frame):
-    """A flat, single-select list of navigation items.
+    """A flat, single-select list of navigation items with a pinned footer.
 
     Args:
         master: Parent widget (a sidebar region).
@@ -40,22 +42,46 @@ class NavPanel(Frame):
         self._items: dict[str, SideNavItem] = {}
         self._selected: str | None = None
 
+        # Footer pinned to the bottom; main area fills the rest above it.
+        self._footer = Frame(self)
+        self._footer.pack(side="bottom", fill="x")
+        self._main = Frame(self)
+        self._main.pack(side="top", fill="both", expand=True)
+
     def add_item(self, key: str, *, text: str = "", icon=None) -> SideNavItem:
-        """Add a navigation item and wire its click to `on_select`.
+        """Add a selectable item to the main area; wire its click to `on_select`."""
+        return self._add_item(self._main, key, text=text, icon=icon)
 
-        Args:
-            key: Unique item key (also the page key).
-            text: Display label.
-            icon: Icon name or icon-spec dict.
+    def add_footer_item(self, key: str, *, text: str = "", icon=None) -> SideNavItem:
+        """Add a selectable item pinned to the footer."""
+        return self._add_item(self._footer, key, text=text, icon=icon)
 
-        Returns:
-            The created `SideNavItem`.
-        """
-        item = SideNavItem(self, key=key, text=text, icon=icon, accent=self._accent)
+    def _add_item(self, parent: Frame, key: str, *, text: str, icon) -> SideNavItem:
+        if key in self._items:
+            raise ValueError(f"duplicate nav item key: {key!r}")
+        item = SideNavItem(parent, key=key, text=text, icon=icon, accent=self._accent)
         item.pack(fill="x")
         item.on_invoked(lambda _event, k=key: self._on_select(k))
         self._items[key] = item
         return item
+
+    def add_header(self, text: str) -> SideNavHeader:
+        """Add a static (non-collapsible) section header to the main area.
+
+        Uses a tighter top margin than the stock `SideNavHeader` default — the
+        header alone carries enough separation, so a roomy top gap reads as
+        excess (especially when it follows an item).
+        """
+        # (left, top, right, bottom) — aligned to the item icon column.
+        header = SideNavHeader(self._main, text=text, padding=(12, 10, 12, 4))
+        header.pack(fill="x")
+        return header
+
+    def add_separator(self) -> SideNavSeparator:
+        """Add a separator to the main area."""
+        sep = SideNavSeparator(self._main)
+        sep.pack(fill="x")
+        return sep
 
     def select(self, key: str | None) -> None:
         """Set the visual selection to `key` (or clear it with `None`)."""
@@ -69,5 +95,5 @@ class NavPanel(Frame):
         return self._selected
 
     def item_keys(self) -> tuple[str, ...]:
-        """All item keys in insertion order."""
+        """All item keys (main + footer) in insertion order."""
         return tuple(self._items)

--- a/src/bootstack/widgets/_impl/composites/shell/providers.py
+++ b/src/bootstack/widgets/_impl/composites/shell/providers.py
@@ -33,7 +33,13 @@ class NavProvider(Protocol):
     """
 
     supports_compact: bool
-    """Whether the sidebar may collapse to an icon rail (false for custom panels)."""
+    """Whether the sidebar may render icon-only (compact).
+
+    True only for the static provider, whose items carry authored icons. A
+    data-bound list (`list_nav`) or hierarchy (`tree_nav`) cannot meaningfully
+    compact, so theirs is False — they are hidden or shown, never icon-only.
+    Compaction is also gated by the host to the standalone case (no rail).
+    """
 
     def mount(
         self,
@@ -47,6 +53,13 @@ class NavProvider(Protocol):
 
         `on_refresh` (optional) is invoked after the provider rebuilds its items
         from a changed source, so the host can reconcile the active selection.
+        """
+        ...
+
+    def set_compact(self, compact: bool) -> None:
+        """Render the sidebar icon-only (`compact`) or with labels.
+
+        A no-op for providers where `supports_compact` is False.
         """
         ...
 
@@ -114,6 +127,9 @@ class StaticProvider:
 
     # ----- Provider contract -----
 
+    def set_compact(self, compact: bool) -> None:
+        self._nav.set_compact(compact)
+
     def show(self, key: str, data: dict | None = None) -> None:
         self._pages.navigate(key, data=data)
 
@@ -151,7 +167,9 @@ class ListNavProvider:
         accent: Accent token for the active nav item.
     """
 
-    supports_compact = True
+    # A label-less data list is a poor nav, so list_nav is hidden-or-shown,
+    # never icon-only (spec Revision 2 / R1).
+    supports_compact = False
 
     def __init__(
         self,
@@ -264,6 +282,10 @@ class ListNavProvider:
             self._sub = None
 
     # ----- Provider contract -----
+
+    def set_compact(self, compact: bool) -> None:
+        # list_nav never compacts (supports_compact is False); see R1.
+        pass
 
     def show(self, key: str, data: dict | None = None) -> None:
         record = self._records.get(key)
@@ -384,6 +406,10 @@ class TreeNavProvider:
         self._on_select(self._key_for(node))
 
     # ----- Provider contract -----
+
+    def set_compact(self, compact: bool) -> None:
+        # A hierarchy cannot render as icons; tree_nav never compacts (see R1).
+        pass
 
     def show(self, key: str, data: dict | None = None) -> None:
         node = self._nodes_by_key.get(key)

--- a/src/bootstack/widgets/_impl/composites/shell/providers.py
+++ b/src/bootstack/widgets/_impl/composites/shell/providers.py
@@ -85,8 +85,10 @@ class StaticProvider:
 
     supports_compact = True
 
-    def __init__(self, *, accent: str = "primary") -> None:
+    def __init__(self, *, accent: str = "primary", variant: str = "nav-quiet", surface: str = "card") -> None:
         self._accent = accent
+        self._variant = variant
+        self._surface = surface
         self._nav: NavPanel | None = None
         self._pages: PageStack | None = None
         self._keys: list[str] = []
@@ -100,7 +102,10 @@ class StaticProvider:
         on_refresh: Callable[[], None] | None = None,
     ) -> None:
         # Static authoring never refreshes from a source; on_refresh is ignored.
-        self._nav = NavPanel(sidebar, on_select=on_select, accent=self._accent)
+        self._nav = NavPanel(
+            sidebar, on_select=on_select, accent=self._accent,
+            variant=self._variant, surface=self._surface,
+        )
         self._nav.pack(fill="both", expand=True)
         self._pages = PageStack(content)
         self._pages.pack(fill="both", expand=True)
@@ -186,11 +191,13 @@ class ListNavProvider:
         text_field: str = "text",
         icon_field: str = "icon",
         accent: str = "primary",
+        surface: str = "card",
     ) -> None:
         self._source = source
         self._text_field = text_field
         self._icon_field = icon_field
         self._accent = accent
+        self._surface = surface
         self._nav: NavPanel | None = None
         self._host: ContentHost | None = None
         self._detail: Callable[[dict], Any] | None = None
@@ -208,7 +215,9 @@ class ListNavProvider:
         on_refresh: Callable[[], None] | None = None,
     ) -> None:
         self._on_refresh = on_refresh
-        self._nav = NavPanel(sidebar, on_select=on_select, accent=self._accent)
+        self._nav = NavPanel(
+            sidebar, on_select=on_select, accent=self._accent, surface=self._surface
+        )
         self._nav.pack(fill="both", expand=True)
         self._host = ContentHost(content)
         self._populate()

--- a/src/bootstack/widgets/_impl/composites/shell/providers.py
+++ b/src/bootstack/widgets/_impl/composites/shell/providers.py
@@ -166,18 +166,19 @@ class StaticProvider:
 
 
 class ListNavProvider:
-    """Flat, data-bound provider — a `DataSource` drives the sidebar list.
+    """Flat, data-bound provider — a `DataSource` drives a sidebar `ListView`.
 
-    Each record becomes a single-select nav item (keyed by record id); selecting
-    one re-renders a single `@detail` body parameterized by that record. The
-    detail body receives the **public record dict** (the universal `.selection`
-    shape) — not a bespoke node object.
+    Each record becomes a single-select row (keyed by record id); selecting one
+    re-renders a single `@detail` body parameterized by that record — the public
+    record dict (the universal `.selection` shape). Rows render the record's
+    `text`/`icon`; the recycling `ListView` follows the source live and inherits
+    the sidebar surface (no surface plumbing needed).
 
     Args:
-        source: A `DataSourceProtocol` supplying records.
-        text_field: Record field used for the item label.
-        icon_field: Record field used for the item icon.
-        accent: Accent token for the active nav item.
+        source: A `DataSourceProtocol` supplying records (with `text`/`icon`).
+        accent: Accent token (the selection control follows it; the row
+            selection itself is a neutral wash by default).
+        separator: Draw separator lines between rows. Default False (flush).
     """
 
     # A label-less data list is a poor nav, so list_nav is hidden-or-shown,
@@ -188,23 +189,22 @@ class ListNavProvider:
         self,
         source: Any,
         *,
-        text_field: str = "text",
-        icon_field: str = "icon",
         accent: str = "primary",
-        surface: str = "card",
+        separator: bool = False,
     ) -> None:
         self._source = source
-        self._text_field = text_field
-        self._icon_field = icon_field
         self._accent = accent
-        self._surface = surface
-        self._nav: NavPanel | None = None
+        self._separator = separator
+        self._listview: Any = None
         self._host: ContentHost | None = None
+        self._sidebar_host: ContentHost | None = None
         self._detail: Callable[[dict], Any] | None = None
-        self._records: dict[str, dict] = {}
-        self._order: list[str] = []
+        self._selected: str | None = None
+        self._cache: dict[str, dict] = {}
+        self._on_select: Callable[[str], None] | None = None
         self._on_refresh: Callable[[], None] | None = None
         self._sub: Any = None
+        self._src_sub: Any = None
 
     def mount(
         self,
@@ -214,16 +214,29 @@ class ListNavProvider:
         on_select: Callable[[str], None],
         on_refresh: Callable[[], None] | None = None,
     ) -> None:
+        from bootstack.widgets.listview import ListView
+
+        self._on_select = on_select
         self._on_refresh = on_refresh
-        self._nav = NavPanel(
-            sidebar, on_select=on_select, accent=self._accent, surface=self._surface
-        )
-        self._nav.pack(fill="both", expand=True)
         self._host = ContentHost(content)
-        self._populate()
-        # Live updates: rebuild items when the source changes (delivered on the
-        # UI thread by the data layer). Stored so it can be cancelled on close.
-        self._sub = self._source.on_change(self._on_source_change)
+        self._sidebar_host = ContentHost(sidebar)
+        self._listview = ListView(
+            parent=self._sidebar_host,
+            data_source=self._source,
+            selection_mode="single",
+            show_separators=self._separator,
+            show_scrollbar=False,   # mousewheel scrolls; no always-on bar in a nav
+            density="compact",      # dense data list; also differentiates from the static pill nav
+            accent=self._accent,
+            fill="both",
+            expand=True,
+        )
+        self._cache = self._read()
+        self._sub = self._listview.on_select(self._on_listview_select)
+        # The ListView refreshes its own rows from the source; we observe too, to
+        # re-render the open detail when the selected record changes in place and
+        # to let the host reconcile selection on add/remove.
+        self._src_sub = self._source.on_change(self._on_source_change)
 
     def set_detail(self, fn: Callable[[dict], Any]) -> None:
         """Register the parameterized detail body builder."""
@@ -238,65 +251,41 @@ class ListNavProvider:
             out[str(rec.get("id"))] = rec
         return out
 
-    def _label(self, rec: dict) -> str:
-        return str(rec.get(self._text_field, ""))
-
-    def _icon(self, rec: dict):
-        return rec.get(self._icon_field)
-
-    def _populate(self) -> None:
-        self._records = self._read()
-        self._order = list(self._records)
-        for key, rec in self._records.items():
-            self._nav.add_item(key, text=self._label(rec), icon=self._icon(rec))
+    def _on_listview_select(self, _event: Any = None) -> None:
+        sel = self._listview.selection
+        if not sel:
+            return
+        self._selected = str(sel.get("id"))
+        self._on_select(self._selected)
 
     def _on_source_change(self, _event: Any = None) -> None:
-        """Reconcile the sidebar against the source (add / remove / update).
+        """React to a source change (the ListView refreshes its own rows).
 
-        Incremental: removed records drop their items, new records append, and
-        changed labels/icons update in place. Source reordering is not reflected
-        (new items append) — acceptable for a small nav list.
+        Re-render the open detail if the selected record changed in place, and
+        let the host reconcile the active selection (e.g. the selected record was
+        removed).
         """
         new = self._read()
-        old_keys = set(self._records)
-        new_keys = set(new)
-
-        for key in old_keys - new_keys:
-            self._nav.remove_item(key)
-            self._records.pop(key, None)
-            if key in self._order:
-                self._order.remove(key)
-
-        updated: set[str] = set()
-        for key, rec in new.items():
-            if key not in self._records:
-                self._order.append(key)
-                self._nav.add_item(key, text=self._label(rec), icon=self._icon(rec))
-            else:
-                old = self._records[key]
-                if self._label(old) != self._label(rec) or self._icon(old) != self._icon(rec):
-                    self._nav.update_item(key, text=self._label(rec), icon=self._icon(rec))
-                if old != rec:
-                    updated.add(key)
-            self._records[key] = rec
-
-        # If the selected record's data changed, re-render its detail in place
-        # (only then — no flicker on unrelated changes).
-        sel = self._nav.selected
-        if sel is not None and sel in updated:
-            self.show(sel)
-
+        key = self._selected
+        changed = (
+            key is not None and key in new and key in self._cache
+            and new[key] != self._cache[key]
+        )
+        self._cache = new
+        if changed:
+            self.show(key)
         if self._on_refresh is not None:
             self._on_refresh()
 
     def close(self) -> None:
-        """Cancel the source subscription."""
-        if self._sub is not None:
-            try:
-                self._sub.cancel()
-            except Exception:
-                pass
-            self._sub = None
+        """Cancel the selection + source subscriptions."""
+        for sub in (self._sub, self._src_sub):
+            if sub is not None:
+                try:
+                    sub.cancel()
+                except Exception:
+                    pass
+        self._sub = self._src_sub = None
 
     # ----- Provider contract -----
 
@@ -305,24 +294,35 @@ class ListNavProvider:
         pass
 
     def show(self, key: str, data: dict | None = None) -> None:
-        record = self._records.get(key)
+        record = self._cache.get(key)
         self._host.clear()
         if self._detail is not None and record is not None:
             with self._host:
                 self._detail(record)
 
     def select_visual(self, key: str | None) -> None:
-        self._nav.select(key)
+        self._selected = key
+        if key is None:
+            self._listview.clear_selection()
+            return
+        record = self._cache.get(key)
+        if record is not None:
+            self._listview.select_items([record.get("id")])
 
     def keys(self) -> tuple[str, ...]:
-        return tuple(self._order)
+        return tuple(self._read().keys())
 
     # ----- Accessors -----
 
     @property
-    def nav(self) -> NavPanel:
-        """The sidebar navigation panel."""
-        return self._nav
+    def nav(self) -> Any:
+        """The sidebar list widget (the `ListView`)."""
+        return self._listview
+
+    @property
+    def listview(self) -> Any:
+        """The sidebar `ListView`."""
+        return self._listview
 
 
 class TreeNavProvider:
@@ -382,6 +382,7 @@ class TreeNavProvider:
             "parent": self._sidebar_host,
             "selection_mode": "single",
             "show_scrollbar": False,
+            "density": "compact",   # dense, matching list_nav; distinct from the static pill nav
             "accent": self._accent,
             "fill": "both",
             "expand": True,

--- a/src/bootstack/widgets/_impl/composites/shell/providers.py
+++ b/src/bootstack/widgets/_impl/composites/shell/providers.py
@@ -191,10 +191,12 @@ class ListNavProvider:
         *,
         accent: str = "primary",
         separator: bool = False,
+        density: str = "default",
     ) -> None:
         self._source = source
         self._accent = accent
         self._separator = separator
+        self._density = density
         self._listview: Any = None
         self._host: ContentHost | None = None
         self._sidebar_host: ContentHost | None = None
@@ -226,7 +228,8 @@ class ListNavProvider:
             selection_mode="single",
             show_separators=self._separator,
             show_scrollbar=False,   # mousewheel scrolls; no always-on bar in a nav
-            density="compact",      # dense data list; also differentiates from the static pill nav
+            show_chevron=True,      # disclosure affordance — this is a nav list
+            density=self._density,
             accent=self._accent,
             fill="both",
             expand=True,
@@ -349,6 +352,7 @@ class TreeNavProvider:
         label_field: str = "name",
         icon_field: str = "icon",
         accent: str = "primary",
+        density: str = "default",
     ) -> None:
         self._nodes = nodes
         self._source = source
@@ -356,6 +360,7 @@ class TreeNavProvider:
         self._label_field = label_field
         self._icon_field = icon_field
         self._accent = accent
+        self._density = density
         self._tree: Any = None
         self._host: ContentHost | None = None
         self._sidebar_host: ContentHost | None = None
@@ -382,7 +387,7 @@ class TreeNavProvider:
             "parent": self._sidebar_host,
             "selection_mode": "single",
             "show_scrollbar": False,
-            "density": "compact",   # dense, matching list_nav; distinct from the static pill nav
+            "density": self._density,
             "accent": self._accent,
             "fill": "both",
             "expand": True,

--- a/src/bootstack/widgets/_impl/composites/shell/providers.py
+++ b/src/bootstack/widgets/_impl/composites/shell/providers.py
@@ -122,17 +122,9 @@ class StaticProvider:
         self._keys.append(key)
         return page
 
-    def add_header(self, text: str, *, collapsible: bool = False) -> Any:
-        """Add a section header (optionally a 1-level collapsible group)."""
-        return self._nav.add_header(text, collapsible=collapsible)
-
-    def expand_all(self) -> None:
-        """Expand every collapsible group."""
-        self._nav.expand_all()
-
-    def collapse_all(self) -> None:
-        """Collapse every collapsible group."""
-        self._nav.collapse_all()
+    def add_header(self, text: str) -> Any:
+        """Add a plain section-label header."""
+        return self._nav.add_header(text)
 
     def add_separator(self) -> Any:
         """Add a separator."""

--- a/src/bootstack/widgets/_impl/composites/shell/providers.py
+++ b/src/bootstack/widgets/_impl/composites/shell/providers.py
@@ -284,3 +284,137 @@ class ListNavProvider:
     def nav(self) -> NavPanel:
         """The sidebar navigation panel."""
         return self._nav
+
+
+class TreeNavProvider:
+    """Hierarchical, data-bound provider — a `Tree` drives the sidebar.
+
+    Nodes may be declared inline (`nodes=`) or projected from a flat
+    adjacency-list `source` (`source=`/`parent_field=`). Selecting a node
+    re-renders one `@detail` body with the node normalized to a record dict
+    (`text` from the node label, `icon`, the node id, plus the node's data bag) —
+    the same universal `.selection` shape `list_nav` uses (spec decision #10).
+
+    Hierarchy is incompatible with the icon-rail (a branch cannot render as one
+    glyph), so this provider does not support compaction.
+    """
+
+    supports_compact = False
+
+    def __init__(
+        self,
+        *,
+        nodes: list | None = None,
+        source: Any = None,
+        parent_field: str = "parent_id",
+        label_field: str = "name",
+        icon_field: str = "icon",
+        accent: str = "primary",
+    ) -> None:
+        self._nodes = nodes
+        self._source = source
+        self._parent_field = parent_field
+        self._label_field = label_field
+        self._icon_field = icon_field
+        self._accent = accent
+        self._tree: Any = None
+        self._host: ContentHost | None = None
+        self._sidebar_host: ContentHost | None = None
+        self._detail: Callable[[dict], Any] | None = None
+        self._on_select: Callable[[str], None] | None = None
+        self._nodes_by_key: dict[str, Any] = {}
+        self._sub: Any = None
+
+    def mount(
+        self,
+        sidebar: Frame,
+        content: Frame,
+        *,
+        on_select: Callable[[str], None],
+        on_refresh: Callable[[], None] | None = None,
+    ) -> None:
+        from bootstack.widgets.tree import Tree
+
+        self._on_select = on_select
+        self._host = ContentHost(content)
+        self._sidebar_host = ContentHost(sidebar)
+
+        tree_kwargs: dict[str, Any] = {
+            "parent": self._sidebar_host,
+            "selection_mode": "single",
+            "show_scrollbar": False,
+            "accent": self._accent,
+            "fill": "both",
+            "expand": True,
+        }
+        if self._source is not None:
+            tree_kwargs.update(
+                data_source=self._source,
+                parent_field=self._parent_field,
+                label_field=self._label_field,
+                icon_field=self._icon_field,
+            )
+        elif self._nodes is not None:
+            tree_kwargs["nodes"] = self._nodes
+        self._tree = Tree(**tree_kwargs)
+        self._sub = self._tree.on_select(self._on_tree_select)
+
+    def set_detail(self, fn: Callable[[dict], Any]) -> None:
+        """Register the parameterized detail body builder."""
+        self._detail = fn
+
+    # ----- Selection plumbing (node identity -> string key) -----
+
+    def _key_for(self, node: Any) -> str:
+        key = str(id(node))
+        self._nodes_by_key[key] = node
+        return key
+
+    def _record(self, node: Any, key: str) -> dict:
+        rec = dict(getattr(node, "data", {}) or {})
+        rec["text"] = node.label
+        rec["icon"] = node.icon
+        rec["id"] = key
+        return rec
+
+    def _on_tree_select(self, _event: Any) -> None:
+        node = self._tree.selection
+        if node is None:
+            return
+        self._on_select(self._key_for(node))
+
+    # ----- Provider contract -----
+
+    def show(self, key: str, data: dict | None = None) -> None:
+        node = self._nodes_by_key.get(key)
+        self._host.clear()
+        if self._detail is not None and node is not None:
+            with self._host:
+                self._detail(self._record(node, key))
+
+    def select_visual(self, key: str | None) -> None:
+        node = self._nodes_by_key.get(key) if key is not None else None
+        if node is not None:
+            self._tree.select(node)
+
+    def keys(self) -> tuple[str, ...]:
+        # Trees register keys lazily as nodes are selected (nodes may be created
+        # on expand). Empty until the first selection — so the shell never
+        # auto-selects a tree (a tree opens with nothing selected).
+        return tuple(self._nodes_by_key)
+
+    def close(self) -> None:
+        """Cancel the tree selection subscription."""
+        if self._sub is not None:
+            try:
+                self._sub.cancel()
+            except Exception:
+                pass
+            self._sub = None
+
+    # ----- Accessors -----
+
+    @property
+    def tree(self) -> Any:
+        """The sidebar `Tree` widget."""
+        return self._tree

--- a/src/bootstack/widgets/_impl/composites/shell/providers.py
+++ b/src/bootstack/widgets/_impl/composites/shell/providers.py
@@ -117,9 +117,17 @@ class StaticProvider:
         self._keys.append(key)
         return page
 
-    def add_header(self, text: str) -> Any:
-        """Add a static section header."""
-        return self._nav.add_header(text)
+    def add_header(self, text: str, *, collapsible: bool = False) -> Any:
+        """Add a section header (optionally a 1-level collapsible group)."""
+        return self._nav.add_header(text, collapsible=collapsible)
+
+    def expand_all(self) -> None:
+        """Expand every collapsible group."""
+        self._nav.expand_all()
+
+    def collapse_all(self) -> None:
+        """Collapse every collapsible group."""
+        self._nav.collapse_all()
 
     def add_separator(self) -> Any:
         """Add a separator."""
@@ -444,3 +452,54 @@ class TreeNavProvider:
     def tree(self) -> Any:
         """The sidebar `Tree` widget."""
         return self._tree
+
+
+class CustomProvider:
+    """Escape-hatch provider — a blank sidebar container the user fills.
+
+    There is no cascade and no per-page memory: the workspace hands back the
+    sidebar container (via `panel`) and its content region (via `Workspace.content`)
+    and the user drives content-switching themselves. A custom panel cannot
+    collapse to icons (its content is arbitrary), so `supports_compact` is False —
+    it only hides.
+    """
+
+    supports_compact = False
+
+    def __init__(self) -> None:
+        self._container: Frame | None = None
+        self._content: Frame | None = None
+
+    def mount(
+        self,
+        sidebar: Frame,
+        content: Frame,
+        *,
+        on_select: Callable[[str], None],
+        on_refresh: Callable[[], None] | None = None,
+    ) -> None:
+        # No selection model: on_select/on_refresh are unused.
+        self._container = Frame(sidebar)
+        self._container.pack(fill="both", expand=True)
+        self._content = content
+
+    # ----- Provider contract (mostly inert) -----
+
+    def set_compact(self, compact: bool) -> None:
+        pass
+
+    def show(self, key: str, data: dict | None = None) -> None:
+        pass
+
+    def select_visual(self, key: str | None) -> None:
+        pass
+
+    def keys(self) -> tuple[str, ...]:
+        return ()
+
+    # ----- Accessors -----
+
+    @property
+    def container(self) -> Frame:
+        """The blank sidebar container to fill."""
+        return self._container

--- a/src/bootstack/widgets/_impl/composites/shell/providers.py
+++ b/src/bootstack/widgets/_impl/composites/shell/providers.py
@@ -345,6 +345,7 @@ class TreeNavProvider:
         icon_field: str = "icon",
         accent: str = "primary",
         density: str = "default",
+        placeholder: str = "Select an item to view",
     ) -> None:
         self._nodes = nodes
         self._source = source
@@ -353,6 +354,7 @@ class TreeNavProvider:
         self._icon_field = icon_field
         self._accent = accent
         self._density = density
+        self._placeholder = placeholder
         self._tree: Any = None
         self._host: ContentHost | None = None
         self._sidebar_host: ContentHost | None = None
@@ -395,6 +397,16 @@ class TreeNavProvider:
             tree_kwargs["nodes"] = self._nodes
         self._tree = Tree(**tree_kwargs)
         self._sub = self._tree.on_select(self._on_tree_select)
+        # A tree opens with nothing selected, so the content area would be blank.
+        # Show a quiet placeholder until the first node is picked.
+        self._render_placeholder()
+
+    def _render_placeholder(self) -> None:
+        """Render a centered, muted empty-state in the content region."""
+        from bootstack.widgets._impl.primitives.label import Label
+
+        self._host.clear()
+        Label(self._host._internal, text=self._placeholder, accent="muted").pack(expand=True)
 
     def set_detail(self, fn: Callable[[dict], Any]) -> None:
         """Register the parameterized detail body builder."""
@@ -428,10 +440,12 @@ class TreeNavProvider:
 
     def show(self, key: str, data: dict | None = None) -> None:
         node = self._nodes_by_key.get(key)
-        self._host.clear()
         if self._detail is not None and node is not None:
+            self._host.clear()
             with self._host:
                 self._detail(self._record(node, key))
+        else:
+            self._render_placeholder()
 
     def select_visual(self, key: str | None) -> None:
         node = self._nodes_by_key.get(key) if key is not None else None

--- a/src/bootstack/widgets/_impl/composites/shell/providers.py
+++ b/src/bootstack/widgets/_impl/composites/shell/providers.py
@@ -184,11 +184,13 @@ class ListNavProvider:
         accent: str = "primary",
         separator: bool = False,
         density: str = "default",
+        placeholder: str = "Select an item to view",
     ) -> None:
         self._source = source
         self._accent = accent
         self._separator = separator
         self._density = density
+        self._placeholder = placeholder
         self._listview: Any = None
         self._host: ContentHost | None = None
         self._sidebar_host: ContentHost | None = None
@@ -232,6 +234,17 @@ class ListNavProvider:
         # re-render the open detail when the selected record changes in place and
         # to let the host reconcile selection on add/remove.
         self._src_sub = self._source.on_change(self._on_source_change)
+        # An empty source has no first record to auto-select, so the content area
+        # would be blank — show a quiet placeholder until rows arrive.
+        if not self._cache:
+            self._render_placeholder()
+
+    def _render_placeholder(self) -> None:
+        """Render a centered, muted empty-state in the content region."""
+        from bootstack.widgets._impl.primitives.label import Label
+
+        self._host.clear()
+        Label(self._host._internal, text=self._placeholder, accent="muted").pack(expand=True)
 
     def set_detail(self, fn: Callable[[dict], Any]) -> None:
         """Register the parameterized detail body builder."""
@@ -266,9 +279,15 @@ class ListNavProvider:
             key is not None and key in new and key in self._cache
             and new[key] != self._cache[key]
         )
+        emptied = bool(self._cache) and not new
         self._cache = new
         if changed:
             self.show(key)
+        elif emptied:
+            # The list drained to nothing — replace the stale detail with the
+            # placeholder (the host won't reconcile to a new selection).
+            self._selected = None
+            self._render_placeholder()
         if self._on_refresh is not None:
             self._on_refresh()
 
@@ -290,10 +309,12 @@ class ListNavProvider:
 
     def show(self, key: str, data: dict | None = None) -> None:
         record = self._cache.get(key)
-        self._host.clear()
         if self._detail is not None and record is not None:
+            self._host.clear()
             with self._host:
                 self._detail(record)
+        else:
+            self._render_placeholder()
 
     def select_visual(self, key: str | None) -> None:
         self._selected = key

--- a/src/bootstack/widgets/_impl/composites/shell/providers.py
+++ b/src/bootstack/widgets/_impl/composites/shell/providers.py
@@ -1,0 +1,116 @@
+"""Navigation providers — what fills a workspace's sidebar panel.
+
+A provider owns one workspace's sidebar UI *and* its content-rendering strategy,
+behind a small contract: populate the sidebar, report selections via an
+`on_select` callback, and render content for the active key. The shell hosts one
+provider per workspace, routes selections through `NavModel`, and asks the active
+provider to show content. This is the seam that lets static (`add_page`) and the
+data-bound providers (`list_nav`/`tree_nav`, later) be interchangeable.
+
+`StaticProvider` is the first concrete provider: authored items, each with its
+own authored page (N items -> N independent bodies), rendered through a
+`PageStack`.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Protocol, runtime_checkable
+
+from bootstack.widgets._impl.primitives.frame import Frame
+from bootstack.widgets._impl.composites.pagestack import PageStack
+from bootstack.widgets._impl.composites.shell.nav_panel import NavPanel
+
+
+@runtime_checkable
+class NavProvider(Protocol):
+    """The contract a workspace's sidebar provider fulfills.
+
+    A provider populates the sidebar and renders content; selection truth lives
+    in the shell's `NavModel`, so the provider only *reports* clicks (via the
+    `on_select` callback given to `mount`) and *reflects* the active key (via
+    `select_visual` / `show`).
+    """
+
+    supports_compact: bool
+    """Whether the sidebar may collapse to an icon rail (false for custom panels)."""
+
+    def mount(self, sidebar: Frame, content: Frame, *, on_select: Callable[[str], None]) -> None:
+        """Build the sidebar UI in `sidebar` and prepare the `content` region."""
+        ...
+
+    def show(self, key: str, data: dict | None = None) -> None:
+        """Render content for the selected `key`."""
+        ...
+
+    def select_visual(self, key: str | None) -> None:
+        """Reflect the active `key` in the sidebar's selection visual."""
+        ...
+
+    def keys(self) -> tuple[str, ...]:
+        """All selectable keys this provider exposes."""
+        ...
+
+
+class StaticProvider:
+    """Static provider — authored items, each with its own authored page.
+
+    Args:
+        accent: Accent token for the active nav item.
+    """
+
+    supports_compact = True
+
+    def __init__(self, *, accent: str = "primary") -> None:
+        self._accent = accent
+        self._nav: NavPanel | None = None
+        self._pages: PageStack | None = None
+        self._keys: list[str] = []
+
+    def mount(self, sidebar: Frame, content: Frame, *, on_select: Callable[[str], None]) -> None:
+        self._nav = NavPanel(sidebar, on_select=on_select, accent=self._accent)
+        self._nav.pack(fill="both", expand=True)
+        self._pages = PageStack(content)
+        self._pages.pack(fill="both", expand=True)
+
+    # ----- Authoring -----
+
+    def add_page(self, key: str, *, text: str = "", icon=None, footer: bool = False) -> Any:
+        """Add a nav item and its page; return the page frame."""
+        page = self._pages.add(key)
+        if footer:
+            self._nav.add_footer_item(key, text=text, icon=icon)
+        else:
+            self._nav.add_item(key, text=text, icon=icon)
+        self._keys.append(key)
+        return page
+
+    def add_header(self, text: str) -> Any:
+        """Add a static section header."""
+        return self._nav.add_header(text)
+
+    def add_separator(self) -> Any:
+        """Add a separator."""
+        return self._nav.add_separator()
+
+    # ----- Provider contract -----
+
+    def show(self, key: str, data: dict | None = None) -> None:
+        self._pages.navigate(key, data=data)
+
+    def select_visual(self, key: str | None) -> None:
+        self._nav.select(key)
+
+    def keys(self) -> tuple[str, ...]:
+        return tuple(self._keys)
+
+    # ----- Accessors -----
+
+    @property
+    def nav(self) -> NavPanel:
+        """The sidebar navigation panel."""
+        return self._nav
+
+    @property
+    def pages(self) -> PageStack:
+        """The content page deck."""
+        return self._pages

--- a/src/bootstack/widgets/_impl/composites/shell/providers.py
+++ b/src/bootstack/widgets/_impl/composites/shell/providers.py
@@ -35,8 +35,19 @@ class NavProvider(Protocol):
     supports_compact: bool
     """Whether the sidebar may collapse to an icon rail (false for custom panels)."""
 
-    def mount(self, sidebar: Frame, content: Frame, *, on_select: Callable[[str], None]) -> None:
-        """Build the sidebar UI in `sidebar` and prepare the `content` region."""
+    def mount(
+        self,
+        sidebar: Frame,
+        content: Frame,
+        *,
+        on_select: Callable[[str], None],
+        on_refresh: Callable[[], None] | None = None,
+    ) -> None:
+        """Build the sidebar UI in `sidebar` and prepare the `content` region.
+
+        `on_refresh` (optional) is invoked after the provider rebuilds its items
+        from a changed source, so the host can reconcile the active selection.
+        """
         ...
 
     def show(self, key: str, data: dict | None = None) -> None:
@@ -67,7 +78,15 @@ class StaticProvider:
         self._pages: PageStack | None = None
         self._keys: list[str] = []
 
-    def mount(self, sidebar: Frame, content: Frame, *, on_select: Callable[[str], None]) -> None:
+    def mount(
+        self,
+        sidebar: Frame,
+        content: Frame,
+        *,
+        on_select: Callable[[str], None],
+        on_refresh: Callable[[], None] | None = None,
+    ) -> None:
+        # Static authoring never refreshes from a source; on_refresh is ignored.
         self._nav = NavPanel(sidebar, on_select=on_select, accent=self._accent)
         self._nav.pack(fill="both", expand=True)
         self._pages = PageStack(content)
@@ -151,31 +170,98 @@ class ListNavProvider:
         self._detail: Callable[[dict], Any] | None = None
         self._records: dict[str, dict] = {}
         self._order: list[str] = []
+        self._on_refresh: Callable[[], None] | None = None
+        self._sub: Any = None
 
-    def mount(self, sidebar: Frame, content: Frame, *, on_select: Callable[[str], None]) -> None:
+    def mount(
+        self,
+        sidebar: Frame,
+        content: Frame,
+        *,
+        on_select: Callable[[str], None],
+        on_refresh: Callable[[], None] | None = None,
+    ) -> None:
+        self._on_refresh = on_refresh
         self._nav = NavPanel(sidebar, on_select=on_select, accent=self._accent)
         self._nav.pack(fill="both", expand=True)
         self._host = ContentHost(content)
         self._populate()
+        # Live updates: rebuild items when the source changes (delivered on the
+        # UI thread by the data layer). Stored so it can be cancelled on close.
+        self._sub = self._source.on_change(self._on_source_change)
 
     def set_detail(self, fn: Callable[[dict], Any]) -> None:
         """Register the parameterized detail body builder."""
         self._detail = fn
 
-    def _populate(self) -> None:
-        self._records.clear()
-        self._order.clear()
+    def _read(self) -> dict[str, dict]:
+        """Read all current public records keyed by id, in source order."""
         src = self._source
-        records = [src._public_record(r) for r in src.page_slice(0, src.count)]
-        for rec in records:
-            key = str(rec.get("id"))
+        out: dict[str, dict] = {}
+        for raw in src.page_slice(0, src.count):
+            rec = src._public_record(raw)
+            out[str(rec.get("id"))] = rec
+        return out
+
+    def _label(self, rec: dict) -> str:
+        return str(rec.get(self._text_field, ""))
+
+    def _icon(self, rec: dict):
+        return rec.get(self._icon_field)
+
+    def _populate(self) -> None:
+        self._records = self._read()
+        self._order = list(self._records)
+        for key, rec in self._records.items():
+            self._nav.add_item(key, text=self._label(rec), icon=self._icon(rec))
+
+    def _on_source_change(self, _event: Any = None) -> None:
+        """Reconcile the sidebar against the source (add / remove / update).
+
+        Incremental: removed records drop their items, new records append, and
+        changed labels/icons update in place. Source reordering is not reflected
+        (new items append) — acceptable for a small nav list.
+        """
+        new = self._read()
+        old_keys = set(self._records)
+        new_keys = set(new)
+
+        for key in old_keys - new_keys:
+            self._nav.remove_item(key)
+            self._records.pop(key, None)
+            if key in self._order:
+                self._order.remove(key)
+
+        updated: set[str] = set()
+        for key, rec in new.items():
+            if key not in self._records:
+                self._order.append(key)
+                self._nav.add_item(key, text=self._label(rec), icon=self._icon(rec))
+            else:
+                old = self._records[key]
+                if self._label(old) != self._label(rec) or self._icon(old) != self._icon(rec):
+                    self._nav.update_item(key, text=self._label(rec), icon=self._icon(rec))
+                if old != rec:
+                    updated.add(key)
             self._records[key] = rec
-            self._order.append(key)
-            self._nav.add_item(
-                key,
-                text=str(rec.get(self._text_field, "")),
-                icon=rec.get(self._icon_field),
-            )
+
+        # If the selected record's data changed, re-render its detail in place
+        # (only then — no flicker on unrelated changes).
+        sel = self._nav.selected
+        if sel is not None and sel in updated:
+            self.show(sel)
+
+        if self._on_refresh is not None:
+            self._on_refresh()
+
+    def close(self) -> None:
+        """Cancel the source subscription."""
+        if self._sub is not None:
+            try:
+                self._sub.cancel()
+            except Exception:
+                pass
+            self._sub = None
 
     # ----- Provider contract -----
 

--- a/src/bootstack/widgets/_impl/composites/shell/providers.py
+++ b/src/bootstack/widgets/_impl/composites/shell/providers.py
@@ -18,6 +18,7 @@ from typing import Any, Callable, Protocol, runtime_checkable
 
 from bootstack.widgets._impl.primitives.frame import Frame
 from bootstack.widgets._impl.composites.pagestack import PageStack
+from bootstack.widgets._impl.composites.shell.content_host import ContentHost
 from bootstack.widgets._impl.composites.shell.nav_panel import NavPanel
 
 
@@ -114,3 +115,86 @@ class StaticProvider:
     def pages(self) -> PageStack:
         """The content page deck."""
         return self._pages
+
+
+class ListNavProvider:
+    """Flat, data-bound provider — a `DataSource` drives the sidebar list.
+
+    Each record becomes a single-select nav item (keyed by record id); selecting
+    one re-renders a single `@detail` body parameterized by that record. The
+    detail body receives the **public record dict** (the universal `.selection`
+    shape) — not a bespoke node object.
+
+    Args:
+        source: A `DataSourceProtocol` supplying records.
+        text_field: Record field used for the item label.
+        icon_field: Record field used for the item icon.
+        accent: Accent token for the active nav item.
+    """
+
+    supports_compact = True
+
+    def __init__(
+        self,
+        source: Any,
+        *,
+        text_field: str = "text",
+        icon_field: str = "icon",
+        accent: str = "primary",
+    ) -> None:
+        self._source = source
+        self._text_field = text_field
+        self._icon_field = icon_field
+        self._accent = accent
+        self._nav: NavPanel | None = None
+        self._host: ContentHost | None = None
+        self._detail: Callable[[dict], Any] | None = None
+        self._records: dict[str, dict] = {}
+        self._order: list[str] = []
+
+    def mount(self, sidebar: Frame, content: Frame, *, on_select: Callable[[str], None]) -> None:
+        self._nav = NavPanel(sidebar, on_select=on_select, accent=self._accent)
+        self._nav.pack(fill="both", expand=True)
+        self._host = ContentHost(content)
+        self._populate()
+
+    def set_detail(self, fn: Callable[[dict], Any]) -> None:
+        """Register the parameterized detail body builder."""
+        self._detail = fn
+
+    def _populate(self) -> None:
+        self._records.clear()
+        self._order.clear()
+        src = self._source
+        records = [src._public_record(r) for r in src.page_slice(0, src.count)]
+        for rec in records:
+            key = str(rec.get("id"))
+            self._records[key] = rec
+            self._order.append(key)
+            self._nav.add_item(
+                key,
+                text=str(rec.get(self._text_field, "")),
+                icon=rec.get(self._icon_field),
+            )
+
+    # ----- Provider contract -----
+
+    def show(self, key: str, data: dict | None = None) -> None:
+        record = self._records.get(key)
+        self._host.clear()
+        if self._detail is not None and record is not None:
+            with self._host:
+                self._detail(record)
+
+    def select_visual(self, key: str | None) -> None:
+        self._nav.select(key)
+
+    def keys(self) -> tuple[str, ...]:
+        return tuple(self._order)
+
+    # ----- Accessors -----
+
+    @property
+    def nav(self) -> NavPanel:
+        """The sidebar navigation panel."""
+        return self._nav

--- a/src/bootstack/widgets/_impl/composites/shell/rail.py
+++ b/src/bootstack/widgets/_impl/composites/shell/rail.py
@@ -1,0 +1,93 @@
+"""The workspace rail — the tier-1 icon switcher.
+
+A vertical strip of icon-only items, one per workspace, with a pinned footer
+(for global workspaces like Settings). Selection is single and driven externally
+by the shell from `NavModel` (the VS Code gesture lives in the model); the rail
+just reports clicks and reflects the active workspace.
+
+Rail items reuse `SideNavItem` in compact (icon-only) mode, which renders the
+sidebar's subtle accent wash with no left bar — matching decision #13's rail
+paradigm (wash + glyph, no bar). The decision-#13 icon-size / elevation tokens
+are applied in the styling step.
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+from bootstack.widgets._impl.primitives.frame import Frame
+from bootstack.widgets._impl.composites.sidenav.item import SideNavItem
+
+
+class Rail(Frame):
+    """A single-select icon rail of workspaces.
+
+    Args:
+        master: Parent widget (the rail region).
+        on_select: Called with a workspace key when its icon is clicked.
+        accent: Accent token for the active item.
+    """
+
+    # Rail glyphs read as standalone, categorical marks — distinctly larger than
+    # the inline sidebar icons (~20px). Decision #13's rail_icon_size.
+    DEFAULT_ICON_SIZE = 28
+
+    def __init__(
+        self,
+        master,
+        *,
+        on_select: Callable[[str], None],
+        accent: str = "primary",
+        icon_size: int | None = None,
+    ) -> None:
+        super().__init__(master, surface="chrome")
+        self._on_select = on_select
+        self._accent = accent
+        self._icon_size = icon_size if icon_size is not None else self.DEFAULT_ICON_SIZE
+        self._items: dict[str, SideNavItem] = {}
+        self._selected: str | None = None
+
+        self._footer = Frame(self, surface="chrome")
+        self._footer.pack(side="bottom", fill="x")
+        self._main = Frame(self, surface="chrome")
+        self._main.pack(side="top", fill="both", expand=True)
+
+    def add_workspace(self, key: str, *, icon=None, text: str = "", footer: bool = False) -> SideNavItem:
+        """Add a workspace icon to the rail (or its footer)."""
+        if key in self._items:
+            raise ValueError(f"duplicate rail key: {key!r}")
+        parent = self._footer if footer else self._main
+        # Render the glyph at the larger rail size (explicit spec size overrides
+        # the nav label style's default 20px).
+        spec = self._icon_spec(icon)
+        item = SideNavItem(parent, key=key, text=text, icon=spec, accent=self._accent)
+        item.set_compact(True)              # icon-only, centered
+        item.pack(fill="x")
+        item.on_invoked(lambda _event, k=key: self._on_select(k))
+        self._items[key] = item
+        return item
+
+    def _icon_spec(self, icon):
+        """Normalize an icon name/spec to carry the rail icon size."""
+        if icon is None:
+            return None
+        if isinstance(icon, dict):
+            spec = dict(icon)
+            spec.setdefault("size", self._icon_size)
+            return spec
+        return {"name": icon, "size": self._icon_size}
+
+    def select(self, key: str | None) -> None:
+        """Set the visual selection to `key` (or clear with `None`)."""
+        for k, item in self._items.items():
+            item.set_selected(k == key)
+        self._selected = key
+
+    @property
+    def selected(self) -> str | None:
+        """The selected workspace key, or `None`."""
+        return self._selected
+
+    def keys(self) -> tuple[str, ...]:
+        """All workspace keys in insertion order."""
+        return tuple(self._items)

--- a/src/bootstack/widgets/_impl/composites/shell/rail.py
+++ b/src/bootstack/widgets/_impl/composites/shell/rail.py
@@ -1,26 +1,32 @@
 """The workspace rail — the tier-1 icon switcher.
 
 A vertical strip of icon-only items, one per workspace, with a pinned footer
-(for global workspaces like Settings). Selection is single and driven externally
-by the shell from `NavModel` (the VS Code gesture lives in the model); the rail
-just reports clicks and reflects the active workspace.
+(for global workspaces like Settings). The rail is a single-select **radio
+group**: every item is a `RadioToggle` sharing one `Signal`, so single-select is
+the radio machinery itself — no hand-rolled selection state.
 
-Rail items reuse `SideNavItem` in compact (icon-only) mode, which renders the
-sidebar's subtle accent wash with no left bar — matching decision #13's rail
-paradigm (wash + glyph, no bar). The decision-#13 icon-size / elevation tokens
-are applied in the styling step.
+The items use the `rail` Toolbutton style variant (the VS Code activity-bar
+treatment: muted glyph -> full-strength glyph + accent indicator bar on the
+chrome surface). Selection truth still lives in the shell's `NavModel`; the rail
+reports clicks and reflects the active workspace by setting its shared signal.
+
+The VS Code gesture (click the active icon -> hide the sidebar) needs *every*
+click — including a re-click on the already-selected item, which a radio does not
+report as a change — so each item also has a direct click binding that routes to
+the shell.
 """
 
 from __future__ import annotations
 
 from typing import Callable
 
+from bootstack.signals import Signal
 from bootstack.widgets._impl.primitives.frame import Frame
-from bootstack.widgets._impl.composites.sidenav.item import SideNavItem
+from bootstack.widgets._impl.primitives.radiotoggle import RadioToggle
 
 
 class Rail(Frame):
-    """A single-select icon rail of workspaces.
+    """A single-select icon rail of workspaces (a radio-toggle group).
 
     Args:
         master: Parent widget (the rail region).
@@ -29,7 +35,7 @@ class Rail(Frame):
     """
 
     # Rail glyphs read as standalone, categorical marks — distinctly larger than
-    # the inline sidebar icons (~20px). Decision #13's rail_icon_size.
+    # the inline sidebar icons. Decision #13's rail_icon_size.
     DEFAULT_ICON_SIZE = 28
 
     def __init__(
@@ -44,26 +50,37 @@ class Rail(Frame):
         self._on_select = on_select
         self._accent = accent
         self._icon_size = icon_size if icon_size is not None else self.DEFAULT_ICON_SIZE
-        self._items: dict[str, SideNavItem] = {}
-        self._selected: str | None = None
+        # Shared selection signal: the value is the active workspace key, so the
+        # matching RadioToggle renders selected (radio single-select). A Signal is
+        # typed by its initial value, so use an empty-string sentinel for "none"
+        # (no workspace key is empty) rather than None.
+        self._signal: Signal = Signal("")
+        self._items: dict[str, RadioToggle] = {}
 
         self._footer = Frame(self, surface="chrome")
         self._footer.pack(side="bottom", fill="x")
         self._main = Frame(self, surface="chrome")
         self._main.pack(side="top", fill="both", expand=True)
 
-    def add_workspace(self, key: str, *, icon=None, text: str = "", footer: bool = False) -> SideNavItem:
+    def add_workspace(self, key: str, *, icon=None, text: str = "", footer: bool = False) -> RadioToggle:
         """Add a workspace icon to the rail (or its footer)."""
         if key in self._items:
             raise ValueError(f"duplicate rail key: {key!r}")
         parent = self._footer if footer else self._main
-        # Render the glyph at the larger rail size (explicit spec size overrides
-        # the nav label style's default 20px).
-        spec = self._icon_spec(icon)
-        item = SideNavItem(parent, key=key, text=text, icon=spec, accent=self._accent)
-        item.set_compact(True)              # icon-only, centered
+        item = RadioToggle(
+            parent,
+            value=key,
+            signal=self._signal,
+            icon=self._icon_spec(icon),
+            icon_only=True,
+            accent=self._accent,
+            variant="rail",
+            surface="chrome",
+        )
         item.pack(fill="x")
-        item.on_invoked(lambda _event, k=key: self._on_select(k))
+        # Catch ALL clicks (including a re-click on the active item) so the shell
+        # can run the VS Code gesture; the radio itself only reports changes.
+        item.bind("<Button-1>", lambda _e, k=key: self._on_select(k), add="+")
         self._items[key] = item
         return item
 
@@ -79,14 +96,12 @@ class Rail(Frame):
 
     def select(self, key: str | None) -> None:
         """Set the visual selection to `key` (or clear with `None`)."""
-        for k, item in self._items.items():
-            item.set_selected(k == key)
-        self._selected = key
+        self._signal.set(key if key is not None else "")
 
     @property
     def selected(self) -> str | None:
         """The selected workspace key, or `None`."""
-        return self._selected
+        return self._signal() or None
 
     def keys(self) -> tuple[str, ...]:
         """All workspace keys in insertion order."""

--- a/src/bootstack/widgets/_impl/composites/shell/rail.py
+++ b/src/bootstack/widgets/_impl/composites/shell/rail.py
@@ -45,10 +45,12 @@ class Rail(Frame):
         on_select: Callable[[str], None],
         accent: str = "primary",
         icon_size: int | None = None,
+        labels: bool = False,
     ) -> None:
         super().__init__(master, surface="chrome")
         self._on_select = on_select
         self._accent = accent
+        self._labels = labels
         self._icon_size = icon_size if icon_size is not None else self.DEFAULT_ICON_SIZE
         # Shared selection signal: the value is the active workspace key, so the
         # matching RadioToggle renders selected (radio single-select). A Signal is
@@ -67,16 +69,21 @@ class Rail(Frame):
         if key in self._items:
             raise ValueError(f"duplicate rail key: {key!r}")
         parent = self._footer if footer else self._main
-        item = RadioToggle(
-            parent,
+        # Labeled rail: a small caption under the icon (compound='top'); otherwise
+        # icon-only (relies on tooltips for discoverability — a future add).
+        toggle_kwargs: dict = dict(
             value=key,
             signal=self._signal,
             icon=self._icon_spec(icon),
-            icon_only=True,
             accent=self._accent,
             variant="rail",
             surface="chrome",
         )
+        if self._labels:
+            toggle_kwargs.update(text=text, compound="top", style_options={"labeled": True})
+        else:
+            toggle_kwargs.update(icon_only=True)
+        item = RadioToggle(parent, **toggle_kwargs)
         item.pack(fill="x")
         # Catch ALL clicks (including a re-click on the active item) so the shell
         # can run the VS Code gesture; the radio itself only reports changes.

--- a/src/bootstack/widgets/_impl/composites/shell/shell.py
+++ b/src/bootstack/widgets/_impl/composites/shell/shell.py
@@ -26,6 +26,7 @@ from bootstack.widgets._impl.composites.shell.layout import ShellLayout
 from bootstack.widgets._impl.composites.shell.providers import (
     ListNavProvider,
     StaticProvider,
+    TreeNavProvider,
 )
 
 
@@ -159,6 +160,39 @@ class Shell(ShellLayout):
         self._claim_provider()
         self._provider = ListNavProvider(
             source, text_field=text_field, icon_field=icon_field, accent=self._nav_accent
+        )
+        self._mount_provider()
+        return self._provider
+
+    def tree_nav(
+        self,
+        *,
+        nodes: list | None = None,
+        source: Any = None,
+        parent_field: str = "parent_id",
+        label_field: str = "name",
+        icon_field: str = "icon",
+    ) -> Any:
+        """Fill the workspace from a hierarchy (tree master-detail).
+
+        Pass `nodes=` for an inline hierarchy, or `source=`/`parent_field=` to
+        project a flat adjacency-list `DataSource`. Pair with `@detail` to render
+        the selected node. A tree opens with nothing selected.
+
+        Returns:
+            The `TreeNavProvider`.
+
+        Raises:
+            RuntimeError: If the workspace already has a provider.
+        """
+        self._claim_provider()
+        self._provider = TreeNavProvider(
+            nodes=nodes,
+            source=source,
+            parent_field=parent_field,
+            label_field=label_field,
+            icon_field=icon_field,
+            accent=self._nav_accent,
         )
         self._mount_provider()
         return self._provider

--- a/src/bootstack/widgets/_impl/composites/shell/shell.py
+++ b/src/bootstack/widgets/_impl/composites/shell/shell.py
@@ -103,12 +103,19 @@ class Shell(ShellLayout):
     def _create_workspace(self, key: str, *, text: str = "", icon=None, is_footer: bool = False) -> Workspace:
         panel = self._panel_stack.add(key)
         content = self._content_stack.add(key)
+        # Tier-relative static treatment: the implicit default workspace is the
+        # standalone primary nav (no rail) -> prominent pills; a named workspace
+        # sits under the rail -> quiet rows. (list_nav/tree keep their own row
+        # language regardless; only the static provider reads this.)
+        nav_variant = "nav-pill" if key == _DEFAULT_WORKSPACE else "nav-quiet"
         ws = Workspace(
             key, panel, content,
             nav_accent=self._nav_accent,
             on_select=self._workspace_select,
             on_refresh=self._workspace_refresh,
             on_first_page=self._on_first_page,
+            nav_variant=nav_variant,
+            nav_surface=self.sidebar_surface,
         )
         self._workspaces[key] = ws
         # The implicit default workspace never gets a rail icon (single-tier).

--- a/src/bootstack/widgets/_impl/composites/shell/shell.py
+++ b/src/bootstack/widgets/_impl/composites/shell/shell.py
@@ -185,9 +185,18 @@ class Shell(ShellLayout):
         """Claim the implicit workspace as a custom panel; return its container."""
         return self._default_workspace().panel()
 
-    def list_nav(self, source: Any, *, separator: bool = False, density: str = "default") -> Any:
+    def list_nav(
+        self,
+        source: Any,
+        *,
+        separator: bool = False,
+        density: str = "default",
+        placeholder: str = "Select an item to view",
+    ) -> Any:
         """Fill the implicit workspace from a `DataSource` (flat master-detail)."""
-        return self._default_workspace().list_nav(source, separator=separator, density=density)
+        return self._default_workspace().list_nav(
+            source, separator=separator, density=density, placeholder=placeholder
+        )
 
     def tree_nav(self, **kwargs: Any) -> Any:
         """Fill the implicit workspace from a hierarchy (tree master-detail)."""

--- a/src/bootstack/widgets/_impl/composites/shell/shell.py
+++ b/src/bootstack/widgets/_impl/composites/shell/shell.py
@@ -19,6 +19,7 @@ from bootstack.widgets._core.navmodel import NavChange, NavModel, SidebarMode
 from bootstack.widgets._impl.composites.pagestack import PageStack
 from bootstack.widgets._impl.composites.shell.layout import ShellLayout
 from bootstack.widgets._impl.composites.shell.nav_panel import NavPanel
+from bootstack.widgets._impl.composites.shell.providers import StaticProvider
 
 
 # Key of the implicit single workspace backing the shell-level page methods.
@@ -57,19 +58,18 @@ class Shell(ShellLayout):
         self._page_keys: set[str] = set()
         self._pending_data: dict | None = None
 
-        # Content deck (active page) + nav panel (sidebar items).
-        self._pages = PageStack(self.content)
-        self._pages.pack(fill="both", expand=True)
-        self._nav = NavPanel(self.sidebar, on_select=self._on_nav_select, accent=nav_accent)
-        self._nav.pack(fill="both", expand=True)
+        # One provider fills the sidebar + content for the (single, implicit)
+        # workspace. Static is the default; data-bound providers slot in later.
+        self._provider = StaticProvider(accent=nav_accent)
+        self._provider.mount(self.sidebar, self.content, on_select=self._on_nav_select)
 
         # React to model changes; re-emit page changes on the shell itself.
         self._model.subscribe(self._on_model_change)
-        self._pages.on_page_changed(self._reemit_page_change)
+        self._provider.pages.on_page_changed(self._reemit_page_change)
 
     # ----- Content API -----
 
-    def add_page(self, key: str, *, text: str = "", icon=None) -> Any:
+    def add_page(self, key: str, *, text: str = "", icon=None, footer: bool = False) -> Any:
         """Add a nav item and its page; return the page frame.
 
         The first page added is auto-selected so the content area is never
@@ -79,6 +79,7 @@ class Shell(ShellLayout):
             key: Unique key for the nav item and page.
             text: Sidebar label.
             icon: Icon name or icon-spec dict.
+            footer: Pin the nav item to the sidebar footer.
 
         Returns:
             The page `Frame` to parent content into.
@@ -94,13 +95,24 @@ class Shell(ShellLayout):
         if not self._model.has_workspace(_DEFAULT_WORKSPACE):
             self._model.add_workspace(_DEFAULT_WORKSPACE)
 
-        page = self._pages.add(key)
-        self._nav.add_item(key, text=text, icon=icon)
+        page = self._provider.add_page(key, text=text, icon=icon, footer=footer)
         self._page_keys.add(key)
 
         if self._model.active_page() is None:
             self.navigate(key)
         return page
+
+    def add_footer_page(self, key: str, *, text: str = "", icon=None) -> Any:
+        """Add a nav item pinned to the sidebar footer and its page."""
+        return self.add_page(key, text=text, icon=icon, footer=True)
+
+    def add_header(self, text: str) -> Any:
+        """Add a static section header to the sidebar."""
+        return self._provider.add_header(text)
+
+    def add_separator(self) -> Any:
+        """Add a separator to the sidebar."""
+        return self._provider.add_separator()
 
     # ----- Navigation -----
 
@@ -137,8 +149,8 @@ class Shell(ShellLayout):
     def _sync_page(self, key: str) -> None:
         data = self._pending_data
         self._pending_data = None
-        self._nav.select(key)
-        self._pages.navigate(key, data=data)
+        self._provider.select_visual(key)
+        self._provider.show(key, data=data)
 
     def _reemit_page_change(self, event: Any) -> None:
         # Surface the PageStack's change on the shell so consumers bind one place.
@@ -152,11 +164,16 @@ class Shell(ShellLayout):
         return self._model
 
     @property
+    def provider(self) -> StaticProvider:
+        """The active workspace's navigation provider."""
+        return self._provider
+
+    @property
     def pages(self) -> PageStack:
-        """The content page deck."""
-        return self._pages
+        """The content page deck of the active provider."""
+        return self._provider.pages
 
     @property
     def nav(self) -> NavPanel:
-        """The sidebar navigation panel."""
-        return self._nav
+        """The sidebar navigation panel of the active provider."""
+        return self._provider.nav

--- a/src/bootstack/widgets/_impl/composites/shell/shell.py
+++ b/src/bootstack/widgets/_impl/composites/shell/shell.py
@@ -197,9 +197,9 @@ class Shell(ShellLayout):
         if ws is not None:
             ws.collapse_all()
 
-    def list_nav(self, source: Any, *, text_field: str = "text", icon_field: str = "icon") -> Any:
+    def list_nav(self, source: Any, *, separator: bool = False) -> Any:
         """Fill the implicit workspace from a `DataSource` (flat master-detail)."""
-        return self._default_workspace().list_nav(source, text_field=text_field, icon_field=icon_field)
+        return self._default_workspace().list_nav(source, separator=separator)
 
     def tree_nav(self, **kwargs: Any) -> Any:
         """Fill the implicit workspace from a hierarchy (tree master-detail)."""

--- a/src/bootstack/widgets/_impl/composites/shell/shell.py
+++ b/src/bootstack/widgets/_impl/composites/shell/shell.py
@@ -1,0 +1,162 @@
+"""The shell composite — wires `NavModel` to the region layout (single-tier).
+
+`Shell` ties Layer 1 (`ShellLayout` regions) to Layer 2 (`NavModel`): it puts a
+content page deck in the `content` region and a `NavPanel` in the `sidebar`, and
+`add_page()` registers a page + a nav item so that selecting an item swaps the
+content. The `NavModel` is the single source of truth; the view reacts to its
+notifications.
+
+This step implements the single-tier path only — one implicit workspace, so the
+rail stays hidden. Workspaces / the rail, data-bound providers, and collapse are
+layered on in later steps (see `docs/_dev/appshell-navigation-spec.md`).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from bootstack.widgets._core.navmodel import NavChange, NavModel, SidebarMode
+from bootstack.widgets._impl.composites.pagestack import PageStack
+from bootstack.widgets._impl.composites.shell.layout import ShellLayout
+from bootstack.widgets._impl.composites.shell.nav_panel import NavPanel
+
+
+# Key of the implicit single workspace backing the shell-level page methods.
+_DEFAULT_WORKSPACE = "__shell__"
+
+
+class Shell(ShellLayout):
+    """Application shell with single-tier page navigation.
+
+    Args:
+        title: Window title.
+        theme: Theme name, or None for the default.
+        size: Initial window size as `(width, height)`.
+        undecorated: Remove OS chrome and draw a custom border.
+        sidebar_mode: Initial sidebar mode (`'expanded'`/`'compact'`/`'hidden'`).
+        nav_accent: Accent token for the active nav item.
+        **kwargs: Forwarded to `ShellLayout` / `App` (widths, position, etc.).
+    """
+
+    def __init__(
+        self,
+        *,
+        title: str = "",
+        theme: str | None = None,
+        size: tuple[int, int] | None = None,
+        undecorated: bool = False,
+        sidebar_mode: SidebarMode = "expanded",
+        nav_accent: str = "primary",
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            title=title, theme=theme, size=size, undecorated=undecorated, **kwargs
+        )
+
+        self._model = NavModel(sidebar_mode=sidebar_mode)
+        self._page_keys: set[str] = set()
+        self._pending_data: dict | None = None
+
+        # Content deck (active page) + nav panel (sidebar items).
+        self._pages = PageStack(self.content)
+        self._pages.pack(fill="both", expand=True)
+        self._nav = NavPanel(self.sidebar, on_select=self._on_nav_select, accent=nav_accent)
+        self._nav.pack(fill="both", expand=True)
+
+        # React to model changes; re-emit page changes on the shell itself.
+        self._model.subscribe(self._on_model_change)
+        self._pages.on_page_changed(self._reemit_page_change)
+
+    # ----- Content API -----
+
+    def add_page(self, key: str, *, text: str = "", icon=None) -> Any:
+        """Add a nav item and its page; return the page frame.
+
+        The first page added is auto-selected so the content area is never
+        blank.
+
+        Args:
+            key: Unique key for the nav item and page.
+            text: Sidebar label.
+            icon: Icon name or icon-spec dict.
+
+        Returns:
+            The page `Frame` to parent content into.
+
+        Raises:
+            ValueError: If `key` is empty or already used.
+        """
+        if not key:
+            raise ValueError("page key must be non-empty")
+        if key in self._page_keys:
+            raise ValueError(f"duplicate page key: {key!r}")
+
+        if not self._model.has_workspace(_DEFAULT_WORKSPACE):
+            self._model.add_workspace(_DEFAULT_WORKSPACE)
+
+        page = self._pages.add(key)
+        self._nav.add_item(key, text=text, icon=icon)
+        self._page_keys.add(key)
+
+        if self._model.active_page() is None:
+            self.navigate(key)
+        return page
+
+    # ----- Navigation -----
+
+    def navigate(self, key: str, data: dict | None = None) -> None:
+        """Navigate to a page, updating the nav selection and content.
+
+        Args:
+            key: Page key to navigate to.
+            data: Optional data passed to the page and its change event.
+
+        Raises:
+            KeyError: If no page with that key exists.
+        """
+        if key not in self._page_keys:
+            raise KeyError(key)
+        self._pending_data = data
+        # Drives _on_model_change -> view sync (no-op if already active).
+        self._model.select_page(key)
+
+    @property
+    def current_page(self) -> str | None:
+        """Key of the active page, or `None`."""
+        return self._model.active_page()
+
+    # ----- Model -> view -----
+
+    def _on_nav_select(self, key: str) -> None:
+        self._model.select_page(key)
+
+    def _on_model_change(self, change: NavChange) -> None:
+        if change.facet == "page" and change.page is not None:
+            self._sync_page(change.page)
+
+    def _sync_page(self, key: str) -> None:
+        data = self._pending_data
+        self._pending_data = None
+        self._nav.select(key)
+        self._pages.navigate(key, data=data)
+
+    def _reemit_page_change(self, event: Any) -> None:
+        # Surface the PageStack's change on the shell so consumers bind one place.
+        self.event_generate("<<PageChange>>", data=getattr(event, "data", None), when="tail")
+
+    # ----- Accessors -----
+
+    @property
+    def model(self) -> NavModel:
+        """The navigation model (single source of truth)."""
+        return self._model
+
+    @property
+    def pages(self) -> PageStack:
+        """The content page deck."""
+        return self._pages
+
+    @property
+    def nav(self) -> NavPanel:
+        """The sidebar navigation panel."""
+        return self._nav

--- a/src/bootstack/widgets/_impl/composites/shell/shell.py
+++ b/src/bootstack/widgets/_impl/composites/shell/shell.py
@@ -1,25 +1,32 @@
 """The shell composite — wires `NavModel` to the region layout (single-tier).
 
-`Shell` ties Layer 1 (`ShellLayout` regions) to Layer 2 (`NavModel`): it puts a
-content page deck in the `content` region and a `NavPanel` in the `sidebar`, and
-`add_page()` registers a page + a nav item so that selecting an item swaps the
-content. The `NavModel` is the single source of truth; the view reacts to its
+`Shell` ties Layer 1 (`ShellLayout` regions) to Layer 2 (`NavModel`) through a
+single Layer 3 provider that fills the sidebar + content for the one implicit
+workspace. The `NavModel` is the single source of truth; the view reacts to its
 notifications.
 
-This step implements the single-tier path only — one implicit workspace, so the
-rail stays hidden. Workspaces / the rail, data-bound providers, and collapse are
-layered on in later steps (see `docs/_dev/appshell-navigation-spec.md`).
+One provider per workspace, chosen lazily and mutually exclusive:
+
+- `add_page()` (with `add_header`/`add_separator`/`add_footer_page`) → the static
+  provider — authored items, each with its own authored page.
+- `list_nav(source=...)` + `@detail` → the flat data-bound provider — records
+  drive the sidebar, selection re-renders one detail body.
+
+Mixing the two in one workspace is an error. Workspaces / the rail and collapse
+are layered on in later steps (see `docs/_dev/appshell-navigation-spec.md`).
 """
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Callable
 
+from bootstack.events import PageChangeEvent
 from bootstack.widgets._core.navmodel import NavChange, NavModel, SidebarMode
-from bootstack.widgets._impl.composites.pagestack import PageStack
 from bootstack.widgets._impl.composites.shell.layout import ShellLayout
-from bootstack.widgets._impl.composites.shell.nav_panel import NavPanel
-from bootstack.widgets._impl.composites.shell.providers import StaticProvider
+from bootstack.widgets._impl.composites.shell.providers import (
+    ListNavProvider,
+    StaticProvider,
+)
 
 
 # Key of the implicit single workspace backing the shell-level page methods.
@@ -55,25 +62,40 @@ class Shell(ShellLayout):
         )
 
         self._model = NavModel(sidebar_mode=sidebar_mode)
-        self._page_keys: set[str] = set()
+        self._nav_accent = nav_accent
+        self._provider: Any = None          # chosen lazily on first content call
         self._pending_data: dict | None = None
+        self._prev_page: str | None = None
 
-        # One provider fills the sidebar + content for the (single, implicit)
-        # workspace. Static is the default; data-bound providers slot in later.
-        self._provider = StaticProvider(accent=nav_accent)
+        self._model.subscribe(self._on_model_change)
+
+    # ----- Provider selection (lazy + mutually exclusive) -----
+
+    def _ensure_static(self) -> StaticProvider:
+        if self._provider is None:
+            self._provider = StaticProvider(accent=self._nav_accent)
+            self._mount_provider()
+        elif not isinstance(self._provider, StaticProvider):
+            raise RuntimeError(
+                "cannot mix add_page() with a data-bound provider in one workspace"
+            )
+        return self._provider
+
+    def _claim_provider(self) -> None:
+        if self._provider is not None:
+            raise RuntimeError("this workspace already has a navigation provider")
+
+    def _mount_provider(self) -> None:
+        if not self._model.has_workspace(_DEFAULT_WORKSPACE):
+            self._model.add_workspace(_DEFAULT_WORKSPACE)
         self._provider.mount(self.sidebar, self.content, on_select=self._on_nav_select)
 
-        # React to model changes; re-emit page changes on the shell itself.
-        self._model.subscribe(self._on_model_change)
-        self._provider.pages.on_page_changed(self._reemit_page_change)
-
-    # ----- Content API -----
+    # ----- Static content API -----
 
     def add_page(self, key: str, *, text: str = "", icon=None, footer: bool = False) -> Any:
         """Add a nav item and its page; return the page frame.
 
-        The first page added is auto-selected so the content area is never
-        blank.
+        The first page added is auto-selected so the content area is never blank.
 
         Args:
             key: Unique key for the nav item and page.
@@ -86,18 +108,15 @@ class Shell(ShellLayout):
 
         Raises:
             ValueError: If `key` is empty or already used.
+            RuntimeError: If a data-bound provider already claimed the workspace.
         """
         if not key:
             raise ValueError("page key must be non-empty")
-        if key in self._page_keys:
+        provider = self._ensure_static()
+        if key in provider.keys():
             raise ValueError(f"duplicate page key: {key!r}")
 
-        if not self._model.has_workspace(_DEFAULT_WORKSPACE):
-            self._model.add_workspace(_DEFAULT_WORKSPACE)
-
-        page = self._provider.add_page(key, text=text, icon=icon, footer=footer)
-        self._page_keys.add(key)
-
+        page = provider.add_page(key, text=text, icon=icon, footer=footer)
         if self._model.active_page() is None:
             self.navigate(key)
         return page
@@ -108,25 +127,66 @@ class Shell(ShellLayout):
 
     def add_header(self, text: str) -> Any:
         """Add a static section header to the sidebar."""
-        return self._provider.add_header(text)
+        return self._ensure_static().add_header(text)
 
     def add_separator(self) -> Any:
         """Add a separator to the sidebar."""
-        return self._provider.add_separator()
+        return self._ensure_static().add_separator()
+
+    # ----- Data-bound content API -----
+
+    def list_nav(self, source: Any, *, text_field: str = "text", icon_field: str = "icon") -> Any:
+        """Fill the workspace from a `DataSource` (flat master-detail).
+
+        Pair with `@detail` to declare the body rendered for the selected record.
+
+        Args:
+            source: A `DataSourceProtocol` supplying records.
+            text_field: Record field used for each item's label.
+            icon_field: Record field used for each item's icon.
+
+        Returns:
+            The `ListNavProvider` (so callers may inspect it).
+
+        Raises:
+            RuntimeError: If the workspace already has a provider.
+        """
+        self._claim_provider()
+        self._provider = ListNavProvider(
+            source, text_field=text_field, icon_field=icon_field, accent=self._nav_accent
+        )
+        self._mount_provider()
+        return self._provider
+
+    def detail(self, fn: Callable[[dict], Any]) -> Callable[[dict], Any]:
+        """Register the detail body for a data-bound provider (decorator).
+
+        The first record is auto-selected once the detail builder is known, so
+        the content renders immediately.
+
+        Raises:
+            RuntimeError: If the active provider is not data-bound.
+        """
+        if self._provider is None or not hasattr(self._provider, "set_detail"):
+            raise RuntimeError("detail() requires a data-bound provider (list_nav)")
+        self._provider.set_detail(fn)
+        if self._model.active_page() is None and self._provider.keys():
+            self.navigate(self._provider.keys()[0])
+        return fn
 
     # ----- Navigation -----
 
     def navigate(self, key: str, data: dict | None = None) -> None:
-        """Navigate to a page, updating the nav selection and content.
+        """Navigate to a page/record, updating the nav selection and content.
 
         Args:
-            key: Page key to navigate to.
+            key: Page or record key to navigate to.
             data: Optional data passed to the page and its change event.
 
         Raises:
-            KeyError: If no page with that key exists.
+            KeyError: If no item with that key exists.
         """
-        if key not in self._page_keys:
+        if self._provider is None or key not in self._provider.keys():
             raise KeyError(key)
         self._pending_data = data
         # Drives _on_model_change -> view sync (no-op if already active).
@@ -134,7 +194,7 @@ class Shell(ShellLayout):
 
     @property
     def current_page(self) -> str | None:
-        """Key of the active page, or `None`."""
+        """Key of the active page/record, or `None`."""
         return self._model.active_page()
 
     # ----- Model -> view -----
@@ -147,14 +207,13 @@ class Shell(ShellLayout):
             self._sync_page(change.page)
 
     def _sync_page(self, key: str) -> None:
-        data = self._pending_data
+        data = self._pending_data or {}
         self._pending_data = None
         self._provider.select_visual(key)
         self._provider.show(key, data=data)
-
-    def _reemit_page_change(self, event: Any) -> None:
-        # Surface the PageStack's change on the shell so consumers bind one place.
-        self.event_generate("<<PageChange>>", data=getattr(event, "data", None), when="tail")
+        payload = PageChangeEvent(page=key, prev_page=self._prev_page, data=dict(data))
+        self._prev_page = key
+        self.event_generate("<<PageChange>>", data=payload, when="tail")
 
     # ----- Accessors -----
 
@@ -164,16 +223,16 @@ class Shell(ShellLayout):
         return self._model
 
     @property
-    def provider(self) -> StaticProvider:
-        """The active workspace's navigation provider."""
+    def provider(self) -> Any:
+        """The active workspace's navigation provider (or `None`)."""
         return self._provider
 
     @property
-    def pages(self) -> PageStack:
-        """The content page deck of the active provider."""
-        return self._provider.pages
+    def pages(self) -> Any:
+        """The static provider's content page deck (or `None` if data-bound)."""
+        return getattr(self._provider, "pages", None)
 
     @property
-    def nav(self) -> NavPanel:
-        """The sidebar navigation panel of the active provider."""
-        return self._provider.nav
+    def nav(self) -> Any:
+        """The active provider's sidebar navigation panel (or `None`)."""
+        return getattr(self._provider, "nav", None)

--- a/src/bootstack/widgets/_impl/composites/shell/shell.py
+++ b/src/bootstack/widgets/_impl/composites/shell/shell.py
@@ -159,13 +159,29 @@ class Shell(ShellLayout):
         """Add a footer-pinned nav item and its page in the implicit workspace."""
         return self._default_workspace().add_footer_page(key, text=text, icon=icon)
 
-    def add_header(self, text: str) -> Any:
-        """Add a static section header to the implicit workspace."""
-        return self._default_workspace().add_header(text)
+    def add_header(self, text: str, *, collapsible: bool = False) -> Any:
+        """Add a section header (optionally a 1-level collapsible group)."""
+        return self._default_workspace().add_header(text, collapsible=collapsible)
 
     def add_separator(self) -> Any:
         """Add a separator to the implicit workspace."""
         return self._default_workspace().add_separator()
+
+    def panel(self) -> Any:
+        """Claim the implicit workspace as a custom panel; return its container."""
+        return self._default_workspace().panel()
+
+    def expand_all(self) -> None:
+        """Expand every collapsible group in the active workspace's sidebar."""
+        ws = self.workspace
+        if ws is not None:
+            ws.expand_all()
+
+    def collapse_all(self) -> None:
+        """Collapse every collapsible group in the active workspace's sidebar."""
+        ws = self.workspace
+        if ws is not None:
+            ws.collapse_all()
 
     def list_nav(self, source: Any, *, text_field: str = "text", icon_field: str = "icon") -> Any:
         """Fill the implicit workspace from a `DataSource` (flat master-detail)."""

--- a/src/bootstack/widgets/_impl/composites/shell/shell.py
+++ b/src/bootstack/widgets/_impl/composites/shell/shell.py
@@ -173,9 +173,9 @@ class Shell(ShellLayout):
         """Add a footer-pinned nav item and its page in the implicit workspace."""
         return self._default_workspace().add_footer_page(key, text=text, icon=icon)
 
-    def add_header(self, text: str, *, collapsible: bool = False) -> Any:
-        """Add a section header (optionally a 1-level collapsible group)."""
-        return self._default_workspace().add_header(text, collapsible=collapsible)
+    def add_header(self, text: str) -> Any:
+        """Add a plain section-label header in the implicit workspace."""
+        return self._default_workspace().add_header(text)
 
     def add_separator(self) -> Any:
         """Add a separator to the implicit workspace."""
@@ -184,18 +184,6 @@ class Shell(ShellLayout):
     def panel(self) -> Any:
         """Claim the implicit workspace as a custom panel; return its container."""
         return self._default_workspace().panel()
-
-    def expand_all(self) -> None:
-        """Expand every collapsible group in the active workspace's sidebar."""
-        ws = self.workspace
-        if ws is not None:
-            ws.expand_all()
-
-    def collapse_all(self) -> None:
-        """Collapse every collapsible group in the active workspace's sidebar."""
-        ws = self.workspace
-        if ws is not None:
-            ws.collapse_all()
 
     def list_nav(self, source: Any, *, separator: bool = False, density: str = "default") -> Any:
         """Fill the implicit workspace from a `DataSource` (flat master-detail)."""

--- a/src/bootstack/widgets/_impl/composites/shell/shell.py
+++ b/src/bootstack/widgets/_impl/composites/shell/shell.py
@@ -57,8 +57,13 @@ class Shell(ShellLayout):
         collapsible: bool = True,
         remember_nav_state: bool = False,
         nav_accent: str = "primary",
+        rail_labels: bool = False,
         **kwargs: Any,
     ) -> None:
+        # A labeled rail (caption under each icon) needs a wider strip than the
+        # icon-only default; widen unless the caller pinned rail_width explicitly.
+        if rail_labels and "rail_width" not in kwargs:
+            kwargs["rail_width"] = 72
         super().__init__(
             title=title, theme=theme, size=size, undecorated=undecorated, **kwargs
         )
@@ -81,7 +86,9 @@ class Shell(ShellLayout):
         # The tier-1 workspace switcher (hidden until > 1 workspace).
         # NB: must NOT be named `self._rail` — that is ShellLayout's rail *region*
         # frame; shadowing it orphans the region so it never packs into the body.
-        self._railnav = Rail(self.rail, on_select=self._rail_select, accent=nav_accent)
+        self._railnav = Rail(
+            self.rail, on_select=self._rail_select, accent=nav_accent, labels=rail_labels
+        )
         self._railnav.pack(fill="both", expand=True)
 
         self._model.subscribe(self._on_model_change)

--- a/src/bootstack/widgets/_impl/composites/shell/shell.py
+++ b/src/bootstack/widgets/_impl/composites/shell/shell.py
@@ -1,19 +1,16 @@
-"""The shell composite — wires `NavModel` to the region layout (single-tier).
+"""The shell composite — wires `NavModel` to the region layout.
 
-`Shell` ties Layer 1 (`ShellLayout` regions) to Layer 2 (`NavModel`) through a
-single Layer 3 provider that fills the sidebar + content for the one implicit
-workspace. The `NavModel` is the single source of truth; the view reacts to its
-notifications.
+`Shell` ties Layer 1 (`ShellLayout` regions) to Layer 2 (`NavModel`) via Layer 3
+workspaces. Every workspace owns one provider mounted into its own sidebar-panel
+frame and content frame; the sidebar and content regions are each a *deck* of
+per-workspace frames, and switching the active workspace swaps which frames show
+(the nested page-stack cascade — rail chooses the panel, the panel chooses the
+content). The `NavModel` is the single source of truth; the view reacts to it.
 
-One provider per workspace, chosen lazily and mutually exclusive:
-
-- `add_page()` (with `add_header`/`add_separator`/`add_footer_page`) → the static
-  provider — authored items, each with its own authored page.
-- `list_nav(source=...)` + `@detail` → the flat data-bound provider — records
-  drive the sidebar, selection re-renders one detail body.
-
-Mixing the two in one workspace is an error. Workspaces / the rail and collapse
-are layered on in later steps (see `docs/_dev/appshell-navigation-spec.md`).
+Single-tier is the degenerate case (spec decision #1): shell-level `add_page` /
+`list_nav` / `tree_nav` target an implicit default workspace, so the rail never
+renders. `add_workspace()` creates additional workspaces (revealing the rail in
+step 6b). The two are mutually exclusive — author one style or the other.
 """
 
 from __future__ import annotations
@@ -22,12 +19,10 @@ from typing import Any, Callable
 
 from bootstack.events import PageChangeEvent
 from bootstack.widgets._core.navmodel import NavChange, NavModel, SidebarMode
+from bootstack.widgets._impl.composites.pagestack import PageStack
 from bootstack.widgets._impl.composites.shell.layout import ShellLayout
-from bootstack.widgets._impl.composites.shell.providers import (
-    ListNavProvider,
-    StaticProvider,
-    TreeNavProvider,
-)
+from bootstack.widgets._impl.composites.shell.rail import Rail
+from bootstack.widgets._impl.composites.shell.workspace import Workspace
 
 
 # Key of the implicit single workspace backing the shell-level page methods.
@@ -35,7 +30,7 @@ _DEFAULT_WORKSPACE = "__shell__"
 
 
 class Shell(ShellLayout):
-    """Application shell with single-tier page navigation.
+    """Application shell with workspace-based navigation.
 
     Args:
         title: Window title.
@@ -64,213 +59,217 @@ class Shell(ShellLayout):
 
         self._model = NavModel(sidebar_mode=sidebar_mode)
         self._nav_accent = nav_accent
-        self._provider: Any = None          # chosen lazily on first content call
+        self._workspaces: dict[str, Workspace] = {}
         self._pending_data: dict | None = None
         self._prev_page: str | None = None
 
+        # Sidebar + content are decks of per-workspace frames.
+        self._panel_stack = PageStack(self.sidebar)
+        self._panel_stack.pack(fill="both", expand=True)
+        self._content_stack = PageStack(self.content)
+        self._content_stack.pack(fill="both", expand=True)
+
+        # The tier-1 workspace switcher (hidden until > 1 workspace).
+        # NB: must NOT be named `self._rail` — that is ShellLayout's rail *region*
+        # frame; shadowing it orphans the region so it never packs into the body.
+        self._railnav = Rail(self.rail, on_select=self._rail_select, accent=nav_accent)
+        self._railnav.pack(fill="both", expand=True)
+
         self._model.subscribe(self._on_model_change)
 
-    # ----- Provider selection (lazy + mutually exclusive) -----
+    # ----- Workspace creation -----
 
-    def _ensure_static(self) -> StaticProvider:
-        if self._provider is None:
-            self._provider = StaticProvider(accent=self._nav_accent)
-            self._mount_provider()
-        elif not isinstance(self._provider, StaticProvider):
-            raise RuntimeError(
-                "cannot mix add_page() with a data-bound provider in one workspace"
-            )
-        return self._provider
-
-    def _claim_provider(self) -> None:
-        if self._provider is not None:
-            raise RuntimeError("this workspace already has a navigation provider")
-
-    def _mount_provider(self) -> None:
-        if not self._model.has_workspace(_DEFAULT_WORKSPACE):
-            self._model.add_workspace(_DEFAULT_WORKSPACE)
-        self._provider.mount(
-            self.sidebar,
-            self.content,
-            on_select=self._on_nav_select,
-            on_refresh=self._on_provider_refresh,
+    def _create_workspace(self, key: str, *, text: str = "", icon=None, is_footer: bool = False) -> Workspace:
+        panel = self._panel_stack.add(key)
+        content = self._content_stack.add(key)
+        ws = Workspace(
+            key, panel, content,
+            nav_accent=self._nav_accent,
+            on_select=self._workspace_select,
+            on_refresh=self._workspace_refresh,
+            on_first_page=self._on_first_page,
         )
+        self._workspaces[key] = ws
+        # The implicit default workspace never gets a rail icon (single-tier).
+        if key != _DEFAULT_WORKSPACE:
+            self._railnav.add_workspace(key, icon=icon, text=text, footer=is_footer)
+        self._model.add_workspace(key, text=text, icon=icon, is_footer=is_footer)
+        if self._model.active_workspace == key:
+            self._panel_stack.navigate(key)
+            self._content_stack.navigate(key)
+            if key != _DEFAULT_WORKSPACE:
+                self._railnav.select(key)
+        return ws
 
-    # ----- Static content API -----
+    def _default_workspace(self) -> Workspace:
+        if _DEFAULT_WORKSPACE not in self._workspaces:
+            if self._workspaces:
+                raise RuntimeError(
+                    "cannot use shell-level pages together with add_workspace(); "
+                    "author one style or the other"
+                )
+            self._create_workspace(_DEFAULT_WORKSPACE)
+        return self._workspaces[_DEFAULT_WORKSPACE]
+
+    def add_workspace(self, key: str, *, text: str = "", icon=None) -> Workspace:
+        """Add a workspace (a rail icon → its own sidebar panel + content).
+
+        Adding a second workspace reveals the rail. Mutually exclusive with the
+        shell-level page methods.
+
+        Raises:
+            RuntimeError: If shell-level pages already claimed the implicit
+                workspace, or the key is already used.
+        """
+        if _DEFAULT_WORKSPACE in self._workspaces:
+            raise RuntimeError("cannot mix add_workspace() with shell-level pages")
+        if key in self._workspaces:
+            raise RuntimeError(f"duplicate workspace key: {key!r}")
+        return self._create_workspace(key, text=text, icon=icon)
+
+    def add_footer_workspace(self, key: str, *, text: str = "", icon=None) -> Workspace:
+        """Add a workspace pinned to the bottom of the rail."""
+        if _DEFAULT_WORKSPACE in self._workspaces:
+            raise RuntimeError("cannot mix add_workspace() with shell-level pages")
+        if key in self._workspaces:
+            raise RuntimeError(f"duplicate workspace key: {key!r}")
+        return self._create_workspace(key, text=text, icon=icon, is_footer=True)
+
+    # ----- Shell-level content API (delegates to the default workspace) -----
 
     def add_page(self, key: str, *, text: str = "", icon=None, footer: bool = False) -> Any:
-        """Add a nav item and its page; return the page frame.
-
-        The first page added is auto-selected so the content area is never blank.
-
-        Args:
-            key: Unique key for the nav item and page.
-            text: Sidebar label.
-            icon: Icon name or icon-spec dict.
-            footer: Pin the nav item to the sidebar footer.
-
-        Returns:
-            The page `Frame` to parent content into.
-
-        Raises:
-            ValueError: If `key` is empty or already used.
-            RuntimeError: If a data-bound provider already claimed the workspace.
-        """
-        if not key:
-            raise ValueError("page key must be non-empty")
-        provider = self._ensure_static()
-        if key in provider.keys():
-            raise ValueError(f"duplicate page key: {key!r}")
-
-        page = provider.add_page(key, text=text, icon=icon, footer=footer)
-        if self._model.active_page() is None:
-            self.navigate(key)
-        return page
+        """Add a nav item and its page in the implicit workspace."""
+        return self._default_workspace().add_page(key, text=text, icon=icon, footer=footer)
 
     def add_footer_page(self, key: str, *, text: str = "", icon=None) -> Any:
-        """Add a nav item pinned to the sidebar footer and its page."""
-        return self.add_page(key, text=text, icon=icon, footer=True)
+        """Add a footer-pinned nav item and its page in the implicit workspace."""
+        return self._default_workspace().add_footer_page(key, text=text, icon=icon)
 
     def add_header(self, text: str) -> Any:
-        """Add a static section header to the sidebar."""
-        return self._ensure_static().add_header(text)
+        """Add a static section header to the implicit workspace."""
+        return self._default_workspace().add_header(text)
 
     def add_separator(self) -> Any:
-        """Add a separator to the sidebar."""
-        return self._ensure_static().add_separator()
-
-    # ----- Data-bound content API -----
+        """Add a separator to the implicit workspace."""
+        return self._default_workspace().add_separator()
 
     def list_nav(self, source: Any, *, text_field: str = "text", icon_field: str = "icon") -> Any:
-        """Fill the workspace from a `DataSource` (flat master-detail).
+        """Fill the implicit workspace from a `DataSource` (flat master-detail)."""
+        return self._default_workspace().list_nav(source, text_field=text_field, icon_field=icon_field)
 
-        Pair with `@detail` to declare the body rendered for the selected record.
-
-        Args:
-            source: A `DataSourceProtocol` supplying records.
-            text_field: Record field used for each item's label.
-            icon_field: Record field used for each item's icon.
-
-        Returns:
-            The `ListNavProvider` (so callers may inspect it).
-
-        Raises:
-            RuntimeError: If the workspace already has a provider.
-        """
-        self._claim_provider()
-        self._provider = ListNavProvider(
-            source, text_field=text_field, icon_field=icon_field, accent=self._nav_accent
-        )
-        self._mount_provider()
-        return self._provider
-
-    def tree_nav(
-        self,
-        *,
-        nodes: list | None = None,
-        source: Any = None,
-        parent_field: str = "parent_id",
-        label_field: str = "name",
-        icon_field: str = "icon",
-    ) -> Any:
-        """Fill the workspace from a hierarchy (tree master-detail).
-
-        Pass `nodes=` for an inline hierarchy, or `source=`/`parent_field=` to
-        project a flat adjacency-list `DataSource`. Pair with `@detail` to render
-        the selected node. A tree opens with nothing selected.
-
-        Returns:
-            The `TreeNavProvider`.
-
-        Raises:
-            RuntimeError: If the workspace already has a provider.
-        """
-        self._claim_provider()
-        self._provider = TreeNavProvider(
-            nodes=nodes,
-            source=source,
-            parent_field=parent_field,
-            label_field=label_field,
-            icon_field=icon_field,
-            accent=self._nav_accent,
-        )
-        self._mount_provider()
-        return self._provider
+    def tree_nav(self, **kwargs: Any) -> Any:
+        """Fill the implicit workspace from a hierarchy (tree master-detail)."""
+        return self._default_workspace().tree_nav(**kwargs)
 
     def detail(self, fn: Callable[[dict], Any]) -> Callable[[dict], Any]:
-        """Register the detail body for a data-bound provider (decorator).
-
-        The first record is auto-selected once the detail builder is known, so
-        the content renders immediately.
-
-        Raises:
-            RuntimeError: If the active provider is not data-bound.
-        """
-        if self._provider is None or not hasattr(self._provider, "set_detail"):
-            raise RuntimeError("detail() requires a data-bound provider (list_nav)")
-        self._provider.set_detail(fn)
-        if self._model.active_page() is None and self._provider.keys():
-            self.navigate(self._provider.keys()[0])
-        return fn
+        """Register the implicit workspace's data-bound detail body (decorator)."""
+        return self._default_workspace().detail(fn)
 
     # ----- Navigation -----
 
-    def navigate(self, key: str, data: dict | None = None) -> None:
-        """Navigate to a page/record, updating the nav selection and content.
+    def navigate(self, *args: str, data: dict | None = None) -> None:
+        """Navigate to a page (single-tier) or a workspace + page (two-tier).
 
-        Args:
-            key: Page or record key to navigate to.
-            data: Optional data passed to the page and its change event.
+        `navigate(page)` selects a page in the active workspace;
+        `navigate(workspace, page)` switches workspace and selects a page in it.
 
         Raises:
-            KeyError: If no item with that key exists.
+            KeyError: If the workspace or page does not exist.
+            TypeError: If called with other than one or two positional keys.
         """
-        if self._provider is None or key not in self._provider.keys():
-            raise KeyError(key)
+        if len(args) == 2:
+            ws_key, page = args
+            if ws_key not in self._workspaces:
+                raise KeyError(ws_key)
+            self._model.select_workspace(ws_key)
+            self._model.show_sidebar()
+            self._select_page(ws_key, page, data=data)
+        elif len(args) == 1:
+            ws_key = self._model.active_workspace
+            if ws_key is None:
+                raise RuntimeError("no active workspace to navigate")
+            self._select_page(ws_key, args[0], data=data)
+        else:
+            raise TypeError("navigate() takes 1 (page) or 2 (workspace, page) keys")
+
+    def _select_page(self, ws_key: str, page_key: str, *, data: dict | None = None) -> None:
+        if page_key not in self._workspaces[ws_key].keys():
+            raise KeyError(page_key)
         self._pending_data = data
-        # Drives _on_model_change -> view sync (no-op if already active).
-        self._model.select_page(key)
+        self._model.select_page(page_key, workspace=ws_key)
 
     @property
     def current_page(self) -> str | None:
-        """Key of the active page/record, or `None`."""
+        """Key of the active workspace's active page, or `None`."""
         return self._model.active_page()
+
+    @property
+    def current_workspace(self) -> str | None:
+        """Key of the active workspace, or `None`."""
+        return self._model.active_workspace
 
     # ----- Model -> view -----
 
-    def _on_nav_select(self, key: str) -> None:
-        self._model.select_page(key)
+    def _rail_select(self, ws_key: str) -> None:
+        # The VS Code gesture lives in the model: active icon -> hide sidebar,
+        # different icon -> switch workspace + show.
+        self._model.activate_rail(ws_key)
+
+    def _workspace_select(self, ws_key: str, page_key: str) -> None:
+        self._model.select_page(page_key, workspace=ws_key)
+
+    def _on_first_page(self, ws_key: str, page_key: str) -> None:
+        if self._model.active_page(ws_key) is None:
+            self._model.select_page(page_key, workspace=ws_key)
+
+    def _workspace_refresh(self, ws_key: str) -> None:
+        if ws_key != self._model.active_workspace:
+            return
+        ws = self._workspaces[ws_key]
+        keys = ws.keys()
+        if keys and self._model.active_page(ws_key) not in keys:
+            self._select_page(ws_key, keys[0])
 
     def _on_model_change(self, change: NavChange) -> None:
         if change.facet == "page" and change.page is not None:
-            self._sync_page(change.page)
+            if change.workspace == self._model.active_workspace:
+                self._render_page(change.workspace, change.page)
+        elif change.facet == "workspace" and change.workspace is not None:
+            self._switch_workspace(change.workspace)
+        elif change.facet == "sidebar":
+            self.set_sidebar_visible(change.sidebar_mode != "hidden")
+        elif change.facet == "structure":
+            self._sync_rail_visibility()
 
-    def _on_provider_refresh(self) -> None:
-        # The provider rebuilt its items from a changed source; reconcile the
-        # active selection if it vanished (e.g. the selected record was deleted).
-        keys = self._provider.keys()
-        if keys and self._model.active_page() not in keys:
-            self.navigate(keys[0])
-
-    def _sync_page(self, key: str) -> None:
+    def _render_page(self, ws_key: str, page_key: str) -> None:
+        ws = self._workspaces[ws_key]
         data = self._pending_data or {}
         self._pending_data = None
-        self._provider.select_visual(key)
-        self._provider.show(key, data=data)
-        payload = PageChangeEvent(page=key, prev_page=self._prev_page, data=dict(data))
-        self._prev_page = key
+        ws.select_visual(page_key)
+        ws.show(page_key, data=data)
+        payload = PageChangeEvent(page=page_key, prev_page=self._prev_page, data=dict(data))
+        self._prev_page = page_key
         self.event_generate("<<PageChange>>", data=payload, when="tail")
+
+    def _switch_workspace(self, ws_key: str) -> None:
+        self._panel_stack.navigate(ws_key)
+        self._content_stack.navigate(ws_key)
+        if ws_key in self._railnav.keys():
+            self._railnav.select(ws_key)
+        page = self._model.active_page(ws_key)
+        if page is not None:
+            self._render_page(ws_key, page)
+
+    def _sync_rail_visibility(self) -> None:
+        # The rail widget is wired in step 6b; for now reflect model state only.
+        self.set_rail_visible(self._model.rail_visible)
 
     # ----- Lifecycle -----
 
     def destroy(self) -> None:
-        """Cancel provider subscriptions, then tear down the window."""
-        provider = getattr(self, "_provider", None)
-        if provider is not None and hasattr(provider, "close"):
-            try:
-                provider.close()
-            except Exception:
-                pass
+        """Close provider subscriptions, then tear down the window."""
+        for ws in getattr(self, "_workspaces", {}).values():
+            ws.close()
         super().destroy()
 
     # ----- Accessors -----
@@ -281,16 +280,26 @@ class Shell(ShellLayout):
         return self._model
 
     @property
+    def workspace(self) -> Workspace | None:
+        """The active workspace (or `None`)."""
+        return self._workspaces.get(self._model.active_workspace)
+
+    def workspaces(self) -> tuple[Workspace, ...]:
+        """All workspaces in insertion order."""
+        return tuple(self._workspaces.values())
+
+    @property
     def provider(self) -> Any:
         """The active workspace's navigation provider (or `None`)."""
-        return self._provider
+        ws = self.workspace
+        return ws.provider if ws is not None else None
 
     @property
     def pages(self) -> Any:
-        """The static provider's content page deck (or `None` if data-bound)."""
-        return getattr(self._provider, "pages", None)
+        """The active static provider's content page deck (or `None`)."""
+        return getattr(self.provider, "pages", None)
 
     @property
     def nav(self) -> Any:
         """The active provider's sidebar navigation panel (or `None`)."""
-        return getattr(self._provider, "nav", None)
+        return getattr(self.provider, "nav", None)

--- a/src/bootstack/widgets/_impl/composites/shell/shell.py
+++ b/src/bootstack/widgets/_impl/composites/shell/shell.py
@@ -197,9 +197,9 @@ class Shell(ShellLayout):
         if ws is not None:
             ws.collapse_all()
 
-    def list_nav(self, source: Any, *, separator: bool = False) -> Any:
+    def list_nav(self, source: Any, *, separator: bool = False, density: str = "default") -> Any:
         """Fill the implicit workspace from a `DataSource` (flat master-detail)."""
-        return self._default_workspace().list_nav(source, separator=separator)
+        return self._default_workspace().list_nav(source, separator=separator, density=density)
 
     def tree_nav(self, **kwargs: Any) -> Any:
         """Fill the implicit workspace from a hierarchy (tree master-detail)."""

--- a/src/bootstack/widgets/_impl/composites/shell/shell.py
+++ b/src/bootstack/widgets/_impl/composites/shell/shell.py
@@ -88,7 +88,12 @@ class Shell(ShellLayout):
     def _mount_provider(self) -> None:
         if not self._model.has_workspace(_DEFAULT_WORKSPACE):
             self._model.add_workspace(_DEFAULT_WORKSPACE)
-        self._provider.mount(self.sidebar, self.content, on_select=self._on_nav_select)
+        self._provider.mount(
+            self.sidebar,
+            self.content,
+            on_select=self._on_nav_select,
+            on_refresh=self._on_provider_refresh,
+        )
 
     # ----- Static content API -----
 
@@ -206,6 +211,13 @@ class Shell(ShellLayout):
         if change.facet == "page" and change.page is not None:
             self._sync_page(change.page)
 
+    def _on_provider_refresh(self) -> None:
+        # The provider rebuilt its items from a changed source; reconcile the
+        # active selection if it vanished (e.g. the selected record was deleted).
+        keys = self._provider.keys()
+        if keys and self._model.active_page() not in keys:
+            self.navigate(keys[0])
+
     def _sync_page(self, key: str) -> None:
         data = self._pending_data or {}
         self._pending_data = None
@@ -214,6 +226,18 @@ class Shell(ShellLayout):
         payload = PageChangeEvent(page=key, prev_page=self._prev_page, data=dict(data))
         self._prev_page = key
         self.event_generate("<<PageChange>>", data=payload, when="tail")
+
+    # ----- Lifecycle -----
+
+    def destroy(self) -> None:
+        """Cancel provider subscriptions, then tear down the window."""
+        provider = getattr(self, "_provider", None)
+        if provider is not None and hasattr(provider, "close"):
+            try:
+                provider.close()
+            except Exception:
+                pass
+        super().destroy()
 
     # ----- Accessors -----
 

--- a/src/bootstack/widgets/_impl/composites/shell/shell.py
+++ b/src/bootstack/widgets/_impl/composites/shell/shell.py
@@ -38,6 +38,10 @@ class Shell(ShellLayout):
         size: Initial window size as `(width, height)`.
         undecorated: Remove OS chrome and draw a custom border.
         sidebar_mode: Initial sidebar mode (`'expanded'`/`'compact'`/`'hidden'`).
+            `'compact'` (icon-only) applies only to a standalone static sidebar.
+        collapsible: Allow collapsing the sidebar; binds Ctrl/Cmd-B to toggle it.
+        remember_nav_state: Persist the sidebar mode + per-workspace active page
+            across sessions, restoring them on the next launch.
         nav_accent: Accent token for the active nav item.
         **kwargs: Forwarded to `ShellLayout` / `App` (widths, position, etc.).
     """
@@ -50,6 +54,8 @@ class Shell(ShellLayout):
         size: tuple[int, int] | None = None,
         undecorated: bool = False,
         sidebar_mode: SidebarMode = "expanded",
+        collapsible: bool = True,
+        remember_nav_state: bool = False,
         nav_accent: str = "primary",
         **kwargs: Any,
     ) -> None:
@@ -59,6 +65,9 @@ class Shell(ShellLayout):
 
         self._model = NavModel(sidebar_mode=sidebar_mode)
         self._nav_accent = nav_accent
+        self._collapsible = collapsible
+        self._remember_nav_state = remember_nav_state
+        self._initial_applied = False
         self._workspaces: dict[str, Workspace] = {}
         self._pending_data: dict | None = None
         self._prev_page: str | None = None
@@ -76,6 +85,11 @@ class Shell(ShellLayout):
         self._railnav.pack(fill="both", expand=True)
 
         self._model.subscribe(self._on_model_change)
+
+        # Ctrl/Cmd-B toggles sidebar visibility (the hamburger action).
+        if self._collapsible:
+            self.bind("<Control-b>", self._on_toggle_shortcut, add="+")
+            self.bind("<Command-b>", self._on_toggle_shortcut, add="+")
 
     # ----- Workspace creation -----
 
@@ -208,6 +222,52 @@ class Shell(ShellLayout):
         """Key of the active workspace, or `None`."""
         return self._model.active_workspace
 
+    # ----- Sidebar visibility / compaction -----
+
+    def toggle_sidebar(self) -> None:
+        """Toggle the sidebar between hidden and shown (the hamburger action)."""
+        self._model.toggle_sidebar()
+
+    def show_sidebar(self) -> None:
+        """Show the sidebar, restoring its last non-hidden mode."""
+        self._model.show_sidebar()
+
+    def hide_sidebar(self) -> None:
+        """Hide the sidebar entirely."""
+        self._model.hide_sidebar()
+
+    @property
+    def sidebar_mode(self) -> SidebarMode:
+        """The sidebar mode (`'hidden'`/`'compact'`/`'expanded'`).
+
+        Setting `'compact'` only takes visual effect on a standalone static
+        sidebar (no rail); otherwise it renders as expanded.
+        """
+        return self._model.sidebar_mode
+
+    @sidebar_mode.setter
+    def sidebar_mode(self, mode: SidebarMode) -> None:
+        self._model.set_sidebar_mode(mode)
+
+    def _can_compact_active(self) -> bool:
+        """Whether the active sidebar can compact (standalone static, no rail)."""
+        ws = self.workspace
+        return not self._model.rail_visible and ws is not None and ws.supports_compact
+
+    def _on_toggle_shortcut(self, _event: Any = None) -> str:
+        # Collapse the sidebar as far as is useful: to icons when the active
+        # sidebar can compact (standalone static — never strands the only nav),
+        # otherwise hide it (a data list can't compact; under a rail the rail
+        # stays as nav, so hiding is safe). The explicit toggle_sidebar()/
+        # show_sidebar()/hide_sidebar() verbs remain pure visibility.
+        if self._can_compact_active():
+            self.sidebar_mode = (
+                "expanded" if self._model.sidebar_mode == "compact" else "compact"
+            )
+        else:
+            self.toggle_sidebar()
+        return "break"
+
     # ----- Model -> view -----
 
     def _rail_select(self, ws_key: str) -> None:
@@ -237,9 +297,35 @@ class Shell(ShellLayout):
         elif change.facet == "workspace" and change.workspace is not None:
             self._switch_workspace(change.workspace)
         elif change.facet == "sidebar":
-            self.set_sidebar_visible(change.sidebar_mode != "hidden")
+            self._apply_sidebar_mode(change.sidebar_mode)
         elif change.facet == "structure":
             self._sync_rail_visibility()
+
+    def _apply_sidebar_mode(self, mode: SidebarMode | None) -> None:
+        """Reflect a sidebar mode in the view.
+
+        `compact` (icon-only + narrower width) is gated to the standalone static
+        case: it applies only when no rail is showing and the active provider
+        supports it; otherwise the sidebar renders expanded.
+        """
+        if mode is None:
+            mode = self._model.sidebar_mode
+        if mode == "hidden":
+            self.set_sidebar_visible(False)
+            return
+        self.set_sidebar_visible(True)
+        ws = self.workspace
+        compact = (
+            mode == "compact"
+            and not self._model.rail_visible
+            and ws is not None
+            and ws.supports_compact
+        )
+        # Configure the slot frame directly so the stored expanded-width token is
+        # not clobbered (set_sidebar_width mutates the token).
+        self.sidebar.configure(width=self._rail_width if compact else self._sidebar_width)
+        if ws is not None:
+            ws.set_compact(compact)
 
     def _render_page(self, ws_key: str, page_key: str) -> None:
         ws = self._workspaces[ws_key]
@@ -266,8 +352,85 @@ class Shell(ShellLayout):
 
     # ----- Lifecycle -----
 
+    def mainloop(self, n: int = 0) -> None:
+        """Apply the initial (and any persisted) nav state, then run the loop."""
+        self._apply_initial_state()
+        super().mainloop(n=n)
+
+    def _apply_initial_state(self) -> None:
+        """Restore persisted state (if enabled) and reflect the sidebar mode.
+
+        Runs once, just before the event loop starts — after all pages have been
+        authored — so a restored page/workspace overrides the authored default
+        (mirroring window-geometry restore).
+        """
+        if self._initial_applied:
+            return
+        self._initial_applied = True
+        if self._remember_nav_state:
+            self._restore_nav_state()
+        self._apply_sidebar_mode(self._model.sidebar_mode)
+
+    # ----- Nav-state persistence -----
+
+    def _nav_state_path(self):
+        from bootstack._core.paths import app_config_file
+        return app_config_file("nav_state.json", self.settings.app_name)
+
+    def _restore_nav_state(self) -> None:
+        import json
+        try:
+            raw = self._nav_state_path().read_text()
+            data = json.loads(raw)
+        except (FileNotFoundError, OSError, json.JSONDecodeError):
+            return
+        if not isinstance(data, dict):
+            return
+        # Per-workspace remembered pages (only those still present).
+        pages = data.get("active_page")
+        if isinstance(pages, dict):
+            for ws_key, page in pages.items():
+                ws = self._workspaces.get(ws_key)
+                if ws is not None and page in ws.keys():
+                    self._model.select_page(page, workspace=ws_key)
+        # Active workspace.
+        active_ws = data.get("active_workspace")
+        if isinstance(active_ws, str) and self._model.has_workspace(active_ws):
+            self._model.select_workspace(active_ws)
+        # Sidebar mode.
+        mode = data.get("sidebar_mode")
+        if mode in ("hidden", "compact", "expanded"):
+            self._model.set_sidebar_mode(mode)
+
+    def _save_nav_state(self) -> None:
+        import json
+        path = self._nav_state_path()
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            return
+        pages = {
+            k: self._model.active_page(k)
+            for k in self._workspaces
+            if self._model.active_page(k) is not None
+        }
+        data = {
+            "sidebar_mode": self._model.sidebar_mode,
+            "active_workspace": self._model.active_workspace,
+            "active_page": pages,
+        }
+        try:
+            path.write_text(json.dumps(data))
+        except OSError:
+            pass
+
     def destroy(self) -> None:
-        """Close provider subscriptions, then tear down the window."""
+        """Persist nav state, close provider subscriptions, then tear down."""
+        if getattr(self, "_remember_nav_state", False):
+            try:
+                self._save_nav_state()
+            except Exception:
+                pass
         for ws in getattr(self, "_workspaces", {}).values():
             ws.close()
         super().destroy()

--- a/src/bootstack/widgets/_impl/composites/shell/workspace.py
+++ b/src/bootstack/widgets/_impl/composites/shell/workspace.py
@@ -189,10 +189,13 @@ class Workspace:
         label_field: str = "name",
         icon_field: str = "icon",
         density: str = "default",
+        placeholder: str = "Select an item to view",
     ) -> Any:
         """Fill the workspace from a hierarchy (tree master-detail).
 
-        `density` is `'default'`/`'compact'`.
+        `density` is `'default'`/`'compact'`. `placeholder` is the quiet
+        empty-state shown in the content area until a node is picked (a tree
+        opens unselected).
         """
         self._claim_provider()
         self._provider = TreeNavProvider(
@@ -203,6 +206,7 @@ class Workspace:
             icon_field=icon_field,
             accent=self._nav_accent,
             density=density,
+            placeholder=placeholder,
         )
         self._mount_provider()
         return self._provider

--- a/src/bootstack/widgets/_impl/composites/shell/workspace.py
+++ b/src/bootstack/widgets/_impl/composites/shell/workspace.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from typing import Any, Callable
 
 from bootstack.widgets._impl.composites.shell.providers import (
+    CustomProvider,
     ListNavProvider,
     StaticProvider,
     TreeNavProvider,
@@ -120,13 +121,42 @@ class Workspace:
         """Add a nav item pinned to the sidebar footer and its page."""
         return self.add_page(key, text=text, icon=icon, footer=True)
 
-    def add_header(self, text: str) -> Any:
-        """Add a static section header to the sidebar."""
-        return self._ensure_static().add_header(text)
+    def add_header(self, text: str, *, collapsible: bool = False) -> Any:
+        """Add a section header (optionally a 1-level collapsible group)."""
+        return self._ensure_static().add_header(text, collapsible=collapsible)
 
     def add_separator(self) -> Any:
         """Add a separator to the sidebar."""
         return self._ensure_static().add_separator()
+
+    def expand_all(self) -> None:
+        """Expand every collapsible group in the sidebar (if any)."""
+        if self._provider is not None and hasattr(self._provider, "expand_all"):
+            self._provider.expand_all()
+
+    def collapse_all(self) -> None:
+        """Collapse every collapsible group in the sidebar (if any)."""
+        if self._provider is not None and hasattr(self._provider, "collapse_all"):
+            self._provider.collapse_all()
+
+    # ----- Custom mode -----
+
+    def panel(self) -> Any:
+        """Claim the workspace as a custom panel; return its sidebar container.
+
+        The workspace enters custom mode: no provider cascade, no compaction.
+        Fill the returned container with your own sidebar UI and drive the
+        content region yourself via `content`.
+        """
+        self._claim_provider()
+        self._provider = CustomProvider()
+        self._mount_provider()
+        return self._provider.container
+
+    @property
+    def content(self) -> Any:
+        """The workspace's content region frame (for hand-driven swapping)."""
+        return self._content
 
     # ----- Data-bound content API -----
 

--- a/src/bootstack/widgets/_impl/composites/shell/workspace.py
+++ b/src/bootstack/widgets/_impl/composites/shell/workspace.py
@@ -165,17 +165,27 @@ class Workspace:
 
     # ----- Data-bound content API -----
 
-    def list_nav(self, source: Any, *, separator: bool = False, density: str = "default") -> Any:
+    def list_nav(
+        self,
+        source: Any,
+        *,
+        separator: bool = False,
+        density: str = "default",
+        placeholder: str = "Select an item to view",
+    ) -> Any:
         """Fill the workspace from a `DataSource` (flat master-detail).
 
         Records render their `icon`/`title`/`text` in a recycling `ListView`
         (which inherits the sidebar surface). `separator` draws divider lines
         between rows (default flush); `density` is `'default'`/`'compact'`
         (compact suits one-line items, default suits richer two-line items).
+        `placeholder` is the quiet empty-state shown in the content area when the
+        source has no records.
         """
         self._claim_provider()
         self._provider = ListNavProvider(
-            source, accent=self._nav_accent, separator=separator, density=density
+            source, accent=self._nav_accent, separator=separator,
+            density=density, placeholder=placeholder,
         )
         self._mount_provider()
         return self._provider

--- a/src/bootstack/widgets/_impl/composites/shell/workspace.py
+++ b/src/bootstack/widgets/_impl/composites/shell/workspace.py
@@ -10,6 +10,12 @@ The workspace exposes the same content API the shell does — `add_page` /
 `list_nav` / `tree_nav` / `@detail` / headers — so a single-tier app and a
 two-tier workspace are authored identically (the spec's degenerate-case
 unification).
+
+The sidebar has three authored shapes: a flat nav list (`add_page`), the same
+list chunked by static `add_header` labels (grouped-static), or a data-bound
+`list_nav` / `tree_nav`. There is no built-in collapsible accordion — a section
+that hides/reveals a sub-list is a content concern; compose `bs.Accordion`
+inside a custom `panel()` if you need one.
 """
 
 from __future__ import annotations
@@ -36,6 +42,9 @@ class Workspace:
         on_refresh: Called `(workspace_key)` after a data-bound provider rebuilds.
         on_first_page: Called `(workspace_key, page_key)` when the workspace's
             first page is added (so the shell can auto-select it).
+        nav_variant: Static-item style variant for the tier (`'nav-pill'`
+            standalone, `'nav-quiet'` under a rail).
+        nav_surface: Surface token the sidebar items sit on.
     """
 
     def __init__(
@@ -127,23 +136,13 @@ class Workspace:
         """Add a nav item pinned to the sidebar footer and its page."""
         return self.add_page(key, text=text, icon=icon, footer=True)
 
-    def add_header(self, text: str, *, collapsible: bool = False) -> Any:
-        """Add a section header (optionally a 1-level collapsible group)."""
-        return self._ensure_static().add_header(text, collapsible=collapsible)
+    def add_header(self, text: str) -> Any:
+        """Add a plain section-label header (grouped-static)."""
+        return self._ensure_static().add_header(text)
 
     def add_separator(self) -> Any:
         """Add a separator to the sidebar."""
         return self._ensure_static().add_separator()
-
-    def expand_all(self) -> None:
-        """Expand every collapsible group in the sidebar (if any)."""
-        if self._provider is not None and hasattr(self._provider, "expand_all"):
-            self._provider.expand_all()
-
-    def collapse_all(self) -> None:
-        """Collapse every collapsible group in the sidebar (if any)."""
-        if self._provider is not None and hasattr(self._provider, "collapse_all"):
-            self._provider.collapse_all()
 
     # ----- Custom mode -----
 
@@ -151,8 +150,8 @@ class Workspace:
         """Claim the workspace as a custom panel; return its sidebar container.
 
         The workspace enters custom mode: no provider cascade, no compaction.
-        Fill the returned container with your own sidebar UI and drive the
-        content region yourself via `content`.
+        Fill the returned container with your own sidebar UI (e.g. a
+        `bs.Accordion`) and drive the content region yourself via `content`.
         """
         self._claim_provider()
         self._provider = CustomProvider()

--- a/src/bootstack/widgets/_impl/composites/shell/workspace.py
+++ b/src/bootstack/widgets/_impl/composites/shell/workspace.py
@@ -48,11 +48,15 @@ class Workspace:
         on_select: Callable[[str, str], None],
         on_refresh: Callable[[str], None],
         on_first_page: Callable[[str, str], None],
+        nav_variant: str = "nav-quiet",
+        nav_surface: str = "card",
     ) -> None:
         self._key = key
         self._sidebar = sidebar_panel
         self._content = content_frame
         self._nav_accent = nav_accent
+        self._nav_variant = nav_variant
+        self._nav_surface = nav_surface
         self._on_select = on_select
         self._on_refresh = on_refresh
         self._on_first_page = on_first_page
@@ -82,7 +86,9 @@ class Workspace:
 
     def _ensure_static(self) -> StaticProvider:
         if self._provider is None:
-            self._provider = StaticProvider(accent=self._nav_accent)
+            self._provider = StaticProvider(
+                accent=self._nav_accent, variant=self._nav_variant, surface=self._nav_surface
+            )
             self._mount_provider()
         elif not isinstance(self._provider, StaticProvider):
             raise RuntimeError(
@@ -164,7 +170,8 @@ class Workspace:
         """Fill the workspace from a `DataSource` (flat master-detail)."""
         self._claim_provider()
         self._provider = ListNavProvider(
-            source, text_field=text_field, icon_field=icon_field, accent=self._nav_accent
+            source, text_field=text_field, icon_field=icon_field,
+            accent=self._nav_accent, surface=self._nav_surface,
         )
         self._mount_provider()
         return self._provider

--- a/src/bootstack/widgets/_impl/composites/shell/workspace.py
+++ b/src/bootstack/widgets/_impl/composites/shell/workspace.py
@@ -166,15 +166,18 @@ class Workspace:
 
     # ----- Data-bound content API -----
 
-    def list_nav(self, source: Any, *, separator: bool = False) -> Any:
+    def list_nav(self, source: Any, *, separator: bool = False, density: str = "default") -> Any:
         """Fill the workspace from a `DataSource` (flat master-detail).
 
-        Records render their `text`/`icon` in a recycling `ListView` (which
-        inherits the sidebar surface). `separator` draws divider lines between
-        rows; default is flush.
+        Records render their `icon`/`title`/`text` in a recycling `ListView`
+        (which inherits the sidebar surface). `separator` draws divider lines
+        between rows (default flush); `density` is `'default'`/`'compact'`
+        (compact suits one-line items, default suits richer two-line items).
         """
         self._claim_provider()
-        self._provider = ListNavProvider(source, accent=self._nav_accent, separator=separator)
+        self._provider = ListNavProvider(
+            source, accent=self._nav_accent, separator=separator, density=density
+        )
         self._mount_provider()
         return self._provider
 
@@ -186,8 +189,12 @@ class Workspace:
         parent_field: str = "parent_id",
         label_field: str = "name",
         icon_field: str = "icon",
+        density: str = "default",
     ) -> Any:
-        """Fill the workspace from a hierarchy (tree master-detail)."""
+        """Fill the workspace from a hierarchy (tree master-detail).
+
+        `density` is `'default'`/`'compact'`.
+        """
         self._claim_provider()
         self._provider = TreeNavProvider(
             nodes=nodes,
@@ -196,6 +203,7 @@ class Workspace:
             label_field=label_field,
             icon_field=icon_field,
             accent=self._nav_accent,
+            density=density,
         )
         self._mount_provider()
         return self._provider

--- a/src/bootstack/widgets/_impl/composites/shell/workspace.py
+++ b/src/bootstack/widgets/_impl/composites/shell/workspace.py
@@ -166,13 +166,15 @@ class Workspace:
 
     # ----- Data-bound content API -----
 
-    def list_nav(self, source: Any, *, text_field: str = "text", icon_field: str = "icon") -> Any:
-        """Fill the workspace from a `DataSource` (flat master-detail)."""
+    def list_nav(self, source: Any, *, separator: bool = False) -> Any:
+        """Fill the workspace from a `DataSource` (flat master-detail).
+
+        Records render their `text`/`icon` in a recycling `ListView` (which
+        inherits the sidebar surface). `separator` draws divider lines between
+        rows; default is flush.
+        """
         self._claim_provider()
-        self._provider = ListNavProvider(
-            source, text_field=text_field, icon_field=icon_field,
-            accent=self._nav_accent, surface=self._nav_surface,
-        )
+        self._provider = ListNavProvider(source, accent=self._nav_accent, separator=separator)
         self._mount_provider()
         return self._provider
 

--- a/src/bootstack/widgets/_impl/composites/shell/workspace.py
+++ b/src/bootstack/widgets/_impl/composites/shell/workspace.py
@@ -1,0 +1,185 @@
+"""A workspace — one sidebar panel + content, filled by one provider.
+
+A `Workspace` owns a single navigation provider (chosen lazily and mutually
+exclusive) mounted into its own sidebar-panel frame and content frame. The shell
+holds one workspace per rail icon (and an implicit default workspace for the
+single-tier case). Selection truth lives in the shell's `NavModel`; the workspace
+reports clicks/refreshes back to the shell, which drives the model.
+
+The workspace exposes the same content API the shell does — `add_page` /
+`list_nav` / `tree_nav` / `@detail` / headers — so a single-tier app and a
+two-tier workspace are authored identically (the spec's degenerate-case
+unification).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from bootstack.widgets._impl.composites.shell.providers import (
+    ListNavProvider,
+    StaticProvider,
+    TreeNavProvider,
+)
+
+
+class Workspace:
+    """One workspace's provider + sidebar-panel/content frames.
+
+    Args:
+        key: Workspace identifier.
+        sidebar_panel: The frame this workspace's sidebar provider mounts into.
+        content_frame: The frame this workspace's content renders into.
+        nav_accent: Accent token for the active nav item.
+        on_select: Called `(workspace_key, page_key)` when an item is clicked.
+        on_refresh: Called `(workspace_key)` after a data-bound provider rebuilds.
+        on_first_page: Called `(workspace_key, page_key)` when the workspace's
+            first page is added (so the shell can auto-select it).
+    """
+
+    def __init__(
+        self,
+        key: str,
+        sidebar_panel: Any,
+        content_frame: Any,
+        *,
+        nav_accent: str,
+        on_select: Callable[[str, str], None],
+        on_refresh: Callable[[str], None],
+        on_first_page: Callable[[str, str], None],
+    ) -> None:
+        self._key = key
+        self._sidebar = sidebar_panel
+        self._content = content_frame
+        self._nav_accent = nav_accent
+        self._on_select = on_select
+        self._on_refresh = on_refresh
+        self._on_first_page = on_first_page
+        self._provider: Any = None
+
+    @property
+    def key(self) -> str:
+        """The workspace identifier."""
+        return self._key
+
+    @property
+    def provider(self) -> Any:
+        """The workspace's navigation provider (or `None`)."""
+        return self._provider
+
+    # ----- Provider selection (lazy + mutually exclusive) -----
+
+    def _ensure_static(self) -> StaticProvider:
+        if self._provider is None:
+            self._provider = StaticProvider(accent=self._nav_accent)
+            self._mount_provider()
+        elif not isinstance(self._provider, StaticProvider):
+            raise RuntimeError(
+                "cannot mix add_page() with a data-bound provider in one workspace"
+            )
+        return self._provider
+
+    def _claim_provider(self) -> None:
+        if self._provider is not None:
+            raise RuntimeError("this workspace already has a navigation provider")
+
+    def _mount_provider(self) -> None:
+        self._provider.mount(
+            self._sidebar,
+            self._content,
+            on_select=lambda page_key: self._on_select(self._key, page_key),
+            on_refresh=lambda: self._on_refresh(self._key),
+        )
+
+    # ----- Static content API -----
+
+    def add_page(self, key: str, *, text: str = "", icon=None, footer: bool = False) -> Any:
+        """Add a nav item and its page; return the page frame."""
+        if not key:
+            raise ValueError("page key must be non-empty")
+        provider = self._ensure_static()
+        if key in provider.keys():
+            raise ValueError(f"duplicate page key: {key!r}")
+        first = not provider.keys()
+        page = provider.add_page(key, text=text, icon=icon, footer=footer)
+        if first:
+            self._on_first_page(self._key, key)
+        return page
+
+    def add_footer_page(self, key: str, *, text: str = "", icon=None) -> Any:
+        """Add a nav item pinned to the sidebar footer and its page."""
+        return self.add_page(key, text=text, icon=icon, footer=True)
+
+    def add_header(self, text: str) -> Any:
+        """Add a static section header to the sidebar."""
+        return self._ensure_static().add_header(text)
+
+    def add_separator(self) -> Any:
+        """Add a separator to the sidebar."""
+        return self._ensure_static().add_separator()
+
+    # ----- Data-bound content API -----
+
+    def list_nav(self, source: Any, *, text_field: str = "text", icon_field: str = "icon") -> Any:
+        """Fill the workspace from a `DataSource` (flat master-detail)."""
+        self._claim_provider()
+        self._provider = ListNavProvider(
+            source, text_field=text_field, icon_field=icon_field, accent=self._nav_accent
+        )
+        self._mount_provider()
+        return self._provider
+
+    def tree_nav(
+        self,
+        *,
+        nodes: list | None = None,
+        source: Any = None,
+        parent_field: str = "parent_id",
+        label_field: str = "name",
+        icon_field: str = "icon",
+    ) -> Any:
+        """Fill the workspace from a hierarchy (tree master-detail)."""
+        self._claim_provider()
+        self._provider = TreeNavProvider(
+            nodes=nodes,
+            source=source,
+            parent_field=parent_field,
+            label_field=label_field,
+            icon_field=icon_field,
+            accent=self._nav_accent,
+        )
+        self._mount_provider()
+        return self._provider
+
+    def detail(self, fn: Callable[[dict], Any]) -> Callable[[dict], Any]:
+        """Register the detail body for a data-bound provider (decorator)."""
+        if self._provider is None or not hasattr(self._provider, "set_detail"):
+            raise RuntimeError("detail() requires a data-bound provider (list_nav/tree_nav)")
+        self._provider.set_detail(fn)
+        if self._provider.keys():
+            self._on_first_page(self._key, self._provider.keys()[0])
+        return fn
+
+    # ----- Provider plumbing -----
+
+    def keys(self) -> tuple[str, ...]:
+        """All selectable page/record keys this workspace exposes."""
+        return self._provider.keys() if self._provider is not None else ()
+
+    def show(self, key: str, data: dict | None = None) -> None:
+        """Render content for `key` (delegates to the provider)."""
+        if self._provider is not None:
+            self._provider.show(key, data=data)
+
+    def select_visual(self, key: str | None) -> None:
+        """Reflect the active `key` in the sidebar selection (delegates)."""
+        if self._provider is not None:
+            self._provider.select_visual(key)
+
+    def close(self) -> None:
+        """Release provider resources (e.g. data-source subscriptions)."""
+        if self._provider is not None and hasattr(self._provider, "close"):
+            try:
+                self._provider.close()
+            except Exception:
+                pass

--- a/src/bootstack/widgets/_impl/composites/shell/workspace.py
+++ b/src/bootstack/widgets/_impl/composites/shell/workspace.py
@@ -67,6 +67,16 @@ class Workspace:
         """The workspace's navigation provider (or `None`)."""
         return self._provider
 
+    @property
+    def supports_compact(self) -> bool:
+        """Whether this workspace's provider can render icon-only (compact)."""
+        return bool(getattr(self._provider, "supports_compact", False))
+
+    def set_compact(self, compact: bool) -> None:
+        """Render the sidebar icon-only (`compact`) or with labels."""
+        if self._provider is not None and hasattr(self._provider, "set_compact"):
+            self._provider.set_compact(compact)
+
     # ----- Provider selection (lazy + mutually exclusive) -----
 
     def _ensure_static(self) -> StaticProvider:

--- a/src/bootstack/widgets/_impl/composites/sidenav/header.py
+++ b/src/bootstack/widgets/_impl/composites/sidenav/header.py
@@ -1,6 +1,6 @@
 ﻿"""SideNavHeader widget for section labels in navigation menus."""
 
-from typing import Any
+from typing import Any, Callable
 
 from typing_extensions import TypedDict, Unpack
 
@@ -19,11 +19,17 @@ class SideNavHeaderKwargs(TypedDict, total=False):
 
 
 class SideNavHeader(Frame):
-    """A non-selectable section header for grouping navigation items.
+    """A section header for grouping navigation items.
 
     SideNavHeader provides a text label to identify groups of related
     navigation items. Unlike SideNavItem, headers are not selectable
     and serve only as visual labels. Uses the 'label' font token for styling.
+
+    When `collapsible` is True the header gains a chevron and reports clicks via
+    `on_toggle`; the owner (e.g. `NavPanel`) flips `collapsed` and re-lays out the
+    group's items. The header itself holds only the collapsed flag + chevron — it
+    does not own the items. The chevron styling is refined in the shell styling
+    pass; here it is a functional affordance.
 
     """
 
@@ -35,6 +41,8 @@ class SideNavHeader(Frame):
         self,
         master: Master = None,
         text: str = '',
+        collapsible: bool = False,
+        on_toggle: Callable[[], None] | None = None,
         **kwargs: Unpack[SideNavHeaderKwargs]
     ):
         """Initialize a SideNavHeader.
@@ -42,16 +50,21 @@ class SideNavHeader(Frame):
         Args:
             master: Parent widget.
             text: The header text to display.
+            collapsible: Render a chevron and report clicks via `on_toggle`.
+            on_toggle: Called (no args) when a collapsible header is clicked.
             **kwargs: Additional arguments passed to Frame.
         """
         self._text = text
+        self._collapsible = collapsible
+        self._collapsed = False
+        self._on_toggle = on_toggle
 
         # Default padding: more top margin for visual separation between sections
         kwargs.setdefault('padding', self.DEFAULT_PADDING)
 
         super().__init__(master, **kwargs)
 
-        # Create header label with 'label' font (smaller, bold) and secondary accent
+        # Header label with 'label' font (smaller, bold) and secondary accent.
         self._text_label = Label(
             self,
             text=text,
@@ -59,7 +72,45 @@ class SideNavHeader(Frame):
             accent=self.DEFAULT_ACCENT,
             anchor='w',
         )
-        self._text_label.pack(fill='x')
+        self._chevron: Label | None = None
+
+        if self._collapsible:
+            self._text_label.pack(side='left', fill='x', expand=True)
+            self._chevron = Label(
+                self,
+                icon=self._chevron_icon(),
+                icon_only=True,
+                accent=self.DEFAULT_ACCENT,
+            )
+            self._chevron.pack(side='right')
+            for widget in (self, self._text_label, self._chevron):
+                widget.bind('<Button-1>', self._on_click, add='+')
+        else:
+            self._text_label.pack(fill='x')
+
+    def _chevron_icon(self) -> dict:
+        name = 'chevron-right' if self._collapsed else 'chevron-down'
+        return {'name': name, 'size': 14}
+
+    def _on_click(self, _event=None):
+        if self._on_toggle is not None:
+            self._on_toggle()
+
+    def set_collapsed(self, collapsed: bool) -> None:
+        """Set the collapsed flag and update the chevron (visual only)."""
+        self._collapsed = collapsed
+        if self._chevron is not None:
+            self._chevron.configure(icon=self._chevron_icon())
+
+    @property
+    def collapsible(self) -> bool:
+        """Whether this header toggles a group of items."""
+        return self._collapsible
+
+    @property
+    def collapsed(self) -> bool:
+        """Whether this header's group is currently collapsed."""
+        return self._collapsed
 
     @property
     def text(self) -> str:

--- a/src/bootstack/widgets/_impl/composites/sidenav/header.py
+++ b/src/bootstack/widgets/_impl/composites/sidenav/header.py
@@ -1,6 +1,6 @@
-﻿"""SideNavHeader widget for section labels in navigation menus."""
+"""SideNavHeader widget for section labels in navigation menus."""
 
-from typing import Any, Callable
+from typing import Any
 
 from typing_extensions import TypedDict, Unpack
 
@@ -23,26 +23,23 @@ class SideNavHeader(Frame):
 
     SideNavHeader provides a text label to identify groups of related
     navigation items. Unlike SideNavItem, headers are not selectable
-    and serve only as visual labels. Uses the 'label' font token for styling.
+    and serve only as visual labels — a quiet, non-interactive section
+    marker. Uses the 'label' font token for styling.
 
-    When `collapsible` is True the header gains a chevron and reports clicks via
-    `on_toggle`; the owner (e.g. `NavPanel`) flips `collapsed` and re-lays out the
-    group's items. The header itself holds only the collapsed flag + chevron — it
-    does not own the items. The chevron styling is refined in the shell styling
-    pass; here it is a functional affordance.
-
+    A header is always a plain label; it does not collapse its items (a
+    collapsible sub-list is a content concern — use a `bs.Accordion`).
     """
 
     DEFAULT_PADDING = (8, 20, 8, 4)
     DEFAULT_FONT = 'label'
-    DEFAULT_ACCENT = 'default'
+    # Muted, not full-strength: a section header is quiet chrome that names a
+    # group — it should recede so the clickable items carry the contrast.
+    DEFAULT_ACCENT = 'muted'
 
     def __init__(
         self,
         master: Master = None,
         text: str = '',
-        collapsible: bool = False,
-        on_toggle: Callable[[], None] | None = None,
         **kwargs: Unpack[SideNavHeaderKwargs]
     ):
         """Initialize a SideNavHeader.
@@ -50,14 +47,9 @@ class SideNavHeader(Frame):
         Args:
             master: Parent widget.
             text: The header text to display.
-            collapsible: Render a chevron and report clicks via `on_toggle`.
-            on_toggle: Called (no args) when a collapsible header is clicked.
             **kwargs: Additional arguments passed to Frame.
         """
         self._text = text
-        self._collapsible = collapsible
-        self._collapsed = False
-        self._on_toggle = on_toggle
 
         # Default padding: more top margin for visual separation between sections
         kwargs.setdefault('padding', self.DEFAULT_PADDING)
@@ -72,45 +64,7 @@ class SideNavHeader(Frame):
             accent=self.DEFAULT_ACCENT,
             anchor='w',
         )
-        self._chevron: Label | None = None
-
-        if self._collapsible:
-            self._text_label.pack(side='left', fill='x', expand=True)
-            self._chevron = Label(
-                self,
-                icon=self._chevron_icon(),
-                icon_only=True,
-                accent=self.DEFAULT_ACCENT,
-            )
-            self._chevron.pack(side='right')
-            for widget in (self, self._text_label, self._chevron):
-                widget.bind('<Button-1>', self._on_click, add='+')
-        else:
-            self._text_label.pack(fill='x')
-
-    def _chevron_icon(self) -> dict:
-        name = 'chevron-right' if self._collapsed else 'chevron-down'
-        return {'name': name, 'size': 14}
-
-    def _on_click(self, _event=None):
-        if self._on_toggle is not None:
-            self._on_toggle()
-
-    def set_collapsed(self, collapsed: bool) -> None:
-        """Set the collapsed flag and update the chevron (visual only)."""
-        self._collapsed = collapsed
-        if self._chevron is not None:
-            self._chevron.configure(icon=self._chevron_icon())
-
-    @property
-    def collapsible(self) -> bool:
-        """Whether this header toggles a group of items."""
-        return self._collapsible
-
-    @property
-    def collapsed(self) -> bool:
-        """Whether this header's group is currently collapsed."""
-        return self._collapsed
+        self._text_label.pack(fill='x')
 
     @property
     def text(self) -> str:

--- a/tests/test_navmodel.py
+++ b/tests/test_navmodel.py
@@ -1,0 +1,326 @@
+"""Headless unit tests for `NavModel` — the shell's navigation state.
+
+No Tk / App required; this is pure state-machine coverage.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bootstack.widgets._core.navmodel import NavChange, NavModel, WorkspaceState
+
+
+# ----- Workspaces & activation -----
+
+def test_add_workspace_returns_state():
+    m = NavModel()
+    ws = m.add_workspace("home", text="Home", icon="house")
+    assert isinstance(ws, WorkspaceState)
+    assert ws.key == "home"
+    assert ws.text == "Home"
+    assert ws.icon == "house"
+    assert ws.provider == "pages"
+    assert m.has_workspace("home")
+    assert m.workspace("home") is ws
+
+
+def test_first_non_footer_workspace_becomes_active():
+    m = NavModel()
+    assert m.active_workspace is None
+    m.add_workspace("a")
+    assert m.active_workspace == "a"
+    # a second workspace does not steal active
+    m.add_workspace("b")
+    assert m.active_workspace == "a"
+
+
+def test_footer_workspace_does_not_auto_activate():
+    m = NavModel()
+    m.add_workspace("settings", is_footer=True)
+    assert m.active_workspace is None
+    m.add_workspace("home")
+    assert m.active_workspace == "home"
+
+
+def test_duplicate_and_empty_workspace_keys_raise():
+    m = NavModel()
+    m.add_workspace("a")
+    with pytest.raises(ValueError):
+        m.add_workspace("a")
+    with pytest.raises(ValueError):
+        m.add_workspace("")
+
+
+def test_workspace_unknown_key_raises():
+    m = NavModel()
+    with pytest.raises(KeyError):
+        m.workspace("nope")
+
+
+# ----- Rail visibility (the degenerate-case unification) -----
+
+def test_rail_hidden_until_more_than_one_workspace():
+    m = NavModel()
+    assert m.rail_visible is False
+    m.add_workspace("a")
+    assert m.rail_visible is False          # single-tier: no rail
+    m.add_workspace("b")
+    assert m.rail_visible is True           # two-tier: rail appears
+
+
+def test_footer_workspace_counts_toward_rail():
+    m = NavModel()
+    m.add_workspace("home")
+    m.add_workspace("settings", is_footer=True)
+    assert m.rail_visible is True
+
+
+# ----- Workspace selection -----
+
+def test_select_workspace_sets_active_and_notifies():
+    m = NavModel()
+    m.add_workspace("a")
+    m.add_workspace("b")
+    seen: list[NavChange] = []
+    m.subscribe(seen.append)
+    m.select_workspace("b")
+    assert m.active_workspace == "b"
+    assert seen[-1].facet == "workspace"
+    assert seen[-1].workspace == "b"
+
+
+def test_select_workspace_same_is_noop():
+    m = NavModel()
+    m.add_workspace("a")
+    seen: list[NavChange] = []
+    m.subscribe(seen.append)
+    m.select_workspace("a")                 # already active
+    assert seen == []
+
+
+def test_select_unknown_workspace_raises():
+    m = NavModel()
+    with pytest.raises(KeyError):
+        m.select_workspace("nope")
+
+
+# ----- Page selection & per-workspace memory -----
+
+def test_select_page_defaults_to_active_workspace():
+    m = NavModel()
+    m.add_workspace("a")
+    m.select_page("p1")
+    assert m.active_page() == "p1"
+    assert m.active_page("a") == "p1"
+
+
+def test_per_workspace_page_memory_survives_switching():
+    m = NavModel()
+    m.add_workspace("a")
+    m.add_workspace("b")
+    m.select_page("a1")                     # on active 'a'
+    m.select_workspace("b")
+    m.select_page("b1")
+    assert m.active_page("a") == "a1"       # remembered independently
+    assert m.active_page("b") == "b1"
+    m.select_workspace("a")
+    assert m.active_page() == "a1"          # switching back restores memory
+
+
+def test_select_page_explicit_workspace():
+    m = NavModel()
+    m.add_workspace("a")
+    m.add_workspace("b")
+    m.select_page("b1", workspace="b")      # set non-active workspace's page
+    assert m.active_workspace == "a"        # active unchanged
+    assert m.active_page("b") == "b1"
+
+
+def test_select_page_without_active_workspace_raises():
+    m = NavModel()
+    with pytest.raises(ValueError):
+        m.select_page("p1")
+
+
+def test_select_page_unknown_workspace_raises():
+    m = NavModel()
+    m.add_workspace("a")
+    with pytest.raises(KeyError):
+        m.select_page("p1", workspace="nope")
+
+
+def test_active_page_none_when_unset():
+    m = NavModel()
+    m.add_workspace("a")
+    assert m.active_page() is None
+
+
+# ----- The VS Code rail gesture -----
+
+def test_activate_rail_different_workspace_switches_and_shows():
+    m = NavModel()
+    m.add_workspace("a")
+    m.add_workspace("b")
+    m.hide_sidebar()
+    m.activate_rail("b")
+    assert m.active_workspace == "b"
+    assert m.sidebar_visible is True
+
+
+def test_activate_rail_active_workspace_hides_when_visible():
+    m = NavModel()
+    m.add_workspace("a")
+    m.add_workspace("b")
+    assert m.sidebar_visible is True
+    m.activate_rail("a")                    # clicking the active icon
+    assert m.sidebar_visible is False
+    assert m.active_workspace == "a"
+
+
+def test_activate_rail_active_workspace_shows_when_hidden():
+    m = NavModel()
+    m.add_workspace("a")
+    m.hide_sidebar()
+    m.activate_rail("a")
+    assert m.sidebar_visible is True
+
+
+def test_activate_rail_unknown_raises():
+    m = NavModel()
+    m.add_workspace("a")
+    with pytest.raises(KeyError):
+        m.activate_rail("nope")
+
+
+# ----- Sidebar axis: hidden -> compact -> expanded -----
+
+def test_default_sidebar_mode_expanded():
+    assert NavModel().sidebar_mode == "expanded"
+
+
+def test_set_sidebar_mode_validates():
+    m = NavModel()
+    with pytest.raises(ValueError):
+        m.set_sidebar_mode("bogus")  # type: ignore[arg-type]
+
+
+def test_set_sidebar_mode_notifies_once_and_dedupes():
+    m = NavModel()
+    seen: list[NavChange] = []
+    m.subscribe(seen.append)
+    m.set_sidebar_mode("compact")
+    m.set_sidebar_mode("compact")           # no-op
+    assert len(seen) == 1
+    assert seen[0].facet == "sidebar"
+    assert seen[0].sidebar_mode == "compact"
+
+
+def test_hide_then_show_restores_prior_mode():
+    m = NavModel()
+    m.set_sidebar_mode("compact")
+    m.hide_sidebar()
+    assert m.sidebar_mode == "hidden"
+    m.show_sidebar()
+    assert m.sidebar_mode == "compact"      # not the default 'expanded'
+
+
+def test_toggle_sidebar_round_trip():
+    m = NavModel()                          # expanded
+    m.toggle_sidebar()
+    assert m.sidebar_mode == "hidden"
+    m.toggle_sidebar()
+    assert m.sidebar_mode == "expanded"
+
+
+def test_show_sidebar_when_visible_is_noop():
+    m = NavModel()
+    seen: list[NavChange] = []
+    m.subscribe(seen.append)
+    m.show_sidebar()                        # already expanded
+    assert seen == []
+
+
+def test_initial_hidden_restores_to_expanded():
+    m = NavModel(sidebar_mode="hidden")
+    assert m.sidebar_mode == "hidden"
+    m.show_sidebar()
+    assert m.sidebar_mode == "expanded"
+
+
+# ----- Dock -----
+
+def test_toggle_dock():
+    m = NavModel()
+    assert m.dock_visible is False
+    seen: list[NavChange] = []
+    m.subscribe(seen.append)
+    m.toggle_dock()
+    assert m.dock_visible is True
+    assert seen[-1].facet == "dock"
+    assert seen[-1].dock_visible is True
+    m.toggle_dock()
+    assert m.dock_visible is False
+
+
+# ----- Subscription mechanics -----
+
+def test_unsubscribe_stops_notifications():
+    m = NavModel()
+    m.add_workspace("a")
+    m.add_workspace("b")
+    seen: list[NavChange] = []
+    handle = m.subscribe(seen.append)
+    m.select_workspace("b")
+    handle.cancel()
+    m.select_workspace("a")
+    assert [c.workspace for c in seen] == ["b"]
+
+
+def test_unsubscribe_during_dispatch_is_safe():
+    m = NavModel()
+    m.add_workspace("a")
+    m.add_workspace("b")
+    calls: list[str] = []
+
+    def once(change: NavChange) -> None:
+        calls.append("once")
+        handle.cancel()
+
+    handle = m.subscribe(once)
+    m.subscribe(lambda c: calls.append("other"))
+    m.select_workspace("b")                 # both fire; 'once' removes itself
+    m.select_workspace("a")                 # only 'other' fires
+    assert calls == ["once", "other", "other"]
+
+
+def test_subscribe_returns_cancellable_handle():
+    m = NavModel()
+    m.add_workspace("a")
+    m.add_workspace("b")
+    seen: list[NavChange] = []
+    handle = m.subscribe(seen.append)
+    assert handle.cancelled is False
+    handle.cancel()
+    assert handle.cancelled is True
+    m.select_workspace("b")
+    assert seen == []
+
+
+def test_subscribe_handle_works_as_context_manager():
+    m = NavModel()
+    m.add_workspace("a")
+    m.add_workspace("b")
+    seen: list[NavChange] = []
+    with m.subscribe(seen.append):
+        m.select_workspace("b")
+    m.select_workspace("a")                 # after context exit: unsubscribed
+    assert [c.workspace for c in seen] == ["b"]
+
+
+def test_add_workspace_emits_structure_change():
+    m = NavModel()
+    seen: list[NavChange] = []
+    m.subscribe(seen.append)
+    m.add_workspace("a")
+    assert seen[-1].facet == "structure"
+    assert seen[-1].workspace == "a"

--- a/tests/widgets/test_shell_collapse.py
+++ b/tests/widgets/test_shell_collapse.py
@@ -1,0 +1,78 @@
+"""Step 7 — sidebar collapse mechanics (single-tier static). One App/process.
+
+Verifies the hidden/compact/expanded axis wired to the view: toggle/show/hide
+visibility, `compact` rendering the static sidebar icon-only at the rail width
+(gated to the standalone case), the `sidebar_mode` property, and Ctrl-B toggling.
+"""
+
+from __future__ import annotations
+
+from bootstack.widgets._impl.composites.shell import Shell
+
+
+def test_sidebar_collapse_single_tier():
+    shell = Shell(title="Collapse", size=(800, 540))
+    try:
+        shell.add_page("home", text="Home", icon="house")
+        shell.add_header("Docs")
+        shell.add_page("files", text="Files", icon="folder")
+
+        nav = shell.nav
+        # Starts expanded + visible.
+        assert shell.sidebar_mode == "expanded"
+        assert shell.sidebar_visible is True
+        assert nav.compact is False
+
+        # Hamburger/toggle hides; show restores the prior non-hidden mode.
+        shell.toggle_sidebar()
+        assert shell.sidebar_visible is False
+        assert shell.sidebar_mode == "hidden"
+        shell.show_sidebar()
+        assert shell.sidebar_visible is True
+        assert shell.sidebar_mode == "expanded"
+
+        # Compact (static + standalone, no rail) -> icon-only at the rail width.
+        shell.sidebar_mode = "compact"
+        assert shell.sidebar_visible is True
+        assert nav.compact is True
+        shell.update_idletasks()
+        assert int(shell.sidebar.cget("width")) == shell._rail_width
+
+        # Expanded -> labels return, width restored to the expanded token.
+        shell.sidebar_mode = "expanded"
+        assert nav.compact is False
+        shell.update_idletasks()
+        assert int(shell.sidebar.cget("width")) == shell._sidebar_width
+
+        # The explicit verbs are pure visibility.
+        shell.hide_sidebar()
+        assert shell.sidebar_visible is False
+        shell.show_sidebar()
+        assert shell.sidebar_visible is True
+
+        # Ctrl-B on a standalone static sidebar collapses to/from compact (it is
+        # the only nav, so the shortcut never fully hides it).
+        shell.sidebar_mode = "expanded"
+        shell._on_toggle_shortcut()
+        assert shell.sidebar_mode == "compact"
+        assert nav.compact is True
+        shell._on_toggle_shortcut()
+        assert shell.sidebar_mode == "expanded"
+        assert nav.compact is False
+
+        # The standalone static workspace supports compaction.
+        assert shell.workspace.supports_compact is True
+        assert shell._can_compact_active() is True
+    finally:
+        shell.destroy()
+
+
+def test_data_bound_providers_not_compactable():
+    from bootstack.widgets._impl.composites.shell import (
+        ListNavProvider,
+        TreeNavProvider,
+    )
+
+    # A label-less data list / icon-only hierarchy is meaningless: hidden-or-shown.
+    assert ListNavProvider.supports_compact is False
+    assert TreeNavProvider.supports_compact is False

--- a/tests/widgets/test_shell_custompanel.py
+++ b/tests/widgets/test_shell_custompanel.py
@@ -1,0 +1,41 @@
+"""Step 8 — custom panel mode (escape hatch). One App/process.
+
+`panel()` claims the workspace as a blank container the user fills, with no
+provider cascade and no compaction; content is driven by hand via `content`.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bootstack.widgets._impl.composites.shell import CustomProvider, Shell
+from bootstack.widgets._impl.primitives.label import Label
+
+
+def test_custom_panel_mode():
+    shell = Shell(title="Custom")
+    try:
+        container = shell.panel()
+        # Returns a usable container frame to fill directly.
+        Label(container, text="Filters").pack()
+
+        provider = shell.provider
+        assert isinstance(provider, CustomProvider)
+        assert provider.supports_compact is False
+        assert provider.keys() == ()
+        assert shell.workspace.supports_compact is False
+        # Content region is exposed for hand-driven swapping.
+        assert shell.workspace.content is not None
+
+        # Ctrl-B can't compact a custom panel -> it hides.
+        assert shell._can_compact_active() is False
+
+        # The workspace already has a provider -> add_page is rejected.
+        with pytest.raises(RuntimeError):
+            shell.add_page("x")
+    finally:
+        shell.destroy()
+
+
+def test_custom_provider_not_compactable():
+    assert CustomProvider.supports_compact is False

--- a/tests/widgets/test_shell_groups.py
+++ b/tests/widgets/test_shell_groups.py
@@ -1,20 +1,23 @@
-"""Step 8 — 1-level collapsible groups in the static provider. One App/process.
+"""Grouped-static sidebar — `add_header` chunks a flat nav list with plain labels.
 
-A collapsible header toggles the run of items that follow it (up to the next
-header or separator). Compact flattens the group (items reappear as icons),
-preserving and restoring the collapse state on expand.
+There is no built-in collapsible accordion (dropped — a section that hides/reveals
+a sub-list is a content concern; compose `bs.Accordion` in a custom `panel()` if
+you need one). A header is a quiet, non-interactive label: it groups the items
+that follow it and hides while the sidebar is compacted. One App/process.
 """
 
 from __future__ import annotations
 
+import bootstack as bs
 from bootstack.widgets._impl.composites.shell import Shell
+from bootstack.widgets._impl.composites.sidenav.header import SideNavHeader
 
 
-def test_collapsible_group_single_tier():
-    shell = Shell(title="Groups")
+def test_grouped_static_sidebar():
+    shell = Shell(title="Grouped", size=(800, 540))
     try:
         shell.add_page("home", text="Home", icon="house")
-        docs = shell.add_header("Documents", collapsible=True)
+        header = shell.add_header("Documents")
         shell.add_page("files", text="Files", icon="folder")
         shell.add_page("photos", text="Photos", icon="image")
         shell.add_separator()
@@ -23,58 +26,36 @@ def test_collapsible_group_single_tier():
         nav = shell.nav
         shell.update_idletasks()
 
-        # Group starts expanded.
-        assert docs.collapsible is True
-        assert docs.collapsed is False
-        assert nav._items["files"].winfo_manager() == "pack"
+        # The header is a plain, non-interactive label — not a collapsible control.
+        assert isinstance(header, SideNavHeader)
+        assert header.text == "Documents"
+        assert not hasattr(header, "collapsed")
+        assert not hasattr(header, "collapsible")
+        assert not hasattr(header, "set_collapsed")
 
-        # Collapse hides the run (files, photos) only.
-        nav._toggle_group(docs)
+        # First page auto-selects; every item is mapped (a header groups items but
+        # never hides them — the run does not collapse).
+        assert shell.current_page == "home"
+        for key in ("home", "files", "photos", "trash"):
+            assert nav._items[key].winfo_manager() == "pack"
+        assert header.winfo_manager() == "pack"
+
+        # Navigation across grouped items works.
+        shell.navigate("photos")
         shell.update_idletasks()
-        assert docs.collapsed is True
-        assert nav._items["files"].winfo_manager() == ""
-        assert nav._items["photos"].winfo_manager() == ""
-        assert nav._items["home"].winfo_manager() == "pack"   # before the group
-        assert nav._items["trash"].winfo_manager() == "pack"  # after the separator
+        assert shell.current_page == "photos"
+        assert nav.selected == "photos"
 
-        # Expand restores.
-        nav._toggle_group(docs)
-        shell.update_idletasks()
-        assert nav._items["files"].winfo_manager() == "pack"
-
-        # Compact flattens: collapse, then compact -> grouped items reappear as
-        # icons and the header hides.
-        nav._toggle_group(docs)                # collapse again
+        # Compaction hides the header + separator (icon-only strip), items stay.
         shell.sidebar_mode = "compact"
         shell.update_idletasks()
         assert nav.compact is True
+        assert header.winfo_manager() == ""
         assert nav._items["files"].winfo_manager() == "pack"
-        assert docs.winfo_manager() == ""      # header hidden in compact
 
-        # Expand -> collapse state is preserved (files hidden again).
+        # Expanding restores the header.
         shell.sidebar_mode = "expanded"
         shell.update_idletasks()
-        assert docs.collapsed is True
-        assert nav._items["files"].winfo_manager() == ""
-
-        # A non-collapsible header is a plain label (no chevron, no toggle).
-        plain = shell.add_header("Other")
-        assert plain.collapsible is False
-
-        # expand_all / collapse_all drive every collapsible group at once.
-        lib = shell.add_header("Library", collapsible=True)
-        shell.add_page("books", text="Books", icon="book")
-        shell.expand_all()
-        shell.update_idletasks()
-        assert docs.collapsed is False and lib.collapsed is False
-        assert nav._items["files"].winfo_manager() == "pack"
-
-        shell.collapse_all()
-        shell.update_idletasks()
-        assert docs.collapsed is True and lib.collapsed is True
-        assert nav._items["files"].winfo_manager() == ""
-        assert nav._items["books"].winfo_manager() == ""
-        # Non-grouped items are unaffected.
-        assert nav._items["home"].winfo_manager() == "pack"
+        assert header.winfo_manager() == "pack"
     finally:
         shell.destroy()

--- a/tests/widgets/test_shell_groups.py
+++ b/tests/widgets/test_shell_groups.py
@@ -1,0 +1,80 @@
+"""Step 8 — 1-level collapsible groups in the static provider. One App/process.
+
+A collapsible header toggles the run of items that follow it (up to the next
+header or separator). Compact flattens the group (items reappear as icons),
+preserving and restoring the collapse state on expand.
+"""
+
+from __future__ import annotations
+
+from bootstack.widgets._impl.composites.shell import Shell
+
+
+def test_collapsible_group_single_tier():
+    shell = Shell(title="Groups")
+    try:
+        shell.add_page("home", text="Home", icon="house")
+        docs = shell.add_header("Documents", collapsible=True)
+        shell.add_page("files", text="Files", icon="folder")
+        shell.add_page("photos", text="Photos", icon="image")
+        shell.add_separator()
+        shell.add_page("trash", text="Trash", icon="trash")
+
+        nav = shell.nav
+        shell.update_idletasks()
+
+        # Group starts expanded.
+        assert docs.collapsible is True
+        assert docs.collapsed is False
+        assert nav._items["files"].winfo_manager() == "pack"
+
+        # Collapse hides the run (files, photos) only.
+        nav._toggle_group(docs)
+        shell.update_idletasks()
+        assert docs.collapsed is True
+        assert nav._items["files"].winfo_manager() == ""
+        assert nav._items["photos"].winfo_manager() == ""
+        assert nav._items["home"].winfo_manager() == "pack"   # before the group
+        assert nav._items["trash"].winfo_manager() == "pack"  # after the separator
+
+        # Expand restores.
+        nav._toggle_group(docs)
+        shell.update_idletasks()
+        assert nav._items["files"].winfo_manager() == "pack"
+
+        # Compact flattens: collapse, then compact -> grouped items reappear as
+        # icons and the header hides.
+        nav._toggle_group(docs)                # collapse again
+        shell.sidebar_mode = "compact"
+        shell.update_idletasks()
+        assert nav.compact is True
+        assert nav._items["files"].winfo_manager() == "pack"
+        assert docs.winfo_manager() == ""      # header hidden in compact
+
+        # Expand -> collapse state is preserved (files hidden again).
+        shell.sidebar_mode = "expanded"
+        shell.update_idletasks()
+        assert docs.collapsed is True
+        assert nav._items["files"].winfo_manager() == ""
+
+        # A non-collapsible header is a plain label (no chevron, no toggle).
+        plain = shell.add_header("Other")
+        assert plain.collapsible is False
+
+        # expand_all / collapse_all drive every collapsible group at once.
+        lib = shell.add_header("Library", collapsible=True)
+        shell.add_page("books", text="Books", icon="book")
+        shell.expand_all()
+        shell.update_idletasks()
+        assert docs.collapsed is False and lib.collapsed is False
+        assert nav._items["files"].winfo_manager() == "pack"
+
+        shell.collapse_all()
+        shell.update_idletasks()
+        assert docs.collapsed is True and lib.collapsed is True
+        assert nav._items["files"].winfo_manager() == ""
+        assert nav._items["books"].winfo_manager() == ""
+        # Non-grouped items are unaffected.
+        assert nav._items["home"].winfo_manager() == "pack"
+    finally:
+        shell.destroy()

--- a/tests/widgets/test_shell_layout.py
+++ b/tests/widgets/test_shell_layout.py
@@ -1,0 +1,63 @@
+"""Structural smoke test for the shell region layout (Layer 1).
+
+Asserts that regions construct and that show/hide toggles their geometry
+management — no visual inspection. One `App` per process: a single test owns
+the window and tears it down.
+"""
+
+from __future__ import annotations
+
+from bootstack.widgets._impl.composites.shell import ShellLayout
+
+
+def test_region_layout_construction_and_toggles():
+    shell = ShellLayout(title="Smoke")
+    try:
+        # Regions exist.
+        for name in ("chrome", "statusbar", "rail", "sidebar", "content", "dock"):
+            assert getattr(shell, name) is not None
+
+        # Guard: internal attributes must not shadow tkinter's `Misc._root()`
+        # method (doing so breaks event dispatch in the mainloop).
+        assert shell._root() is shell
+        shell.update_idletasks()
+
+        # Default visibility: content + sidebar shown; everything else hidden.
+        assert shell.content.winfo_manager() == "pack"
+        assert shell.sidebar.winfo_manager() == "pack"
+        for hidden in (shell.chrome, shell.statusbar, shell.rail, shell.dock):
+            assert hidden.winfo_manager() == ""
+
+        # Reflected in the visibility properties.
+        assert shell.sidebar_visible is True
+        assert shell.rail_visible is False
+        assert shell.chrome_visible is False
+        assert shell.statusbar_visible is False
+        assert shell.dock_visible is False
+
+        # Toggle each slot on.
+        shell.set_rail_visible(True)
+        shell.set_chrome_visible(True)
+        shell.set_statusbar_visible(True)
+        shell.set_dock_visible(True)
+        assert shell.rail.winfo_manager() == "pack"
+        assert shell.chrome.winfo_manager() == "pack"
+        assert shell.statusbar.winfo_manager() == "pack"
+        assert shell.dock.winfo_manager() == "pack"
+
+        # Hide the sidebar; content stays.
+        shell.set_sidebar_visible(False)
+        assert shell.sidebar.winfo_manager() == ""
+        assert shell.content.winfo_manager() == "pack"
+
+        # Toggles are idempotent (no error, state unchanged).
+        shell.set_rail_visible(True)
+        assert shell.rail_visible is True
+
+        # Width setters apply to the slot frames.
+        shell.set_sidebar_width(300)
+        assert int(shell.sidebar.cget("width")) == 300
+        shell.set_rail_width(64)
+        assert int(shell.rail.cget("width")) == 64
+    finally:
+        shell.destroy()

--- a/tests/widgets/test_shell_listnav.py
+++ b/tests/widgets/test_shell_listnav.py
@@ -39,7 +39,7 @@ def test_list_nav_master_detail_cascade():
         # Selecting another record re-renders the detail.
         keys = shell.provider.keys()
         assert len(keys) == 2
-        shell._on_nav_select(keys[1])
+        shell._workspace_select(shell.current_workspace, keys[1])
         assert seen[-1]["text"] == "Thermocouple"
         sel_id = seen[-1]["id"]               # real record id (for source ops)
 

--- a/tests/widgets/test_shell_listnav.py
+++ b/tests/widgets/test_shell_listnav.py
@@ -1,0 +1,50 @@
+"""Smoke test for the data-bound list_nav provider + @detail (step 5).
+
+Verifies: records populate the sidebar, the detail builder receives the public
+record dict, the first record auto-selects once detail is set, selection
+re-renders the detail, and add_page after list_nav is rejected. One App/process.
+"""
+
+from __future__ import annotations
+
+import bootstack as bs
+from bootstack.data import MemoryDataSource
+from bootstack.widgets._impl.composites.shell import Shell
+
+
+def test_list_nav_master_detail_cascade():
+    shell = Shell(title="ListNav")
+    try:
+        source = MemoryDataSource().load([
+            {"text": "Spectrometer", "icon": "cpu", "status": "active"},
+            {"text": "Thermocouple", "icon": "thermometer", "status": "idle"},
+        ])
+
+        shell.list_nav(source=source)
+
+        seen: list[dict] = []
+
+        @shell.detail
+        def render(record):
+            seen.append(record)
+            bs.Label(record["text"])          # parents into the content region
+
+        # Detail registration auto-selects the first record.
+        assert seen, "detail should render the first record on registration"
+        first = seen[0]
+        assert first["text"] == "Spectrometer"
+        assert "id" in first                  # normalized public record dict
+        assert shell.content.winfo_children(), "detail body should be mounted"
+
+        # Selecting another record re-renders the detail.
+        keys = shell.provider.keys()
+        assert len(keys) == 2
+        shell._on_nav_select(keys[1])
+        assert seen[-1]["text"] == "Thermocouple"
+
+        # Mutual exclusivity: add_page after list_nav is rejected.
+        import pytest
+        with pytest.raises(RuntimeError):
+            shell.add_page("home", text="Home")
+    finally:
+        shell.destroy()

--- a/tests/widgets/test_shell_listnav.py
+++ b/tests/widgets/test_shell_listnav.py
@@ -41,6 +41,27 @@ def test_list_nav_master_detail_cascade():
         assert len(keys) == 2
         shell._on_nav_select(keys[1])
         assert seen[-1]["text"] == "Thermocouple"
+        sel_id = seen[-1]["id"]               # real record id (for source ops)
+
+        # --- Live source refresh (changes are coalesced via after_idle) ---
+        seen.clear()
+
+        # Insert: a new record appears in the sidebar.
+        new_id = source.insert({"text": "DAQ-9211", "icon": "hdd", "status": "active"})
+        shell.update()                        # flush the coalesced change
+        assert str(new_id) in shell.provider.keys()
+        assert len(shell.provider.keys()) == 3
+
+        # Update the SELECTED record -> its detail re-renders with fresh data.
+        source.update(sel_id, {"text": "Thermocouple", "icon": "thermometer", "status": "offline"})
+        shell.update()
+        assert seen and seen[-1]["status"] == "offline"
+
+        # Delete the selected record -> selection reconciles to the first item.
+        source.delete(sel_id)
+        shell.update()
+        assert str(sel_id) not in shell.provider.keys()
+        assert shell.current_page in shell.provider.keys()
 
         # Mutual exclusivity: add_page after list_nav is rejected.
         import pytest

--- a/tests/widgets/test_shell_nav.py
+++ b/tests/widgets/test_shell_nav.py
@@ -49,5 +49,24 @@ def test_single_tier_navigation_cascade():
             shell.navigate("nope")
         with pytest.raises(ValueError):
             shell.add_page("home")             # duplicate
+
+        # Static nav extras: headers, separators, footer pages.
+        shell.add_header("Documents")
+        shell.add_separator()
+        shell.add_page("files", text="Files", icon="folder")
+        shell.add_footer_page("settings", text="Settings", icon="gear")
+        assert "files" in shell.nav.item_keys()
+        assert "settings" in shell.nav.item_keys()
+        shell.navigate("settings")             # footer item is navigable
+        assert shell.current_page == "settings"
+        assert shell.pages.current()[0] == "settings"
     finally:
         shell.destroy()
+
+
+def test_static_provider_satisfies_protocol():
+    from bootstack.widgets._impl.composites.shell import NavProvider, StaticProvider
+
+    provider = StaticProvider()
+    assert isinstance(provider, NavProvider)   # runtime-checkable Protocol
+    assert provider.supports_compact is True

--- a/tests/widgets/test_shell_nav.py
+++ b/tests/widgets/test_shell_nav.py
@@ -1,0 +1,53 @@
+"""Smoke test for single-tier shell navigation (step 3).
+
+Verifies the NavModel <-> region wiring: add_page registers a page + nav item,
+the first page auto-selects, selecting drives the content swap, and navigate()
+plus the <<PageChange>> re-emit work. One App per process.
+"""
+
+from __future__ import annotations
+
+from bootstack.widgets._impl.composites.shell import Shell
+
+
+def test_single_tier_navigation_cascade():
+    shell = Shell(title="Nav")
+    try:
+        # First page auto-selects.
+        shell.add_page("home", text="Home", icon="house")
+        assert shell.current_page == "home"
+        assert shell.model.active_page() == "home"
+        assert shell.nav.selected == "home"
+        assert shell.pages.current()[0] == "home"
+
+        # Second page does not steal selection.
+        shell.add_page("inbox", text="Inbox", icon="inbox")
+        assert shell.current_page == "home"
+
+        # Rail stays hidden in single-tier (one implicit workspace).
+        assert shell.rail_visible is False
+        assert shell.model.rail_visible is False
+
+        # navigate() swaps the active page + nav selection + content.
+        changes: list = []
+        shell.bind("<<PageChange>>", lambda e: changes.append(e), add="+")
+        shell.navigate("inbox")
+        assert shell.current_page == "inbox"
+        assert shell.nav.selected == "inbox"
+        assert shell.pages.current()[0] == "inbox"
+        shell.update()                         # flush queued (when="tail") events
+        assert len(changes) >= 1               # <<PageChange>> re-emitted on the shell
+
+        # Selecting via the nav panel routes through the model.
+        shell._on_nav_select("home")
+        assert shell.current_page == "home"
+        assert shell.pages.current()[0] == "home"
+
+        # Unknown page raises.
+        import pytest
+        with pytest.raises(KeyError):
+            shell.navigate("nope")
+        with pytest.raises(ValueError):
+            shell.add_page("home")             # duplicate
+    finally:
+        shell.destroy()

--- a/tests/widgets/test_shell_nav.py
+++ b/tests/widgets/test_shell_nav.py
@@ -60,6 +60,13 @@ def test_single_tier_navigation_cascade():
         shell.navigate("settings")             # footer item is navigable
         assert shell.current_page == "settings"
         assert shell.pages.current()[0] == "settings"
+
+        # detail() is rejected on a static (non-data-bound) provider.
+        with pytest.raises(RuntimeError):
+            shell.detail(lambda record: None)
+        # add_page already claimed a static provider -> list_nav is rejected.
+        with pytest.raises(RuntimeError):
+            shell.list_nav(source=object())
     finally:
         shell.destroy()
 

--- a/tests/widgets/test_shell_nav.py
+++ b/tests/widgets/test_shell_nav.py
@@ -39,7 +39,7 @@ def test_single_tier_navigation_cascade():
         assert len(changes) >= 1               # <<PageChange>> re-emitted on the shell
 
         # Selecting via the nav panel routes through the model.
-        shell._on_nav_select("home")
+        shell._workspace_select(shell.current_workspace, "home")
         assert shell.current_page == "home"
         assert shell.pages.current()[0] == "home"
 

--- a/tests/widgets/test_shell_treenav.py
+++ b/tests/widgets/test_shell_treenav.py
@@ -1,0 +1,54 @@
+"""Smoke test for the hierarchical tree_nav provider + @detail (step 5c).
+
+Verifies: an inline node hierarchy mounts, a tree opens with nothing selected
+(no auto-select), selecting a node renders the detail with the node normalized
+to a record dict, and TreeNavProvider does not support compaction. One App/process.
+"""
+
+from __future__ import annotations
+
+import bootstack as bs
+from bootstack.widgets._impl.composites.shell import Shell, TreeNavProvider
+
+
+def test_tree_nav_master_detail():
+    shell = Shell(title="TreeNav")
+    try:
+        shell.tree_nav(nodes=[
+            {"label": "Datasets", "icon": "folder", "expanded": True, "children": [
+                {"label": "run_001.csv", "icon": "filetype-csv", "data": {"rows": 1024}},
+                {"label": "run_002.csv", "icon": "filetype-csv", "data": {"rows": 2048}},
+            ]},
+            {"label": "README.md", "icon": "filetype-md"},
+        ])
+
+        seen: list[dict] = []
+
+        @shell.detail
+        def render(record):
+            seen.append(record)
+            bs.Label(record["text"])
+
+        # A tree opens with nothing selected -> no auto-render.
+        assert seen == []
+        assert shell.current_page is None
+        assert isinstance(shell.provider, TreeNavProvider)
+        assert shell.provider.supports_compact is False
+
+        # Select a leaf node -> detail renders with the normalized record dict.
+        tree = shell.provider.tree
+        leaf = tree.selection  # None yet
+        assert leaf is None
+        # Find a node to select via the public tree handle.
+        datasets = tree.find(lambda n: n.label == "run_002.csv")
+        assert datasets is not None
+        tree.select(datasets)
+        shell.update()
+        assert seen, "selecting a node should render its detail"
+        rec = seen[-1]
+        assert rec["text"] == "run_002.csv"
+        assert rec["rows"] == 2048           # node.data bag flattened into the record
+        assert "id" in rec
+        assert shell.content.winfo_children()
+    finally:
+        shell.destroy()

--- a/tests/widgets/test_shell_twotier.py
+++ b/tests/widgets/test_shell_twotier.py
@@ -65,6 +65,21 @@ def test_two_tier_rail_and_gesture():
         shell._rail_select("acquire")
         assert shell.sidebar_visible is True
 
+        # Compact is gated OFF under a rail: a tier-2 sidebar stays expanded even
+        # when the mode is compact (an icon panel beside the icon rail is noise).
+        assert ws1.supports_compact is True            # provider can, in principle
+        shell.sidebar_mode = "compact"
+        assert shell.sidebar_visible is True
+        assert ws1.provider.nav.compact is False       # but not icon-compacted here
+        shell.sidebar_mode = "expanded"
+
+        # Under a rail, Ctrl-B hides/shows (the rail stays as nav) — no compact.
+        assert shell._can_compact_active() is False
+        shell._on_toggle_shortcut()
+        assert shell.sidebar_visible is False
+        shell._on_toggle_shortcut()
+        assert shell.sidebar_visible is True
+
         # Mixing shell-level pages with workspaces is rejected.
         import pytest
         with pytest.raises(RuntimeError):

--- a/tests/widgets/test_shell_twotier.py
+++ b/tests/widgets/test_shell_twotier.py
@@ -1,0 +1,73 @@
+"""Smoke test for the two-tier rail + the VS Code gesture (step 6).
+
+Verifies: add_workspace reveals the rail, each workspace owns its own provider,
+the rail switches workspaces (with per-workspace page memory), and the gesture
+(active icon hides the sidebar, different icon switches + shows). One App/process.
+"""
+
+from __future__ import annotations
+
+import bootstack as bs
+from bootstack.widgets._impl.composites.shell import Shell
+
+
+def test_two_tier_rail_and_gesture():
+    shell = Shell(title="TwoTier", size=(900, 600))
+    try:
+        # Workspace 1 — static pages.
+        ws1 = shell.add_workspace("acquire", text="Acquire", icon="cpu")
+        ws1.add_page("sensors", text="Sensors", icon="thermometer-half")
+        ws1.add_page("ports", text="Ports", icon="usb-symbol")
+
+        # One workspace: rail still hidden.
+        assert shell.rail_visible is False
+        assert shell.current_workspace == "acquire"
+        assert shell.current_page == "sensors"     # first page auto-selected
+
+        # Workspace 2 — different provider; rail now appears.
+        ws2 = shell.add_workspace("library", text="Library", icon="folder")
+        ws2.tree_nav(nodes=[{"label": "README.md", "icon": "filetype-md"}])
+
+        @ws2.detail
+        def render(record):
+            bs.Label(record["text"])
+
+        assert shell.rail_visible is True
+        assert shell.model.rail_visible is True
+        # The rail REGION must actually be packed into the body (guards the
+        # _rail attribute-collision orphan bug).
+        shell.update_idletasks()
+        assert shell.rail.winfo_manager() == "pack"
+        assert set(shell._railnav.keys()) == {"acquire", "library"}
+
+        # Switch within ws1, then to ws2, then back -> per-workspace page memory.
+        shell.navigate("acquire", "ports")
+        assert shell.current_workspace == "acquire"
+        assert shell.current_page == "ports"
+
+        # Rail gesture: click a DIFFERENT workspace -> switch + show.
+        shell._rail_select("library")
+        assert shell.current_workspace == "library"
+        assert shell.sidebar_visible is True
+        assert shell._railnav.selected == "library"
+
+        # Back to ws1 remembers "ports".
+        shell._rail_select("acquire")
+        assert shell.current_workspace == "acquire"
+        assert shell.current_page == "ports"
+
+        # Rail gesture: click the ACTIVE workspace -> hide the sidebar.
+        shell._rail_select("acquire")
+        assert shell.sidebar_visible is False
+        assert shell.current_workspace == "acquire"   # still active, just hidden
+
+        # Click it again -> show.
+        shell._rail_select("acquire")
+        assert shell.sidebar_visible is True
+
+        # Mixing shell-level pages with workspaces is rejected.
+        import pytest
+        with pytest.raises(RuntimeError):
+            shell.add_page("loose")
+    finally:
+        shell.destroy()


### PR DESCRIPTION
Clean-slate, VS Code-style rewrite of the application shell's navigation, built as a layered internal composite. **Internal-only — not yet swapped onto the public \`bs.AppShell\` (that's the follow-up PR), so this changes no public API.** Spec: \`docs/_dev/appshell-navigation-spec.md\` (read Revision 4).

## What's here

**Three-layer architecture** (spec §2): \`NavModel\` (headless state machine) · \`ShellLayout\` (dumb region/band layout) · providers (what fills a sidebar).

**Navigation**
- Single-tier (implicit default workspace, no rail) and two-tier (rail + swappable workspaces) — single-tier is the degenerate one-workspace case, authored identically.
- Three providers: \`add_page\` (static), \`list_nav\`, \`tree_nav\` — one per workspace, mutually exclusive; master–detail via \`@detail\` with a normalized record payload.
- VS Code rail gesture, per-workspace memory, sidebar collapse/visibility + \`remember_nav_state\` persistence.

**Sidebar = three authored shapes** (the accordion was tried then **cut** — a collapsible sub-list is a content concern; compose \`bs.Accordion\` in a custom \`panel()\`):
- flat-static (compactable) · grouped-static (\`add_header\` = a plain **muted** label, larger group break) · data-bound (\`list_nav\`/\`tree_nav\`).

**Styling**
- Scrollable static nav: \`ScrollView\`-wrapped item area, footer pinned outside; overflow-gated bar + footer divider; the scrollbar gutter is absorbed into the right inset (even margins) and the footer re-aligns to the scrolled rows.
- New reusable **\`'thin'\` scrollbar variant** (4px solid square thumb, Pillow-generated; \`ScrollView\` threads its surface to its scrollbars).
- Neutral-by-default selection washes; dark rail/chrome surface; muted section headers.
- Empty-state placeholders for \`tree_nav\` (opens unselected) and empty \`list_nav\`.

## Not in this PR (→ step 11, the public-AppShell swap)

- Swap the new \`Shell\` onto public \`bs.AppShell\` (replacing the old sidenav-based one) — the breaking change, isolated.
- Drop the standalone \`bs.SideNav\` (coupled to removing the old AppShell).
- Wire + style the statusbar and menubar/command bar into the new shell.
- \`Workspace\` context-manager support + the public façade (\`commandbar\`/\`nav\`/\`pages\` + window controls).

Separate initiative: expose/document the \`'thin'\` scrollbar variant publicly + audit other scrollable widgets for narrow bars.

## Tests

\`tests/widgets/test_shell_*\` (one App per process — run modules individually). Public-surface guard unchanged (the new shell adds no public names). All green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)