### PR TITLE
docs: post-layout cleanup — README, docs-home install, handoff

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -369,107 +369,51 @@ memories and git history.
 > "0.1.0 API-freeze pass" pointer at the top of "Recently completed"). What's left
 > below is the stable-cut closeout + a fresh regression + the standing backlog.
 
-### ★ ACTIVE INITIATIVE — Layout redesign (screen-axis vocabulary on a grid engine)
+### ✅ SHIPPED — Layout redesign (screen-axis vocabulary on a grid engine) — MERGED #170
 
-> Branch **`feat/grid-layout-engine`** — `git checkout` it to continue; the engine +
-> full public surface + the gallery demo are BUILT and committed there (NOT pushed/
-> merged). Full design brief + the LOCKED vocabulary + per-decision rationale +
-> progress log: **`docs/_dev/layout-redesign.md`** on the branch (read the
-> "★ FINAL VOCABULARY" block first — the version on `main` is stale). Memories
-> `project_layout_redesign`, `feedback_layout_conversion_rules`. **Breaking, core-engine
-> — land before the 0.1.0 freeze.**
+Replaced the Tk pack stack layout with a **screen-axis** vocabulary on the Tk **grid**
+geometry manager. Merged to `main` via **PR #170** (the long-running
+`feat/grid-layout-engine`). Memories `project_layout_redesign`,
+`feedback_layout_conversion_rules`, `project_layout_crossaxis_default`,
+`project_divider_rename`, `project_dialog_content_builder_native`.
 
-Replaces the Tk pack stack layout with a **screen-axis** vocabulary on the Tk **grid**
-geometry manager. Engine + Row/Column/Grid/Card/GroupBox/nav-containers + `cli/demo.py`
-done and verified (import clean, 183 tests pass, all 18 demo pages render, `bootstack
-demo` runs).
-
-- **FINAL vocabulary (locked):** axes fixed to the SCREEN (`horizontal`=x, `vertical`=y;
-  no main/cross flip). **Bare = self, `_items` = children** (a container is also a
-  widget): self → `horizontal`/`vertical`/`grow`; container → `horizontal_items`/
-  `vertical_items`/`grow_items`. `align_self`/`justify_self` are GONE. **Edge-name
-  values:** horizontal `left`/`center`/`right`/`stretch`; vertical `top`/`center`/
-  `bottom`/`stretch`; + `space-between`/`-around`/`-evenly` on the stacking axis.
-  `HStack`/`VStack` → **`Row`/`Column`** (+ `Spacer`); `layout=` values `vstack`/`hstack`
-  → **`column`/`row`** (`LayoutKind=['column','row','grid']`). Aliases `HAlign`/`VAlign`/
-  `HArrange`/`VArrange`. `weights=` kept (positional per-child `grow` shorthand).
-- **DONE on the branch** (commits `dee25316`·`151c326f`·`a3ee4f92`·`fc704e6e`·
-  `528281d0`·`42d07159`): `FlexFrame` (axis-aware engine), container plumbing,
-  Row/Column/Spacer, Grid 2-D, App/Window/Card/GroupBox + PageStack/Tabs/SplitView/
-  Accordion + ListView/Tree/AppShell/ScrollView, and the full `cli/demo.py`.
+- **Vocabulary (shipped):** axes fixed to the SCREEN (`horizontal`=x, `vertical`=y; no
+  main/cross flip). **Bare = self, `_items` = children** (a container is also a widget):
+  self → `horizontal`/`vertical`/`grow`; container → `horizontal_items`/`vertical_items`/
+  `grow_items`. Edge-name values (`left`/`center`/`right`/`stretch`; `top`/`center`/
+  `bottom`/`stretch`) + `space-between`/`-around`/`-evenly` on the stacking axis.
+  `HStack`/`VStack`→**`Row`/`Column`**; `Separator`→**`Divider`**; new **`Spacer`**;
+  `layout=` values `column`/`row`/`grid`. `weights=` kept (positional `grow` shorthand).
+- **Cross-axis default = `center`**, uniform across all stacks; the stacking (main) axis
+  starts top/left; grid stays `stretch`. **Legacy child kwargs (`fill`/`expand`/`anchor`/
+  `sticky`) now RAISE** a clear error instead of silently collapsing a child.
 - **Conversion rules** (memory `feedback_layout_conversion_rules`): axis-aware
   (`fill="x"`→`horizontal` stretch in a Column, `grow` in a Row); HOIST uniform child
-  alignment to the parent `*_items`; NEVER write a default value (drop the kwarg).
-  Data/canvas widgets (ListView/Tree/DataTable/Gallery/Carousel) collapse without
-  `grow`/`horizontal`.
-- **Bugs filed while reviewing the demo** (pre-existing, NOT from this work): #165
-  undecorated-window drag offset · #166 ContextMenu/Tooltip don't cover container
-  children · #167 Gauge theme repaint · #168 Tabs overflow.
+  alignment to the parent `*_items`; NEVER write a default. Data/canvas widgets
+  (ListView/Tree/DataTable/Gallery/Carousel) collapse without `grow`/`stretch`.
+- **Engine fixes shipped in #170:** undefined grid rows default `weight=0` (no more rows
+  spreading down a `layout="grid"` page); `Grid` honors `width=`/`height=` (propagation
+  bug); `FlexFrame` prunes children destroyed out-of-band (no more `bad window path
+  name`); O(1) append fast-path for plain stacks (build O(N²)→O(N), N=1000 ~7.4s→~0.5s).
+- **Docs shipped:** Row/Column guides rewritten for teaching quality, new **Spacer**
+  page, Divider hero redesigned, `tasks/layout.rst` ("Arranging Widgets") tightened, all
+  examples/screenshots/CLI scaffold/`cli/demo.py` converted; `-W` build clean. README +
+  docs-home install refreshed to the new vocabulary + `--pre`.
 
-#### ★★ SESSION 2026-06-16/17 — Stage 3 SUBSTANTIALLY DONE + 3 decisions + 2 framework fixes. PICK UP HERE.
+**OPEN PRs (post-merge, in review):**
+- **#171** `perf(layout)` — GridFrame O(N) build (gate the per-add prune scan on a
+  `<Destroy>`-set flag; N=1000 grid 827ms→501ms; destroy-recreate correctness preserved).
+- **#169** `ci(docs)` — deploy docs only on a new release (`workflow_run` after the
+  Release workflow; runs in the `main` context so it passes the github-pages branch
+  protection a tag-ref deploy would fail). Takes effect once merged to `main`.
 
-**Committed on the branch this session** (in order): `d82067ef` CLI (appicon + scaffold
-templates; `cli/icons.py` left — raw internal `.pack()`) · `cd2ab472` all ~69
-`docs/examples/` converted+verified · `42c00603` **Separator→Divider** rename ·
-`31c5d50e` **center cross-axis default** · `4936dacd` docs migration (hstack/vstack→
-**Row/Column** rename: new `row.rst`/`column.rst`/`row.py`/`column.py`, old files
-removed; full RST + screenshot-source vocab sweep; `tasks/layout.rst` rewritten;
-toctree + api-reference) · `df08ac4b` + `ecb51f11` + `3595f587` dialog fixes (below).
-
-**3 DECISIONS LOCKED this session (these SUPERSEDE the "FINAL vocabulary" block above):**
-1. **Cross-axis default = `center`, uniform across ALL stacks** (App/Window/Row/Column/
-   Card/GroupBox/page-hosts); stacking (main) axis stays start (top/left); grid stays
-   `stretch`. This REVERSES the brief's "locked top/left." Restores old pack centering
-   (App used to center its children) so re-shot screenshots match originals. Engine:
-   `stacks.py`/`app.py`/`window.py` defaults + layout-aware resolver in `card.py`/
-   `groupbox.py`/`expander.py`/`pagestack.py`/`tabs.py`/`splitview.py`. Memory
-   `project_layout_crossaxis_default`.
-2. **`bs.Separator` → `bs.Divider`** (pairs with `Spacer`). Renamed the public widget +
-   layout `add_divider()` (Toolbar/AppShell/nav) + the MENU surface (`add_divider()`,
-   item type `'divider'`). KEPT internal: ttk `Separator` primitive, `TSeparator` style,
-   `MenuItem.type=='separator'`, `tk.Menu.add_separator()`. Memory `project_divider_rename`.
-3. **Dialog `content_builder` is parent-free** — the content area is a public `Column`
-   set as the active parent, so the body is written like an App body (no `parent=`);
-   `Dialog(padding=, gap=)` configure it; arity-flexible (`def build()` / `def
-   build(content)` / old `def build(frame)` all work). bootstack's own verb/Form
-   dialogs render raw and opt out via private `_raw_content=True` (9 sites). Enabled by
-   `_RawTkContainer` in `widgets/_core/base.py` `_resolve_parent` (`df08ac4b`) — lets a
-   public widget be parented into a bare Tk frame.
-
-**Verification tooling (untracked, `development/`):** `verify_example.py` (runs an
-example headlessly, one App per subprocess; catches construction/placement CRASHES —
-does NOT trigger dialog `show()` or detect visual collapse) · `verify_screenshots.py`
-(runs each `SCENES` scene per-process). 183 tests pass; clean `-W` docs build EXCEPT
-the 36 missing `row-`/`column-`/`divider-` images (pending re-shoot).
-
-**HELD uncommitted — `docs/examples/` only** (the user is reviewing/running them; they
-have real issues). Includes the converted `.py`, the hstack/vstack/separator deletions,
-new `row.py`/`column.py`/`divider.py`, plus this session's example fixes: `column.py`/
-`row.py` (+ their screenshots) got `horizontal="stretch"` on fixed-height demos that
-were collapsing to lines; `datatable.py` → `COLUMNS: list[ColumnSpec]`; `dialog.py`/
-`dialogs.py` → parent-free. DO NOT commit `docs/examples/` until the user says so.
-
-**OPEN — resume here:**
-1. **`pagestack.py` settings grid: rows spread down the page** (last thing hit, NOT yet
-   fixed). Cause: `GridFrame` auto-weights every row not defined via `rows=` with
-   `weight=1` (pre-existing, commit `ca4e3df9`; asymmetric — columns default to 0). The
-   page uses `layout="grid"` which fills the PageStack, so the weight-1 rows divide that
-   height and spread. Trigger: the conversion dropped `sticky_items="ew"` (a non-default
-   that pinned cells horizontally only; the new default stretches both axes). DECIDE:
-   example-level fix (put a content-sized `Grid` *inside* a normal column page — RECOMMENDED)
-   vs framework-level (undefined Grid rows default `weight=0` + update `grid.py`'s
-   `height=80` demos to explicit `rows=[1]`). Watch for the same "page=grid fills→spreads"
-   in other held examples.
-2. **RE-SHOOT screenshots** (user's visual-verify step) — required for a `-W`-clean
-   build: `row`, `column`, `divider` (mandatory, new image names) + refresh `grid`/
-   `statusbar`/etc.: `py -3.12 docs/scripts/take_screenshots.py [widget]` (no arg = all).
-3. **Keep reviewing held `docs/examples/`** for the bug classes found this session:
-   collapsed fixed-size containers (need `horizontal`/`vertical="stretch"` AND a parent
-   that supplies that axis), untyped constants feeding TypedDict params (annotate),
-   lambda/raw `content_builder`s, the grid-row-spread above.
-4. **Commit `docs/examples/` + regenerated PNGs** once the user finishes review.
-5. **#5 `add_spacer()`→public `Spacer`** still deferred — entangled with
-   `feat/unified-toolbars` (internal `Toolbar` is pack-based). Memory `project_unified_toolbars`.
+**Follow-ups (not blockers):**
+- `cli/icons.py` (the appicon designer's own UI) still uses raw Tk `.pack()` — convert.
+- **`add_spacer()`→public `Spacer`** still deferred — entangled with
+  `feat/unified-toolbars` (internal `Toolbar` is pack-based). Memory `project_unified_toolbars`.
+- Demo bugs (pre-existing, NOT layout-caused): #165 undecorated-window drag offset · #166
+  ContextMenu/Tooltip don't cover container children · #167 Gauge theme repaint · #168
+  Tabs overflow.
 
 ### Toward the 0.1.0 stable release
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Most Python desktop frameworks make you fight the framework. bootstack gets out 
 
 - **30% less code** — the declarative, context-manager layout eliminates geometry calls, explicit parenting, and most of the wiring boilerplate
 - **Reads like Python** — nested `with` blocks mirror your UI structure; the code hierarchy *is* the layout
-- **Modern layout system** — `HStack`, `VStack`, and `Grid` containers handle spacing, alignment, and fill automatically; CSS conventions (`gap`, `padding`, `margin`, `fill`, `anchor`) without writing CSS
+- **Modern layout system** — `Row`, `Column`, and `Grid` containers handle spacing, alignment, and growth automatically; a screen-axis vocabulary (`gap`, `padding`, `margin`, `horizontal`, `vertical`, `grow`) without writing CSS
 - **60+ widgets out of the box** — primitives through full composites: tables, trees, calendars, date pickers, gauges, sliders, and more — including a full `CodeEditor` with syntax highlighting, line numbers, bracket matching, smart indent, and search; no external editor dependency required
 - **Reactive signals** — observable state that flows between widgets; bind once, update everywhere
 - **Event and stream pipelines** — compose, filter, debounce, and throttle UI events with a chainable stream API
@@ -109,11 +109,11 @@ shell.run()
 
 ### Layout containers
 
-`VStack`, `HStack`, and `Grid` let you describe a layout once instead of repeating geometry calls on each child:
+`Column`, `Row`, and `Grid` let you describe a layout once instead of repeating geometry calls on each child:
 
 ```python
 with bs.App(title="Sign In") as app:
-    with bs.Grid(columns=["auto", 1], gap=(12, 6), sticky_items="ew", padding=16):
+    with bs.Grid(columns=["auto", 1], gap=(12, 6), horizontal_items="stretch", padding=16):
         bs.Label("Name:")
         bs.TextField(placeholder="Full name")
         bs.Label("Email:")
@@ -165,7 +165,7 @@ app.run()
 - **Application scaffolding** — `App` for blank windows, `AppShell` for command-bar + sidebar + page-stack apps, undecorated windows with custom chrome
 - **60+ themed widgets** — primitives plus higher-level composites (DataTable, Tree, ListView, Calendar, DateField, Form, Gauge, ToggleGroup, PageStack, Carousel, Tooltip, and more)
 - **Dialogs and messages** — `alert()` / `confirm()` / `ask_*()` prompts and `FormDialog` / `FontDialog` / `FilterDialog`, plus non-blocking `toast()`, `Notification`, and `Snackbar` surfaces
-- **Layout containers** — `VStack`, `HStack`, and `Grid` for declarative layouts; `Card`, `GroupBox`, `ScrollView`, `SplitView`, `Accordion`, `Expander`
+- **Layout containers** — `Column`, `Row`, `Grid`, and `Spacer` for declarative layouts; `Card`, `GroupBox`, `ScrollView`, `SplitView`, `Accordion`, `Divider`
 - **Design system** — semantic `accent` colors (primary, secondary, success, danger, warning, info) and `variant` tokens (solid, outline, ghost), consistent across widgets
 - **Built-in themes** — paired light/dark variants (amber, aurora, bootstrap, classic, docs, forest, ocean, rose) with runtime theme switching and a custom-theme API
 - **Reactive signals** — observable state with subscribe/set, integrates with widgets via `signal=` / `textsignal=`
@@ -185,8 +185,8 @@ app.run()
 | **Selection** | Checkbox, Switch, ToggleButton, Radio, RadioGroup, ToggleGroup, Select, SelectButton, Calendar |
 | **Data Display** | Label, Badge, ListView, Tree, DataTable, ProgressBar, Gauge |
 | **Media** | Avatar, Picture, Gallery, Carousel |
-| **Layout** | VStack, HStack, Grid, Card, GroupBox, SplitView, ScrollView, Accordion, Separator |
-| **Navigation** | AppShell, SideNav, StatusBar, Tabs, PageStack |
+| **Layout** | Column, Row, Grid, Spacer, Card, GroupBox, SplitView, ScrollView, Accordion, Divider |
+| **Navigation** | AppShell, StatusBar, Tabs, PageStack |
 | **Dialogs** | `alert()`, `confirm()`, `ask_*()` prompts, FormDialog, FontDialog, FilterDialog |
 | **Overlays** | `toast()`, Notification, Snackbar, Tooltip |
 | **Forms** | Form, with field-level validation |

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -124,11 +124,12 @@ Start here
 Install
 -------
 
-bootstack requires Python 3.12 or newer:
+bootstack requires Python 3.12 or newer. It is in pre-release, so opt in with
+``--pre``:
 
 .. code-block:: bash
 
-   pip install git+https://github.com/israel-dryer/bootstack.git
+   pip install --pre bootstack
 
 To tour everything bootstack ships without writing a line of code, launch the
 gallery:


### PR DESCRIPTION
Cleanup after the layout engine merged (#170).

## README.md
Still referenced the pre-conversion widgets:
- `HStack`/`VStack` → **`Row`/`Column`**, `Separator` → **`Divider`**, added **`Spacer`** to the layout lists.
- Dropped the now-internal `Expander` and the removed `SideNav`.
- Swapped the stale layout example (`sticky_items="ew"`, `fill`/`anchor` vocabulary) to `horizontal_items="stretch"` + the screen-axis vocabulary.

(`Toolbar` is left as-is — verified `bs.Toolbar` is the current public name, not `CommandBar`.)

## docs/index.rst
The home-page install used `pip install git+https://…`. Switched to the pre-release method: `pip install --pre bootstack`.

## CLAUDE.md
The handoff still described `feat/grid-layout-engine` as built-but-unmerged with a "resume here" worklist. Replaced that with a SHIPPED (#170) summary, the engine/docs fixes that landed, the open follow-up PRs (#171, #169), and the remaining non-blockers.

`-W` docs build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)