### PR TITLE
feat(theme): Theme.from_existing() to derive a theme from a base

### DIFF
--- a/docs/reference/theming.rst
+++ b/docs/reference/theming.rst
@@ -1,15 +1,35 @@
 Theming
 =======
 
-A theme defines the application's color palette — the text and background colors,
-the named accent roles (``primary``, ``success``, ``danger`` …) that widgets draw
-with, and the surface colors behind cards, menus, and inputs. bootstack ships ten
-light/dark theme pairs, and you can declare your own.
+A theme defines the application's colors — the text and background, the named
+accent roles (``primary``, ``success``, ``danger``, …) that widgets draw with,
+and the surfaces behind cards, menus, and inputs. bootstack ships ten color
+themes, and you can declare your own.
+
+Theme families and variants
+---------------------------
+
+Every theme is a **family** with a light and/or dark **variant**. The variants
+are named ``<family>-<mode>`` — ``bootstrap-light``, ``nord-dark``, and so on.
+
+You always activate a *variant*, by its full name. The bare family name is not a
+theme you can set:
+
+.. code-block:: python
+
+   bs.set_theme("nord-dark")    # ok — a variant
+   bs.set_theme("nord")         # ThemeError — a family, not a variant
+
+The ten built-ins are families — ``bootstrap``, ``pydata``, ``nord``,
+``solarized``, ``catppuccin``, ``gruvbox``, ``dracula``, ``tokyo-night``,
+``one``, ``everforest`` — and the themes you declare or derive follow the same
+rule. A family needs at least one mode, but not both: a light-only family
+registers just ``<family>-light``.
 
 Setting the theme
 -----------------
 
-Choose the starting theme through the app settings, then switch at runtime with
+Set the starting theme with ``bs.App(theme=)``, and switch at runtime with
 ``set_theme``:
 
 .. code-block:: python
@@ -20,8 +40,8 @@ Choose the starting theme through the app settings, then switch at runtime with
        bs.Button("Day mode", on_click=lambda: bs.set_theme("nord-light"))
    app.run()
 
-``toggle_theme()`` flips between the configured light and dark themes, and
-``get_theme()`` returns the name of the active one:
+``toggle_theme()`` flips between the configured light and dark variants, and
+``get_theme()`` returns the active one's name:
 
 .. code-block:: python
 
@@ -30,38 +50,39 @@ Choose the starting theme through the app settings, then switch at runtime with
    bs.toggle_theme()
    get_theme()        # "nord-light"
 
-.. note::
-
-   ``bs.App`` accepts ``theme=`` directly to set the startup theme, and the
-   active theme can be read or changed at runtime through ``app.theme``. The
-   pair that ``toggle_theme`` switches between comes from the ``light_theme``
-   and ``dark_theme`` options (default ``"bootstrap-light"`` and
-   ``"bootstrap-dark"``), passed as ``bs.App`` kwargs.
+The pair ``toggle_theme`` switches between comes from the ``light_theme`` and
+``dark_theme`` app options (default ``"bootstrap-light"`` and
+``"bootstrap-dark"``). Read or change the active theme at runtime through
+``app.theme``.
 
 Listing the available themes
 ----------------------------
 
 ``get_themes()`` returns the installed themes as ``{"name", "display_name"}``
-dictionaries — ready to populate a theme picker:
+dictionaries — ready to populate a picker:
 
 .. code-block:: python
 
-   with bs.App() as app:
-       themes = get_themes()
-       by_label = {t["display_name"]: t["name"] for t in themes}
+   from bootstack.style import get_themes
 
-       choice = bs.Signal(themes[0]["display_name"])
+   with bs.App() as app:
+       by_label = {t["display_name"]: t["name"] for t in get_themes()}
+
+       choice = bs.Signal(next(iter(by_label)))
        bs.Select(options=list(by_label), signal=choice)
        choice.subscribe(lambda label: bs.set_theme(by_label[label]))
    app.run()
 
-Reading theme colors
---------------------
+Color tokens
+------------
 
-``get_theme_color(token)`` resolves a color token to a hex string in the active
-theme. Reach for it when you need a theme color for custom drawing:
+Widgets pull their colors from named **tokens**. ``get_theme_color(token)``
+resolves one to a hex string in the active theme — reach for it when you draw
+something custom:
 
 .. code-block:: python
+
+   from bootstack.style import get_theme_color
 
    get_theme_color("primary")        # a semantic role
    get_theme_color("background")     # the window background
@@ -70,30 +91,23 @@ theme. Reach for it when you need a theme color for custom drawing:
 Tokens come in a few forms:
 
 - **Semantic roles** — ``primary``, ``secondary``, ``info``, ``success``,
-  ``warning``, ``danger``. These are what widgets use through ``accent=``.
+  ``warning``, ``danger``. These are what ``accent=`` selects on a widget.
 - **Base colors** — ``foreground``, ``background``, ``white``, ``black``.
-- **Shades and their spectrum** — every accent role (and the neutral ``gray``)
-  expands into a 50-step spectrum, addressed as ``primary[50]`` (lightest)
-  through ``primary[500]`` (the declared anchor) to ``primary[950]`` (darkest).
-  The shade families are named for their roles — ``gray``, ``primary``,
-  ``success``, ``info``, ``warning``, ``danger`` (and ``secondary`` when the
-  theme declares a colored secondary).
+- **Shades** — every accent role (and the neutral ``gray``) expands into a
+  50-step spectrum, addressed ``primary[50]`` (lightest) through ``primary[500]``
+  (the anchor) to ``primary[950]`` (darkest).
 - **Surfaces** — container backgrounds: ``content``, ``card``, ``chrome``,
-  ``raised``, ``overlay``, and ``input``.
+  ``raised``, ``overlay``, ``input``.
 
 Declaring a custom theme
 ------------------------
 
-A theme is a **family**: declare each semantic accent once — as the ``[500]``
-midpoint of its ramp — plus a ``light`` and/or ``dark`` block giving the
-``background`` and ``foreground``. ``install()`` generates and registers both the
-``<name>-light`` and ``<name>-dark`` variant; the framework picks the right ramp
-step per mode (a darker solid on a light background, a brighter one on dark) so
-you never hand-write per-mode shades:
+Declare a family by giving each semantic accent its anchor — the ``[500]``
+midpoint of the ramp — plus a ``light`` and/or ``dark`` block for the background
+and foreground. ``install()`` generates and registers both variants:
 
 .. code-block:: python
 
-   import bootstack as bs
    from bootstack.style import Theme
 
    Theme(
@@ -102,7 +116,7 @@ you never hand-write per-mode shades:
        primary="#fd7e14", success="#198754", info="#0dcaf0",
        warning="#ffc107", danger="#dc3545",   # the [500] anchors
        secondary="#9d4edd",                    # optional colored secondary
-       neutral="#8c8a93",                      # gray base for borders/muted text
+       neutral="#8c8a93",                      # gray base for borders and muted text
        light=dict(background="#fbf7f2", foreground="#2b2118"),
        dark=dict(background="#211a14", foreground="#f3e9dd"),
    ).install()
@@ -111,24 +125,27 @@ you never hand-write per-mode shades:
        bs.Button("Primary", accent="primary")
    app.run()
 
-Each accent expands into a full 50–950 spectrum from its anchor, and the neutral
-gray drives borders, muted text, and the ``secondary`` role when no colored
-``secondary`` is given. Surface colors (cards, chrome, inputs) are derived from
-the background automatically, preserving its hue.
+You declare those colors once; the framework derives the rest:
 
-You only need one of ``light`` / ``dark`` — provide both for a matched pair.
-``install(activate=True)`` registers **and** activates the light variant in one
-call; pass a variant name to activate that one instead:
+- Each accent **anchor** expands into its full 50–950 ramp, and the framework
+  picks the step per mode — a darker solid on light, a brighter one on dark.
+- The **neutral** gray drives borders, muted text, and the ``secondary`` role
+  when no colored ``secondary`` is given.
+- **Surfaces** (cards, chrome, inputs) are derived from the background, keeping
+  its hue.
+
+``install(activate=True)`` registers and activates the light variant in one call;
+pass a variant name to activate a specific one:
 
 .. code-block:: python
 
    Theme(name="sunset", primary="#fd7e14",
-         dark=dict(background="#211a14", foreground="#f3e9dd")
+         dark=dict(background="#211a14", foreground="#f3e9dd"),
    ).install(activate="sunset-dark")
 
-When the auto-derived surfaces don't suit a particular background — a very dark
-chrome band, say — pin them with ``surfaces=`` (a flat dict applies to both
-modes; a ``{"light": ..., "dark": ...}`` dict targets one mode):
+When an auto-derived surface doesn't suit a background — a very dark chrome band,
+say — pin it with ``surfaces=``. A flat dict applies to both modes; a
+``{"light": …, "dark": …}`` dict targets one:
 
 .. code-block:: python
 
@@ -139,24 +156,54 @@ modes; a ``{"light": ..., "dark": ...}`` dict targets one mode):
        surfaces={"dark": {"chrome": "#171109"}},
    ).install()
 
-.. note::
-
-   A theme can be declared and installed at module level, before ``bs.App()``
-   exists — its colors are resolved when the theme is activated, not when it is
-   created.
-
-To build a theme from data you already have (loaded from a file, say), unpack the
-mapping into the constructor — ``Theme`` is a plain dataclass, so the keys are
-just its fields:
+``Theme`` is a plain dataclass, so you can build one from a mapping you already
+have — loaded from a file, say — by unpacking it:
 
 .. code-block:: python
 
-   spec = {
-       "name": "sunset",
-       "primary": "#fd7e14",
-       "dark": {"background": "#211a14", "foreground": "#f3e9dd"},
-   }
+   spec = {"name": "sunset", "primary": "#fd7e14",
+           "dark": {"background": "#211a14", "foreground": "#f3e9dd"}}
    Theme(**spec).install()
+
+.. note::
+
+   Declare and install at module level, before ``bs.App()`` exists — a theme's
+   colors are resolved when it is activated, not when it is created.
+
+Deriving from an existing theme
+-------------------------------
+
+To brand an existing family without redeclaring every color, use
+:meth:`Theme.from_existing <bootstack.style.Theme.from_existing>`. It copies a
+base family and replaces only the tokens you pass:
+
+.. code-block:: python
+
+   # Bootstrap, but with our brand primary — everything else inherited.
+   Theme.from_existing("bootstrap", name="acme", primary="#ff5722").install()
+
+   with bs.App(theme="acme-light") as app:
+       bs.Button("Primary", accent="primary")
+   app.run()
+
+``base`` is a family name (``"bootstrap"``, ``"pydata"``, …) or a ``Theme``;
+``name`` is the new family's own name.
+
+The result is a full family, so you can override more than one accent — give it a
+new light/dark canvas and surfaces while inheriting the base's accent ramps:
+
+.. code-block:: python
+
+   Theme.from_existing(
+       "bootstrap",
+       name="midnight",
+       light=dict(background="#fafafa", foreground="#1a1a1a"),
+       dark=dict(background="#0a0a0a", foreground="#e0e0e0"),
+       surfaces={"dark": {"chrome": "#000000"}},
+   ).install()   # registers midnight-light and midnight-dark
+
+Whatever you don't override is inherited. An unknown token, or an unknown base
+name, raises :class:`ThemeError <bootstack.errors.ThemeError>`.
 
 See also
 --------
@@ -168,8 +215,8 @@ API reference
 -------------
 
 The complete reference — the :class:`Theme <bootstack.style.Theme>` class and the
-theme-control functions — lives in :doc:`/api-reference/theming` (which also covers
-the font functions). At a glance:
+theme-control functions — lives in :doc:`/api-reference/theming` (which also
+covers the font functions). At a glance:
 
 .. currentmodule:: bootstack.style
 

--- a/src/bootstack/style/theme.py
+++ b/src/bootstack/style/theme.py
@@ -27,13 +27,18 @@ resolution is deferred until activation.
 """
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, fields, replace
 from typing import Literal
 
 from bootstack._core.exceptions import ThemeError
 from bootstack.style.theme_provider import register_theme
 
 ThemeMode = Literal["light", "dark"]
+
+# Registry of declared theme FAMILIES by name (e.g. "bootstrap" -> Theme), so a
+# theme can be derived from an existing one by name. Built-ins register
+# themselves via install() at startup; see _resolve_base().
+_FAMILIES: dict[str, "Theme"] = {}
 
 # Accent roles that take a `[500]` anchor and generate their own ramp.
 _ACCENT_ROLES = ("primary", "success", "info", "warning", "danger")
@@ -152,6 +157,39 @@ class Theme:
                 schema["surfaces"] = dict(override)
         return schema
 
+    @classmethod
+    def from_existing(cls, base: "str | Theme", *, name: str, **overrides) -> "Theme":
+        """Derive a new theme from an existing one, overriding only some tokens.
+
+        Every token you don't override is inherited from `base`, so you can brand
+        a built-in family by changing just its `primary` (and any others you want):
+
+            Theme.from_existing("bootstrap", name="acme", primary="#ff5722").install()
+            bs.set_theme("acme-light")
+
+        Args:
+            base: The theme to build on — a built-in or already-installed family
+                name (e.g. `'bootstrap'`), or a `Theme` instance. Required.
+            name: Family name for the derived theme; its `install()` registers
+                `<name>-light` / `<name>-dark`. Required.
+            **overrides: Any `Theme` token to replace (`primary`, `neutral`,
+                `light`, `dark`, `surfaces`, `display_name`, ...).
+
+        Returns:
+            A new `Theme`; call `install()` on it to register its variants.
+
+        Raises:
+            ThemeError: If `base` names a theme family that is not registered, or
+                an override names a token that is not a `Theme` field.
+        """
+        source = base if isinstance(base, Theme) else _resolve_base(base)
+        unknown = set(overrides) - {f.name for f in fields(cls)}
+        if unknown:
+            raise ThemeError(
+                f"Unknown theme token(s): {', '.join(sorted(unknown))}."
+            )
+        return replace(source, name=name, **overrides)
+
     def variants(self) -> list[dict]:
         """Return the generated per-mode schema dicts (light first, then dark)."""
         return [s for s in (self._schema("light"), self._schema("dark")) if s]
@@ -173,6 +211,7 @@ class Theme:
             )
         for schema in schemas:
             register_theme(schema["name"], schema)
+        _FAMILIES[self.name] = self
         if activate:
             from bootstack.style.style import set_theme
             target = activate if isinstance(activate, str) else schemas[0]["name"]
@@ -182,3 +221,25 @@ class Theme:
     def __repr__(self) -> str:
         modes = "+".join(m for m, b in (("light", self.light), ("dark", self.dark)) if b)
         return f"<Theme {self.name} ({modes or 'empty'})>"
+
+
+def _resolve_base(name: str) -> Theme:
+    """Resolve a theme-family name to its `Theme`, seeding built-ins lazily."""
+    if name not in _FAMILIES:
+        # Seed the built-in families on demand (lazy import avoids a cycle).
+        try:
+            from bootstack.style.themes import BUILTIN_THEMES
+            for theme in BUILTIN_THEMES:
+                _FAMILIES.setdefault(theme.name, theme)
+        except Exception:
+            pass
+    source = _FAMILIES.get(name)
+    if source is None and (name.endswith("-light") or name.endswith("-dark")):
+        source = _FAMILIES.get(name.rsplit("-", 1)[0])
+    if source is None:
+        known = ", ".join(sorted(_FAMILIES)) or "none"
+        raise ThemeError(
+            f"Unknown base theme '{name}'. Pass a registered family name "
+            f"(known: {known}) or a Theme instance."
+        )
+    return source

--- a/tests/test_theme_from_existing.py
+++ b/tests/test_theme_from_existing.py
@@ -1,0 +1,64 @@
+"""Theme.from_existing — derive a theme from a base, overriding only some tokens."""
+from __future__ import annotations
+
+import pytest
+
+from bootstack.errors import ThemeError
+from bootstack.style import Theme
+from bootstack.style.themes import BOOTSTRAP
+
+
+def test_derive_from_builtin_name_inherits_and_overrides():
+    t = Theme.from_existing("bootstrap", name="acme", primary="#ff5722")
+    assert isinstance(t, Theme)
+    assert t.name == "acme"
+    assert t.primary == "#ff5722"          # overridden
+    assert t.success == BOOTSTRAP.success  # inherited
+    assert t.danger == BOOTSTRAP.danger
+    assert BOOTSTRAP.primary != "#ff5722"  # base untouched
+
+
+def test_derive_from_theme_instance():
+    t = Theme.from_existing(
+        BOOTSTRAP, name="acme2", dark=dict(background="#101010", foreground="#eeeeee")
+    )
+    assert t.dark["background"] == "#101010"
+    assert t.primary == BOOTSTRAP.primary
+
+
+def test_variant_suffix_base_resolves_to_family():
+    t = Theme.from_existing("bootstrap-dark", name="acme3", info="#00bcd4")
+    assert t.info == "#00bcd4"
+    assert t.success == BOOTSTRAP.success
+
+
+def test_fork_family_with_own_canvas():
+    t = Theme.from_existing(
+        "bootstrap", name="midnight",
+        light=dict(background="#fafafa", foreground="#1a1a1a"),
+        dark=dict(background="#0a0a0a", foreground="#e0e0e0"),
+        surfaces={"dark": {"chrome": "#000000"}},
+    )
+    assert t.primary == BOOTSTRAP.primary          # accent ramps inherited
+    assert t.dark["background"] == "#0a0a0a"        # own canvas
+    assert {v["name"] for v in t.variants()} == {"midnight-light", "midnight-dark"}
+
+
+def test_single_mode_derivative():
+    t = Theme.from_existing("bootstrap", name="dayonly", dark=None)
+    assert [v["name"] for v in t.variants()] == ["dayonly-light"]
+
+
+def test_unknown_base_raises_themeerror():
+    with pytest.raises(ThemeError):
+        Theme.from_existing("not-a-theme", name="x")
+
+
+def test_unknown_override_token_raises_themeerror():
+    with pytest.raises(ThemeError):
+        Theme.from_existing("bootstrap", name="x", primarry="#000000")
+
+
+def test_name_is_required():
+    with pytest.raises(TypeError):
+        Theme.from_existing("bootstrap")  # type: ignore[call-arg]


### PR DESCRIPTION
Closes #154.

## Why
The pre-v2 ability to create a theme from an existing base and override only specific tokens isn't a documented public path anymore. It technically still worked via `dataclasses.replace`, but the base instances live in an internal module, so there was no clean way to get one.

## What
**`Theme.from_existing(base, *, name, **overrides)`** classmethod:
- `base` (required) — a family name (`"bootstrap"`, `"pydata"`, …) or a `Theme` instance. Names resolve the built-ins + your installed families, and a variant name (`"bootstrap-dark"`) is accepted (the `-mode` suffix is stripped).
- `name` (required, keyword-only) — the derived family's own name.
- `**overrides` — any `Theme` token. Unknown tokens, or an unknown base name, raise `ThemeError`.
- The result is a **full family**: override one accent, or fork the whole light/dark canvas + surfaces while inheriting the base's accent ramps; `install()` generates `<name>-light`/`<name>-dark` (or one, for a single-mode family).

Backed by a small family registry that `install()` populates (built-ins register at startup) plus a lazy seed from `BUILTIN_THEMES`.

## Docs
A full technical-writer pass on `reference/theming.rst` (motivated by needing to teach the family model so `from_existing` makes sense):
- New **"Theme families and variants"** section up front — family vs variant, the `<family>-<mode>` naming, "you activate a variant, not the bare family name", single-mode families.
- Broke up the kitchen-sink paragraphs into focused points; refocused "Reading theme colors" → "Color tokens"; added missing snippet imports.
- New **"Deriving from an existing theme"** section with the family-fork example.

## Verify
`tests/test_theme_from_existing.py` (8 cases) pass; clean `-W` docs build; verified end-to-end (derive by name, fork canvas, single-mode, error cases).

Follow-up filed: #155 (same editorial review for the other Topic guides — separate branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)