### PR TITLE
ci: bump workflow actions to Node 24 majors

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,9 +18,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip
@@ -35,7 +35,7 @@ jobs:
       - name: Build docs
         run: sphinx-build docs docs/_build/html -b html -W --keep-going
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: docs/_build/html
 
@@ -47,4 +47,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,9 +10,9 @@ jobs:
     name: Build distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -22,7 +22,7 @@ jobs:
       - name: Build sdist + wheel
         run: python -m build
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/
@@ -34,7 +34,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/
@@ -48,12 +48,12 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/
 
-      - uses: softprops/action-gh-release@v2
+      - uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
           prerelease: ${{ contains(github.ref_name, 'a') || contains(github.ref_name, 'b') || contains(github.ref_name, 'rc') }}


### PR DESCRIPTION
## Why

GitHub starts forcing Node 24 on actions still declaring `runs.using: node20` from **2026-06-16**. Both workflows pinned old majors that run on Node 20, which would emit deprecation warnings. This bumps each to its current major that defaults to the Node 24 runtime.

## Changes

| Action | Was | Now |
|---|---|---|
| `actions/checkout` | v4 | v6 |
| `actions/setup-python` | v5 | v6 |
| `actions/upload-artifact` | v4 | v7 |
| `actions/download-artifact` | v4 | v8 |
| `actions/upload-pages-artifact` | v3 | v5 |
| `actions/deploy-pages` | v4 | v5 |
| `softprops/action-gh-release` | v2 | v3 |

## Notes

- `upload-artifact@v7` and `download-artifact@v8` share the `@actions/artifact` v4 backend and are the intended direct-upload/direct-download pairing.
- `download-artifact@v8` now errors on hash mismatch by default — fine here since upload and download happen within the same run.
- `action-gh-release@v3` is a pure Node 24 runtime move; the `generate_release_notes`/`prerelease`/`files` usage is unchanged.
- `pypa/gh-action-pypi-publish@release/v1` left as-is (Docker-based, unaffected).

CI-only change; no effect until the next docs push (`docs.yml`) or release tag (`release.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)