### PR TITLE
feat(widgets): ThemeToggle — a sun/moon button that flips the theme

### DIFF
--- a/docs/api-reference/widgets.rst
+++ b/docs/api-reference/widgets.rst
@@ -19,6 +19,7 @@ Buttons and button groups for triggering commands.
 
    Button
    ButtonGroup
+   ThemeToggle
 
 Inputs
 ------
@@ -251,6 +252,7 @@ groups, and tabbed sections.
       TabsItem
       TextArea
       TextField
+      ThemeToggle
       TimeField
       toast
       ToggleButton

--- a/docs/examples/appshell.py
+++ b/docs/examples/appshell.py
@@ -4,7 +4,7 @@ with bs.AppShell(title="My App", size=(800, 540)) as shell:
 
     # ── Toolbar ───────────────────────────────────────────────────────────────
     shell.commandbar.add_spacer()
-    shell.commandbar.add_button(icon="circle-half", on_click=bs.toggle_theme)
+    shell.commandbar.add_theme_toggle()
 
     # ── Pages ─────────────────────────────────────────────────────────────────
     with shell.add_page("dashboard", text="Dashboard", icon="speedometer2"):

--- a/docs/examples/commandbar.py
+++ b/docs/examples/commandbar.py
@@ -15,7 +15,7 @@ with bs.App(title="CommandBar demo", minsize=(700, 300), padding=16) as app:
             tb1.add_button("Open", icon="folder2-open")
             tb1.add_button("Save", icon="floppy")
             tb1.add_spacer()
-            tb1.add_button(icon="circle-half", on_click=bs.toggle_theme)
+            tb1.add_theme_toggle()
             tb1.add_button(icon="gear")
 
         # ── Compact density ────────────────────────────────────────────────

--- a/docs/examples/menu.py
+++ b/docs/examples/menu.py
@@ -34,7 +34,7 @@ with bs.App(title="Menu demo", size=(600, 380)) as app:
 
     # Theme switcher: a toggle in the toolbar, fused to the right of the menus.
     app.commandbar.add_spacer()
-    app.commandbar.add_button(icon="circle-half", on_click=bs.toggle_theme)
+    app.commandbar.add_theme_toggle()
 
     bs.Label("A sample menu, with a theme switcher in the toolbar.",
              font="heading-md")

--- a/docs/examples/navigation/custom_sidebar.py
+++ b/docs/examples/navigation/custom_sidebar.py
@@ -19,7 +19,7 @@ PRODUCTS = [
 with bs.AppShell(title="Shop", size=(900, 580)) as shell:
     shell.commandbar.add_label("Shop", font="heading-md")
     shell.commandbar.add_spacer()
-    shell.commandbar.add_button(icon="circle-half", on_click=bs.toggle_theme)
+    shell.commandbar.add_theme_toggle()
 
     category = bs.Signal("All")
     max_price = bs.Signal(100)

--- a/docs/examples/navigation/grouped_sidebar.py
+++ b/docs/examples/navigation/grouped_sidebar.py
@@ -10,7 +10,7 @@ import bootstack as bs
 with bs.AppShell(title="Settings", size=(860, 580)) as shell:
     shell.commandbar.add_label("Settings", font="heading-md")
     shell.commandbar.add_spacer()
-    shell.commandbar.add_button(icon="circle-half", on_click=bs.toggle_theme)
+    shell.commandbar.add_theme_toggle()
 
     shell.add_header("Account")
     with shell.add_page("profile", text="Profile", icon="person"):

--- a/docs/examples/navigation/master_detail_list.py
+++ b/docs/examples/navigation/master_detail_list.py
@@ -22,7 +22,7 @@ inbox = MemoryDataSource().load([
 with bs.AppShell(title="Mail", size=(900, 580)) as shell:
     shell.commandbar.add_button(icon="pencil-square", label="Compose", on_click=lambda: None)
     shell.commandbar.add_spacer()
-    shell.commandbar.add_button(icon="circle-half", on_click=bs.toggle_theme)
+    shell.commandbar.add_theme_toggle()
 
     shell.list_nav(inbox, chevron=True)
 

--- a/docs/examples/navigation/master_detail_tree.py
+++ b/docs/examples/navigation/master_detail_tree.py
@@ -31,7 +31,7 @@ tree_nodes = [
 with bs.AppShell(title="Files", size=(900, 580)) as shell:
     shell.commandbar.add_label("Project", font="heading-md")
     shell.commandbar.add_spacer()
-    shell.commandbar.add_button(icon="circle-half", on_click=bs.toggle_theme)
+    shell.commandbar.add_theme_toggle()
 
     tree = shell.tree_nav(nodes=tree_nodes, placeholder="Select a file")
 

--- a/docs/examples/navigation/single_tier.py
+++ b/docs/examples/navigation/single_tier.py
@@ -9,7 +9,7 @@ import bootstack as bs
 with bs.AppShell(title="Acme Analytics", size=(900, 580)) as shell:
     shell.commandbar.add_label("Acme Analytics", font="heading-md")
     shell.commandbar.add_spacer()
-    shell.commandbar.add_button(icon="circle-half", on_click=bs.toggle_theme)
+    shell.commandbar.add_theme_toggle()
 
     with shell.add_page("overview", text="Overview", icon="speedometer2"):
         with bs.VStack(fill="both", expand=True, anchor_items="w", gap=12, padding=20):

--- a/docs/examples/navigation/workspaces.py
+++ b/docs/examples/navigation/workspaces.py
@@ -20,7 +20,7 @@ contacts = MemoryDataSource().load([
 
 with bs.AppShell(title="Workspace", size=(980, 620)) as shell:
     shell.commandbar.add_spacer()
-    shell.commandbar.add_button(icon="circle-half", on_click=bs.toggle_theme)
+    shell.commandbar.add_theme_toggle()
 
     # Mail — a master–detail list.
     with shell.add_workspace("mail", text="Mail", icon="envelope") as ws:

--- a/docs/production/app-settings.rst
+++ b/docs/production/app-settings.rst
@@ -99,7 +99,7 @@ flips between the ``light_theme`` and ``dark_theme`` pair:
                 light_theme="bootstrap-light",
                 dark_theme="bootstrap-dark")
 
-   bs.Button("Toggle", on_click=bs.toggle_theme)
+   bs.ThemeToggle()
 
 On macOS, ``follow_system_appearance=True`` switches between the light and dark
 themes automatically when the user changes the OS appearance. See

--- a/docs/reference/store.rst
+++ b/docs/reference/store.rst
@@ -100,7 +100,7 @@ creating the app, and write it whenever it changes:
 
    with bs.App(theme=store.get("theme", "bootstrap-light")) as app:
        app.on_theme_change(lambda theme: store.update(theme=theme))
-       bs.Button("Toggle theme", on_click=bs.toggle_theme)
+       bs.ThemeToggle()
    app.run()
 
 Persisting app configuration

--- a/docs/screenshots/app-structures.py
+++ b/docs/screenshots/app-structures.py
@@ -27,7 +27,7 @@ def appshell():
         shell._capture_full_window = True
         shell.commandbar.add_label("Acme", font="heading-md")
         shell.commandbar.add_spacer()
-        shell.commandbar.add_button(icon="circle-half", on_click=bs.toggle_theme)
+        shell.commandbar.add_theme_toggle()
         with shell.add_page("home", text="Home", icon="house"):
             with bs.VStack(fill="both", expand=True, anchor_items="w", gap=12, padding=20):
                 bs.Label("Home", font="heading-lg")

--- a/docs/screenshots/appshell.py
+++ b/docs/screenshots/appshell.py
@@ -5,7 +5,7 @@ def hero():
     with bs.AppShell(title="My App", size=(720, 520)) as shell:
         shell._capture_full_window = True
         shell.commandbar.add_spacer()
-        shell.commandbar.add_button(icon="circle-half", on_click=bs.toggle_theme)
+        shell.commandbar.add_theme_toggle()
 
         with shell.add_page("dashboard", text="Dashboard", icon="speedometer2"):
             with bs.VStack(fill="x", gap=12, padding=24):
@@ -48,7 +48,7 @@ def compact():
     with bs.AppShell(title="My App", size=(720, 520), sidebar_mode="compact") as shell:
         shell._capture_full_window = True
         shell.commandbar.add_spacer()
-        shell.commandbar.add_button(icon="circle-half", on_click=bs.toggle_theme)
+        shell.commandbar.add_theme_toggle()
 
         with shell.add_page("dashboard", text="Dashboard", icon="speedometer2"):
             with bs.VStack(fill="x", gap=12, padding=24):

--- a/docs/screenshots/home-hero.py
+++ b/docs/screenshots/home-hero.py
@@ -49,7 +49,7 @@ with bs.AppShell(title="Acme Analytics", size=(890, 650),
     shell.commandbar.add_label("Acme Analytics", font="heading-md")
     shell.commandbar.add_spacer()
     shell.commandbar.add_button("Export", icon="download")
-    shell.commandbar.add_button(icon="circle-half", on_click=bs.toggle_theme)
+    shell.commandbar.add_theme_toggle()
 
     shell.statusbar.add_text("Connected", icon="wifi")
     shell.statusbar.add_text("Synced 2 minutes ago", icon="arrow-repeat")

--- a/docs/screenshots/navigation.py
+++ b/docs/screenshots/navigation.py
@@ -15,7 +15,7 @@ def single_tier():
         shell._capture_full_window = True
         shell.commandbar.add_label("Acme Analytics", font="heading-md")
         shell.commandbar.add_spacer()
-        shell.commandbar.add_button(icon="circle-half", on_click=bs.toggle_theme)
+        shell.commandbar.add_theme_toggle()
         with shell.add_page("overview", text="Overview", icon="speedometer2"):
             with bs.VStack(fill="both", expand=True, anchor_items="w", gap=12, padding=20):
                 bs.Label("Overview", font="heading-lg")
@@ -39,7 +39,7 @@ def grouped_sidebar():
         shell._capture_full_window = True
         shell.commandbar.add_label("Settings", font="heading-md")
         shell.commandbar.add_spacer()
-        shell.commandbar.add_button(icon="circle-half", on_click=bs.toggle_theme)
+        shell.commandbar.add_theme_toggle()
         shell.add_header("Account")
         with shell.add_page("profile", text="Profile", icon="person"):
             with bs.VStack(fill="both", expand=True, anchor_items="w", gap=8, padding=20):
@@ -72,7 +72,7 @@ def master_detail_list():
         shell._capture_full_window = True
         shell.commandbar.add_button(icon="pencil-square", label="Compose", on_click=lambda: None)
         shell.commandbar.add_spacer()
-        shell.commandbar.add_button(icon="circle-half", on_click=bs.toggle_theme)
+        shell.commandbar.add_theme_toggle()
         shell.list_nav(inbox, chevron=True)
 
         @shell.detail
@@ -103,7 +103,7 @@ def master_detail_tree():
         shell._capture_full_window = True
         shell.commandbar.add_label("Project", font="heading-md")
         shell.commandbar.add_spacer()
-        shell.commandbar.add_button(icon="circle-half", on_click=bs.toggle_theme)
+        shell.commandbar.add_theme_toggle()
         tree = shell.tree_nav(nodes=tree_nodes, placeholder="Select a file")
 
         @shell.detail
@@ -129,7 +129,7 @@ def workspaces():
     with bs.AppShell(title="Workspace", size=(720, 460)) as shell:
         shell._capture_full_window = True
         shell.commandbar.add_spacer()
-        shell.commandbar.add_button(icon="circle-half", on_click=bs.toggle_theme)
+        shell.commandbar.add_theme_toggle()
         with shell.add_workspace("mail", text="Mail", icon="envelope") as ws:
             ws.list_nav(inbox, chevron=True)
 
@@ -159,7 +159,7 @@ def custom_sidebar():
         shell._capture_full_window = True
         shell.commandbar.add_label("Shop", font="heading-md")
         shell.commandbar.add_spacer()
-        shell.commandbar.add_button(icon="circle-half", on_click=bs.toggle_theme)
+        shell.commandbar.add_theme_toggle()
         category = bs.Signal("All")
         max_price = bs.Signal(100)
         results = bs.Signal("")

--- a/docs/widgets/app.rst
+++ b/docs/widgets/app.rst
@@ -115,7 +115,7 @@ takes effect live.
 .. code-block:: python
 
    with bs.App(title="Notes", theme="bootstrap-dark", locale="de_DE") as app:
-       bs.Button("Toggle theme", on_click=bs.toggle_theme)
+       bs.ThemeToggle()
    app.run()
 
 See :doc:`/production/app-settings` for the full configuration reference — every
@@ -137,7 +137,7 @@ row at the top of the window.
            file.add_action("Quit", shortcut="Mod+Q", on_click=app.close)
 
        app.commandbar.add_spacer()                       # push trailing items right
-       app.commandbar.add_button(icon="circle-half", on_click=bs.toggle_theme)
+       app.commandbar.add_theme_toggle()
    app.run()
 
 Layout

--- a/docs/widgets/appshell.rst
+++ b/docs/widgets/appshell.rst
@@ -159,7 +159,7 @@ to push trailing items to the right.
 .. code-block:: python
 
    shell.commandbar.add_spacer()
-   shell.commandbar.add_button(icon="circle-half", on_click=bs.toggle_theme)
+   shell.commandbar.add_theme_toggle()
    shell.commandbar.add_button(label="Save", icon="save", on_click=save)
 
 Menu bar

--- a/docs/widgets/commandbar.rst
+++ b/docs/widgets/commandbar.rst
@@ -185,7 +185,7 @@ AppShell command bar.
 
    with bs.AppShell(title="My App") as shell:
        shell.commandbar.add_spacer()
-       shell.commandbar.add_button(icon="circle-half", command=bs.toggle_theme)
+       shell.commandbar.add_theme_toggle()
        ...
 
 Widget sizing

--- a/docs/widgets/index.rst
+++ b/docs/widgets/index.rst
@@ -19,7 +19,7 @@ below, or jump straight to a widget from the sidebar.
 
       Buttons that trigger commands.
 
-      :doc:`button` · :doc:`buttongroup`
+      :doc:`button` · :doc:`buttongroup` · :doc:`theme-toggle`
 
    .. grid-item-card:: :octicon:`pencil;1.5em;sd-mr-1` Inputs
 
@@ -104,6 +104,7 @@ below, or jump straight to a widget from the sidebar.
 
    button
    buttongroup
+   theme-toggle
 
 .. toctree::
    :caption: Inputs

--- a/docs/widgets/theme-toggle.rst
+++ b/docs/widgets/theme-toggle.rst
@@ -1,0 +1,43 @@
+Theme Toggle
+============
+
+``ThemeToggle`` is an icon button that switches between the light and dark theme.
+It shows a sun in light mode and a moon in dark mode, calls ``toggle_theme`` on
+click, and its icon follows the active theme — so it stays correct when the theme
+is changed elsewhere too.
+
+.. code-block:: python
+
+   import bootstack as bs
+
+   with bs.App(theme="bootstrap-light") as app:
+       bs.ThemeToggle()
+   app.run()
+
+It is a plain button — a stateless action whose icon merely reflects the current
+theme — so there is no toggle state to keep in sync (just the sun/moon glyph) and
+no risk of looping. It takes the button ``variant`` (default ``'ghost'``) and
+``density``:
+
+.. code-block:: python
+
+   bs.ThemeToggle(variant="outline", density="compact")
+
+Override the icons with any `Bootstrap Icons <https://icons.getbootstrap.com/>`_
+names:
+
+.. code-block:: python
+
+   bs.ThemeToggle(light_icon="brightness-high", dark_icon="moon-stars-fill")
+
+See also
+--------
+
+- :doc:`/reference/theming` — themes, ``set_theme``, and ``toggle_theme``.
+- :doc:`/widgets/button` — the button ``ThemeToggle`` builds on.
+
+API reference
+-------------
+
+See :class:`ThemeToggle <bootstack.ThemeToggle>` on the
+:doc:`/api-reference/widgets` page.

--- a/docs/widgets/window.rst
+++ b/docs/widgets/window.rst
@@ -95,7 +95,7 @@ See the App page's *Menu bar and command bar* section for details.
    with win.menubar.add_menu("File") as file:
        file.add_action("Close", shortcut="Mod+W", on_click=win.close)
    win.commandbar.add_spacer()
-   win.commandbar.add_button(icon="circle-half", on_click=bs.toggle_theme)
+   win.commandbar.add_theme_toggle()
 
 See also
 --------

--- a/src/bootstack/__init__.py
+++ b/src/bootstack/__init__.py
@@ -63,6 +63,7 @@ from bootstack.widgets.window import Window
 from bootstack.widgets.stacks import HStack, VStack
 from bootstack.widgets.grid import Grid
 from bootstack.widgets.boolean_controls import Checkbox, Switch, ToggleButton
+from bootstack.widgets.theme_toggle import ThemeToggle
 from bootstack.widgets.button import Button
 from bootstack.widgets.card import Card
 from bootstack.widgets.buttongroup import ButtonGroup
@@ -131,7 +132,7 @@ __all__ = [
     "HStack", "VStack", "Grid", "Card", "GroupBox", "Separator", "ScrollView",
     "SplitView", "SplitPane", "Accordion", "AccordionSection",
     # Actions
-    "Button", "ButtonGroup", "MenuButton", "CommandBar", "StatusBar",
+    "Button", "ButtonGroup", "ThemeToggle", "MenuButton", "CommandBar", "StatusBar",
     "ContextMenu", "ContextMenuItem",
     # Inputs
     "TextField", "PasswordField", "NumberField", "PathField", "SpinnerField",

--- a/src/bootstack/cli/demo.py
+++ b/src/bootstack/cli/demo.py
@@ -751,7 +751,7 @@ def _build_theme_page():
 
             with bs.HStack(gap=8):
                 bs.Label("Quick:", width=10)
-                bs.Button("Toggle Light / Dark", on_click=bs.toggle_theme)
+                bs.ThemeToggle()
 
         with bs.GroupBox("Accent Colors", fill="horizontal"):
             with bs.HStack(gap=4, fill="horizontal", fill_items="horizontal", expand_items=True):
@@ -831,7 +831,7 @@ def run_demo():
 
         shell.commandbar.add_label("Widget Gallery")
         shell.commandbar.add_spacer()
-        shell.commandbar.add_button(icon="circle-half", on_click=bs.toggle_theme)
+        shell.commandbar.add_theme_toggle()
 
         shell.statusbar.add_text("Ready")
         shell.statusbar.add_spacer()

--- a/src/bootstack/cli/templates/__init__.py
+++ b/src/bootstack/cli/templates/__init__.py
@@ -303,7 +303,7 @@ def _appshell_chrome(app_name: str) -> str:
             )
 
         # --- Command bar ----------------------------------------------------
-        shell.commandbar.add_button(icon="circle-half", on_click=bs.toggle_theme)
+        shell.commandbar.add_theme_toggle()
 
         # --- Status bar -----------------------------------------------------
         shell.statusbar.add_text("Ready")
@@ -536,7 +536,7 @@ class SettingsPage:
         with bs.GroupBox("Preferences", fill="both", expand=True):
             with bs.HStack(gap=8):
                 bs.Label("Theme:")
-                bs.Button("Toggle Light / Dark", on_click=bs.toggle_theme)
+                bs.ThemeToggle()
 '''
 
 

--- a/src/bootstack/widgets/commandbar.py
+++ b/src/bootstack/widgets/commandbar.py
@@ -163,15 +163,51 @@ class CommandBar(PublicWidgetBase):
         """Add a flexible spacer that pushes subsequent items to the right."""
         self._internal.add_spacer()
 
-    def add_widget(self, widget: Any, **pack_kwargs: Any) -> None:
-        """Add an arbitrary widget to the command bar.
+    def add_widget(self, widget: Any, **kwargs: Any) -> Any:
+        """Add a widget to the command bar.
 
-        The widget must have been created with the command bar as its parent, or
-        pass a raw internal widget here.
+        Pass a widget **class** to have the bar build it for you — `kwargs` are
+        forwarded to its constructor:
+
+            bar.add_widget(bs.ThemeToggle, variant="ghost")
+
+        Or pass an existing widget **instance** — `kwargs` are pack options:
+
+            bar.add_widget(my_widget, padx=4)
+
+        Returns:
+            The widget (the new instance when a class is given).
+        """
+        if isinstance(widget, type):
+            return widget(parent=self, **kwargs)
+        tk_widget = getattr(widget, "_internal", widget)
+        self._internal.add_widget(tk_widget, **kwargs)
+        return widget
+
+    # ----- Container protocol (so `parent=commandbar` works) -----
+
+    def _child_master(self) -> Any:
+        return self._internal.content
+
+    def guide_layout(self, child: Any, **layout_kw: Any) -> None:
+        # A widget created with `parent=commandbar` is packed into the bar.
+        self._internal.add_widget(child._internal)
+
+    @property
+    def content(self) -> Any:
+        """The bar's content frame — parent custom widgets here."""
+        return self._internal.content
+
+    def add_theme_toggle(self, **kwargs: Any) -> Any:
+        """Add a `ThemeToggle` — a sun/moon button that flips the theme.
 
         Args:
-            widget: A public widget instance or raw internal widget.
-            **pack_kwargs: Pack options forwarded to the widget's placement.
+            **kwargs: Forwarded to `ThemeToggle` — e.g. `variant`, `density`,
+                `accent`, `light_icon`, `dark_icon`.
+
+        Returns:
+            The created `ThemeToggle`.
         """
-        tk_widget = getattr(widget, "_internal", widget)
-        self._internal.add_widget(tk_widget, **pack_kwargs)
+        from bootstack.widgets.theme_toggle import ThemeToggle
+
+        return ThemeToggle(parent=self, **kwargs)

--- a/src/bootstack/widgets/statusbar.py
+++ b/src/bootstack/widgets/statusbar.py
@@ -97,19 +97,31 @@ class StatusBar(PublicWidgetBase):
             self._internal.add_spacer()
             self._has_right_spacer = True
 
-    def add_widget(self, widget: Any, *, side: Literal["left", "right"] = "left") -> None:
-        """Add a passive widget to the left or right cluster.
+    def add_widget(self, widget: Any, *, side: Literal["left", "right"] = "left", **kwargs: Any) -> Any:
+        """Add a widget to the left or right cluster.
+
+        Pass a widget **class** to have the bar build it (`kwargs` go to its
+        constructor), or an existing widget **instance**:
+
+            status.add_widget(bs.ThemeToggle, side="right")
+            status.add_widget(my_label)
 
         Args:
-            widget: A public widget (or raw internal widget) parented to this
-                status bar's `content` frame.
+            widget: A widget class or instance.
             side: `'left'` (default) or `'right'` (after the spacer).
+            **kwargs: Constructor arguments, used only when `widget` is a class.
+
+        Returns:
+            The widget (the new instance when a class is given).
         """
         if side == "right":
             self._ensure_right()
+        if isinstance(widget, type):
+            return widget(parent=self, **kwargs)
         tk_widget = getattr(widget, "_internal", widget)
         self._internal.add_widget(tk_widget)
         self._show()
+        return widget
 
     def add_text(
         self,

--- a/src/bootstack/widgets/theme_toggle.py
+++ b/src/bootstack/widgets/theme_toggle.py
@@ -1,0 +1,92 @@
+"""ThemeToggle — a sun/moon icon button that flips the application theme."""
+from __future__ import annotations
+
+from typing import Any
+
+from bootstack.style import toggle_theme
+from bootstack.widgets.button import Button
+from bootstack.widgets.types import AccentToken, ButtonVariant, WidgetDensity
+
+
+def _theme_is_dark() -> bool:
+    """Return whether the active theme's mode is dark."""
+    from bootstack.style.theme_provider import use_theme
+
+    try:
+        return use_theme().mode == "dark"
+    except Exception:
+        return False
+
+
+class ThemeToggle(Button):
+    """An icon button that switches between the light and dark theme.
+
+    Shows the `light_icon` (a sun) in light mode and the `dark_icon` (a moon) in
+    dark mode. Clicking it calls `toggle_theme()`; its icon follows the active
+    theme, so it stays correct when the theme is changed elsewhere too.
+
+    It is a plain button — a stateless action whose icon merely reflects the
+    current theme — so there is no checked state to keep in sync and no risk of
+    looping. Supports the button `variant` and `density`.
+
+    Args:
+        light_icon: Bootstrap Icons name shown in light mode. Default `'sun-fill'`.
+        dark_icon: Bootstrap Icons name shown in dark mode. Default
+            `'moon-stars-fill'`.
+        variant: Button style variant — `'default'`, `'solid'`, `'outline'`, or
+            `'ghost'`. Default `'ghost'`.
+        density: Padding density — `'default'` or `'compact'`.
+        accent: Accent token applied to the icon. Defaults to the foreground.
+        parent: Explicit parent widget. If omitted, the current context-stack
+            container is used.
+        **kwargs: Layout placement options applied by the parent container —
+            `fill`, `expand`, `anchor`, `margin`, `row`, `column`, `sticky`.
+            See :doc:`/tasks/layout`.
+    """
+
+    def __init__(
+        self,
+        *,
+        light_icon: str = "sun-fill",
+        dark_icon: str = "moon-stars-fill",
+        variant: ButtonVariant = "ghost",
+        density: WidgetDensity = "default",
+        accent: AccentToken | str | None = None,
+        parent: Any = None,
+        **kwargs: Any,
+    ) -> None:
+        self._light_icon = light_icon
+        self._dark_icon = dark_icon
+        super().__init__(
+            on_click=toggle_theme,
+            icon=self._theme_icon(),
+            variant=variant,
+            density=density,
+            accent=accent,
+            parent=parent,
+            **kwargs,
+        )
+
+        # Keep the icon matching the active theme — clicking this button (or any
+        # other theme change) refreshes it. Setting the icon never fires a click,
+        # so there is no cycle.
+        self._theme_toplevel = self._internal.winfo_toplevel()
+        self._theme_bind = self._theme_toplevel.bind(
+            "<<BsThemeChanged>>", self._sync_icon, add="+"
+        )
+        self.on_destroy(self._cleanup_theme_toggle)
+
+    def _theme_icon(self) -> str:
+        return self._dark_icon if _theme_is_dark() else self._light_icon
+
+    def _sync_icon(self, _event: Any = None) -> None:
+        self.icon = self._theme_icon()
+
+    def _cleanup_theme_toggle(self, _event: Any = None) -> None:
+        try:
+            self._theme_toplevel.unbind("<<BsThemeChanged>>", self._theme_bind)
+        except Exception:
+            pass
+
+
+__all__ = ["ThemeToggle"]

--- a/tests/test_public_surface.py
+++ b/tests/test_public_surface.py
@@ -42,7 +42,7 @@ EXPECTED_TOPLEVEL = {
     "TextField", "PasswordField", "NumberField", "PathField", "SpinnerField",
     "TextArea", "CodeEditor", "DateField", "TimeField", "Slider", "RangeSlider",
     # selection
-    "Checkbox", "Switch", "ToggleButton", "ToggleGroup", "Radio",
+    "Checkbox", "Switch", "ToggleButton", "ThemeToggle", "ToggleGroup", "Radio",
     "RadioToggleButton", "RadioGroup", "Select", "SelectButton", "Calendar",
     # data display
     "Label", "Badge", "ProgressBar", "Gauge", "ListView", "DataTable",

--- a/tests/widgets/public/test_theme_toggle.py
+++ b/tests/widgets/public/test_theme_toggle.py
@@ -1,0 +1,70 @@
+"""ThemeToggle — a button whose icon follows the theme; clicking flips it.
+
+It is stateless (a Button), so the only thing kept in sync is the sun/moon icon,
+which updates on a click *or* a programmatic theme change elsewhere.
+"""
+from __future__ import annotations
+
+import pytest
+
+import bootstack as bs
+from bootstack.style import get_theme
+
+SUN = "sun-fill"
+MOON = "moon-stars-fill"
+
+
+@pytest.fixture(scope="module")
+def app():
+    a = bs.App(theme="bootstrap-light")
+    a.__enter__()
+    a._tk_root.update()
+    try:
+        yield a
+    finally:
+        try:
+            a.__exit__(None, None, None)
+        except Exception:
+            pass
+
+
+def _flush(app):
+    app._tk_root.update()
+
+
+def test_icon_reflects_initial_theme(app):
+    bs.set_theme("bootstrap-light"); _flush(app)
+    tt = bs.ThemeToggle(); _flush(app)
+    assert tt.icon == SUN
+
+
+def test_click_toggles_theme_and_icon(app):
+    bs.set_theme("bootstrap-light"); _flush(app)
+    tt = bs.ThemeToggle(); _flush(app)
+
+    tt._internal.invoke(); _flush(app)            # real click
+    assert get_theme() == "bootstrap-dark"
+    assert tt.icon == MOON
+
+    tt._internal.invoke(); _flush(app)
+    assert get_theme() == "bootstrap-light"
+    assert tt.icon == SUN
+
+
+def test_programmatic_theme_change_syncs_icon(app):
+    bs.set_theme("bootstrap-light"); _flush(app)
+    tt = bs.ThemeToggle(); _flush(app)
+    assert tt.icon == SUN
+
+    bs.set_theme("bootstrap-dark"); _flush(app)   # changed elsewhere, no click
+    assert tt.icon == MOON
+
+
+def test_custom_icons_variant_density(app):
+    bs.set_theme("bootstrap-light"); _flush(app)
+    tt = bs.ThemeToggle(
+        light_icon="brightness-high", dark_icon="moon",
+        variant="outline", density="compact",
+    )
+    _flush(app)
+    assert tt.icon == "brightness-high"


### PR DESCRIPTION
A common UI element, now a first-class widget — plus the command-bar integration to host it, and a sweep replacing the hand-wired toggles across docs/examples/CLI.

## `ThemeToggle`
A stateless **Button**: clicking calls `toggle_theme()`, and its icon follows the active theme (sun in light, moon in dark), resyncing on **any** change — a click *or* a programmatic `set_theme` elsewhere — with no checked state and no loop. Supports `variant` / `density` / `accent`, and overridable `light_icon` / `dark_icon`.

It's an **action** widget (grouped with Button/ButtonGroup), not selection — the checkbutton path was rejected because its checked/unchecked color wash fights an icon-only toggle.

## CommandBar / StatusBar integration
Both now host widgets properly:
- Added the **container protocol** (`_child_master` + `guide_layout`), so `parent=bar` works.
- `add_widget` is **polymorphic** — pass a **class** (the bar builds it, kwargs → constructor) or an **instance** (kwargs → pack opts).
- `CommandBar.add_theme_toggle()` is the one-liner for the common case (theme switching in the chrome).

## Sweep
Replaced hand-wired toggles everywhere: command-bar `add_button(icon="circle-half", on_click=toggle_theme)` → `add_theme_toggle()` (examples, screenshot scripts, the CLI gallery `demo.py`, scaffold templates, app/appshell/commandbar/window doc snippets), and standalone `Button(...toggle_theme)` → `ThemeToggle()`.

## Verify
165 tests pass (incl. new `test_theme_toggle`), clean compile + `-W` docs build, AppShell integration confirmed.

## Notes
- ⚠️ The swept `docs/screenshots/*.py` now render sun/moon instead of circle-half — those PNGs need regenerating (visual pass).
- Follow-up (separate): Gallery/Carousel collapse to zero height in non-expanding containers (e.g. a scrollable page) — they should request a sensible minimum height so a group never collapses. Pre-existing; to be fixed next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)