### PR TITLE
perf(gauge): defer off-screen theme repaints + fix stale face on return

### DIFF
--- a/src/bootstack/widgets/_impl/composites/meter.py
+++ b/src/bootstack/widgets/_impl/composites/meter.py
@@ -135,6 +135,9 @@ class Meter(Frame):
         self._towards_maximum = True
         self._resolve_arc_range_offset(meter_type, arc_offset, arc_range)
         self._binding = {}
+        # Set when a theme change arrives while the meter is off-screen, so the
+        # expensive supersampled redraw is deferred to the next <Map>.
+        self._theme_update_pending = False
 
         # widget variables
         self._last_changed_value = value
@@ -175,6 +178,8 @@ class Meter(Frame):
         name = str(self)
         Publisher.subscribe(name=name, func=self._handle_theme_changed, channel=Channel.STD)
         self.bind('<Destroy>', lambda _e, n=name: Publisher.unsubscribe(n), add='+')
+        # A theme change that arrives while off-screen defers its redraw to here.
+        self.bind('<Map>', self._on_meter_map, add='+')
         self._binding['<<Configure>>'] = self.bind('<<Configure>>', self._handle_theme_changed)
         self._bind_interactive_events()
         self._draw_base_meter_images()
@@ -781,10 +786,30 @@ class Meter(Frame):
     def _apply_theme_update(self):
         if not self.winfo_exists():
             return
+        # Re-resolving colors is cheap; the supersampled image redraw is not. If
+        # the meter is off-screen (e.g. a non-active page), skip the redraw and
+        # mark it pending — the next <Map> repaints it once with current colors.
+        # This keeps a theme toggle from repainting every gauge in the app.
         self._resolve_meter_styles()
         self._canvas.configure(background=self._surface)
+        if not self.winfo_viewable():
+            self._theme_update_pending = True
+            return
+        self._theme_update_pending = False
         self._draw_base_meter_images()
         self._draw_meter()
+
+    def _on_meter_map(self, _event: Any = None) -> None:
+        """Repaint on map if a theme change was missed while off-screen.
+
+        Re-runs the full apply (now that the meter is viewable) so the canvas
+        background is re-configured too — not just the arc/text images — since the
+        face surface can be reset to the default when the page is re-mapped.
+        """
+        if getattr(self, '_theme_update_pending', False):
+            # Defer to idle so the repaint runs after the map cascade settles
+            # (the canvas background can be reset to the default during mapping).
+            self.after_idle(self._apply_theme_update)
 
     def _handle_interaction(self, e):
         """Handle mouse clicks/drags to update meter value in interactive mode."""

--- a/tests/widgets/test_gauge_theme.py
+++ b/tests/widgets/test_gauge_theme.py
@@ -49,6 +49,33 @@ def test_gauge_canvas_repaints_on_theme_change(app):
     assert canvas.cget("background") == light_bg
 
 
+def test_offscreen_theme_change_defers_expensive_redraw(app):
+    # A theme change while the gauge is off-screen must NOT run the expensive
+    # supersampled redraw (so toggling the theme doesn't repaint every gauge in
+    # the app); it marks the repaint pending and runs once when next viewable.
+    import bootstack as bs
+
+    g = bs.Gauge(value=50)
+    app._tk_root.update_idletasks()
+    m = g._internal
+
+    calls = {"n": 0}
+    m._draw_base_meter_images = lambda: calls.__setitem__("n", calls["n"] + 1)
+
+    # Off-screen: defer.
+    m.winfo_viewable = lambda: False
+    m._theme_update_pending = False
+    m._apply_theme_update()
+    assert m._theme_update_pending is True
+    assert calls["n"] == 0  # expensive redraw skipped while hidden
+
+    # Viewable: repaint now, clear pending.
+    m.winfo_viewable = lambda: True
+    m._apply_theme_update()
+    assert m._theme_update_pending is False
+    assert calls["n"] == 1
+
+
 def test_gauge_subscribes_and_releases(app):
     import bootstack as bs
     from bootstack._core.publisher import Publisher


### PR DESCRIPTION
## Summary

Follow-up to #167 (PR #176), from real-demo testing.

Two problems with the publisher-driven repaint:
1. **Slow** — it repainted **every** gauge in the app on each theme toggle, including off-screen ones. Each repaint is a supersampled PIL redraw (cost grows with display scaling), so a toggle was sluggish on pages/apps with several gauges.
2. **Stale face on return** — a gauge whose theme changed while it was on a hidden page could come back with a **white face**: the canvas background is reset to the default during re-map, and the repaint wasn't re-applying it.

## Fix
On a theme change, re-resolve colors (cheap) and reconfigure the canvas background, but **skip the expensive supersampled redraw when the gauge isn't viewable** — mark it pending instead. Repaint once on the next `<Map>`, **deferred to idle** so it runs after the map cascade settles (which otherwise resets the background → the white-face bug).

Net: a theme toggle now repaints only the gauges actually on screen; navigating to a page repaints its gauges correctly to the current theme.

## Tests
`tests/widgets/test_gauge_theme.py` gains an off-screen-defer case (resolve + skip redraw while not viewable; repaint when viewable). All pass.

## Notes
A broader perf lever exists (the supersample `image_scale` dominates redraw cost and balloons on HiDPI) — tracked separately, not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
