### PR TITLE
refactor(signals): Signal.subscribe returns a cancelable Handle

### DIFF
--- a/docs/reference/signals.rst
+++ b/docs/reference/signals.rst
@@ -77,7 +77,7 @@ Reacting to changes
 -------------------
 
 Subscribe a callback to run whenever the value changes. The callback receives
-the new value:
+the new value, and ``subscribe`` returns a cancellable handle:
 
 .. code-block:: python
 
@@ -85,8 +85,16 @@ the new value:
 
    count.set(1)        # prints "count is now 1"
 
-   count.unsubscribe(sub)      # stop listening
-   count.unsubscribe_all()     # drop every subscriber
+   sub.cancel()        # stop listening
+
+The handle is also a context manager, so a subscription can be scoped to a block
+and cancelled automatically on exit:
+
+.. code-block:: python
+
+   with count.subscribe(on_change):
+       ...             # listening here
+   # cancelled on exit
 
 Pass ``immediate=True`` to fire the callback once with the current value at
 subscription time, in addition to future changes:

--- a/src/bootstack/signals/signal.py
+++ b/src/bootstack/signals/signal.py
@@ -5,6 +5,7 @@ from typing import Any, Callable, Generic, Type, TypeVar
 
 from bootstack.signals.types import TraceOperation
 from bootstack._core.variables import SetVar
+from bootstack.streams import Handle
 
 T = TypeVar("T")
 U = TypeVar("U")
@@ -249,7 +250,7 @@ class Signal(Generic[T]):
         self.subscribe(update)
         return derived
 
-    def subscribe(self, callback: Callable[[T], Any], *, immediate: bool = False) -> str:
+    def subscribe(self, callback: Callable[[T], Any], *, immediate: bool = False) -> Handle:
         """
         Subscribe to value changes of this signal.
 
@@ -259,7 +260,8 @@ class Signal(Generic[T]):
                 value at subscription time. Defaults to False.
 
         Returns:
-            A subscription id — pass it to `unsubscribe()` to stop listening.
+            A cancellable `Handle` — call `.cancel()` to stop listening, or use
+            it as a context manager to unsubscribe on exit.
         """
         fid = self._trace.add("write", callback, self)
         self._subscribers[fid] = callback
@@ -268,27 +270,12 @@ class Signal(Generic[T]):
             # Call synchronously at subscription time; let any error surface to
             # the caller rather than swallowing a real bug in the callback.
             callback(self())
-        return fid
+        return Handle(lambda: self._unsubscribe(fid))
 
-    def unsubscribe(self, funcid: str) -> None:
-        """
-        Remove a previously registered subscriber.
-
-        Args:
-            funcid: The function id returned from `subscribe()`.
-        """
+    def _unsubscribe(self, funcid: str) -> None:
+        """Remove a previously registered subscriber by its trace id."""
         self._subscribers.pop(funcid, None)
         self._trace.remove(funcid)
-
-    def unsubscribe_all(self) -> None:
-        """
-        Remove all currently subscribed callbacks.
-        """
-        # Copy keys to avoid mutation during iteration
-        for fid in list(self._subscribers.keys()):
-            self._trace.remove(fid)
-        self._subscribers.clear()
-        self._callback_index.clear()
 
     @property
     def name(self) -> str:

--- a/src/bootstack/widgets/_core/field_mixin.py
+++ b/src/bootstack/widgets/_core/field_mixin.py
@@ -270,7 +270,7 @@ class ValueSignalMixin:
         sub = getattr(self, "_value_sub", None)
         if sub is not None:
             try:
-                self._value_signal.unsubscribe(sub)
+                sub.cancel()
             except Exception:
                 pass
             self._value_sub = None

--- a/src/bootstack/widgets/_impl/_parts/numberentry_part.py
+++ b/src/bootstack/widgets/_impl/_parts/numberentry_part.py
@@ -270,7 +270,7 @@ class NumberEntryPart(TextEntryPart):
             fid = getattr(self, '_on_input_fid', None)
             if fid:
                 try:
-                    self.textsignal.unsubscribe(fid)
+                    fid.cancel()
                 except Exception:
                     pass
 

--- a/src/bootstack/widgets/_impl/_parts/spinnerentry_part.py
+++ b/src/bootstack/widgets/_impl/_parts/spinnerentry_part.py
@@ -324,7 +324,7 @@ class SpinnerEntryPart(ValidationMixin, Spinbox):
             fid = getattr(self, '_on_input_fid', None)
             if fid:
                 try:
-                    self.textsignal.unsubscribe(fid)
+                    fid.cancel()
                 except TclError:
                     pass
             self.textsignal.set(new_text)
@@ -378,7 +378,7 @@ class SpinnerEntryPart(ValidationMixin, Spinbox):
         """Clean up signal subscriptions and destroy the widget."""
         if self._on_input_fid:
             try:
-                self.textsignal.unsubscribe(self._on_input_fid)
+                self._on_input_fid.cancel()
             except Exception:
                 pass  # Ignore all errors during cleanup
             self._on_input_fid = None

--- a/src/bootstack/widgets/_impl/_parts/textentry_part.py
+++ b/src/bootstack/widgets/_impl/_parts/textentry_part.py
@@ -309,7 +309,7 @@ class TextEntryPart(ValidationMixin, Entry):
             fid = getattr(self, '_on_input_fid', None)
             if fid:
                 try:
-                    self.textsignal.unsubscribe(fid)
+                    fid.cancel()
                 except TclError:
                     pass
             self.textsignal.set(new_text)
@@ -375,7 +375,7 @@ class TextEntryPart(ValidationMixin, Entry):
         """Clean up signal subscriptions and destroy the widget."""
         if self._on_input_fid:
             try:
-                self.textsignal.unsubscribe(self._on_input_fid)
+                self._on_input_fid.cancel()
             except Exception:
                 pass  # Ignore all errors during cleanup
             self._on_input_fid = None

--- a/src/bootstack/widgets/_impl/composites/radiogroup.py
+++ b/src/bootstack/widgets/_impl/composites/radiogroup.py
@@ -394,12 +394,13 @@ class RadioGroup(Frame):
         return self._signal.subscribe(callback)
 
     def off_changed(self, bind_id: Any) -> None:
-        """Unsubscribe from value changes.
+        """Cancel a subscription created by `on_changed()`.
 
         Args:
-            bind_id: ID returned by `on_changed()`. If None, removes all.
+            bind_id: The handle returned by `on_changed()`.
         """
-        self._signal.unsubscribe(bind_id)
+        if bind_id is not None:
+            bind_id.cancel()
 
     @configure_delegate('accent')
     def _delegate_accent(self, value=None):

--- a/src/bootstack/widgets/_impl/composites/tabs/tabs.py
+++ b/src/bootstack/widgets/_impl/composites/tabs/tabs.py
@@ -558,9 +558,10 @@ class Tabs(Frame):
         return self._signal.subscribe(callback)
 
     def off_tab_changed(self, bind_id: Any) -> None:
-        """Unsubscribe from tab selection changes.
+        """Cancel a subscription created by `on_tab_changed()`.
 
         Args:
-            bind_id: ID returned by `on_tab_changed()`.
+            bind_id: The handle returned by `on_tab_changed()`.
         """
-        self._signal.unsubscribe(bind_id)
+        if bind_id is not None:
+            bind_id.cancel()

--- a/src/bootstack/widgets/_impl/composites/textarea/core.py
+++ b/src/bootstack/widgets/_impl/composites/textarea/core.py
@@ -260,7 +260,7 @@ class _MultilineCore(tk.Frame):
     def _unbind_signal(self) -> None:
         if self._signal is not None and self._signal_trace_id is not None:
             try:
-                self._signal.unsubscribe(self._signal_trace_id)
+                self._signal_trace_id.cancel()
             except Exception:
                 pass
         self._signal = None

--- a/src/bootstack/widgets/_impl/composites/togglegroup.py
+++ b/src/bootstack/widgets/_impl/composites/togglegroup.py
@@ -369,12 +369,13 @@ class ToggleGroup(Frame):
         return self._signal.subscribe(callback)
 
     def off_changed(self, bind_id: Any) -> None:
-        """Unsubscribe from value changes.
+        """Cancel a subscription created by `on_changed()`.
 
         Args:
-            bind_id: ID returned by `on_changed()`. If None, removes all.
+            bind_id: The handle returned by `on_changed()`.
         """
-        self._signal.unsubscribe(bind_id)
+        if bind_id is not None:
+            bind_id.cancel()
 
     @configure_delegate('accent')
     def _delegate_accent(self, value=None):

--- a/src/bootstack/widgets/_impl/primitives/optionmenu.py
+++ b/src/bootstack/widgets/_impl/primitives/optionmenu.py
@@ -204,7 +204,7 @@ class OptionMenu(MenuButton):
         key changes whenever a selection is made.
         """
         if self._bind_id is not None:
-            self.textsignal.unsubscribe(self._bind_id)
+            self._bind_id.cancel()
 
         def _on_change(text: str) -> None:
             self._sync_display()

--- a/tests/signals/test_signal.py
+++ b/tests/signals/test_signal.py
@@ -89,6 +89,34 @@ def test_subscribe_immediate_fires_with_current_value(app):
 
 
 @pytest.mark.gui
+def test_subscribe_returns_cancellable_handle(app):
+    from bootstack.streams import Handle
+
+    s = bs.Signal(0)
+    seen = []
+    sub = s.subscribe(seen.append)
+    assert isinstance(sub, Handle)
+
+    s.set(1)
+    sub.cancel()
+    s.set(2)            # no longer listening
+    assert seen == [1]
+
+    # idempotent
+    sub.cancel()
+
+
+@pytest.mark.gui
+def test_subscribe_handle_as_context_manager(app):
+    s = bs.Signal(0)
+    seen = []
+    with s.subscribe(seen.append):
+        s.set(1)
+    s.set(2)            # cancelled on exit
+    assert seen == [1]
+
+
+@pytest.mark.gui
 def test_subscribe_immediate_propagates_callback_error(app):
     # A failing immediate callback must surface, not be swallowed.
     s = bs.Signal(0)


### PR DESCRIPTION
Closes #147.

## Why
`Signal.subscribe()` returned a bare `str` token (cancel via `signal.unsubscribe(fid)`), unlike events (`Subscription`) and streams/NavModel (`Handle`), which return cancelable handles. This unifies them.

## What
- **`subscribe()` → `streams.Handle`** — the existing general cancelable handle (`.cancel()`, idempotent; context-manager; `.cancelled`). `NavModel.subscribe()` already returns this, so signals now match.
- Removed the public **`unsubscribe(fid)`** and the dead **`unsubscribe_all()`** (zero callers). `.cancel()` is the single cancel path, consistent with events/streams. Added an internal `_unsubscribe(fid)` the handle calls.
- Migrated the internal callers to `handle.cancel()`: `field_mixin`, the number/spinner/text entry parts, `textarea`, `optionmenu`, and the `off_changed`/`off_tab_changed` wrappers on radiogroup/togglegroup/tabs (also fixed their false "If None, removes all" docstrings).

`is_signal()` duck-types on `name`/`var`/`subscribe`/`set` — not `unsubscribe` — so widget binding is unaffected.

## Tests / docs
- New signal tests: handle return + `.cancel()` stops listening (idempotent), and the context-manager form.
- Signals guide updated to `sub.cancel()` + the `with` form. Swept all examples — they use `subscribe` fire-and-forget, so none needed changes.

## Verify
196 + 75 + 12 + 20 + 4 tests pass; clean compile + `-W` docs build; round-trip verified (cancel stops listening, context-manager cancels on exit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)