### PR TITLE
refactor(clipboard): move clipboard helpers to bootstack.clipboard

### DIFF
--- a/docs/api-reference/clipboard.rst
+++ b/docs/api-reference/clipboard.rst
@@ -1,0 +1,14 @@
+Clipboard
+=========
+
+.. currentmodule:: bootstack.clipboard
+
+Read and write the system clipboard. The clipboard is global to the running
+application, so these are module-level functions rather than per-widget methods;
+they operate on the current `App`'s clipboard.
+
+For a task-oriented introduction, see the :doc:`/tasks/clipboard` how-to.
+
+.. autofunction:: get_clipboard
+
+.. autofunction:: set_clipboard

--- a/docs/api-reference/index.rst
+++ b/docs/api-reference/index.rst
@@ -26,6 +26,7 @@ The following submodules are also public; import the names you need from each
 - ``bootstack.scheduling`` — Running work after a delay or on a repeating interval.
 - ``bootstack.shortcuts`` — Registering application keyboard shortcuts.
 - ``bootstack.store`` — A small file-backed preferences store.
+- ``bootstack.clipboard`` — Read and write the system clipboard.
 - ``bootstack.errors`` — The exception types the framework raises.
 - ``bootstack.types`` — Token and keyword types for annotating your own code.
 - ``bootstack.dialogs`` — Reusable dialog classes, when a one-shot verb isn't enough.
@@ -144,6 +145,12 @@ Services and reference
 
       A persistent, file-backed preferences store.
 
+   .. grid-item-card:: Clipboard
+      :link: clipboard
+      :link-type: doc
+
+      Read and write the system clipboard.
+
    .. grid-item-card:: Errors
       :link: errors
       :link-type: doc
@@ -173,5 +180,6 @@ Services and reference
    scheduling
    shortcuts
    store
+   clipboard
    errors
    types

--- a/docs/reference/images.rst
+++ b/docs/reference/images.rst
@@ -1,4 +1,4 @@
-Images and icons
+Images and Icons
 ================
 
 The :mod:`bootstack.images` module is the framework-native way to show pictures

--- a/docs/screenshots/composing-fields.py
+++ b/docs/screenshots/composing-fields.py
@@ -7,6 +7,7 @@ One scene per recipe, each a self-contained field with addons. Regenerate with::
 import datetime
 
 import bootstack as bs
+from bootstack.clipboard import set_clipboard
 
 
 def search():
@@ -49,7 +50,7 @@ def copy():
         key = bs.TextField(value="sk-live-7f3a9c2b", label="API key", read_only=True, fill="x")
 
         def do_copy():
-            key.set_clipboard(key.value)
+            set_clipboard(key.value)
 
         key.insert_addon("button", "after", name="copy", icon="clipboard",
                          on_click=do_copy, active_when_readonly=True)

--- a/docs/tasks/application-icons.rst
+++ b/docs/tasks/application-icons.rst
@@ -1,4 +1,4 @@
-Application Icons
+Setting App Icons
 =================
 
 An application icon identifies your app wherever the operating system shows it:

--- a/docs/tasks/clipboard.rst
+++ b/docs/tasks/clipboard.rst
@@ -1,0 +1,67 @@
+Using the Clipboard
+===================
+
+Read and write the system clipboard with two functions from
+:mod:`bootstack.clipboard`. The clipboard is global to the application, so these
+are plain functions rather than widget methods — call them from within a running
+app:
+
+.. code-block:: python
+
+   import bootstack as bs
+   from bootstack.clipboard import set_clipboard, get_clipboard
+
+   with bs.App(title="Clipboard") as app:
+       bs.Button("Copy", on_click=lambda: set_clipboard("sk-live-7f3a9c2b"))
+       bs.Button("Paste", on_click=lambda: print(get_clipboard()))
+   app.run()
+
+Copy a field's value
+--------------------
+
+A common pattern is a read-only field with a copy button beside it — for an API
+key, a token, or a generated value. The :doc:`/tasks/composing-fields` how-to
+builds exactly this with an addon button:
+
+.. code-block:: python
+
+   from bootstack.clipboard import set_clipboard
+
+   key = bs.TextField(value="sk-live-7f3a9c2b", label="API key",
+                      read_only=True, fill="x")
+   key.insert_addon("button", "after", name="copy", icon="clipboard",
+                    on_click=lambda: set_clipboard(key.value),
+                    active_when_readonly=True)
+
+Reading the clipboard
+---------------------
+
+:func:`~bootstack.clipboard.get_clipboard` returns the current text, or an empty
+string when the clipboard is empty, holds non-text data, or no app is running:
+
+.. code-block:: python
+
+   text = get_clipboard()
+   if text:
+       use(text)
+
+Platform note
+-------------
+
+On Linux/X11 the clipboard is owned by the running process, so its contents are
+cleared when the app exits unless a system clipboard manager is running. On
+Windows and macOS the operating system owns the clipboard, so contents persist
+after the app closes.
+
+API reference
+-------------
+
+See :doc:`/api-reference/clipboard`.
+
+.. currentmodule:: bootstack.clipboard
+
+.. autosummary::
+   :nosignatures:
+
+   get_clipboard
+   set_clipboard

--- a/docs/tasks/composing-fields.rst
+++ b/docs/tasks/composing-fields.rst
@@ -1,5 +1,5 @@
-Composing Custom Fields
-=======================
+Composing Fields
+================
 
 Every bootstack field — :class:`~bootstack.TextField`,
 :class:`~bootstack.NumberField`, :class:`~bootstack.DateField`, and the rest —
@@ -109,10 +109,12 @@ writes the field to the clipboard, so it opts back in with
 
 .. code-block:: python
 
+   from bootstack.clipboard import set_clipboard
+
    key = bs.TextField(value="sk-live-7f3a9c2b", label="API key", read_only=True, fill="x")
 
    def do_copy():
-       key.set_clipboard(key.value)
+       set_clipboard(key.value)
 
    key.insert_addon("button", "after", name="copy", icon="clipboard",
                     on_click=do_copy, active_when_readonly=True)

--- a/docs/tasks/dialogs.rst
+++ b/docs/tasks/dialogs.rst
@@ -1,5 +1,5 @@
-Dialogs & Alerts
-================
+Showing Dialogs
+===============
 
 A dialog interrupts the app to tell the user something or to collect one quick
 answer. bootstack ships ready-made dialog **verbs** for the common cases — each

--- a/docs/tasks/layout.rst
+++ b/docs/tasks/layout.rst
@@ -1,5 +1,5 @@
-Layout & Spacing
-================
+Arranging Widgets
+=================
 
 bootstack arranges widgets with **container** widgets. A container both *holds*
 its children and decides how they are placed; a widget is parented to the nearest

--- a/docs/tasks/navigation/index.rst
+++ b/docs/tasks/navigation/index.rst
@@ -1,5 +1,5 @@
-Navigation patterns
-====================
+Navigating Views
+================
 
 :class:`AppShell <bootstack.AppShell>` assembles a few building blocks —
 authored pages, data-bound providers, and an optional workspace rail — into the

--- a/docs/user-guide/index.rst
+++ b/docs/user-guide/index.rst
@@ -37,17 +37,17 @@ How-to guides
 .. grid:: 1 2 2 3
    :gutter: 3
 
+   .. grid-item-card:: :octicon:`columns;1.5em;sd-mr-1` Arranging Widgets
+      :link: /tasks/layout
+      :link-type: doc
+
+      Arrange widgets with stacks and grids; fill, expand, and anchor.
+
    .. grid-item-card:: :octicon:`pencil;1.5em;sd-mr-1` Getting Input
       :link: /tasks/getting-input
       :link-type: doc
 
       Text, numbers, dates, choices, and sliders — and binding them to state.
-
-   .. grid-item-card:: :octicon:`plus-circle;1.5em;sd-mr-1` Composing Fields
-      :link: /tasks/composing-fields
-      :link-type: doc
-
-      Add icons, labels, buttons, and toggles inside a field to specialize it.
 
    .. grid-item-card:: :octicon:`zap;1.5em;sd-mr-1` Handling Actions
       :link: /tasks/handling-actions
@@ -55,11 +55,23 @@ How-to guides
 
       Buttons, events, debounced streams, shortcuts, and menus.
 
+   .. grid-item-card:: :octicon:`copy;1.5em;sd-mr-1` Using the Clipboard
+      :link: /tasks/clipboard
+      :link-type: doc
+
+      Read and write the system clipboard.
+
    .. grid-item-card:: :octicon:`table;1.5em;sd-mr-1` Displaying Data
       :link: /tasks/displaying-data
       :link-type: doc
 
       Labels, lists, tables, trees, and the data sources behind them.
+
+   .. grid-item-card:: :octicon:`plus-circle;1.5em;sd-mr-1` Composing Fields
+      :link: /tasks/composing-fields
+      :link-type: doc
+
+      Add icons, labels, buttons, and toggles inside a field to specialize it.
 
    .. grid-item-card:: :octicon:`checklist;1.5em;sd-mr-1` Building Forms
       :link: /tasks/building-forms
@@ -67,25 +79,19 @@ How-to guides
 
       Lay out fields and validate them before submit.
 
-   .. grid-item-card:: :octicon:`comment-discussion;1.5em;sd-mr-1` Dialogs & Alerts
+   .. grid-item-card:: :octicon:`comment-discussion;1.5em;sd-mr-1` Showing Dialogs
       :link: /tasks/dialogs
       :link-type: doc
 
       Alerts, confirmations, prompts, toasts, and custom dialogs.
 
-   .. grid-item-card:: :octicon:`arrow-switch;1.5em;sd-mr-1` Navigation Patterns
+   .. grid-item-card:: :octicon:`arrow-switch;1.5em;sd-mr-1` Navigating Views
       :link: /tasks/navigation/index
       :link-type: doc
 
       Sidebar, master–detail, and workspace navigation shapes.
 
-   .. grid-item-card:: :octicon:`columns;1.5em;sd-mr-1` Layout & Spacing
-      :link: /tasks/layout
-      :link-type: doc
-
-      Arrange widgets with stacks and grids; fill, expand, and anchor.
-
-   .. grid-item-card:: :octicon:`image;1.5em;sd-mr-1` Application Icons
+   .. grid-item-card:: :octicon:`image;1.5em;sd-mr-1` Setting App Icons
       :link: /tasks/application-icons
       :link-type: doc
 
@@ -187,14 +193,15 @@ Topics
    :caption: How-to guides
    :hidden:
 
-   /tasks/displaying-data
+   /tasks/layout
    /tasks/getting-input
-   /tasks/composing-fields
    /tasks/handling-actions
+   /tasks/clipboard
+   /tasks/displaying-data
+   /tasks/composing-fields
    /tasks/building-forms
    /tasks/dialogs
    /tasks/navigation/index
-   /tasks/layout
    /tasks/application-icons
 
 .. toctree::

--- a/src/bootstack/cli/appicon.py
+++ b/src/bootstack/cli/appicon.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import argparse
 
 from bootstack.widgets.types import IconSpec
+from bootstack.clipboard import set_clipboard
 
 
 def add_parser(subparsers: argparse._SubParsersAction) -> None:
@@ -266,7 +267,7 @@ def run_appicon() -> None:
             f'foreground = "{fg_sig()}"\n'
             f"radius = {round(radius_sig(), 3)}\n"
         )
-        app.set_clipboard(snippet)
+        set_clipboard(snippet)
         status_sig.set("Copied [build.icon] snippet to the clipboard.")
 
     _build_preview()

--- a/src/bootstack/clipboard.py
+++ b/src/bootstack/clipboard.py
@@ -1,0 +1,48 @@
+"""System clipboard helpers.
+
+The clipboard is global to the running application, so these are module-level
+functions rather than per-widget methods. They operate on the current `App`'s
+clipboard, so **an `App` must exist when they are called** (i.e. call them from
+within your app's runtime, not at import time).
+
+    from bootstack.clipboard import get_clipboard, set_clipboard
+
+    set_clipboard("hello")
+    text = get_clipboard()
+
+Platform note: on Linux/X11 the clipboard is owned by the running process, so its
+contents are cleared when the `App` exits unless a system clipboard manager is
+running. On Windows and macOS the operating system owns the clipboard, so contents
+persist after the app closes.
+"""
+
+from __future__ import annotations
+
+from bootstack._runtime.app import get_current_app
+
+__all__ = ["get_clipboard", "set_clipboard"]
+
+
+def set_clipboard(text: str) -> None:
+    """Replace the system clipboard contents with `text`.
+
+    Args:
+        text: The text to place on the clipboard.
+
+    Raises:
+        RuntimeError: If called when no `App` is running.
+    """
+    get_current_app().clipboard_set(text)
+
+
+def get_clipboard() -> str:
+    """Return the current text contents of the system clipboard.
+
+    Returns:
+        The clipboard text, or an empty string when the clipboard is empty,
+        holds non-text data, or no `App` is running.
+    """
+    try:
+        return get_current_app().clipboard_get()
+    except Exception:
+        return ""

--- a/src/bootstack/widgets/_core/base.py
+++ b/src/bootstack/widgets/_core/base.py
@@ -109,28 +109,6 @@ class PublicWidgetBase:
             self._schedule = Schedule(self._internal)
         return self._schedule
 
-    # ----- Clipboard ---------------------------------------------------------
-
-    def set_clipboard(self, text: str) -> None:
-        """Replace the system clipboard contents with `text`.
-
-        Args:
-            text: The text to place on the clipboard.
-        """
-        self._internal.clipboard_set(text)
-
-    def get_clipboard(self) -> str:
-        """Return the current text contents of the system clipboard.
-
-        Returns:
-            The clipboard text, or an empty string when the clipboard is empty
-            or holds non-text data.
-        """
-        try:
-            return self._internal.clipboard_get()
-        except Exception:
-            return ""
-
     # ----- on() — overloaded -------------------------------------------------
 
     @overload

--- a/tests/test_public_surface.py
+++ b/tests/test_public_surface.py
@@ -71,6 +71,7 @@ MOVED = {
     "bootstack.scheduling": ["Schedule", "Job"],
     "bootstack.shortcuts": ["Shortcuts", "Shortcut", "get_shortcuts"],
     "bootstack.store": ["Store"],
+    "bootstack.clipboard": ["get_clipboard", "set_clipboard"],
     "bootstack.images": ["Image", "get_icon", "AppIcon", "list_icons"],
     "bootstack.errors": [
         "BootstackError", "UnknownEventError", "ParentResolutionError",


### PR DESCRIPTION
Closes #145.

## Why
`get_clipboard`/`set_clipboard` lived on `PublicWidgetBase`, so they were on *all ~49 widgets* — but the clipboard is a global, app-level concern (`Label.get_clipboard()` is nonsensical surface). One real internal caller (`cli/appicon`).

## What
- **New `bootstack.clipboard`** — module-level `get_clipboard()` / `set_clipboard(text)` that resolve the current `App`'s root. `set_clipboard` raises `RuntimeError` if no `App` is running; `get_clipboard` returns `""` on empty/non-text/no-app. Documents the **Linux/X11 clear-on-exit** behavior (Windows/macOS persist).
- **Removed** `set_clipboard`/`get_clipboard` from `PublicWidgetBase`; updated the two callers (`cli/appicon`, the composing-fields field-copy example).
- `test_public_surface`: registered `bootstack.clipboard` (163 passed).

## Docs
- New **"Using the Clipboard"** how-to + **Clipboard** API-reference page, wired into both indexes.
- A how-to IA pass that came with it:
  - **Action-driven (gerund) titles** for consistency: Setting App Icons · Showing Dialogs · Arranging Widgets · Navigating Views · Composing Fields.
  - **Learning-order reorder** of the How-to card grid *and* the sidebar toctree (they were previously out of sync).
  - Title Case fix: "Images and icons" → "Images and Icons".
  - Convention confirmed: how-to titles Title Case + gerund; in-page section headers sentence case; cards and sidenav titles match the page H1.

## Verify
- `import` + `compileall` clean; clipboard roundtrip works; `set_clipboard` raises without an app.
- `test_public_surface` 163 passed; clean `-W` docs build (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)