### PR TITLE
refactor(cli): rebuild the icons browser on the public layer + Gallery fixes

### DIFF
--- a/src/bootstack/cli/icons.py
+++ b/src/bootstack/cli/icons.py
@@ -2,8 +2,6 @@
 from __future__ import annotations
 
 import argparse
-import sys
-from typing import Any
 
 
 def add_parser(subparsers: argparse._SubParsersAction) -> None:
@@ -20,308 +18,81 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:
     parser.set_defaults(func=lambda args: run_icons())
 
 
-# ── Layout constants ─────────────────────────────────────────────────────────
-_ICON_SIZE = 28
-_CELL_H = 62
-_MIN_CELL_W = 88   # minimum cell width — drives column count calculation
-_RENDER_BATCH = 200
+_DEFAULT_STATUS = (
+    'Click an icon to copy its name  ·  use as  icon="name"  on any widget'
+)
 
 
 def run_icons() -> None:
-    import tkinter as tk
-    from bootstack.signals import Signal
-    from bootstack._core.images import _ImageService
-    from bootstack._runtime.app import App as _App
-    from bootstack.widgets._impl.primitives.frame import Frame as _Frame
-    from bootstack.widgets._impl.primitives.label import Label as _Label
-    from bootstack.widgets._impl.primitives.packframe import PackFrame as _PackFrame
-    from bootstack.widgets._impl.primitives.scrollbar import Scrollbar as _Scrollbar
-    from bootstack.widgets._impl.primitives.separator import Separator as _Separator
-    from bootstack.widgets._impl.composites.textentry import TextEntry as _TextEntry
+    import bootstack as bs
+    from bootstack.clipboard import set_clipboard
+    from bootstack.data import MemoryDataSource, col
+    from bootstack.images import get_icon, list_icons
 
-    app = _App(title="Bootstrap Icons", size=(990, 720))
+    names = list_icons()
 
-    # ── Top bar ──────────────────────────────────────────────────────────────
-    topbar = _PackFrame(app, direction="row", padding=(12, 8), gap=10)
-    topbar.pack(fill="x")
+    with bs.App(title="Bootstrap Icons", size=(990, 720), gap=0) as app:
+        # Each record carries a theme-following Image. Gallery recycles its tiles,
+        # so the thumbnails render lazily as they scroll into view and recolor
+        # with the theme on their own — no manual batching or repaint needed.
+        records = [
+            {"id": i, "name": name, "icon": get_icon(name, size=32)}
+            for i, name in enumerate(names)
+        ]
+        source = MemoryDataSource()
+        source.load(records)
 
-    search = _TextEntry(topbar, width=30)
-    search.insert_addon(_Label, position="before", icon="search", icon_only=True)
-    search.pack(side="left")
+        count = bs.Signal("")
+        status = bs.Signal(_DEFAULT_STATUS)
 
-    count_sig = Signal("loading…")
-    _Label(topbar, textsignal=count_sig, font="caption", accent="muted").pack(side="right")
+        def update_count() -> None:
+            count.set(f"{source.count:,} of {len(names):,} icons")
 
-    _Separator(app, orient="horizontal").pack(fill="x")
+        with bs.Row(padding=(12, 8), gap=10, horizontal="stretch", vertical_items="center"):
+            search = bs.TextField(placeholder="Search icons", grow=True)
+            search.insert_addon("label", "before", icon="search")
+            bs.Label(textsignal=count, font="caption", accent="muted")
 
-    # ── Canvas + scrollbar ───────────────────────────────────────────────────
-    content = _Frame(app)
-    content.pack(fill="both", expand=True)
+        bs.Divider()
 
-    vsb = _Scrollbar(content, orient="vertical")
-    vsb.pack(side="right", fill="y")
-
-    canvas = tk.Canvas(content, highlightthickness=0, bd=0)
-    canvas.pack(side="left", fill="both", expand=True)
-
-    canvas.configure(yscrollcommand=vsb.set)
-    vsb.configure(command=canvas.yview)
-
-    # ── Status bar ───────────────────────────────────────────────────────────
-    _Separator(app, orient="horizontal").pack(fill="x")
-    status_sig = Signal(
-        "Click an icon to copy its name  ·  use as  icon=\"name\"  on any widget"
-    )
-    statusbar = _PackFrame(app, direction="row", padding=(12, 4))
-    statusbar.pack(fill="x")
-    _Label(statusbar, textsignal=status_sig, font="caption", accent="muted").pack(side="left")
-
-    # ── Data + render state ──────────────────────────────────────────────────
-    _, glyphmap = _ImageService._load_icon_assets()
-    all_names: list[str] = sorted(glyphmap.keys())
-
-    _photos: list[Any] = []            # strong refs — prevents Tk GC
-    _item_names: dict[int, str] = {}   # canvas item id → icon name
-    _current_query: list[str] = [""]
-    _current_matches: list[list[str]] = [[]]
-    _current_cols: list[int] = [8]
-    _current_cell_w: list[int] = [_MIN_CELL_W]
-    _render_gen: list[int] = [0]       # incremented on each rebuild to cancel stale batches
-    _search_after: list[Any] = [None]
-    _resize_after: list[Any] = [None]
-    _hover_item: list[int] = [0]       # canvas item id for the hover highlight rect
-    _hover_after: list[Any] = [None]   # pending after() id for click-flash restore
-
-    def _theme_colors() -> tuple[str, str]:
-        try:
-            from bootstack.style.style import get_style
-            style = get_style()
-            return style.colors.get("background", "#ffffff"), style.colors.get("foreground", "#212529")
-        except Exception:
-            return "#ffffff", "#212529"
-
-    def _blend(bg_hex: str, fg_hex: str, ratio: float) -> str:
-        """Blend fg onto bg at ratio (0.0 = all bg, 1.0 = all fg)."""
-        h1 = bg_hex.lstrip("#")
-        h2 = fg_hex.lstrip("#")
-        br, bg_c, bb = int(h1[0:2], 16), int(h1[2:4], 16), int(h1[4:6], 16)
-        fr, fg_c, fb = int(h2[0:2], 16), int(h2[2:4], 16), int(h2[4:6], 16)
-        r = int(br + (fr - br) * ratio)
-        g = int(bg_c + (fg_c - bg_c) * ratio)
-        b = int(bb + (fb - bb) * ratio)
-        return f"#{r:02x}{g:02x}{b:02x}"
-
-    def _layout() -> tuple[int, int]:
-        """Return (cols, cell_w) so the grid exactly fills the canvas width."""
-        w = canvas.winfo_width()
-        if w <= _MIN_CELL_W:
-            return 8, _MIN_CELL_W  # canvas not yet laid out
-        cols = max(1, w // _MIN_CELL_W)
-        cell_w = w // cols          # spread columns evenly across full width
-        return cols, cell_w
-
-    def _cell_at(cx: float, cy: float) -> int | None:
-        """Return index into current matches for scroll-aware canvas coords, or None."""
-        cols = _current_cols[0]
-        cell_w = _current_cell_w[0]
-        matches = _current_matches[0]
-        if cols == 0 or cell_w == 0 or not matches:
-            return None
-        col = int(cx // cell_w)
-        row = int(cy // _CELL_H)
-        if col < 0 or col >= cols:
-            return None
-        idx = row * cols + col
-        if idx < 0 or idx >= len(matches):
-            return None
-        return idx
-
-    def _hover_rect_coords(idx: int) -> tuple[int, int, int, int]:
-        cols = _current_cols[0]
-        cell_w = _current_cell_w[0]
-        col = idx % cols
-        row = idx // cols
-        return (
-            col * cell_w + 2, row * _CELL_H + 2,
-            (col + 1) * cell_w - 2, (row + 1) * _CELL_H - 2,
+        gallery = bs.Gallery(
+            data_source=source,
+            image_field="icon",
+            caption_field="name",
+            columns="auto",
+            tile_size=(72, 40),
+            fit="none",            # show the 32px glyph at native size — crisp, no upscale
+            gap=6,
+            selection_mode="single",
+            grow=True,
+            horizontal="stretch",
         )
 
-    # ── Batched renderer ─────────────────────────────────────────────────────
+        bs.Divider()
 
-    def _render_batch(matches: list[str], start: int, cols: int, cell_w: int,
-                      fg: str, gen: int) -> None:
-        if gen != _render_gen[0]:
-            return  # superseded by a newer rebuild
+        with bs.Row(padding=(12, 4), horizontal="stretch", surface="chrome"):
+            bs.Label(textsignal=status, font="caption", accent="muted")
 
-        end = min(start + _RENDER_BATCH, len(matches))
-        for i in range(start, end):
-            name = matches[i]
-            col = i % cols
-            row = i // cols
-            cx = col * cell_w + cell_w // 2
-            cy = row * _CELL_H + 6
+        def on_search(event) -> None:
+            query = event.text.strip().lower()
+            source.where(col("name").contains(query) if query else None)
+            gallery.reload()
+            update_count()
 
-            photo = _ImageService.get_icon(name, _ICON_SIZE, fg)
-            _photos.append(photo)
+        # Live, as-you-type filtering — debounced so a fast typist isn't reloaded
+        # on every keystroke.
+        search.on_input().debounce(120).listen(on_search)
 
-            img_id = canvas.create_image(
-                cx, cy + _ICON_SIZE // 2, image=photo, anchor="center")
-            _item_names[img_id] = name
+        def on_pick(record: dict) -> None:
+            name = record["name"]
+            set_clipboard(name)
+            status.set(f'Copied  "{name}"  —  ready to paste as  icon="{name}"')
 
-            label = name if len(name) <= 13 else name[:11] + "…"
-            txt_id = canvas.create_text(
-                cx, cy + _ICON_SIZE + 5, text=label,
-                anchor="n", fill=fg,
-                font=("TkDefaultFont", 8),
-                width=cell_w - 6)
-            _item_names[txt_id] = name
+        gallery.on_item_click(on_pick)
 
-            # full-cell transparent hit box (top of z-order — catches mouse events)
-            box_id = canvas.create_rectangle(
-                col * cell_w + 1, row * _CELL_H + 1,
-                (col + 1) * cell_w - 1, (row + 1) * _CELL_H - 1,
-                fill="", outline="")
-            _item_names[box_id] = name
+        update_count()
 
-        total_rows = (len(matches) + cols - 1) // cols
-        canvas.configure(
-            scrollregion=(0, 0, cols * cell_w, total_rows * _CELL_H + 16))
+    app.run()
 
-        if end < len(matches):
-            canvas.after(0, lambda: _render_batch(matches, end, cols, cell_w, fg, gen))
-
-    def rebuild(query: str = "") -> None:
-        query = query or ""
-        _current_query[0] = query
-        _render_gen[0] += 1
-        gen = _render_gen[0]
-
-        canvas.delete("all")
-        _photos.clear()
-        _item_names.clear()
-        canvas.yview_moveto(0)
-
-        q = query.strip().lower()
-        matches = [n for n in all_names if q in n] if q else all_names
-        count_sig.set(f"{len(matches):,} of {len(all_names):,} icons")
-
-        bg, fg = _theme_colors()
-        canvas.configure(bg=bg)
-
-        if not matches:
-            canvas.create_text(
-                max(canvas.winfo_width() // 2, 160), 100,
-                text=f'No icons match "{query}"',
-                fill=fg, font=("TkDefaultFont", 11), anchor="center")
-            _current_matches[0] = []
-            _hover_item[0] = 0
-            return
-
-        cols, cell_w = _layout()
-        _current_matches[0] = matches
-        _current_cols[0] = cols
-        _current_cell_w[0] = cell_w
-
-        # Create hover rect FIRST so icons render on top of it
-        _hover_item[0] = canvas.create_rectangle(
-            0, 0, 0, 0, fill="", outline="", tags="hover")
-
-        _render_batch(matches, 0, cols, cell_w, fg, gen)
-
-    # ── Hover + cursor ───────────────────────────────────────────────────────
-
-    def _on_motion(event: Any) -> None:
-        if not _hover_item[0]:
-            return
-        cx = canvas.canvasx(event.x)
-        cy = canvas.canvasy(event.y)
-        idx = _cell_at(cx, cy)
-        if idx is None:
-            canvas.itemconfigure(_hover_item[0], fill="", outline="")
-            canvas.configure(cursor="")
-            return
-        x1, y1, x2, y2 = _hover_rect_coords(idx)
-        canvas.coords(_hover_item[0], x1, y1, x2, y2)
-        bg, fg = _theme_colors()
-        canvas.itemconfigure(_hover_item[0], fill=_blend(bg, fg, 0.08), outline="")
-        canvas.configure(cursor="hand2")
-
-    def _on_leave(event: Any) -> None:
-        if _hover_item[0]:
-            canvas.itemconfigure(_hover_item[0], fill="", outline="")
-        canvas.configure(cursor="")
-
-    canvas.bind("<Motion>", _on_motion)
-    canvas.bind("<Leave>", _on_leave)
-
-    # ── Click — copy name + press flash ─────────────────────────────────────
-
-    def _on_click(event: Any) -> None:
-        cx = canvas.canvasx(event.x)
-        cy = canvas.canvasy(event.y)
-        idx = _cell_at(cx, cy)
-        if idx is None:
-            return
-        name = _current_matches[0][idx]
-
-        # Press flash: darken highlight for 150 ms then restore to hover tint
-        if _hover_item[0]:
-            bg, fg = _theme_colors()
-            canvas.itemconfigure(_hover_item[0], fill=_blend(bg, fg, 0.22))
-            if _hover_after[0] is not None:
-                app.after_cancel(_hover_after[0])
-
-            def _restore_hover() -> None:
-                if _hover_item[0]:
-                    b, f = _theme_colors()
-                    canvas.itemconfigure(_hover_item[0], fill=_blend(b, f, 0.08))
-                _hover_after[0] = None
-
-            _hover_after[0] = app.after(150, _restore_hover)
-
-        app.clipboard_clear()
-        app.clipboard_append(name)
-        status_sig.set(
-            f"Copied  \"{name}\"  —  ready to paste as  icon=\"{name}\"")
-        app.after(3000, lambda: status_sig.set(
-            "Click an icon to copy its name  ·  use as  icon=\"name\"  on any widget"))
-
-    canvas.bind("<Button-1>", _on_click)
-
-    # ── Scrolling ────────────────────────────────────────────────────────────
-
-    canvas.bind("<MouseWheel>",
-                lambda e: canvas.yview_scroll(int(-1 * (e.delta / 120)), "units"))
-    canvas.bind("<Button-4>", lambda e: canvas.yview_scroll(-1, "units"))
-    canvas.bind("<Button-5>", lambda e: canvas.yview_scroll(1, "units"))
-
-    # ── Search (debounced 120 ms) ─────────────────────────────────────────────
-
-    def _on_search(event: Any) -> None:
-        query = (getattr(event.data, "value", "") or "") if hasattr(event, "data") else ""
-        if _search_after[0] is not None:
-            app.after_cancel(_search_after[0])
-        _search_after[0] = app.after(120, lambda: rebuild(query))
-
-    search.on_changed(_on_search)
-
-    # ── Resize (debounced 80 ms) ──────────────────────────────────────────────
-
-    def _on_resize(event: Any) -> None:
-        if _resize_after[0] is not None:
-            app.after_cancel(_resize_after[0])
-        _resize_after[0] = app.after(80, lambda: rebuild(_current_query[0]))
-
-    canvas.bind("<Configure>", _on_resize)
-
-    # ── Theme change ──────────────────────────────────────────────────────────
-
-    app.bind("<<ThemeChanged>>",
-             lambda e: rebuild(_current_query[0]), add="+")
-
-    # ── First paint ───────────────────────────────────────────────────────────
-
-    app.after(60, lambda: rebuild(""))
-
-    app.mainloop()
-    sys.exit(0)
+if __name__ == '__main__':
+    run_icons()

--- a/src/bootstack/data/memory_source.py
+++ b/src/bootstack/data/memory_source.py
@@ -88,6 +88,20 @@ class MemoryDataSource(BaseDataSource):
         self._id_index: Dict[Any, int] = {}
         self._filter: Optional[Condition] = None
         self._sort: List[SortKey] = []
+        # Cached filter+sort view, rebuilt lazily and busted on any structural
+        # change (see _emit). Avoids re-filtering/re-sorting all rows on every
+        # count/page_slice — the hot path while a recycling widget scrolls.
+        self._view: Optional[List[Dict[str, Any]]] = None
+
+    def _emit(self, event: "DataChangeEvent") -> None:
+        """Emit a change event, busting the cached view for structural changes.
+
+        Selection toggles a row's flag without changing which rows match or their
+        order, so they keep the cached view (and the scroll path stays fast).
+        """
+        if event.kind != "select":
+            self._view = None
+        self._hub.emit(event)
 
     def _rebuild_id_index(self) -> None:
         """Rebuild the ID-to-position index for fast lookups."""
@@ -171,7 +185,7 @@ class MemoryDataSource(BaseDataSource):
             self._data = []
             self._columns = []
             self._rebuild_id_index()
-            self._hub.emit(DataChangeEvent(kind="load"))
+            self._emit(DataChangeEvent(kind="load"))
             return self
 
         if not self._is_mapping(records[0]):
@@ -196,24 +210,30 @@ class MemoryDataSource(BaseDataSource):
         self._columns = list(self._data[0].keys())
         self._ensure_id()
         self._ensure_selected_column()
-        self._hub.emit(DataChangeEvent(kind="load"))
+        self._emit(DataChangeEvent(kind="load"))
         return self
 
     def where(self, condition: Optional[Condition] = None) -> "MemoryDataSource":
         """Filter rows by a condition built with `col` (None clears the filter)."""
         self._filter = condition
-        self._hub.emit(DataChangeEvent(kind="filter"))
+        self._emit(DataChangeEvent(kind="filter"))
         return self
 
     def order(self, *keys) -> "MemoryDataSource":
         """Sort rows by one or more keys (no arguments clears sorting)."""
         self._sort = normalize_sort_keys(keys)
-        self._hub.emit(DataChangeEvent(kind="sort"))
+        self._emit(DataChangeEvent(kind="sort"))
         return self
 
     def _filtered_sorted_rows(self) -> List[Dict[str, Any]]:
-        """Get all rows with current filter and sort applied."""
-        return self._apply_filter_and_sort(self._data)
+        """Get all rows with current filter and sort applied (cached).
+
+        The result is memoized in `self._view` and reused until a structural
+        change (load/filter/sort/insert/update/delete/move) busts it via `_emit`.
+        """
+        if self._view is None:
+            self._view = self._apply_filter_and_sort(self._data)
+        return self._view
 
     def page(self, page: Optional[int] = None) -> List[Dict[str, Any]]:
         """Get records for specified page."""
@@ -272,7 +292,7 @@ class MemoryDataSource(BaseDataSource):
         self._data.append(r)
         self._columns = list(set(self._columns) | set(r.keys()))
         self._id_index[r[self._id_field]] = len(self._data) - 1
-        self._hub.emit(DataChangeEvent(kind="insert", id=r[self._id_field], record=dict(r)))
+        self._emit(DataChangeEvent(kind="insert", id=r[self._id_field], record=dict(r)))
         return r[self._id_field]
 
     def get(self, record_id: Any) -> Optional[Dict[str, Any]]:
@@ -291,7 +311,7 @@ class MemoryDataSource(BaseDataSource):
             return False
         self._data[idx].update(updates)
         self._columns = list(set(self._columns) | set(updates.keys()))
-        self._hub.emit(DataChangeEvent(kind="update", id=record_id, record=dict(updates)))
+        self._emit(DataChangeEvent(kind="update", id=record_id, record=dict(updates)))
         return True
 
     def delete(self, record_id: Any) -> bool:
@@ -301,7 +321,7 @@ class MemoryDataSource(BaseDataSource):
             return False
         self._data.pop(idx)
         self._rebuild_id_index()
-        self._hub.emit(DataChangeEvent(kind="delete", id=record_id))
+        self._emit(DataChangeEvent(kind="delete", id=record_id))
         return True
 
     def _internal_fields(self) -> "frozenset[str]":
@@ -319,14 +339,14 @@ class MemoryDataSource(BaseDataSource):
         """Mark record as selected."""
         changed = self._set_selected_flag(record_id, 1)
         if changed:
-            self._hub.emit(DataChangeEvent(kind="select", id=record_id))
+            self._emit(DataChangeEvent(kind="select", id=record_id))
         return changed
 
     def deselect(self, record_id: Any) -> bool:
         """Mark record as unselected."""
         changed = self._set_selected_flag(record_id, 0)
         if changed:
-            self._hub.emit(DataChangeEvent(kind="select", id=record_id))
+            self._emit(DataChangeEvent(kind="select", id=record_id))
         return changed
 
     def select_all(self, current_page_only: bool = False) -> int:
@@ -347,7 +367,7 @@ class MemoryDataSource(BaseDataSource):
                     r["selected"] = 1
                     count += 1
         if count:
-            self._hub.emit(DataChangeEvent(kind="select"))
+            self._emit(DataChangeEvent(kind="select"))
         return count
 
     def deselect_all(self, current_page_only: bool = False) -> int:
@@ -368,7 +388,7 @@ class MemoryDataSource(BaseDataSource):
                     r["selected"] = 0
                     count += 1
         if count:
-            self._hub.emit(DataChangeEvent(kind="select"))
+            self._emit(DataChangeEvent(kind="select"))
         return count
 
     def move(self, record_id: Any, target_index: int) -> bool:
@@ -393,7 +413,7 @@ class MemoryDataSource(BaseDataSource):
         end = max(source_index, clamped_target) + 1
         for i in range(start, end):
             self._id_index[self._data[i][self._id_field]] = i
-        self._hub.emit(DataChangeEvent(kind="move", id=record_id))
+        self._emit(DataChangeEvent(kind="move", id=record_id))
         return True
 
     def _set_selected_flag(self, record_id: Any, flag: int) -> bool:

--- a/src/bootstack/images.py
+++ b/src/bootstack/images.py
@@ -145,7 +145,7 @@ class Image:
     GIF, BMP, TIFF, WebP, and ICO. (Animated formats load their first frame.)
     """
 
-    __slots__ = ("_pil", "_path", "_data", "_icon", "_photo", "_size")
+    __slots__ = ("_pil", "_path", "_data", "_icon", "_photo", "_icon_pil", "_size")
 
     def __init__(
         self,
@@ -160,6 +160,7 @@ class Image:
         self._data = data
         self._icon = icon
         self._photo: "_Photo | None" = None
+        self._icon_pil: "_PILImage | None" = None   # cached rendered-glyph PIL
         self._size: tuple[int, int] | None = None
 
     # =========================================================================
@@ -239,6 +240,20 @@ class Image:
 
         if self._pil is not None:
             return self._pil
+        if self._icon is not None:
+            # Render the glyph at the PIL level so icon handles work with the
+            # image-display widgets (Picture/Gallery) that fit/round/compose a
+            # PIL frame — not just the `icon=` PhotoImage path via _materialize.
+            # Cached so a recycling grid that re-resolves the same handle on
+            # every scroll doesn't re-render the glyph each time; dropped by
+            # _invalidate() on a theme change so token colors re-render.
+            if self._icon_pil is None:
+                size = self._icon.size
+                size = size if size % 2 == 0 else size + 1
+                self._icon_pil = _ImageService._render_icon(
+                    self._icon.name, size, self._resolve_icon_color()
+                )
+            return self._icon_pil
         if self._path is not None:
             return PILImage.open(self._path)
         if self._data is not None:
@@ -257,6 +272,7 @@ class Image:
     def _invalidate(self) -> None:
         """Drop the rendered image so the next bind re-renders it."""
         self._photo = None
+        self._icon_pil = None
 
     def _materialize(self, master=None) -> "_Photo":
         """Render the source to a cached display image and return it.

--- a/src/bootstack/widgets/_impl/composites/gallery.py
+++ b/src/bootstack/widgets/_impl/composites/gallery.py
@@ -100,7 +100,8 @@ class GalleryTile(Frame):
         if rid != self._cur_id:
             self._cur_id = rid
             if self._caption is not None:
-                self._caption.configure(text="" if empty else str(caption_text))
+                self._caption.configure(
+                    text="" if empty else self._fit_caption(str(caption_text)))
         source = None if empty else image_source
         if source is not self._cur_src and source != self._cur_src:
             self._render_thumb(source)
@@ -108,6 +109,33 @@ class GalleryTile(Frame):
         self._canvas.itemconfigure(
             self._ring_id, state="normal" if (selected and not empty) else "hidden"
         )
+
+    def _fit_caption(self, text: str) -> str:
+        """Ellipsize `text` to the tile width so a caption never widens its tile.
+
+        Keeps every tile a uniform width — so grid columns stay put instead of
+        shifting as longer/shorter captions scroll through them.
+        """
+        if not text:
+            return text
+        avail = self._tw + 2 * _RING_PAD - 6
+        cap = self._caption
+        try:
+            font = cap.cget("font")
+            measure = lambda s: int(cap.tk.call("font", "measure", font, s))
+        except Exception:
+            return text
+        if measure(text) <= avail:
+            return text
+        ell = "…"
+        lo, hi = 0, len(text)
+        while lo < hi:
+            mid = (lo + hi + 1) // 2
+            if measure(text[:mid] + ell) <= avail:
+                lo = mid
+            else:
+                hi = mid - 1
+        return text[:lo] + ell if lo > 0 else ell
 
     def _render_thumb(self, source: Any) -> None:
         pil = resolve_pil(source)
@@ -188,6 +216,7 @@ class Gallery(Frame):
 
         self._tiles: list[GalleryTile] = []
         self._cols = 1
+        self._cfg_cols = 0   # highest grid column given a weight, for resetting
         self._visible_rows = 1
         self._pool_rows = 1
         self._start_row = 0
@@ -268,7 +297,12 @@ class Gallery(Frame):
         if self._columns_opt != "auto":
             return max(1, int(self._columns_opt))
         cell = self._tw + 2 * _RING_PAD
-        return max(1, (width + self._gap) // (cell + self._gap))
+        # Each tile occupies cell + gap of width — _regrid gives every tile a
+        # symmetric padx of gap//2 on both sides. So the count is
+        # width // (cell + gap); the "(n-1) gaps between items" form
+        # ((width + gap) // (cell + gap)) permits one column too many and clips
+        # the last column off the frame's right edge.
+        return max(1, width // (cell + self._gap))
 
     def _on_resize(self, event) -> None:
         self._relayout(event.width, event.height)
@@ -337,6 +371,8 @@ class Gallery(Frame):
             tile.set_ring(self._ring_photo)
             self._bind_scroll(tile)
             self._bind_scroll(tile._canvas)
+            if tile._caption is not None:
+                self._bind_scroll(tile._caption)
             self._tiles.append(tile)
         while len(self._tiles) > needed:
             tile = self._tiles.pop()
@@ -347,6 +383,16 @@ class Gallery(Frame):
 
     def _regrid(self) -> None:
         pad = self._gap // 2
+        # Weight the active columns equally so the fixed-width tiles spread to
+        # fill the row instead of left-packing with a ragged right margin (which
+        # reads as a wasted extra column). Tiles are gridded without sticky, so
+        # each stays its cell width and centers in its column. Stale columns from
+        # a wider previous layout are zeroed.
+        for c in range(self._cfg_cols):
+            self._container.grid_columnconfigure(c, weight=0, uniform="")
+        for c in range(self._cols):
+            self._container.grid_columnconfigure(c, weight=1, uniform="gallerycol")
+        self._cfg_cols = self._cols
         for i, tile in enumerate(self._tiles):
             tile.grid(row=i // self._cols, column=i % self._cols, padx=pad, pady=pad)
 


### PR DESCRIPTION
Converts the last raw-Tk CLI (`bootstack icons`) onto the public layer, and fixes the Gallery/image issues that dogfooding surfaced along the way.

## CLI rewrite (`cli/icons.py`, 326 → 94 lines)
Was built end-to-end on internals: the internal `_runtime.App`, `_impl` primitives (incl. the now-superseded pack-based `PackFrame`), a raw `tk.Canvas` + custom batched renderer, raw clipboard, raw `after()`, and a raw `<<ThemeChanged>>` binding. Now: `bs.App` + `Row`/`Divider`/`TextField` chrome, a `bs.Gallery` for the grid (`data_source` + `MemoryDataSource`, `columns="auto"`, `fit="none"` 32px glyphs, `selection_mode="single"`), `col("name").contains` filtering, public clipboard, and a debounced `on_input()` stream for search. No raw Tk remains.

## Framework fixes (benefit every Gallery / scroll-query widget)
- **`fix(images)`** — `get_icon()` handles render via `_materialize()` (PhotoImage, the `icon=` path) but `_load_pil()` (what Picture/Gallery use to fit/round/compose) raised "no source" → blank tiles. Render the glyph to PIL there too, **cached** on the handle (dropped by `_invalidate()` so token colors re-render on theme change).
- **`fix(gallery)`** — uniform tiles (`_fit_caption` ellipsizes captions to the tile width, so columns don't shift while scrolling); fill the row (weight columns); `_resolve_columns` off-by-one (was clipping the last column); bind the wheel on the caption Label too.
- **`perf(data)`** — `MemoryDataSource` memoizes its filter+sort view; `count`/`page_slice` no longer re-filter every row on each scroll tick (selection keeps the cache hot). `count` → O(1), `page_slice` → O(window).

## Verification
Data tests pass (122; the 2 observable failures are pre-existing harness flakiness — confirmed identical without these changes); Picture/Gallery/Avatar examples render; correctness probes for the cache + memoization pass; scroll feel confirmed in the running app.

## Follow-up (tracked)
Opt-in keyboard-focus ring for Gallery + deferred perf (resize debounce, bounded thumbnail LRU). Hover deliberately excluded (removed from ListView/Tree before for recycling-staleness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)