### PR TITLE
feat(window): built-in title bar + border for undecorated windows (#162, #165)

### DIFF
--- a/docs/widgets/app.rst
+++ b/docs/widgets/app.rst
@@ -159,12 +159,18 @@ independently. On macOS, a toolbar's menus bridge to the native global menu bar
 Undecorated window
 ~~~~~~~~~~~~~~~~~~~
 
-``undecorated=True`` removes the OS title bar and border (ignored on macOS), so
-you build your own title bar: make the first toolbar an
-``add_toolbar(show_window_controls=True)``. It adds minimize / maximize / close at
-the right edge, drags the window (double-click maximizes), and reads as a thin
-compact strip. The same applies to :class:`Window <bootstack.Window>` and
-:class:`AppShell <bootstack.AppShell>`.
+``undecorated=True`` removes the OS title bar and border (ignored on macOS). The
+window is not left stranded: it gets a built-in title bar with minimize /
+maximize / close at the right edge and window dragging (double-click maximizes),
+labeled with the window title. The same applies to
+:class:`Window <bootstack.Window>` and :class:`AppShell <bootstack.AppShell>`
+(:class:`Window <bootstack.Window>` can opt out with ``window_controls=False``
+for a chromeless splash or popover).
+
+To take over the chrome — add a logo, menus, a theme toggle — build your own
+title bar instead: make the first toolbar an
+``add_toolbar(show_window_controls=True)``. Adding any chrome toolbar suppresses
+the built-in one, so you keep full control of the bar's contents.
 
 .. code-block:: python
 

--- a/src/bootstack/widgets/_core/window_menu.py
+++ b/src/bootstack/widgets/_core/window_menu.py
@@ -92,6 +92,42 @@ class ChromeHostMixin:
         self._register_chrome_toolbar(tb, use_macos_menus)
         return tb
 
+    def _ensure_default_titlebar(self) -> None:
+        """Give a borderless window a movable, closeable title bar.
+
+        Batteries-included chrome for an `undecorated` window: when the OS title
+        bar is gone and the author added no chrome toolbar of their own, inject a
+        single `add_toolbar(show_window_controls=True)` band (min/max/close on the
+        right, draggable, double-click to maximize) with the window title as a
+        left label — so a borderless window is never stranded.
+
+        No-op when window controls are turned off (`window_controls=False`), when
+        the window is decorated, on macOS (where `overrideredirect` is
+        force-disabled), or when the author already built chrome with
+        `add_toolbar()`. Idempotent — the author-chrome guard makes a second call
+        a no-op. Called from the window's show/run path, after authoring.
+        """
+        import sys
+
+        if not getattr(self, "_window_controls", True):
+            return
+        if not getattr(self, "_undecorated", False):
+            return
+        if sys.platform == "darwin":
+            return
+        if getattr(self, "_chrome_toolbars", None):
+            return  # the author owns the chrome
+        tb = self.add_toolbar(show_window_controls=True)
+        root = self._menu_root()
+        title = ""
+        if root is not None:
+            try:
+                title = root.title()
+            except Exception:
+                title = ""
+        if title:
+            tb.add_label(title)
+
     def _ensure_toolbar_stack(self) -> Any:
         stack = getattr(self, "_toolbar_stack", None)
         if stack is not None:

--- a/src/bootstack/widgets/_impl/composites/shell/layout.py
+++ b/src/bootstack/widgets/_impl/composites/shell/layout.py
@@ -75,9 +75,10 @@ class ShellLayout(App):
         theme: Theme name, or None for the default.
         size: Initial window size as `(width, height)`.
         undecorated: Remove OS chrome and draw a custom border (ignored on
-            macOS). Build the title bar yourself with
-            `add_toolbar(show_window_controls=True)` — the framework adds no
-            chrome of its own.
+            macOS). The public `AppShell` injects a default title bar (window
+            controls + drag) for a borderless shell unless the author adds their
+            own `add_toolbar(show_window_controls=True)`; this layer itself adds
+            no chrome.
         rail_width: Width of the workspace rail (and compact sidebar) in pixels.
         sidebar_width: Width of the expanded sidebar in pixels.
         dock_width: Width of the detail/inspector dock in pixels.

--- a/src/bootstack/widgets/_impl/composites/toolbar.py
+++ b/src/bootstack/widgets/_impl/composites/toolbar.py
@@ -260,13 +260,24 @@ class Toolbar(Frame):
         """Handle drag motion to move window."""
         window = self.winfo_toplevel()
 
-        # A maximized window snaps back to its normal size before it can move,
-        # re-anchoring the drag origin so the cursor keeps its grip on the bar.
+        # A maximized window snaps back to its normal size before it can move.
+        # The grab offset was captured against the *maximized* width, so simply
+        # restoring would leave the window offset from the cursor (#165). Keep the
+        # pointer on the title bar: capture where the cursor sits over the
+        # maximized window (its horizontal fraction + vertical offset), restore,
+        # then reposition the smaller window so the cursor lands at the same spot.
         if window.state() == 'zoomed':
+            max_w = max(window.winfo_width(), 1)
+            frac_x = (event.x_root - window.winfo_rootx()) / max_w
+            offset_y = event.y_root - window.winfo_rooty()
             try:
                 window.state('normal')
             except Exception:
                 pass
+            window.update_idletasks()
+            new_x = int(event.x_root - frac_x * window.winfo_width())
+            new_y = int(event.y_root - offset_y)
+            window.geometry(f'+{new_x}+{new_y}')
             self._sync_maximize_icon('fullscreen')
             self._drag_start_x = event.x_root
             self._drag_start_y = event.y_root

--- a/src/bootstack/widgets/app.py
+++ b/src/bootstack/widgets/app.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from typing import TYPE_CHECKING, Any, Callable, Literal, Sequence
 
 from bootstack._runtime.app import App as _InternalApp, LocalizeMode
@@ -56,6 +57,10 @@ class App(AppConfigMixin, WindowControlsMixin, ChromeHostMixin, FlexContainer):
         resizable: Whether the window can be resized as `(width, height)`.
         scaling: Explicit UI scaling factor. When None, scaling is automatic.
         hdpi: Enable high-DPI awareness for the application. Default `True`.
+        undecorated: Remove the OS title bar and border (borderless window).
+            Ignored on macOS. The app gets a built-in draggable title bar with
+            min/max/close so it stays movable and closeable; add your own with
+            `add_toolbar(show_window_controls=True)` to take over the chrome.
         padding: Inner padding applied to the content frame.
         gap: Spacing between stacked children. Default `0`.
         horizontal_items: Horizontal alignment of children — `'left'`,
@@ -98,6 +103,7 @@ class App(AppConfigMixin, WindowControlsMixin, ChromeHostMixin, FlexContainer):
         resizable: tuple[bool, bool] | None = None,
         scaling: float | None = None,
         hdpi: bool = True,
+        undecorated: bool = False,
         # Child-guidance (applied to the internal content frame)
         padding: Padding | None = None,
         gap: int = 0,
@@ -123,7 +129,11 @@ class App(AppConfigMixin, WindowControlsMixin, ChromeHostMixin, FlexContainer):
             "state_path": state_path,
             "scaling": scaling,
             "hdpi": hdpi,
+            "override_redirect": undecorated,
         }
+        # overrideredirect has no effect on macOS — so the borderless treatment
+        # (custom border + title bar) is Windows/Linux only.
+        self._undecorated = undecorated and sys.platform != "darwin"
         if title is not None:
             init_kwargs["title"] = title
         if size is not None:
@@ -172,10 +182,24 @@ class App(AppConfigMixin, WindowControlsMixin, ChromeHostMixin, FlexContainer):
         if surface is not None:
             frame_kwargs["surface"] = surface
 
-        self._content_frame = FlexFrame(self._tk_root, **frame_kwargs)
+        # In undecorated mode the OS border is gone; a 1px themed border frame
+        # substitutes it and hosts both the chrome stack and the content.
+        if self._undecorated:
+            from bootstack.widgets._impl.primitives.frame import Frame
+
+            self._region_root = Frame(self._tk_root, show_border=True, padding=1)
+            self._region_root.pack(fill="both", expand=True)
+        else:
+            self._region_root = self._tk_root
+
+        self._content_frame = FlexFrame(self._region_root, **frame_kwargs)
         self._content_frame.pack(fill="both", expand=True)
 
         self._internal = self._tk_root
+
+    def _toolbar_stack_parent(self) -> Any:
+        # The chrome stack lives inside the (bordered) region root, above content.
+        return getattr(self, "_region_root", self._tk_root)
 
     @classmethod
     def from_store(cls, store: Any, **overrides: Any) -> "App":
@@ -220,6 +244,7 @@ class App(AppConfigMixin, WindowControlsMixin, ChromeHostMixin, FlexContainer):
 
     def run(self) -> None:
         """Show the window and start the event loop."""
+        self._ensure_default_titlebar()
         # Let the internal mainloop center and *then* show the window — it
         # flushes layout and applies the window style while still withdrawn, so
         # the window is fully drawn and positioned before it becomes visible.

--- a/src/bootstack/widgets/appshell.py
+++ b/src/bootstack/widgets/appshell.py
@@ -313,8 +313,9 @@ class AppShell(AppConfigMixin, WindowControlsMixin, ChromeHostMixin, PublicWidge
         scaling: Explicit UI scaling factor. When None, scaling is automatic.
         hdpi: Enable high-DPI awareness for the application. Default `True`.
         undecorated: Remove OS window decorations and draw a custom border.
-            Ignored on macOS. Build the title bar yourself with
-            `add_toolbar(show_window_controls=True)`.
+            Ignored on macOS. The shell gets a built-in draggable title bar with
+            min/max/close so it stays movable and closeable; add your own with
+            `add_toolbar(show_window_controls=True)` to take over the chrome.
         show_sidebar: Render the sidebar region. Default `True`.
         sidebar_mode: Initial sidebar mode — `'expanded'`/`'compact'`/`'hidden'`.
             `'compact'` (icon-only) applies only to a standalone static sidebar.
@@ -380,6 +381,7 @@ class AppShell(AppConfigMixin, WindowControlsMixin, ChromeHostMixin, PublicWidge
     ) -> None:
         self._statusbar: StatusBar | None = None
         self._rail: Rail | None = None
+        self._undecorated = undecorated
 
         # `show_sidebar=False` is the hidden mode (the model is the truth).
         if not show_sidebar:
@@ -736,6 +738,7 @@ class AppShell(AppConfigMixin, WindowControlsMixin, ChromeHostMixin, PublicWidge
 
     def run(self) -> None:
         """Show the window and start the event loop."""
+        self._ensure_default_titlebar()
         self._internal.deiconify()
         self._internal.mainloop()
 

--- a/src/bootstack/widgets/window.py
+++ b/src/bootstack/widgets/window.py
@@ -1,5 +1,6 @@
 ﻿from __future__ import annotations
 
+import sys
 from typing import TYPE_CHECKING, Any, Callable, Literal
 
 from bootstack.widgets._impl.primitives.flexframe import FlexFrame
@@ -82,6 +83,14 @@ class Window(WindowControlsMixin, ChromeHostMixin, FlexContainer):
         center_on_screen: Center on the screen.
         topmost: Keep the window above other windows.
         undecorated: Remove OS window decorations (`overrideredirect`).
+            Ignored on macOS. Unless `window_controls=False`, the window gets a
+            built-in draggable title bar with min/max/close so it stays movable
+            and closeable; add your own with `add_toolbar(show_window_controls=True)`
+            to take over the chrome.
+        window_controls: When `undecorated`, provide a built-in title bar with
+            window controls and dragging if you add no chrome toolbar of your
+            own. Set `False` for a truly chromeless window (e.g. a splash or
+            popover). Default `True`. No effect on a decorated window.
         window_style: Windows-only window effect. None inherits the app's setting.
         on_close: Callback invoked when the user clicks the close button.
             Return `False` to veto; return `None` or `True` to allow.
@@ -114,6 +123,7 @@ class Window(WindowControlsMixin, ChromeHostMixin, FlexContainer):
         center_on_screen: bool = False,
         topmost: bool = False,
         undecorated: bool = False,
+        window_controls: bool = True,
         window_style: WindowStyle | str | None = None,
         on_close: Callable[[], bool | None] | None = None,
         # Content frame layout
@@ -128,6 +138,10 @@ class Window(WindowControlsMixin, ChromeHostMixin, FlexContainer):
         from bootstack._runtime.toplevel import Toplevel as _InternalToplevel
 
         self._parent = None
+        # overrideredirect has no effect on macOS — so the borderless treatment
+        # (custom border + title bar) is Windows/Linux only.
+        self._undecorated = undecorated and sys.platform != "darwin"
+        self._window_controls = window_controls
 
         init_kwargs: dict[str, Any] = {
             "title": title,
@@ -184,10 +198,26 @@ class Window(WindowControlsMixin, ChromeHostMixin, FlexContainer):
         if surface is not None:
             frame_kwargs["surface"] = surface
 
-        self._content_frame = FlexFrame(self._tk_toplevel, **frame_kwargs)
+        # In undecorated mode the OS border is gone; a 1px themed border frame
+        # substitutes it and hosts both the chrome stack and the content. A
+        # chromeless window (`window_controls=False`, e.g. a splash) keeps no
+        # border either.
+        if self._undecorated and self._window_controls:
+            from bootstack.widgets._impl.primitives.frame import Frame
+
+            self._region_root = Frame(self._tk_toplevel, show_border=True, padding=1)
+            self._region_root.pack(fill="both", expand=True)
+        else:
+            self._region_root = self._tk_toplevel
+
+        self._content_frame = FlexFrame(self._region_root, **frame_kwargs)
         self._content_frame.pack(fill="both", expand=True)
 
         self._internal = self._tk_toplevel
+
+    def _toolbar_stack_parent(self) -> Any:
+        # The chrome stack lives inside the (bordered) region root, above content.
+        return getattr(self, "_region_root", self._tk_toplevel)
 
     @property
     def _flex_frame(self) -> Any:
@@ -228,6 +258,7 @@ class Window(WindowControlsMixin, ChromeHostMixin, FlexContainer):
         Returns:
             `self` — allows chaining: ``win = Window(...).show()``.
         """
+        self._ensure_default_titlebar()
         if anchor_to is not None:
             from bootstack._runtime.window_utilities import WindowPositioning
 
@@ -252,6 +283,7 @@ class Window(WindowControlsMixin, ChromeHostMixin, FlexContainer):
         Returns:
             The value of `result` at the time the window was closed.
         """
+        self._ensure_default_titlebar()
         return self._tk_toplevel.block_until_closed()
 
     # ----- Properties -----

--- a/tests/features/undecorated.py
+++ b/tests/features/undecorated.py
@@ -1,0 +1,6 @@
+import bootstack as bs
+
+with bs.App(size=(500, 500), undecorated=True) as app:
+    bs.Button("Hello World")
+
+app.run()

--- a/tests/widgets/public/test_undecorated_titlebar.py
+++ b/tests/widgets/public/test_undecorated_titlebar.py
@@ -1,0 +1,130 @@
+"""Auto-injected title bar for undecorated windows (#162).
+
+An undecorated App/Window with no author-supplied chrome gets a built-in,
+draggable title bar (min/max/close) so a borderless window is never stranded.
+`window_controls=False` (Window only) opts out. Structural — drives
+`ChromeHostMixin._ensure_default_titlebar` directly (no mainloop). One
+module-scoped root; Windows are Toplevels under it.
+"""
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+pytestmark = pytest.mark.gui
+
+_NOT_MAC = sys.platform != "darwin"
+_skip_mac = pytest.mark.skipif(not _NOT_MAC, reason="overrideredirect disabled on macOS")
+
+
+@pytest.fixture(scope="module")
+def app():
+    import bootstack as bs
+
+    app = bs.App(title="t", undecorated=True)
+    app._tk_root.withdraw()
+    try:
+        yield app
+    finally:
+        try:
+            app._tk_root.destroy()
+        except Exception:
+            pass
+
+
+def _has_controls(host) -> bool:
+    return any(
+        tb._internal.show_window_controls
+        for tb, _ in (getattr(host, "_chrome_toolbars", None) or [])
+    )
+
+
+def _reset_chrome(host) -> None:
+    for tb, _ in (getattr(host, "_chrome_toolbars", None) or []):
+        try:
+            tb._internal.destroy()
+        except Exception:
+            pass
+    host._chrome_toolbars = []
+
+
+@_skip_mac
+def test_app_undecorated_sets_override_redirect(app):
+    assert app._undecorated is True
+    assert bool(app._tk_root.overrideredirect())
+
+
+@_skip_mac
+def test_app_undecorated_draws_border(app):
+    # Undecorated => a 1px border frame wraps the content (not the bare root).
+    assert app._region_root is not app._tk_root
+
+
+@_skip_mac
+def test_injects_titlebar_when_undecorated_and_no_chrome(app):
+    _reset_chrome(app)
+    app._undecorated = True
+    app._ensure_default_titlebar()
+    assert _has_controls(app)
+
+
+def test_no_titlebar_when_decorated(app):
+    _reset_chrome(app)
+    app._undecorated = False
+    app._ensure_default_titlebar()
+    assert not _has_controls(app)
+    app._undecorated = True  # restore module default
+
+
+@_skip_mac
+def test_skips_when_author_added_own_toolbar(app):
+    # The author owns the chrome — no auto bar is layered on top.
+    _reset_chrome(app)
+    app._undecorated = True
+    app.add_toolbar()  # author chrome, no window controls
+    app._ensure_default_titlebar()
+    assert not _has_controls(app)
+
+
+@_skip_mac
+def test_idempotent(app):
+    _reset_chrome(app)
+    app._undecorated = True
+    app._ensure_default_titlebar()
+    n = len(app._chrome_toolbars)
+    app._ensure_default_titlebar()  # a second show/run is a no-op
+    assert len(app._chrome_toolbars) == n
+
+
+@_skip_mac
+def test_window_default_injects_and_borders(app):
+    import bootstack as bs
+
+    win = bs.Window(title="w", undecorated=True, parent=app)
+    try:
+        win._ensure_default_titlebar()
+        assert _has_controls(win)
+        assert win._region_root is not win._tk_toplevel  # bordered
+    finally:
+        try:
+            win._tk_toplevel.destroy()
+        except Exception:
+            pass
+
+
+@_skip_mac
+def test_window_controls_false_is_chromeless(app):
+    import bootstack as bs
+
+    # window_controls=False => fully chromeless: no title bar AND no border.
+    win = bs.Window(title="w2", undecorated=True, window_controls=False, parent=app)
+    try:
+        win._ensure_default_titlebar()
+        assert not _has_controls(win)
+        assert win._region_root is win._tk_toplevel  # no border wrapper
+    finally:
+        try:
+            win._tk_toplevel.destroy()
+        except Exception:
+            pass

--- a/tests/widgets/test_shell_toolbar.py
+++ b/tests/widgets/test_shell_toolbar.py
@@ -45,3 +45,26 @@ def test_shell_has_no_titlebar_accessor(shell):
     # The #162 titlebar band is retired — undecorated title bars are built with
     # add_toolbar(show_window_controls=True), so there is no shell.titlebar.
     assert not hasattr(shell, "titlebar")
+
+
+def test_undecorated_shell_injects_titlebar(shell):
+    # An undecorated shell with no author chrome gets a built-in window-controls
+    # title bar mounted into its own toolbar_stack region (#162). Runs last — it
+    # clears any chrome toolbars earlier tests added.
+    import sys
+
+    if sys.platform == "darwin":
+        pytest.skip("overrideredirect disabled on macOS")
+    for tb, _ in (getattr(shell, "_chrome_toolbars", None) or []):
+        try:
+            tb._internal.destroy()
+        except Exception:
+            pass
+    shell._chrome_toolbars = []
+    shell._undecorated = True
+    shell._ensure_default_titlebar()
+    bars = shell._chrome_toolbars or []
+    assert any(tb._internal.show_window_controls for tb, _ in bars)
+    # It mounted into the shell's stack region (above the body), not a base stack.
+    tb = bars[0][0]
+    assert tb._internal.winfo_parent().startswith(str(shell._internal.toolbar_stack))

--- a/tests/widgets/test_toolbar_drag.py
+++ b/tests/widgets/test_toolbar_drag.py
@@ -1,0 +1,85 @@
+"""Drag re-anchor math for un-maximizing an undecorated window (#165).
+
+Dragging a maximized window restores it to its normal size *under the cursor*.
+The grab offset is captured against the maximized width, so on restore the
+window must be repositioned to the cursor's same relative spot. Pure logic —
+`_on_drag_motion`'s zoomed branch is exercised against a stub toplevel, so no Tk
+root is needed.
+"""
+from __future__ import annotations
+
+from bootstack.widgets._impl.composites.toolbar import Toolbar
+
+
+class _StubWindow:
+    def __init__(self):
+        self._state = "zoomed"
+        self._w = 1920  # maximized width
+        self._x = 0
+        self._y = 0
+        self.geometry_calls: list[str] = []
+
+    def state(self, value=None):
+        if value is None:
+            return self._state
+        self._state = value
+        if value == "normal":
+            self._w = 800  # restored width
+
+    def winfo_width(self):
+        return self._w
+
+    def winfo_rootx(self):
+        return self._x
+
+    def winfo_rooty(self):
+        return self._y
+
+    def update_idletasks(self):
+        pass
+
+    def geometry(self, spec):
+        self.geometry_calls.append(spec)
+
+
+class _StubEvent:
+    def __init__(self, x_root, y_root):
+        self.x_root = x_root
+        self.y_root = y_root
+
+
+def _drag_motion(window, event):
+    tb = type(
+        "_TB",
+        (),
+        {
+            "winfo_toplevel": lambda self: window,
+            "_sync_maximize_icon": lambda self, name: None,
+            "_drag_start_x": 0,
+            "_drag_start_y": 0,
+        },
+    )()
+    Toolbar._on_drag_motion(tb, event)
+    return tb
+
+
+def test_unmaximize_reanchors_window_under_cursor():
+    # Cursor at the horizontal midpoint of the maximized window, on the title bar.
+    win = _StubWindow()
+    tb = _drag_motion(win, _StubEvent(x_root=960, y_root=10))
+    # frac_x = 960/1920 = 0.5 -> over the 800px restored width that's 400px in;
+    # new_x = 960 - 400 = 560. The 10px title-bar offset is preserved -> new_y = 0.
+    assert win.geometry_calls == ["+560+0"]
+    assert win.state() == "normal"
+    # The drag origin re-anchors to the current cursor for subsequent motion.
+    assert tb._drag_start_x == 960
+    assert tb._drag_start_y == 10
+
+
+def test_unmaximize_keeps_cursor_fraction_near_right_edge():
+    # Cursor near the right edge stays near the right edge of the restored window.
+    win = _StubWindow()
+    _drag_motion(win, _StubEvent(x_root=1824, y_root=5))  # 95% across, on the bar
+    # frac_x = 1824/1920 = 0.95 -> 0.95*800 = 760; new_x = 1824 - 760 = 1064.
+    # 5px title-bar offset preserved -> new_y = 0.
+    assert win.geometry_calls == ["+1064+0"]


### PR DESCRIPTION
## Summary

An `undecorated` window is no longer left stranded. Closes **#162** (lost window controls + chrome dragging) and **#165** (maximized-drag offset from cursor).

### #162 — batteries-included chrome for borderless windows
- New shared `ChromeHostMixin._ensure_default_titlebar()`: when a window is `undecorated` and the author added **no** chrome toolbar of their own, it injects one `add_toolbar(show_window_controls=True)` (min/max/close, draggable, double-click-maximize) labeled with the window title. No-op when decorated, on macOS, or when the author already built chrome. Idempotent. Called from `App.run()` / `AppShell.run()` / `Window.show()` / `Window.block_until_closed()`.
- A 1px themed **border** frame (the `_region_root` wrapper, mirroring `ShellLayout`) substitutes the missing OS border and hosts both the chrome stack and content.
- **`App`** gains an `undecorated` kwarg (it had none) — single-page apps can now go borderless and get controls + border automatically.
- **`AppShell`** already drew its border; now also auto-injects the title bar.
- **`Window`** gains `window_controls=True`; set `False` for a fully **chromeless** window (no controls, no border) — e.g. a splash or popover.
- Adding your own `add_toolbar(show_window_controls=True)` suppresses the built-in bar (you own the chrome).
- Windows/Linux only — `overrideredirect` is force-disabled on macOS, so `_undecorated` normalizes to `False` there.

### #165 — dragging a maximized window now tracks the cursor
The grab offset was captured against the maximized width, so restoring left the window offset from the pointer. On un-maximize we now recompute the cursor's horizontal fraction + title-bar offset and reposition the restored window so the pointer stays on the bar.

## Tests
- `tests/widgets/public/test_undecorated_titlebar.py` — injection, decorated-skip, author-chrome suppression, idempotency, border drawn, `Window` default vs. `window_controls=False` chromeless.
- `tests/widgets/test_toolbar_drag.py` — the #165 re-anchor math (deterministic, stub toplevel, no Tk).
- AppShell case added to `tests/widgets/test_shell_toolbar.py`; `test_add_toolbar.py` + `test_public_surface.py` still green.
- Clean Sphinx `-W` build.

## Docs
Rewrote the `app.rst` "Undecorated window" section (built-in by default; `add_toolbar` is the take-over path) and the `undecorated` docstrings on all three window types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
