### PR TITLE
ci(docs): deploy docs only on a new release

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,8 +1,19 @@
 name: Deploy docs
 
+# Deploy docs only on a new release, so the published site tracks the
+# released API rather than every push to `main` (especially important during
+# active pre-1.0 API development). To restore continuous docs, swap the
+# `workflow_run` trigger back to `push: branches: [main]`.
+#
+# `workflow_run` (not a `release`/tag trigger) is deliberate: a run triggered
+# this way executes in the default-branch (`main`) context, so `deploy-pages`
+# is associated with `main` and passes the `github-pages` environment's
+# branch protection. A tag-ref deployment (from a `release` trigger) is
+# rejected by that protection.
 on:
-  push:
-    branches: [main]
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
   workflow_dispatch:
 
 permissions:
@@ -17,6 +28,9 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # On a release, only build if the Release workflow actually succeeded.
+    # A manual run (workflow_dispatch) always builds.
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@v6
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -369,33 +369,45 @@ memories and git history.
 > "0.1.0 API-freeze pass" pointer at the top of "Recently completed"). What's left
 > below is the stable-cut closeout + a fresh regression + the standing backlog.
 
-### ★ ACTIVE INITIATIVE — Layout redesign (grid engine + flexbox/CSS-grid API)
+### ★ ACTIVE INITIATIVE — Layout redesign (screen-axis vocabulary on a grid engine)
 
-> Branch **`feat/grid-layout-engine`**. Full design brief:
-> **`docs/_dev/layout-redesign.md`** (read it first). Prototype (validated, untracked
-> scratch): **`development/flexlayout_proto.py`** — run scenes with
-> `py -3.12 development/flexlayout_proto.py <scene>` (justify/grow/align/col/weights/
-> toolbars/spacer/overflow/grid/nesting). **Breaking, core-engine — land before the
-> 0.1.0 freeze.**
+> Branch **`feat/grid-layout-engine`** — `git checkout` it to continue; the engine +
+> full public surface + the gallery demo are BUILT and committed there (NOT pushed/
+> merged). Full design brief + the LOCKED vocabulary + per-decision rationale +
+> progress log: **`docs/_dev/layout-redesign.md`** on the branch (read the
+> "★ FINAL VOCABULARY" block first — the version on `main` is stale). Memories
+> `project_layout_redesign`, `feedback_layout_conversion_rules`. **Breaking, core-engine
+> — land before the 0.1.0 freeze.**
 
-Replace the stack layout API — `anchor_items`/`fill_items`/`expand_items` and Grid's
-`sticky_items` (all Tk-isms) — with a flexbox/CSS-grid vocabulary, and reimplement
-stacks on the Tk **grid** geometry manager (not pack). **Trigger:** `HStack(fill="x",
-anchor_items="e")` can't right-align a button row (`anchor_items` is cross-axis only;
-no public main-axis distribution exists). Validated model:
+Replaces the Tk pack stack layout with a **screen-axis** vocabulary on the Tk **grid**
+geometry manager. Engine + Row/Column/Grid/Card/GroupBox/nav-containers + `cli/demo.py`
+done and verified (import clean, 183 tests pass, all 18 demo pages render, `bootstack
+demo` runs).
 
-- **`justify`** (whole-group main-axis: start/center/end/space-*) · **`align`**/`align_self`
-  (cross: start/center/end/stretch) · **`grow`**/`weights=` (item growth) ·
-  **`Spacer()`**/`Spacer(size=)`/`Spacer(weight=)` (composable breaks — unifies the
-  existing `Toolbar`/`StatusBar` `add_spacer()`). 2-D **`Grid`** →
-  **`justify_items`**/**`align_items`** + weighted `columns=`/`rows=`.
-- Per-child collision-free keys are **`grow`/`align_self`/`justify_self`** (never bare
-  `align`/`justify` — would shadow text `justify` / Snackbar `align`). `push` was
-  prototyped and **dropped** (Spacer + nesting + `margin_x` cover it).
-- **★ Top migration risk:** the grid engine **silently ignores legacy `fill`/`expand`
-  child kwargs** — every such child (data/canvas widgets especially: ListView/DataTable/
-  Tree/Gallery/Carousel) must move to `grow`/`align` or it collapses. Other risks +
-  open default decisions + build sequencing are all in the brief.
+- **FINAL vocabulary (locked):** axes fixed to the SCREEN (`horizontal`=x, `vertical`=y;
+  no main/cross flip). **Bare = self, `_items` = children** (a container is also a
+  widget): self → `horizontal`/`vertical`/`grow`; container → `horizontal_items`/
+  `vertical_items`/`grow_items`. `align_self`/`justify_self` are GONE. **Edge-name
+  values:** horizontal `left`/`center`/`right`/`stretch`; vertical `top`/`center`/
+  `bottom`/`stretch`; + `space-between`/`-around`/`-evenly` on the stacking axis.
+  `HStack`/`VStack` → **`Row`/`Column`** (+ `Spacer`); `layout=` values `vstack`/`hstack`
+  → **`column`/`row`** (`LayoutKind=['column','row','grid']`). Aliases `HAlign`/`VAlign`/
+  `HArrange`/`VArrange`. `weights=` kept (positional per-child `grow` shorthand).
+- **DONE on the branch** (commits `dee25316`·`151c326f`·`a3ee4f92`·`fc704e6e`·
+  `528281d0`·`42d07159`): `FlexFrame` (axis-aware engine), container plumbing,
+  Row/Column/Spacer, Grid 2-D, App/Window/Card/GroupBox + PageStack/Tabs/SplitView/
+  Accordion + ListView/Tree/AppShell/ScrollView, and the full `cli/demo.py`.
+- **NEXT — Stage 3 (the ~850-site sweep, fresh session):** `cli/appicon.py` +
+  `cli/templates/__init__.py`, then **all `docs/examples/` + `docs/screenshots/`** +
+  re-shoot screenshots, a layout how-to/topic guide for the new vocab, and re-point
+  `Toolbar`/`StatusBar` `add_spacer()` → the public `Spacer`. **Conversion rules**
+  (memory `feedback_layout_conversion_rules`): axis-aware (`fill="x"`→`horizontal`
+  stretch in a Column, `grow` in a Row); HOIST uniform child alignment to the parent
+  `*_items`; NEVER write a default value (drop the kwarg). Data/canvas widgets
+  (ListView/Tree/DataTable/Gallery/Carousel) collapse without `grow`/`horizontal`.
+- **Bugs filed while reviewing the demo** (pre-existing, NOT from this work): #165
+  undecorated-window drag offset · #166 ContextMenu/Tooltip don't cover container
+  children · #167 Gauge theme repaint · #168 Tabs overflow.
 
 ### Toward the 0.1.0 stable release
 


### PR DESCRIPTION
Switches the docs deploy trigger from every push to `main` to a `workflow_run` that fires after the **Release** workflow completes successfully. This keeps the published site (`bootstack.org`) in sync with the released API instead of in-flight changes on `main` — important during active pre-1.0 API development.

## Why `workflow_run` and not a `release`/tag trigger

The `github-pages` environment's branch protection rejects tag-ref deployments (this bit us before — see the docs-deploy CNAME fix history). A `workflow_run`-triggered run executes in the **default-branch (`main`) context**, so `actions/deploy-pages` associates the deployment with `main` and passes the protection.

## Notes

- `workflow_dispatch` is retained for manual deploys anytime.
- `workflow_run` only fires for workflow files on the default branch, so this takes effect once merged to `main`.
- Easily reversible: swap the `workflow_run` trigger back to `push: branches: [main]` to restore continuous docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)