### PR TITLE
fix(media): give Gallery/Carousel a requested-height floor

### DIFF
--- a/src/bootstack/cli/demo.py
+++ b/src/bootstack/cli/demo.py
@@ -807,13 +807,16 @@ def _build_media_page():
             bs.Picture(photos[1]["image"], width=180, height=120, fit="contain")
             bs.Picture(photos[2]["image"], width=120, height=120, fit="cover", corner_radius=60)
 
-        with bs.GroupBox("Gallery", fill="both", expand=True):
-            bs.Gallery(items=photos, image_field="image", caption_field="title",
-                       tile_size=(120, 120), fill="both", expand=True)
-
         with bs.GroupBox("Carousel", fill="horizontal"):
             bs.Carousel(items=photos, image_field="image", caption_field="title",
                         fit="cover", fill="horizontal")
+
+        # Gallery last: it scrolls internally and swallows the wheel event, so
+        # keeping it at the bottom leaves the carousel/picture rows above it as
+        # places to grab and scroll the page itself.
+        with bs.GroupBox("Gallery", fill="both", expand=True):
+            bs.Gallery(items=photos, image_field="image", caption_field="title",
+                       tile_size=(120, 120), fill="both", expand=True)
 
 
 # =============================================================================

--- a/src/bootstack/widgets/_impl/composites/carousel.py
+++ b/src/bootstack/widgets/_impl/composites/carousel.py
@@ -72,6 +72,8 @@ class Carousel(Frame):
         interval: int = 4000,
         loop: bool = True,
         corner_radius: int = 0,
+        aspect_ratio: float = 1.5,
+        height: int | None = None,
         accent: str | None = None,
         **kwargs: Any,
     ) -> None:
@@ -120,6 +122,13 @@ class Carousel(Frame):
         self._next_photo: PhotoImage | None = None
 
         surface = self._surface_color()
+        # Requested-height FLOOR so the carousel never collapses in a container
+        # that doesn't impose a height (a scroll view, an auto-fit window). The
+        # public wrapper freezes this frame with `pack_propagate(False)`, so its
+        # own configured `height` is its requested height; `fill`/`expand` still
+        # grow it past this floor when the parent has room.
+        floor_h = height if height else round(400 / max(0.1, aspect_ratio))
+        self.configure(height=floor_h)
         self._stage = Canvas(self, highlightthickness=0, bd=0, background=surface)
         self._stage.pack(fill="both", expand=True)
         self._stage.bind("<Configure>", self._on_configure, add="+")

--- a/src/bootstack/widgets/_impl/composites/gallery.py
+++ b/src/bootstack/widgets/_impl/composites/gallery.py
@@ -161,10 +161,12 @@ class Gallery(Frame):
         selection_mode: Literal["none", "single", "multi"] = "none",
         accent: str | None = None,
         scrollbar_variant: ScrollbarVariant = "thin",
+        rows: int = 2,
         **kwargs: Any,
     ) -> None:
         super().__init__(master, **kwargs)
         self._scrollbar_variant = scrollbar_variant
+        self._min_rows = max(1, rows)
 
         self._image_field = image_field
         self._caption_field = caption_field
@@ -200,6 +202,13 @@ class Gallery(Frame):
         self._scrollbar.pack(side="right", fill="y")
         self._container = Frame(self)
         self._container.pack(side="left", fill="both", expand=True)
+
+        # Requested-height FLOOR so the grid never reports ~0 height in a
+        # container that doesn't impose one (a scroll view, an auto-fit window).
+        # The public wrapper freezes this frame with `pack_propagate(False)`, so
+        # its own configured `height` is its requested height; `fill`/`expand`
+        # still grow it past this floor when the parent has room.
+        self.configure(height=self._min_rows * self._row_h)
 
         # Bind resize on the CONTAINER and use the event's width/height directly —
         # winfo_width() read during the parent's <Configure> lags a cycle behind

--- a/src/bootstack/widgets/carousel.py
+++ b/src/bootstack/widgets/carousel.py
@@ -50,6 +50,12 @@ class Carousel(PublicWidgetBase):
         loop: Wrap around past the first and last slides. Default `True`.
         corner_radius: Rounded-corner radius for the slide image, in pixels.
             Default `0`.
+        aspect_ratio: Width-to-height ratio used to derive the carousel's minimum
+            height when it sits in a container that doesn't impose one (a scroll
+            view, an auto-fit window). Default `1.5`. Ignored when `height` is
+            set. `fill`/`expand` still grow the stage past this floor.
+        height: Explicit minimum height for the slide stage, in pixels. Overrides
+            `aspect_ratio`. Default `None` (derive from `aspect_ratio`).
         accent: Color intent token to brand the active indicator dot. By default
             the dots are neutral (white), which reads on any image; set this to
             color the active dot.
@@ -76,6 +82,8 @@ class Carousel(PublicWidgetBase):
         interval: int = 4000,
         loop: bool = True,
         corner_radius: int = 0,
+        aspect_ratio: float = 1.5,
+        height: int | None = None,
         accent: AccentToken | str | None = None,
         surface: SurfaceToken | str | None = None,
         parent: Any = None,
@@ -97,6 +105,8 @@ class Carousel(PublicWidgetBase):
             "interval": interval,
             "loop": loop,
             "corner_radius": corner_radius,
+            "aspect_ratio": aspect_ratio,
+            "height": height,
         }
         if items is not None:
             internal_kwargs["items"] = items

--- a/src/bootstack/widgets/gallery.py
+++ b/src/bootstack/widgets/gallery.py
@@ -50,6 +50,10 @@ class Gallery(PublicWidgetBase):
             `'none'` (default). Selected tiles show an accent highlight ring.
         scrollbar_variant: Scrollbar style — `'thin'` (default) for a slim bar,
             or `'default'` for the standard rounded bar.
+        rows: Number of tile rows used to derive the gallery's minimum height
+            when it sits in a container that doesn't impose one (a scroll view,
+            an auto-fit window). Default `2`. `fill`/`expand` still grow the grid
+            past this floor and reflow more rows in.
         accent: Color intent token for the selection ring. Defaults to the
             theme's primary color.
         surface: Background surface token shown behind the tiles.
@@ -73,6 +77,7 @@ class Gallery(PublicWidgetBase):
         gap: int = 8,
         selection_mode: SelectionMode = "none",
         scrollbar_variant: ScrollbarVariant = "thin",
+        rows: int = 2,
         accent: AccentToken | str | None = None,
         surface: SurfaceToken | str | None = None,
         parent: Any = None,
@@ -93,6 +98,7 @@ class Gallery(PublicWidgetBase):
             "gap": gap,
             "selection_mode": selection_mode,
             "scrollbar_variant": scrollbar_variant,
+            "rows": rows,
         }
         if items is not None:
             internal_kwargs["items"] = items


### PR DESCRIPTION
## Problem

`Gallery` and `Carousel` collapsed to a ~1px sliver in any container that doesn't impose a height — a `ScrollView` or an auto-fit window. They only rendered correctly inside a parent that already gave them a fixed/expanding height.

Root cause: the public wrappers freeze the widget frame with `pack_propagate(False)` (from the earlier media work), so the frame reports its *own* configured height — which defaulted to `1`. A floor set on an inner canvas or via grid `minsize` can't propagate *up* through a `pack_propagate(False)` frame, which is why earlier attempts didn't take.

## Fix

Each internal composite now configures a content-derived height floor on its own (frozen) frame:

- **Carousel** — `height=` or `round(400 / aspect_ratio)`
- **Gallery** — `rows * row_height`

`fill`/`expand` still grow the widget past the floor — the same model `Picture` already uses.

New public params (documented):
- `Carousel(aspect_ratio=1.5, height=None)`
- `Gallery(rows=2)`

## Verified

| Case | Before | After |
|---|---|---|
| Gallery in scroll | reqh `1` | reqh `328` (2 rows) |
| Carousel in scroll | reqh `1` | reqh `267` (400/1.5) |
| `Gallery(rows=1)` | — | reqh `100` |
| `Carousel(height=320)` | — | reqh `320` |
| `Carousel(aspect_ratio=2.0)` | — | reqh `200` |

- `test_public_surface.py` — 161 passed
- Clean `-W` Sphinx build — no new warnings

## Also

Reorders the demo Media page so **Carousel sits above Gallery**: the Gallery scrolls internally and swallows the wheel event, so keeping it at the bottom leaves the carousel/picture rows above it as places to grab and scroll the page itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)