### PR TITLE
fix(nav): raise NavigationError uniformly on a missing/duplicate key

### DIFF
--- a/docs/reference/errors.rst
+++ b/docs/reference/errors.rst
@@ -99,9 +99,10 @@ object, use an in-memory source instead:
 ``NavigationError``
 ~~~~~~~~~~~~~~~~~~~
 
-Raised by navigation containers — :class:`PageStack <bootstack.PageStack>` and
-:class:`Tabs <bootstack.Tabs>` — when a key is wrong: adding a page or tab whose
-key already exists, or navigating to a key that doesn't:
+Raised by the navigation containers — :class:`PageStack <bootstack.PageStack>`
+and :class:`Tabs <bootstack.Tabs>`, and the AppShell side navigation — when a key
+is wrong: adding a page, tab, or workspace whose key already exists, or selecting,
+looking up, or removing one whose key doesn't exist:
 
 .. code-block:: python
 

--- a/src/bootstack/errors.py
+++ b/src/bootstack/errors.py
@@ -32,10 +32,10 @@ class SerializationError(BootstackError):
 
 
 class NavigationError(BootstackError):
-    """Raised when a navigation operation fails.
+    """Raised when a navigation operation references a wrong key.
 
-    Examples: adding a page or tab whose key already exists, navigating to a
-    key that does not exist, or supplying an out-of-range index.
+    Examples: adding a page, tab, or workspace whose key already exists, or
+    selecting, looking up, or removing one whose key does not exist.
     """
 
 

--- a/src/bootstack/widgets/_core/navmodel.py
+++ b/src/bootstack/widgets/_core/navmodel.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Callable, Literal
 
+from bootstack._core import NavigationError
 from bootstack.streams import Handle
 
 
@@ -146,8 +147,10 @@ class NavModel:
         """Return the workspace registered under `key`.
 
         Raises:
-            KeyError: If no workspace with that key exists.
+            NavigationError: If no workspace with that key exists.
         """
+        if key not in self._index:
+            raise NavigationError(f"No workspace with key {key!r}")
         return self._index[key]
 
     def has_workspace(self, key: str) -> bool:
@@ -195,12 +198,13 @@ class NavModel:
             The created `WorkspaceState`.
 
         Raises:
-            ValueError: If `key` is empty or already registered.
+            ValueError: If `key` is empty.
+            NavigationError: If `key` is already registered.
         """
         if not key:
             raise ValueError("workspace key must be non-empty")
         if key in self._index:
-            raise ValueError(f"duplicate workspace key: {key!r}")
+            raise NavigationError(f"Workspace {key!r} already exists")
 
         ws = WorkspaceState(
             key=key, text=text, icon=icon, is_footer=is_footer, provider=provider
@@ -221,10 +225,10 @@ class NavModel:
         rail gesture on top.
 
         Raises:
-            KeyError: If no workspace with that key exists.
+            NavigationError: If no workspace with that key exists.
         """
         if key not in self._index:
-            raise KeyError(key)
+            raise NavigationError(f"No workspace with key {key!r}")
         if key == self._active_workspace:
             return
         self._active_workspace = key
@@ -238,14 +242,14 @@ class NavModel:
             workspace: Workspace to set it on; defaults to the active workspace.
 
         Raises:
-            KeyError: If the target workspace does not exist.
+            NavigationError: If the target workspace does not exist.
             ValueError: If there is no active workspace and none is given.
         """
         ws_key = workspace if workspace is not None else self._active_workspace
         if ws_key is None:
             raise ValueError("no active workspace to select a page on")
         if ws_key not in self._index:
-            raise KeyError(ws_key)
+            raise NavigationError(f"No workspace with key {ws_key!r}")
         if self._active_page.get(ws_key) == key:
             return
         self._active_page[ws_key] = key
@@ -259,10 +263,10 @@ class NavModel:
         switches to it and shows the sidebar.
 
         Raises:
-            KeyError: If no workspace with that key exists.
+            NavigationError: If no workspace with that key exists.
         """
         if key not in self._index:
-            raise KeyError(key)
+            raise NavigationError(f"No workspace with key {key!r}")
         if key == self._active_workspace:
             self.toggle_sidebar()
         else:

--- a/src/bootstack/widgets/_impl/composites/pagestack.py
+++ b/src/bootstack/widgets/_impl/composites/pagestack.py
@@ -90,13 +90,20 @@ class PageStack(Frame):
         Args:
             key: The identifier of the page to remove
 
+        Raises:
+            NavigationError: If no page with the given key exists.
+            ValueError: If key is an empty string.
+
         Note:
             If the removed page is currently displayed, the current page
             will be set to None without navigating to another page.
         """
-        if key in self._pages:
-            page = self._pages.pop(key)
-            page.destroy()
+        if not key:
+            raise ValueError("Page key cannot be an empty string")
+        if key not in self._pages:
+            raise NavigationError(f"Page {key} does not exist")
+        page = self._pages.pop(key)
+        page.destroy()
         if self._current == key:
             self._current = None
 
@@ -246,13 +253,13 @@ class PageStack(Frame):
             The page widget.
 
         Raises:
-            KeyError: If no page with the given key exists.
+            NavigationError: If no page with the given key exists.
             ValueError: If key is an empty string.
         """
         if not key:
             raise ValueError("Page key cannot be an empty string")
         if key not in self._pages:
-            raise KeyError(f"No page with key '{key}'")
+            raise NavigationError(f"Page {key} does not exist")
         return self._pages[key]
 
     def items(self) -> tuple[tkinter.Widget, ...]:
@@ -284,13 +291,13 @@ class PageStack(Frame):
             Otherwise returns the result of configure() if kwargs are provided.
 
         Raises:
-            KeyError: If no page with the given key exists.
+            NavigationError: If no page with the given key exists.
             ValueError: If key is an empty string.
         """
         if not key:
             raise ValueError("Page key cannot be an empty string")
         if key not in self._pages:
-            raise KeyError(f"No page with key '{key}'")
+            raise NavigationError(f"Page {key} does not exist")
         if option is not None:
             return self._pages[key].cget(option)
         else:

--- a/src/bootstack/widgets/_impl/composites/tabs/tabview.py
+++ b/src/bootstack/widgets/_impl/composites/tabs/tabview.py
@@ -285,10 +285,16 @@ class TabView(Frame):
 
         Args:
             key: The identifier of the tab to select.
+
+        Raises:
+            NavigationError: If no tab with the given key exists.
         """
-        if key in self._tab_map and key not in self._hidden_tabs:
-            self._set_next_change("api", "programmatic")
-            self._tab_variable.set(key)
+        if key not in self._tab_map:
+            raise NavigationError(f"No tab with key '{key}'")
+        if key in self._hidden_tabs:
+            return
+        self._set_next_change("api", "programmatic")
+        self._tab_variable.set(key)
 
     def navigate(self, key: str, data: dict = None) -> None:
         """Navigate to a tab/page with optional data.
@@ -296,12 +302,18 @@ class TabView(Frame):
         Args:
             key: The identifier of the tab/page to navigate to.
             data: Optional data to pass to the page.
+
+        Raises:
+            NavigationError: If no tab with the given key exists.
         """
-        if key in self._tab_map and key not in self._hidden_tabs:
-            self._set_next_change("api", "programmatic")
-            self._tab_variable.set(key)
-            if data:
-                self._page_stack.navigate(key, data=data)
+        if key not in self._tab_map:
+            raise NavigationError(f"No tab with key '{key}'")
+        if key in self._hidden_tabs:
+            return
+        self._set_next_change("api", "programmatic")
+        self._tab_variable.set(key)
+        if data:
+            self._page_stack.navigate(key, data=data)
 
     def hide_tab(self, key: str) -> None:
         """Hide a tab without removing it from the registry.
@@ -314,7 +326,7 @@ class TabView(Frame):
             key: The identifier of the tab to hide.
 
         Raises:
-            KeyError: If no tab with the given key exists.
+            NavigationError: If no tab with the given key exists.
         """
         if key not in self._tab_map:
             raise NavigationError(f"No tab with key '{key}'")
@@ -340,7 +352,7 @@ class TabView(Frame):
             key: The identifier of the tab to show.
 
         Raises:
-            KeyError: If no tab with the given key exists.
+            NavigationError: If no tab with the given key exists.
         """
         if key not in self._tab_map:
             raise NavigationError(f"No tab with key '{key}'")
@@ -355,9 +367,12 @@ class TabView(Frame):
 
         Args:
             key: The identifier of the tab/page to remove.
+
+        Raises:
+            NavigationError: If no tab with the given key exists.
         """
         if key not in self._tab_map:
-            return
+            raise NavigationError(f"No tab with key '{key}'")
 
         was_selected = self._tab_variable.get() == key
 

--- a/src/bootstack/widgets/pagestack.py
+++ b/src/bootstack/widgets/pagestack.py
@@ -12,6 +12,7 @@ from bootstack.widgets._core.context import push_container, pop_container
 from bootstack.widgets._core.events import register_widget_events
 from bootstack.events import PageChangeEvent, Subscription
 from bootstack.streams import Stream
+from bootstack._core import NavigationError
 from bootstack.widgets.types import (
     Event, Padding, Fill, Anchor, Sticky, LayoutKind, AutoFlow,
 )
@@ -231,7 +232,11 @@ class PageStack(PublicWidgetBase):
         return page
 
     def remove(self, key: str) -> None:
-        """Remove a page and destroy its widget."""
+        """Remove a page and destroy its widget.
+
+        Raises:
+            NavigationError: If no page with the given key exists.
+        """
         self._internal.remove(key)
         self._pages.pop(key, None)
 
@@ -243,6 +248,9 @@ class PageStack(PublicWidgetBase):
         Args:
             key: Page identifier to navigate to.
             data: Optional data dict passed to the page's mount event.
+
+        Raises:
+            NavigationError: If no page with the given key exists.
         """
         self._internal.navigate(key, data=data)
 
@@ -284,7 +292,12 @@ class PageStack(PublicWidgetBase):
 
         Returns:
             The `StackPage` for that key — read its `key` or `navigate()` to it.
+
+        Raises:
+            NavigationError: If no page with the given key exists.
         """
+        if key not in self._pages:
+            raise NavigationError(f"No page with key '{key}'")
         return self._pages[key]
 
     def items(self) -> tuple[StackPage, ...]:

--- a/src/bootstack/widgets/tabs.py
+++ b/src/bootstack/widgets/tabs.py
@@ -12,6 +12,7 @@ from bootstack.widgets._core.container import PACK_KEYS, GRID_KEYS, normalize_fi
 from bootstack.widgets._core.context import push_container, pop_container
 from bootstack.widgets._core.events import register_widget_events, resolve_event
 from bootstack.events import Subscription
+from bootstack._core import NavigationError
 from bootstack.streams import Stream
 from bootstack.widgets.types import (
     Event, AccentToken, Padding, Fill, Anchor, Sticky, LayoutKind, AutoFlow,
@@ -294,19 +295,35 @@ class Tabs(PublicWidgetBase):
         return page
 
     def select(self, key: str) -> None:
-        """Select the tab identified by `key`."""
+        """Select the tab identified by `key`.
+
+        Raises:
+            NavigationError: If no tab with the given key exists.
+        """
         self._internal.select(key)
 
     def hide_tab(self, key: str) -> None:
-        """Hide a tab without removing it. Restore with `show_tab()`."""
+        """Hide a tab without removing it. Restore with `show_tab()`.
+
+        Raises:
+            NavigationError: If no tab with the given key exists.
+        """
         self._internal.hide_tab(key)
 
     def show_tab(self, key: str) -> None:
-        """Restore a previously hidden tab."""
+        """Restore a previously hidden tab.
+
+        Raises:
+            NavigationError: If no tab with the given key exists.
+        """
         self._internal.show_tab(key)
 
     def forget_tab(self, key: str) -> None:
-        """Remove a tab and its page entirely."""
+        """Remove a tab and its page entirely.
+
+        Raises:
+            NavigationError: If no tab with the given key exists.
+        """
         self._internal.forget_tab(key)
         self._pages.pop(key, None)
 
@@ -334,7 +351,12 @@ class Tabs(PublicWidgetBase):
         Returns:
             The `TabPage` for that key — read/set its `label` or call
             `select()`/`hide()`/`show()`/`remove()`.
+
+        Raises:
+            NavigationError: If no tab with the given key exists.
         """
+        if key not in self._pages:
+            raise NavigationError(f"No tab with key '{key}'")
         return self._pages[key]
 
     def items(self) -> tuple[TabPage, ...]:

--- a/tests/test_navmodel.py
+++ b/tests/test_navmodel.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import pytest
 
+from bootstack.errors import NavigationError
 from bootstack.widgets._core.navmodel import NavChange, NavModel, WorkspaceState
 
 
@@ -45,7 +46,7 @@ def test_footer_workspace_does_not_auto_activate():
 def test_duplicate_and_empty_workspace_keys_raise():
     m = NavModel()
     m.add_workspace("a")
-    with pytest.raises(ValueError):
+    with pytest.raises(NavigationError):
         m.add_workspace("a")
     with pytest.raises(ValueError):
         m.add_workspace("")
@@ -53,7 +54,7 @@ def test_duplicate_and_empty_workspace_keys_raise():
 
 def test_workspace_unknown_key_raises():
     m = NavModel()
-    with pytest.raises(KeyError):
+    with pytest.raises(NavigationError):
         m.workspace("nope")
 
 
@@ -100,7 +101,7 @@ def test_select_workspace_same_is_noop():
 
 def test_select_unknown_workspace_raises():
     m = NavModel()
-    with pytest.raises(KeyError):
+    with pytest.raises(NavigationError):
         m.select_workspace("nope")
 
 
@@ -145,7 +146,7 @@ def test_select_page_without_active_workspace_raises():
 def test_select_page_unknown_workspace_raises():
     m = NavModel()
     m.add_workspace("a")
-    with pytest.raises(KeyError):
+    with pytest.raises(NavigationError):
         m.select_page("p1", workspace="nope")
 
 
@@ -188,7 +189,7 @@ def test_activate_rail_active_workspace_shows_when_hidden():
 def test_activate_rail_unknown_raises():
     m = NavModel()
     m.add_workspace("a")
-    with pytest.raises(KeyError):
+    with pytest.raises(NavigationError):
         m.activate_rail("nope")
 
 

--- a/tests/widgets/public/test_nav_errors.py
+++ b/tests/widgets/public/test_nav_errors.py
@@ -1,0 +1,68 @@
+"""Missing-key behavior for the navigation containers — uniform NavigationError.
+
+Tabs and PageStack raise NavigationError on any key operation that names a key
+which does not exist (select, item, show/hide, navigate, remove/forget) and on a
+duplicate add. NavModel has its own non-GUI coverage in tests/test_navmodel.py.
+"""
+from __future__ import annotations
+
+import pytest
+
+import bootstack as bs
+from bootstack.errors import NavigationError
+
+
+@pytest.fixture(scope="module")
+def app():
+    a = bs.App()
+    a.__enter__()
+    a._tk_root.update_idletasks()
+    try:
+        yield a
+    finally:
+        try:
+            a.__exit__(None, None, None)
+        except Exception:
+            pass
+
+
+def test_tabs_missing_key_raises(app):
+    t = bs.Tabs()
+    t.add("a", label="A")
+    for fn in (
+        lambda: t.select("nope"),
+        lambda: t.item("nope"),
+        lambda: t.show_tab("nope"),
+        lambda: t.hide_tab("nope"),
+        lambda: t.forget_tab("nope"),
+    ):
+        with pytest.raises(NavigationError):
+            fn()
+
+
+def test_tabs_duplicate_key_raises(app):
+    t = bs.Tabs()
+    t.add("a", label="A")
+    with pytest.raises(NavigationError):
+        t.add("a")
+
+
+def test_pagestack_missing_key_raises(app):
+    ps = bs.PageStack()
+    with ps.add("p"):
+        bs.Label("P")
+    for fn in (
+        lambda: ps.navigate("nope"),
+        lambda: ps.item("nope"),
+        lambda: ps.remove("nope"),
+    ):
+        with pytest.raises(NavigationError):
+            fn()
+
+
+def test_pagestack_duplicate_key_raises(app):
+    ps = bs.PageStack()
+    with ps.add("p"):
+        bs.Label("P")
+    with pytest.raises(NavigationError):
+        ps.add("p")


### PR DESCRIPTION
Closes #148.

## Why
Nav containers were inconsistent on a wrong key — some operations silently no-opped, some raised a bare `KeyError`, some raised `NavigationError`. This makes **every** key operation across the nav surface raise `NavigationError`, so one `except NavigationError` covers them all and typos surface instead of hiding.

Scope grew (with the maintainer) beyond just Tabs to **PageStack** (the sibling had the same split) and the **AppShell side nav** (`NavModel`).

## What
- **Tabs** (`tabview.py` + public wrapper): `select`/`navigate`/`forget_tab` were silent no-ops → raise; `item()` raised a bare dict `KeyError` → `NavigationError`; `hide`/`show` already raised (fixed their stale `KeyError` docstrings).
- **PageStack** (`pagestack.py` + public wrapper): `remove()` no-opped → raise; `item()`/`configure_item()` raised bare `KeyError` → `NavigationError`.
- **AppShell side nav** (`NavModel`): `workspace`/`select_workspace`/`select_page`/`activate_rail` raised `KeyError` → `NavigationError`; duplicate `add_workspace` raised `ValueError` → `NavigationError` (matches the page/tab dup convention). `ValueError` is kept for malformed/state cases (empty key, no active workspace, invalid sidebar mode).

## Tests / docs
- `test_navmodel.py` assertions updated; new `tests/widgets/public/test_nav_errors.py` (Tabs + PageStack, 4 tests).
- Broadened the `NavigationError` docstring and the errors guide.

## Verify
- 200 tests pass (navmodel/nav_errors/public_surface); shell GUI tests green individually; `compileall` clean; clean `-W` docs build; 8-case functional smoke all raise `NavigationError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)