### PR TITLE
perf(gauge): cap the supersample factor so HiDPI doesn't balloon redraws

### DIFF
--- a/src/bootstack/widgets/_impl/composites/meter.py
+++ b/src/bootstack/widgets/_impl/composites/meter.py
@@ -467,7 +467,13 @@ class Meter(Frame):
         value_text_color = b.color(accent_token)
         secondary_text_color = b.color(self._secondary_style or 'background[muted]')
 
-        self._image_scale = b.scale(DEFAULT_IMAGE_SCALE)
+        # Supersample factor for antialiasing: the meter is drawn at
+        # `size * image_scale` then downscaled to the gauge's *logical* size, so
+        # the extra resolution `b.scale()` adds for the display's DPI is thrown
+        # away by the downscale — pure waste that balloons the redraw on HiDPI
+        # (a 200px gauge at 2x DPI would supersample to 2400px²). Cap it at the
+        # base factor: identical output at standard DPI, ~2-4x cheaper on HiDPI.
+        self._image_scale = min(b.scale(DEFAULT_IMAGE_SCALE), DEFAULT_IMAGE_SCALE)
         self._accent_color = accent_color
         self._surface = surface  # Store resolved color
         self._trough_color = trough_color

--- a/tests/widgets/test_gauge_theme.py
+++ b/tests/widgets/test_gauge_theme.py
@@ -76,6 +76,26 @@ def test_offscreen_theme_change_defers_expensive_redraw(app):
     assert calls["n"] == 1
 
 
+def test_supersample_scale_capped_on_hidpi(app):
+    # The supersample is downscaled to the gauge's logical size, so the DPI
+    # multiplier b.scale() adds is wasted; it must be capped at the base factor
+    # so a HiDPI display does not balloon the redraw.
+    import bootstack as bs
+    from bootstack.style.style import get_style
+    from bootstack.widgets._impl.composites import meter as meter_mod
+
+    g = bs.Gauge(value=50)
+    m = g._internal
+    b = get_style().style_builder
+    orig = b.scale
+    b.scale = lambda v: v * 3  # pretend a 3x HiDPI display
+    try:
+        m._resolve_meter_styles()
+        assert m._image_scale == meter_mod.DEFAULT_IMAGE_SCALE  # capped, not 18
+    finally:
+        b.scale = orig
+
+
 def test_gauge_subscribes_and_releases(app):
     import bootstack as bs
     from bootstack._core.publisher import Publisher


### PR DESCRIPTION
## Summary

Speeds up gauge redraws, especially on HiDPI displays.

Profiling a gauge redraw showed the cost is almost entirely `_draw_meter`'s **copy + downscale of a supersampled image** sized `gauge_size × image_scale`, where `image_scale = b.scale(6)` is multiplied by the display's DPI scaling. But that supersample is then downscaled back to the gauge's **logical** size — so the DPI-added resolution is **discarded**. On a 2× display a 200px gauge supersamples to ~2400px² and throws most of it away.

## Fix
Cap `image_scale` at the base factor (`DEFAULT_IMAGE_SCALE`):
- **Standard DPI:** the cap doesn't bind → output is **identical** (verified: `image_scale` unchanged, render unchanged).
- **HiDPI:** supersample is ~2–4× smaller → per-gauge redraw drops proportionally, for **both** theme repaints and live value updates (animated gauges call the same path each tick).

Quality-neutral by construction — the final image is downscaled to the logical size regardless of supersample factor; the cap only removes resolution the downscale was discarding.

## Tests
`test_gauge_theme.py` adds a cap assertion (simulates a 3× display via `scale()` and checks `image_scale` is capped, not 18). All 4 gauge tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
