### PR TITLE
fix(gauge): repaint canvas on theme change via the STD publisher (#167)

### DIFF
--- a/src/bootstack/widgets/_impl/composites/meter.py
+++ b/src/bootstack/widgets/_impl/composites/meter.py
@@ -163,7 +163,18 @@ class Meter(Frame):
         self._subtitle_text_id = None
 
         # update bindings
-        self._binding['<<ThemeChanged>>'] = self.bind('<<ThemeChanged>>', self._handle_theme_changed)
+        # The meter face / track / arc / text are painted imperatively onto the
+        # canvas, so they live outside the ttk style loop and must be re-resolved
+        # on a theme change. Subscribe to the STD publisher channel: it fires
+        # AFTER `_rebuild_all_styles()` (so the resolved colors are the new
+        # theme's), calls the handler directly (no virtual-event propagation to
+        # descendants), and is auto-released on `<Destroy>`. The old ttk
+        # `<<ThemeChanged>>` binding fired *before* the rebuild and raced it,
+        # leaving stale colors (#167). Same pattern as the Combobox popdown.
+        from bootstack._core.publisher import Channel, Publisher
+        name = str(self)
+        Publisher.subscribe(name=name, func=self._handle_theme_changed, channel=Channel.STD)
+        self.bind('<Destroy>', lambda _e, n=name: Publisher.unsubscribe(n), add='+')
         self._binding['<<Configure>>'] = self.bind('<<Configure>>', self._handle_theme_changed)
         self._bind_interactive_events()
         self._draw_base_meter_images()
@@ -761,12 +772,15 @@ class Meter(Frame):
 
         return int(normalized * self._arc_range + self._arc_offset)
 
-    def _handle_theme_changed(self, *_):
-        # Defer until after _rebuild_all_styles() has run so b.color() returns
-        # the new theme's colors, not the previous theme's.
+    def _handle_theme_changed(self, *_, **__):
+        # Accepts both the publisher's theme/mode kwargs and a Tk event arg.
+        # Coalesce a burst of notifications into one idle repaint; the colors are
+        # already the new theme's (the STD publisher fires after the rebuild).
         self.after_idle(self._apply_theme_update)
 
     def _apply_theme_update(self):
+        if not self.winfo_exists():
+            return
         self._resolve_meter_styles()
         self._canvas.configure(background=self._surface)
         self._draw_base_meter_images()

--- a/tests/widgets/test_gauge_theme.py
+++ b/tests/widgets/test_gauge_theme.py
@@ -1,0 +1,64 @@
+"""Gauge repaints its canvas on theme change (#167).
+
+The Gauge (internal Meter) paints its face / track / arc / text imperatively,
+outside the ttk style loop, so it re-resolves its colors via the STD publisher
+channel — which fires *after* the theme rebuild (the old ttk `<<ThemeChanged>>`
+binding fired before and raced it, leaving stale colors). Structural; one App
+per process.
+"""
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.gui
+
+
+@pytest.fixture(scope="module")
+def app():
+    import bootstack as bs
+
+    app = bs.App(theme="bootstrap-light")
+    app._tk_root.withdraw()
+    try:
+        yield app
+    finally:
+        try:
+            app._tk_root.destroy()
+        except Exception:
+            pass
+
+
+def test_gauge_canvas_repaints_on_theme_change(app):
+    import bootstack as bs
+
+    g = bs.Gauge(value=50)
+    app._tk_root.update_idletasks()
+    canvas = g._internal._canvas
+    light_bg = canvas.cget("background")
+
+    bs.set_theme("bootstrap-dark")
+    app._tk_root.update()
+    app._tk_root.update_idletasks()
+    dark_bg = canvas.cget("background")
+
+    assert dark_bg != light_bg, "gauge canvas kept the light-theme background"
+
+    bs.set_theme("bootstrap-light")
+    app._tk_root.update()
+    app._tk_root.update_idletasks()
+    assert canvas.cget("background") == light_bg
+
+
+def test_gauge_subscribes_and_releases(app):
+    import bootstack as bs
+    from bootstack._core.publisher import Publisher
+
+    base = Publisher.subscriber_count()
+    g = bs.Gauge(value=10)
+    app._tk_root.update_idletasks()
+    assert Publisher.subscriber_count() == base + 1
+
+    g._internal.destroy()
+    app._tk_root.update()
+    app._tk_root.update_idletasks()
+    assert Publisher.subscriber_count() == base


### PR DESCRIPTION
## Summary

Closes #167. The `Gauge` (internal `Meter`) keeps the previous theme's surface/colors after a theme switch — e.g. gauge faces stay white in dark mode while the rest of the UI updates.

The Meter paints its face / track / arc / text **imperatively onto a canvas**, so those colors live outside the ttk style loop. It was bound to the ttk `<<ThemeChanged>>` event, which fires **before** (and during) bootstack's `_rebuild_all_styles()` — so the repaint could resolve the *old* theme's colors.

### Fix
Switch to the established mechanism for raw/canvas widgets — subscribe to the `Publisher` `Channel.STD`:
- Fires **after** the rebuild (`style.py` publishes once the new colors are resolved) → no race.
- Calls the handler **directly** (no virtual-event propagation — `<<BsThemeChanged>>` is generated on the root and does not reach descendants; a self-bind to it never fires).
- Auto-released by the global `<Destroy>` net in `_runtime/app.py` (plus an explicit `unsubscribe`).
- Same pattern as the `Combobox` popdown. `_apply_theme_update` now guards on `winfo_exists()`.

## Tests
`tests/widgets/test_gauge_theme.py` — the canvas background flips light↔dark on theme change, and the subscriber is added on create / released on destroy (no leak).

## Follow-up
A separate audit (tracked in a new issue) covers other canvas widgets still on the racy `<<ThemeChanged>>` — `FloodGauge`, `Slider`, `RangeSlider`, and the code-editor textarea bindings — and standardizing the three theme-update mechanisms currently in the tree (publisher STD, root `<<BsThemeChanged>>`, ttk `<<ThemeChanged>>`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
