### PR TITLE
docs: align code blocks with their screenshots

### DIFF
--- a/docs/getting-started/app-structures.rst
+++ b/docs/getting-started/app-structures.rst
@@ -23,10 +23,15 @@ a `with` block — every widget built inside the block becomes a child, with no
 
    import bootstack as bs
 
-   with bs.App(title="Notes", size=(600, 400), padding=16, gap=8) as app:
-       bs.Label("Welcome to Notes", font="heading-lg")
-       bs.TextField(placeholder="Jot something down…")
-       bs.Button("Save", accent="primary", on_click=app.close)
+   with bs.App(title="Notes", size=(480, 340), padding=20, gap=10) as app:
+       bs.Label("Notes", font="heading-lg")
+       bs.Label("A single window you fill with widgets.", accent="secondary")
+       bs.TextField(placeholder="Title", fill="x")
+       bs.TextArea(value="Reach for App first — it covers anything that fits "
+                         "on one screen.", fill="both", expand=True)
+       with bs.HStack(fill="x", gap=8, anchor_items="e"):
+           bs.Button("Discard", variant="ghost")
+           bs.Button("Save", accent="primary")
 
    app.run()
 
@@ -64,15 +69,26 @@ context manager for that page's content — and pick the starting page with
 
    import bootstack as bs
 
-   with bs.AppShell(title="Tasks") as shell:
-       with shell.add_page("inbox", text="Inbox", icon="inbox"):
-           bs.Label("Inbox", font="heading-lg")
-           bs.Label("No new tasks", accent="secondary")
+   with bs.AppShell(title="Acme") as shell:
+       with shell.add_toolbar() as bar:
+           with bar.add_menu("File") as file:
+               file.add_action("New", shortcut="Mod+N", on_click=lambda: None)
+               file.add_action("Quit", shortcut="Mod+Q", on_click=shell.close)
+           bar.add_spacer()
+           bar.add_theme_toggle()
 
-       with shell.add_page("done", text="Completed", icon="check-circle"):
-           bs.Label("Completed", font="heading-lg")
+       with shell.add_page("home", text="Home", icon="house"):
+           bs.Label("Home", font="heading-lg")
+           bs.Label("A window with a sidebar and swappable pages.", accent="secondary")
+       with shell.add_page("reports", text="Reports", icon="bar-chart"):
+           bs.Label("Reports", font="heading-lg")
+       with shell.add_page("team", text="Team", icon="people"):
+           bs.Label("Team", font="heading-lg")
 
-       shell.navigate("inbox")
+       with shell.add_footer_page("settings", text="Settings", icon="gear"):
+           bs.Label("Settings", font="heading-lg")
+
+       shell.navigate("home")
 
    shell.run()
 

--- a/docs/tasks/building-forms.rst
+++ b/docs/tasks/building-forms.rst
@@ -68,7 +68,7 @@ when they all pass — each failing field shows its own message:
 
 .. code-block:: python
 
-   form.field("email").add_validation_rule("email", message="Enter a valid email.")
+   form.field("email").add_validation_rule("email", message="Enter a valid email address.")
    form.field("first").add_validation_rule("stringLength", min=2, max=50)
 
    def submit():

--- a/docs/tasks/composing-fields.rst
+++ b/docs/tasks/composing-fields.rst
@@ -81,7 +81,7 @@ the left for recognition, and a clear button on the right that empties the field
 
 .. code-block:: python
 
-   field = bs.TextField(placeholder="Search products...", fill="x")
+   field = bs.TextField(placeholder="Search products...", value="wireless", fill="x")
    field.insert_addon("label", "before", icon="search")
 
    def clear():
@@ -140,8 +140,8 @@ app — here, whether a width is measured in pixels or percent:
 .. code-block:: python
 
    size = bs.NumberField(value=64, label="Width", fill="x")
-   percent = bs.Signal(False)        # False -> px, True -> %
-   size.insert_addon("toggle", "after", name="unit", text="px", signal=percent)
+   percent = bs.Signal(True)         # False -> px, True -> %
+   size.insert_addon("toggle", "after", name="unit", text="%", signal=percent)
 
    def show_unit(is_percent):
        size.update_addon("unit", text="%" if is_percent else "px")

--- a/docs/tasks/layout.rst
+++ b/docs/tasks/layout.rst
@@ -129,8 +129,24 @@ them with `row=`/`column=` and span with `rowspan=`/`columnspan=`.
        bs.Label("Name");  bs.TextField()
        bs.Label("Email"); bs.TextField()
 
-Column weights control how the spare width is shared — a fixed column, a flexible
-one, and another fixed column:
+Column weights control how the spare width is shared. A column can be an equal
+weight, content-sized (`"auto"`), a fixed pixel width (`"120px"`), or a flexible
+weight that soaks up the remaining width:
+
+.. code-block:: python
+
+   with bs.Grid(columns=[1, 1, 1], gap=8, sticky_items="ew", fill="x"):
+       for label in ("Equal", "Weight", "Columns"):
+           bs.Button(label)
+
+   with bs.Grid(columns=["auto", 1], gap=8, sticky_items="ew", fill="x"):
+       bs.Button("auto")
+       bs.Button("weight=1 (fills remaining)")
+
+   with bs.Grid(columns=["120px", 1, "80px"], gap=8, sticky_items="ew", fill="x"):
+       bs.Button("120px")
+       bs.Button("weight=1")
+       bs.Button("80px")
 
 .. image:: /_static/examples/grid-columns-light.png
    :class: bs-screenshot-light

--- a/docs/widgets/accordion.rst
+++ b/docs/widgets/accordion.rst
@@ -118,12 +118,12 @@ title.
 .. code-block:: python
 
    acc = bs.Accordion(accent="primary")
-   with acc.add("Documents", icon="folder"):
-       bs.Label("Files here.")
+   with acc.add("Documents", icon="folder", expanded=True):
+       bs.Label("PDF reports, spreadsheets, and presentations.")
    with acc.add("Images", icon="image"):
-       bs.Label("Images here.")
+       bs.Label("Photos and exported graphics.")
    with acc.add("Music", icon="file-music"):
-       bs.Label("Music here.")
+       bs.Label("Audio files and playlists.")
 
 .. image:: /_static/examples/accordion-icons-light.png
    :class: bs-screenshot-light

--- a/docs/widgets/badge.rst
+++ b/docs/widgets/badge.rst
@@ -32,12 +32,21 @@ Accent colors
 
 .. code-block:: python
 
+   # Square (default)
    bs.Badge("Primary",   accent="primary")
    bs.Badge("Secondary", accent="secondary")
    bs.Badge("Info",      accent="info")
    bs.Badge("Success",   accent="success")
    bs.Badge("Warning",   accent="warning")
    bs.Badge("Danger",    accent="danger")
+
+   # Pill
+   bs.Badge("Primary",   accent="primary",   variant="pill")
+   bs.Badge("Secondary", accent="secondary", variant="pill")
+   bs.Badge("Info",      accent="info",      variant="pill")
+   bs.Badge("Success",   accent="success",   variant="pill")
+   bs.Badge("Warning",   accent="warning",   variant="pill")
+   bs.Badge("Danger",    accent="danger",    variant="pill")
 
 .. image:: /_static/examples/badge-accents-light.png
    :class: bs-screenshot-light
@@ -60,11 +69,19 @@ in a table cell, or in a sidebar item.
        bs.Label("Inbox", font="heading-md")
        bs.Badge("12", accent="primary", variant="pill")
 
+   with bs.HStack(gap=8, anchor_items="center"):
+       bs.Label("Alerts", font="heading-md")
+       bs.Badge("3", accent="danger", variant="pill")
+
    # Status in a data row
    with bs.HStack(gap=8, anchor_items="center"):
        bs.Label("Run-A15")
        bs.Badge("Complete", accent="success", variant="pill")
+
+   with bs.HStack(gap=8, anchor_items="center"):
+       bs.Label("Run-A14")
        bs.Badge("2 warnings", accent="warning")
+       bs.Badge("Fail",       accent="danger",  variant="pill")
 
 .. image:: /_static/examples/badge-context-light.png
    :class: bs-screenshot-light

--- a/docs/widgets/buttongroup.rst
+++ b/docs/widgets/buttongroup.rst
@@ -37,9 +37,10 @@ button inherits the group accent unless you override it individually via
 
 .. code-block:: python
 
-   bg = bs.ButtonGroup(accent="primary")
-   bg.add("Save")
-   bg.add("Cancel")
+   for accent in ("default", "primary", "secondary", "success", "warning", "danger"):
+       bg = bs.ButtonGroup(accent=accent)
+       bg.add("Save")
+       bg.add("Cancel")
 
 .. image:: /_static/examples/buttongroup-accents-light.png
    :class: bs-screenshot-light
@@ -56,9 +57,11 @@ Use ``variant=`` to control visual weight across the whole group.
 
 .. code-block:: python
 
-   bs.ButtonGroup(accent="primary", variant="solid")    # default
-   bs.ButtonGroup(accent="primary", variant="outline")
-   bs.ButtonGroup(accent="primary", variant="ghost")
+   for variant in ("solid", "outline", "ghost"):
+       bg = bs.ButtonGroup(accent="primary", variant=variant)
+       bg.add("Save")
+       bg.add("Cancel")
+       bg.add("Reset")
 
 .. image:: /_static/examples/buttongroup-variants-light.png
    :class: bs-screenshot-light
@@ -96,11 +99,16 @@ automatically, same as for :doc:`button`.
 
 .. code-block:: python
 
-   bg = bs.ButtonGroup(variant="outline", accent="primary")
-   bg.add(icon="type-bold")
-   bg.add(icon="type-italic")
-   bg.add(icon="type-underline")
-   bg.add(icon="type-strikethrough")
+   bg1 = bs.ButtonGroup(variant="outline", accent="primary")
+   bg1.add(icon="type-bold")
+   bg1.add(icon="type-italic")
+   bg1.add(icon="type-underline")
+   bg1.add(icon="type-strikethrough")
+
+   bg2 = bs.ButtonGroup()
+   bg2.add(icon="scissors")
+   bg2.add(icon="copy")
+   bg2.add(icon="clipboard")
 
 .. image:: /_static/examples/buttongroup-icon-only-light.png
    :class: bs-screenshot-light
@@ -138,10 +146,15 @@ Use ``density='compact'`` to reduce button padding — useful inside toolbars.
 
 .. code-block:: python
 
-   bg = bs.ButtonGroup(accent="primary", density="compact")
-   bg.add("Cut",   icon="scissors")
-   bg.add("Copy",  icon="copy")
-   bg.add("Paste", icon="clipboard")
+   bg1 = bs.ButtonGroup(accent="primary")
+   bg1.add("Cut",   icon="scissors")
+   bg1.add("Copy",  icon="copy")
+   bg1.add("Paste", icon="clipboard")
+
+   bg2 = bs.ButtonGroup(accent="primary", density="compact")
+   bg2.add("Cut",   icon="scissors")
+   bg2.add("Copy",  icon="copy")
+   bg2.add("Paste", icon="clipboard")
 
 .. image:: /_static/examples/buttongroup-density-light.png
    :class: bs-screenshot-light
@@ -159,12 +172,16 @@ once. Toggle the ``disabled`` property at runtime to re-enable.
 
 .. code-block:: python
 
-   bg = bs.ButtonGroup(accent="primary", disabled=True)
-   bg.add("Save")
-   bg.add("Cancel")
+   bg1 = bs.ButtonGroup(accent="primary")
+   bg1.add("Save")
+   bg1.add("Cancel")
+
+   bg2 = bs.ButtonGroup(accent="primary", disabled=True)
+   bg2.add("Save")
+   bg2.add("Cancel")
 
    # Toggle at runtime
-   bg.disabled = False
+   bg2.disabled = False
 
 .. image:: /_static/examples/buttongroup-disabled-light.png
    :class: bs-screenshot-light

--- a/docs/widgets/card.rst
+++ b/docs/widgets/card.rst
@@ -26,9 +26,10 @@ and the next surface step.
 
 .. code-block:: python
 
-   with bs.Card(accent="primary", padding=16, gap=8):
-       bs.Label("Primary", accent="primary", font="heading-sm")
-       bs.Label("Card content")
+   for accent in ("primary", "secondary", "info", "success", "warning", "danger"):
+       with bs.Card(accent=accent, padding=24, gap=4):
+           bs.Label(accent.title(), accent=accent, font="heading-sm")
+           bs.Label("Card content")
 
 .. image:: /_static/examples/card-accent-light.png
    :class: bs-screenshot-light

--- a/docs/widgets/checkbox.rst
+++ b/docs/widgets/checkbox.rst
@@ -120,8 +120,8 @@ Disabled
 
 .. code-block:: python
 
-   bs.Checkbox("Cannot change", disabled=True)
-   bs.Checkbox("Locked on", value=True, disabled=True)
+   bs.Checkbox("Disabled",         disabled=True)
+   bs.Checkbox("Disabled checked", value=True, disabled=True)
 
 .. image:: /_static/examples/checkbox-disabled-light.png
    :class: bs-screenshot-light

--- a/docs/widgets/codeeditor.rst
+++ b/docs/widgets/codeeditor.rst
@@ -30,10 +30,9 @@ name is accepted.
 
 .. code-block:: python
 
-   bs.CodeEditor(language="python")
-   bs.CodeEditor(language="sql")
-   bs.CodeEditor(language="javascript")
-   bs.CodeEditor(language="html")
+   bs.CodeEditor(value=python_source, language="python")
+   bs.CodeEditor(value=sql_source,    language="sql")
+   # Any Pygments lexer name works — "javascript", "html", "yaml", …
 
 .. image:: /_static/examples/codeeditor-languages-light.png
    :class: bs-screenshot-light
@@ -64,7 +63,8 @@ Read-only state
 
 .. code-block:: python
 
-   bs.CodeEditor(value=code, language="python", read_only=True)
+   bs.CodeEditor(value=code, language="python")                   # editable
+   bs.CodeEditor(value=code, language="python", read_only=True)   # read-only
 
 .. image:: /_static/examples/codeeditor-states-light.png
    :class: bs-screenshot-light

--- a/docs/widgets/contextmenu.rst
+++ b/docs/widgets/contextmenu.rst
@@ -42,13 +42,13 @@ radiobutton items, and separators.
 .. code-block:: python
 
    menu = bs.ContextMenu(target)
-   menu.add_item("Open",          icon="folder2-open")   # command
+   menu.add_item("Command item", icon="pencil")          # command
    menu.add_separator()
-   menu.add_check_item("Starred", value=True)            # checkbutton
+   menu.add_check_item("Check item (on)", value=True)    # checkbutton
+   menu.add_check_item("Check item (off)")
    menu.add_separator()
-   menu.add_radio_item("Low",     value="low")           # radiobutton
-   menu.add_radio_item("Medium",  value="med")
-   menu.add_radio_item("High",    value="high")
+   menu.add_radio_item("Radio item A", value="a")        # radiobutton
+   menu.add_radio_item("Radio item B", value="b")
 
 .. image:: /_static/examples/contextmenu-item-types-light.png
    :class: bs-screenshot-light
@@ -109,9 +109,11 @@ Three forms are accepted:
 .. code-block:: python
 
    menu = bs.ContextMenu(target)
-   menu.add_item("Cut",   icon="scissors",  shortcut="Mod+X")
-   menu.add_item("Copy",  icon="copy",      shortcut="Mod+C")
-   menu.add_item("Paste", icon="clipboard", shortcut="Mod+V")
+   menu.add_item("Cut",        icon="scissors",  shortcut="Mod+X")
+   menu.add_item("Copy",       icon="copy",      shortcut="Mod+C")
+   menu.add_item("Paste",      icon="clipboard", shortcut="Mod+V")
+   menu.add_separator()
+   menu.add_item("Select All",                   shortcut="Mod+A")
 
 .. image:: /_static/examples/contextmenu-shortcuts-light.png
    :class: bs-screenshot-light

--- a/docs/widgets/datefield.rst
+++ b/docs/widgets/datefield.rst
@@ -33,7 +33,6 @@ Any `ICU date format`_ pattern or named preset is accepted.
    bs.DateField(value=today, value_format="longDate")     # January 15, 2025
    bs.DateField(value=today, value_format="shortDate")    # 1/15/25
    bs.DateField(value=today, value_format="monthAndYear") # January 2025
-   bs.DateField(value=today, value_format="yyyy-MM-dd")   # 2025-01-15
 
 .. _ICU date format: https://unicode-org.github.io/icu/userguide/format_parse/datetime/
 

--- a/docs/widgets/forms.rst
+++ b/docs/widgets/forms.rst
@@ -48,10 +48,10 @@ Use ``col_count=`` to distribute fields across multiple columns:
 
    bs.Form(
        data={
-           "street": "",
-           "city": "",
-           "state": "",
-           "zip": "",
+           "street": "123 Main St",
+           "city": "Springfield",
+           "state": "IL",
+           "zip": "62701",
        },
        col_count=2,
    )
@@ -139,7 +139,7 @@ section with its own column layout:
    bs.Form(
        items=[
            bs.GroupItem(
-               label="Personal Info",
+               label="Contact",
                col_count=2,
                items=[
                    bs.FieldItem(key="first_name", label="First Name"),

--- a/docs/widgets/gauge.rst
+++ b/docs/widgets/gauge.rst
@@ -75,10 +75,9 @@ Accent colors
 
 .. code-block:: python
 
-   bs.Gauge(value=65, accent="primary")
-   bs.Gauge(value=65, accent="success")
-   bs.Gauge(value=65, accent="warning")
-   bs.Gauge(value=65, accent="danger")
+   for accent in ("primary", "secondary", "info", "success", "warning", "danger"):
+       bs.Gauge(value=65, accent=accent, size=140, thickness=14,
+                subtitle=accent.title())
 
 .. image:: /_static/examples/gauge-accents-light.png
    :class: bs-screenshot-light
@@ -96,8 +95,11 @@ produce finer dashes:
 
 .. code-block:: python
 
-   bs.Gauge(value=55, segment_width=8,  accent="primary")   # coarse segments
-   bs.Gauge(value=55, segment_width=4,  accent="secondary") # fine segments
+   bs.Gauge(value=55, subtitle="Solid", accent="primary")           # solid arc
+   bs.Gauge(value=55, segment_width=8, subtitle="Segmented",        # coarse segments
+            accent="primary")
+   bs.Gauge(value=55, segment_width=4, subtitle="Fine segments",    # fine segments
+            accent="secondary")
 
 .. image:: /_static/examples/gauge-segments-light.png
    :class: bs-screenshot-light
@@ -114,9 +116,9 @@ Arc thickness
 
 .. code-block:: python
 
-   bs.Gauge(value=70, thickness=6,  subtitle="Thin")
-   bs.Gauge(value=70, thickness=14, subtitle="Default")
-   bs.Gauge(value=70, thickness=24, subtitle="Thick")
+   bs.Gauge(value=70, thickness=6,  subtitle="Thin",    accent="info")
+   bs.Gauge(value=70, thickness=14, subtitle="Default", accent="info")
+   bs.Gauge(value=70, thickness=24, subtitle="Thick",   accent="info")
 
 .. image:: /_static/examples/gauge-thickness-light.png
    :class: bs-screenshot-light

--- a/docs/widgets/grid.rst
+++ b/docs/widgets/grid.rst
@@ -32,17 +32,21 @@ Column definitions
 
 .. code-block:: python
 
-   # Three equal columns — integer shorthand
-   bs.Grid(columns=3)
-
-   # Same, written explicitly
-   bs.Grid(columns=[1, 1, 1])
+   # Three equal-weight columns (columns=3 is the same shorthand)
+   with bs.Grid(columns=[1, 1, 1], gap=8, sticky_items="ew", fill="x"):
+       for label in ("Equal", "Weight", "Columns"):
+           bs.Button(label)
 
    # Label column sizes to content; field column takes the rest
-   bs.Grid(columns=["auto", 1])
+   with bs.Grid(columns=["auto", 1], gap=8, sticky_items="ew", fill="x"):
+       bs.Button("auto")
+       bs.Button("weight=1 (fills remaining)")
 
    # Fixed sidebar, flexible content, fixed panel
-   bs.Grid(columns=["120px", 1, "80px"])
+   with bs.Grid(columns=["120px", 1, "80px"], gap=8, sticky_items="ew", fill="x"):
+       bs.Button("120px")
+       bs.Button("weight=1")
+       bs.Button("80px")
 
 .. image:: /_static/examples/grid-columns-light.png
    :class: bs-screenshot-light
@@ -80,8 +84,15 @@ a 2-tuple ``(col_gap, row_gap)`` sets them independently.
 
 .. code-block:: python
 
-   bs.Grid(columns=[1, 1], gap=8)            # 8 px between all cells
-   bs.Grid(columns=[1, 1], gap=(32, 8))      # 32 px between columns, 8 px between rows
+   # 8 px between all cells
+   with bs.Grid(columns=[1, 1], gap=8, sticky_items="ew"):
+       for label in ("A", "B", "C", "D"):
+           bs.Button(label)
+
+   # 32 px between columns, 8 px between rows
+   with bs.Grid(columns=[1, 1], gap=(32, 8), sticky_items="ew"):
+       for label in ("A", "B", "C", "D"):
+           bs.Button(label)
 
 .. image:: /_static/examples/grid-gap-light.png
    :class: bs-screenshot-light

--- a/docs/widgets/groupbox.rst
+++ b/docs/widgets/groupbox.rst
@@ -24,9 +24,10 @@ automatically inherits the accent color.
 
 .. code-block:: python
 
-   with bs.GroupBox("Primary", accent="primary", padding=20, gap=16):
-       bs.Label("Item one")
-       bs.Label("Item two")
+   for accent in ("primary", "secondary", "info", "success", "warning", "danger"):
+       with bs.GroupBox(accent.title(), accent=accent, padding=10, gap=4):
+           bs.Label("Item one")
+           bs.Label("Item two")
 .. image:: /_static/examples/groupbox-accent-light.png
    :class: bs-screenshot-light
    :alt: GroupBox accent borders — light theme
@@ -44,18 +45,19 @@ them side by side. ``'grid'`` arranges children in a column-row grid.
 .. code-block:: python
 
    # Default vertical stack
-   with bs.GroupBox("Details", gap=8):
+   with bs.GroupBox("VStack (default)", gap=8):
        bs.Label("First")
        bs.Label("Second")
+       bs.Label("Third")
 
    # Horizontal stack
-   with bs.GroupBox("Steps", layout="hstack", gap=12, anchor_items="center"):
+   with bs.GroupBox("HStack", layout="hstack", gap=12, anchor_items="center"):
        bs.Label("A")
        bs.Label("B")
        bs.Label("C")
 
    # Grid — two columns, key/value pairs
-   with bs.GroupBox("Info", layout="grid", columns=[1, 1], gap=8, sticky_items="ew"):
+   with bs.GroupBox("Grid", layout="grid", columns=[1, 1], gap=8, sticky_items="ew"):
        bs.Label("Name:")  ; bs.Label("Ada Lovelace")
        bs.Label("Role:")  ; bs.Label("Engineer")
 

--- a/docs/widgets/hstack.rst
+++ b/docs/widgets/hstack.rst
@@ -76,8 +76,8 @@ making buttons or panels match the height of the tallest sibling.
 
 .. code-block:: python
 
-   with bs.HStack(gap=8, fill_items="y", height=60):
-       bs.Button("A")   # stretches to 60 px tall
+   with bs.HStack(gap=8, fill_items="y", height=150):
+       bs.Button("A")   # stretches to 150 px tall
        bs.Button("B")
        bs.Button("C")
 

--- a/docs/widgets/label.rst
+++ b/docs/widgets/label.rst
@@ -71,7 +71,7 @@ present.
 
    bs.Label("Home",     icon="house")
    bs.Label("Settings", icon="gear",      icon_position="right")
-   bs.Label("Alert",    icon="exclamation-triangle", accent="warning")
+   bs.Label("Warning",  icon="exclamation-triangle", accent="warning")
 
    # Icon-only — auto-detected when text is empty
    bs.Label(icon="heart-fill", accent="danger")

--- a/docs/widgets/message-dialogs.rst
+++ b/docs/widgets/message-dialogs.rst
@@ -25,12 +25,6 @@ user dismisses it.
 
    bs.alert("File saved successfully.", title="Done")
 
-Customize the button label or add an icon:
-
-.. code-block:: python
-
-   bs.alert("Session expired.", ok_text="Sign in again", icon="exclamation-circle")
-
 .. image:: /_static/examples/message-dialogs-alert-light.png
    :class: bs-screenshot-light bs-dialog-screenshot
    :alt: Message Dialogs — alert dialog, light theme
@@ -38,6 +32,12 @@ Customize the button label or add an icon:
 .. image:: /_static/examples/message-dialogs-alert-dark.png
    :class: bs-screenshot-dark bs-dialog-screenshot
    :alt: Message Dialogs — alert dialog, dark theme
+
+Customize the button label or add an icon:
+
+.. code-block:: python
+
+   bs.alert("Session expired.", ok_text="Sign in again", icon="exclamation-circle")
 
 Alert sound
 ^^^^^^^^^^^

--- a/docs/widgets/pathfield.rst
+++ b/docs/widgets/pathfield.rst
@@ -61,8 +61,13 @@ Set ``required=True`` to mark the field visually.
 .. code-block:: python
 
    bs.PathField(
+       label="Source file",
+       placeholder="Select a file…",
+       message="Accepted formats: .py, .txt, .csv",
+   )
+   bs.PathField(
        label="Output directory",
-       message="Folder must be writable.",
+       placeholder="Choose output folder…",
        mode="directory",
        required=True,
    )

--- a/docs/widgets/picture.rst
+++ b/docs/widgets/picture.rst
@@ -74,7 +74,9 @@ avatars and thumbnails:
 
 .. code-block:: python
 
-   bs.Picture(photo, fit="cover", width=150, height=150, corner_radius=20)
+   bs.Picture(photo, fit="cover", width=150, height=150, corner_radius=0)
+   bs.Picture(photo, fit="cover", width=150, height=150, corner_radius=16)
+   bs.Picture(photo, fit="cover", width=150, height=150, corner_radius=36)
 
 .. image:: /_static/examples/picture-corners-light.png
    :class: bs-screenshot-light

--- a/docs/widgets/progressbar.rst
+++ b/docs/widgets/progressbar.rst
@@ -75,6 +75,8 @@ Accent colors
 .. code-block:: python
 
    bs.ProgressBar(value=65, accent="primary")
+   bs.ProgressBar(value=65, accent="secondary")
+   bs.ProgressBar(value=65, accent="info")
    bs.ProgressBar(value=65, accent="success")
    bs.ProgressBar(value=65, accent="warning")
    bs.ProgressBar(value=65, accent="danger")
@@ -95,14 +97,19 @@ progress indicators:
 
 .. code-block:: python
 
+   bs.ProgressBar(value=40, variant="thin")
    bs.ProgressBar(value=70, accent="primary", variant="thin")
+   bs.ProgressBar(value=90, accent="success", variant="thin")
 
 Vertical orientation
 ~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: python
 
-   bs.ProgressBar(value=60, orient="vertical")
+   bs.ProgressBar(value=25, orient="vertical")
+   bs.ProgressBar(value=50, orient="vertical")
+   bs.ProgressBar(value=75, orient="vertical")
+   bs.ProgressBar(value=100, orient="vertical")
 
 .. image:: /_static/examples/progressbar-variants-light.png
    :class: bs-screenshot-light

--- a/docs/widgets/radiogroup.rst
+++ b/docs/widgets/radiogroup.rst
@@ -46,8 +46,8 @@ Orientation
 
 .. code-block:: python
 
-   bs.RadioGroup(["A", "B", "C"], orient="horizontal")  # default
-   bs.RadioGroup(["A", "B", "C"], orient="vertical")
+   bs.RadioGroup(["A", "B", "C"], value="A", title="Horizontal")  # default
+   bs.RadioGroup(["A", "B", "C"], value="A", title="Vertical", orient="vertical")
 
 .. image:: /_static/examples/radiogroup-orientation-light.png
    :class: bs-screenshot-light

--- a/docs/widgets/rangeslider.rst
+++ b/docs/widgets/rangeslider.rst
@@ -101,6 +101,7 @@ Disabled
 
 .. code-block:: python
 
+   bs.RangeSlider(20, 80)
    bs.RangeSlider(20, 80, disabled=True)
 
 .. image:: /_static/examples/rangeslider-disabled-light.png

--- a/docs/widgets/scrollview.rst
+++ b/docs/widgets/scrollview.rst
@@ -51,11 +51,12 @@ for most use cases), ``'horizontal'``, or ``'both'``.
    with bs.ScrollView(scroll_direction="vertical", fill="both", expand=True):
        ...
 
-   # Horizontal — useful for wide content like a row of cards
-   with bs.ScrollView(scroll_direction="horizontal", fill="x"):
+   # Horizontal — useful for wide content like a row of buttons
+   with bs.ScrollView(scroll_direction="horizontal", fill="x",
+                      height=60, show_border=True):
        with bs.HStack(gap=8, padding=8):
-           for card in cards:
-               bs.Card(...)
+           for i in range(1, 20):
+               bs.Button(f"Section {i:02d}", variant="outline")
 
    # Both axes
    with bs.ScrollView(scroll_direction="both", fill="both", expand=True):

--- a/docs/widgets/select.rst
+++ b/docs/widgets/select.rst
@@ -104,11 +104,15 @@ your data. Grouping is purely presentational: ``value``, ``.selection``, and
        options=[
            {"text": "Apple",    "value": "apple",    "category": "Fruit"},
            {"text": "Banana",   "value": "banana",   "category": "Fruit"},
+           {"text": "Cherry",   "value": "cherry",   "category": "Fruit"},
            {"text": "Carrot",   "value": "carrot",   "category": "Vegetable"},
+           {"text": "Broccoli", "value": "broccoli", "category": "Vegetable"},
            {"text": "Basil",    "value": "basil",    "category": "Herb"},
+           {"text": "Mint",     "value": "mint",     "category": "Herb"},
        ],
        group_by="category",
        label="Ingredient",
+       value="banana",
    )
 
 Groups appear in first-appearance order; an option that lacks the field renders

--- a/docs/widgets/selectbutton.rst
+++ b/docs/widgets/selectbutton.rst
@@ -70,9 +70,9 @@ Style variants
 
 .. code-block:: python
 
-   bs.SelectButton(["Solid"],   accent="primary", variant="solid")
-   bs.SelectButton(["Outline"], accent="primary", variant="outline")
-   bs.SelectButton(["Ghost"],   accent="primary", variant="ghost")
+   bs.SelectButton(["Solid"],   value="Solid",   accent="primary", variant="solid")
+   bs.SelectButton(["Outline"], value="Outline", accent="primary", variant="outline")
+   bs.SelectButton(["Ghost"],   value="Ghost",   accent="primary", variant="ghost")
 
 .. image:: /_static/examples/selectbutton-variants-light.png
    :class: bs-screenshot-light

--- a/docs/widgets/slider.rst
+++ b/docs/widgets/slider.rst
@@ -99,6 +99,7 @@ Disabled
 
 .. code-block:: python
 
+   bs.Slider(60)
    bs.Slider(60, disabled=True)
 
 .. image:: /_static/examples/slider-disabled-light.png

--- a/docs/widgets/spinnerfield.rst
+++ b/docs/widgets/spinnerfield.rst
@@ -24,8 +24,8 @@ cycle forward and back through the list.
 .. code-block:: python
 
    bs.SpinnerField(
-       label="Priority",
-       options=["Low", "Medium", "High", "Critical"],
+       label="Text mode",
+       options=["Small", "Medium", "Large", "X-Large"],
        value="Medium",
    )
 
@@ -38,11 +38,11 @@ for a numeric range. Only one mode should be used at a time.
 .. code-block:: python
 
    bs.SpinnerField(
-       label="Quantity",
-       value=1,
-       min_value=1,
-       max_value=99,
-       step=1,
+       label="Numeric mode",
+       value=10,
+       min_value=0,
+       max_value=100,
+       step=5,
    )
 
 .. image:: /_static/examples/spinnerfield-modes-light.png

--- a/docs/widgets/splitview.rst
+++ b/docs/widgets/splitview.rst
@@ -38,11 +38,14 @@ horizontal sash.
 
 .. code-block:: python
 
-   # Side-by-side (default)
-   sv = bs.SplitView(orient="horizontal", fill="both", expand=True)
-
-   # Stacked
+   # Stacked top-to-bottom with a horizontal sash
    sv = bs.SplitView(orient="vertical", fill="both", expand=True)
+   with sv.add(weight=1, padding=12, gap=4):
+       bs.Label("Top pane", font="heading-md")
+       bs.Label("Upper content area.")
+   with sv.add(weight=1, padding=12, gap=4):
+       bs.Label("Bottom pane", font="heading-md")
+       bs.Label("Lower content area.")
 
 .. image:: /_static/examples/splitview-vertical-light.png
    :class: bs-screenshot-light

--- a/docs/widgets/statusbar.rst
+++ b/docs/widgets/statusbar.rst
@@ -44,7 +44,9 @@ split the band at a chosen point.
 .. code-block:: python
 
    sb.add_text("Ready", icon="check-circle")   # left
-   sb.add_text("UTF-8", side="right")           # right cluster
+   sb.add_text("Errors: 0", icon="x-circle", side="right")   # right cluster
+   sb.add_text("Warnings: 2", icon="exclamation-triangle", side="right")
+   sb.add_text("UTF-8", side="right")
    sb.add_text("main", icon="git", side="right")
 
 .. image:: /_static/examples/statusbar-segments-light.png
@@ -94,6 +96,7 @@ quiet, recessed band; ``'card'`` lifts it from the page.
    sb = bs.StatusBar(fill="x", surface="card")
    sb.add_text("Card surface", icon="layers")
    sb.add_text("3 warnings", icon="exclamation-triangle", side="right")
+   sb.add_text("main", icon="git", side="right")
 
 .. image:: /_static/examples/statusbar-surface-light.png
    :class: bs-screenshot-light

--- a/docs/widgets/tabs.rst
+++ b/docs/widgets/tabs.rst
@@ -46,6 +46,9 @@ Pass ``icon=`` to show an icon alongside the tab label.
    with tabs.add("files", label="Files", icon="folder"):
        bs.Label("Files")
 
+   with tabs.add("settings", label="Settings", icon="gear"):
+       bs.Label("Settings")
+
 .. image:: /_static/examples/tabs-icons-light.png
    :class: bs-screenshot-light
    :alt: Tabs with icons — light theme
@@ -64,11 +67,14 @@ right. The default is ``'horizontal'`` (tabs above content).
 
    tabs = bs.Tabs(orient="vertical", fill="both", expand=True)
 
-   with tabs.add("editor", label="Editor"):
+   with tabs.add("editor", label="Editor", icon="code-slash"):
        bs.Label("Editor panel")
 
-   with tabs.add("preview", label="Preview"):
+   with tabs.add("preview", label="Preview", icon="eye"):
        bs.Label("Preview panel")
+
+   with tabs.add("console", label="Console", icon="terminal"):
+       bs.Label("Console panel")
 
 .. image:: /_static/examples/tabs-vertical-light.png
    :class: bs-screenshot-light
@@ -102,12 +108,14 @@ argument of `add()`.
    # All tabs closable
    tabs = bs.Tabs(allow_close=True)
 
-   # Per-tab override
-   with tabs.add("pinned", label="Pinned", closable=False):
-       bs.Label("This tab cannot be closed.")
+   with tabs.add("report", label="Report.pdf"):
+       bs.Label("Annual report content.")
 
-   with tabs.add("doc", label="Document", closable=True):
-       bs.Label("Close button always visible.")
+   with tabs.add("notes", label="Notes.txt"):
+       bs.Label("Your notes.")
+
+   with tabs.add("draft", label="Draft.md"):
+       bs.Label("Work in progress.")
 
 .. image:: /_static/examples/tabs-closable-light.png
    :class: bs-screenshot-light

--- a/docs/widgets/textarea.rst
+++ b/docs/widgets/textarea.rst
@@ -67,10 +67,10 @@ shows scrollbars only when content overflows.
 
 .. code-block:: python
 
-   bs.TextArea(scrollbars="auto")      # default — appears on overflow
+   bs.TextArea(scrollbars="none")      # never shown
    bs.TextArea(scrollbars="vertical")  # always visible
    bs.TextArea(scrollbars="both")      # horizontal + vertical, always
-   bs.TextArea(scrollbars="none")      # never shown
+   # 'auto' (the default) shows scrollbars only when content overflows
 
 .. image:: /_static/examples/textarea-scrollbars-light.png
    :class: bs-screenshot-light

--- a/docs/widgets/textfield.rst
+++ b/docs/widgets/textfield.rst
@@ -62,10 +62,10 @@ Requires localization to be enabled.
 
 .. code-block:: python
 
-   bs.TextField(value_format="#,##0.00", label="Decimal")
-   bs.TextField(value_format="percent",  label="Percent")
-   bs.TextField(value_format="currency", label="Currency")
-   bs.TextField(value_format="yyyy-MM-dd", label="Date")
+   bs.TextField(value="1234.5",     value_format="#,##0.00",  label="Decimal")
+   bs.TextField(value="0.42",       value_format="percent",   label="Percent")
+   bs.TextField(value="9.99",       value_format="currency",  label="Currency")
+   bs.TextField(value="2024-06-01", value_format="yyyy-MM-dd", label="Date")
 
 .. image:: /_static/examples/textfield-value-format-light.png
    :class: bs-screenshot-light

--- a/docs/widgets/timefield.rst
+++ b/docs/widgets/timefield.rst
@@ -34,7 +34,6 @@ Any `ICU time format`_ pattern or named preset is accepted.
    bs.TimeField(value=now, value_format="shortTime")   # 2:30 PM
    bs.TimeField(value=now, value_format="HH:mm")       # 14:30
    bs.TimeField(value=now, value_format="HH:mm:ss")    # 14:30:00
-   bs.TimeField(value=now, value_format="h:mm a")      # 2:30 PM
 
 .. _ICU time format: https://unicode-org.github.io/icu/userguide/format_parse/datetime/
 

--- a/docs/widgets/togglegroup.rst
+++ b/docs/widgets/togglegroup.rst
@@ -83,6 +83,11 @@ the widget infers this automatically, so a compact toolbar group needs no
        {"icon": "text-right",  "value": "right"},
        {"icon": "justify",     "value": "justify"},
    ], value="left")
+   bs.ToggleGroup(options=[
+       {"icon": "type-bold",      "value": "b"},
+       {"icon": "type-italic",    "value": "i"},
+       {"icon": "type-underline", "value": "u"},
+   ], mode="multi", value={"b"})
 
 .. image:: /_static/examples/togglegroup-icon_only-light.png
    :class: bs-screenshot-light
@@ -158,7 +163,6 @@ Orientation
 
 .. code-block:: python
 
-   bs.ToggleGroup(["Top", "Middle", "Bottom"], orient="horizontal")           # default
    bs.ToggleGroup(["Top", "Middle", "Bottom"], orient="vertical", value="Middle")
 
 .. image:: /_static/examples/togglegroup-orientation-light.png

--- a/docs/widgets/toolbar.rst
+++ b/docs/widgets/toolbar.rst
@@ -38,6 +38,9 @@ intent to individual buttons.
 .. code-block:: python
 
    tb.add_button("Publish", icon="cloud-upload", accent="primary", on_click=publish)
+   tb.add_button("Preview", icon="eye")
+   tb.add_button("Draft",   icon="pencil")
+   tb.add_spacer()
    tb.add_button("Discard", icon="trash", accent="danger", on_click=discard)
 
 .. image:: /_static/examples/toolbar-accents-light.png
@@ -57,10 +60,12 @@ to the right side.
 
 .. code-block:: python
 
-   tb.add_button("Bold", icon="type-bold")
+   tb.add_button("Bold",   icon="type-bold")
    tb.add_button("Italic", icon="type-italic")
    tb.add_separator()
-   tb.add_button("Align left", icon="text-left")
+   tb.add_button("Align left",   icon="text-left")
+   tb.add_button("Align center", icon="text-center")
+   tb.add_button("Align right",  icon="text-right")
    tb.add_spacer()
    tb.add_button(icon="gear")          # pinned to the right
 
@@ -128,6 +133,16 @@ standalone ``bs.Toolbar`` defaults to ``"default"``.
    tb.add_button(icon="type-bold")
    tb.add_button(icon="type-italic")
    tb.add_button(icon="type-underline")
+   tb.add_separator()
+   tb.add_button(icon="text-left")
+   tb.add_button(icon="text-center")
+   tb.add_button(icon="text-right")
+   tb.add_separator()
+   tb.add_button(icon="list-ul")
+   tb.add_button(icon="list-ol")
+   tb.add_spacer()
+   tb.add_button(icon="arrow-counterclockwise")
+   tb.add_button(icon="arrow-clockwise")
 
 .. image:: /_static/examples/toolbar-density-light.png
    :class: bs-screenshot-light
@@ -162,6 +177,8 @@ the background token — ``'card'`` lifts it slightly from the page background.
    tb.add_button("New",  icon="file-earmark-plus")
    tb.add_button("Open", icon="folder2-open")
    tb.add_button("Save", icon="floppy")
+   tb.add_spacer()
+   tb.add_button(icon="gear")
 
 .. image:: /_static/examples/toolbar-surface-light.png
    :class: bs-screenshot-light

--- a/docs/widgets/tooltip.rst
+++ b/docs/widgets/tooltip.rst
@@ -54,9 +54,10 @@ Color-code tooltips by intent with ``accent=``.
 
 .. code-block:: python
 
-   bs.Tooltip(btn, "Required field", accent="danger")
-   bs.Tooltip(btn, "Saved successfully", accent="success")
-   bs.Tooltip(btn, "New in this release", accent="info")
+   bs.Tooltip(btn_p, "Primary tooltip", accent="primary")
+   bs.Tooltip(btn_s, "Success tooltip", accent="success")
+   bs.Tooltip(btn_w, "Warning tooltip", accent="warning")
+   bs.Tooltip(btn_d, "Danger tooltip",  accent="danger")
 
 .. image:: /_static/examples/tooltip-accents-light.png
    :class: bs-screenshot-light


### PR DESCRIPTION
## What

Audited every documentation code block that sits next to a screenshot and aligned the shown code to the scene that actually generated the image. Previously many code blocks were hand-written illustrations that drifted from their screenshots (different widgets, text, props, or counts), which is confusing — a reader expects the code and the picture to match.

The screenshot scene files (`docs/screenshots/*.py`) are the source of truth for each image; this PR adjusts the **code blocks** to match them (never the scenes, never the images). Where reproducing a full scene would be noise, the block is trimmed to the salient part and marked incomplete.

## Scope

- **Guide pages:** `app-structures` (App + AppShell examples now match the rendered windows), `layout` (grid column-weights block now shows all three grids in the image), `composing-fields`, `building-forms`.
- **Widget pages (~34):** buttongroup, spinnerfield, textfield, textarea, codeeditor, pathfield, checkbox, radiogroup, togglegroup, select, selectbutton, slider, rangeslider, datefield, timefield, label, badge, progressbar, gauge, card, groupbox, picture, hstack, grid, accordion, splitview, scrollview, tabs, toolbar, statusbar, contextmenu, tooltip, forms, message-dialogs.

Most widget pages were already aligned by construction; the real drift was in the guide pages. Navigation guides were audited and needed no changes.

## Note

A layout-API redesign (flexbox/CSS-grid vocabulary) is in design and will touch some of these examples again later. Aligning them now is still worthwhile — better than leaving them in their current drifted state until then.

## Verification

Clean Sphinx build (`sphinx-build -W --keep-going`) passes warning-free with all edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
