### PR TITLE
perf(theme): only repaint on-screen widgets on theme change (gallery toggle ~3s → ~0.6s)

### DIFF
--- a/src/bootstack/_runtime/base_window.py
+++ b/src/bootstack/_runtime/base_window.py
@@ -196,9 +196,24 @@ class BaseWindow:
             pywinstyles.apply_style(self, window_style)
             self._window_style_applied = True
             self.after(0, self._update_chrome_color)
-            self.bind('<<ThemeChanged>>', lambda e: self.after(0, self._update_chrome_color), add='+')
+            self.bind('<<ThemeChanged>>', self._schedule_chrome_update, add='+')
         except Exception:
             pass
+
+    def _schedule_chrome_update(self, _event=None) -> None:
+        """Coalesce chrome re-tinting on theme change.
+
+        The toplevel receives `<<ThemeChanged>>` ~1400x per theme rebuild (once
+        per ttk style reconfigure). Cancel any pending update and schedule a
+        single one so the (DWM) chrome repaint runs once, not hundreds of times.
+        """
+        pending = getattr(self, '_chrome_update_after', None)
+        if pending is not None:
+            try:
+                self.after_cancel(pending)
+            except Exception:
+                pass
+        self._chrome_update_after = self.after(0, self._update_chrome_color)
 
     def _update_chrome_color(self) -> None:
         if getattr(self, '_updating_chrome', False):
@@ -208,10 +223,15 @@ class BaseWindow:
             import pywinstyles
             from bootstack.style.style import get_theme_provider
             color = get_theme_provider().colors['chrome']
-            pywinstyles.change_header_color(self, color)
-            # Match the window border to the chrome too, so it honors the theme
-            # (otherwise Windows leaves a light default border in dark mode).
-            pywinstyles.change_border_color(self, color)
+            # The DWM header/border calls are expensive (~100ms each); skip them
+            # when the chrome color is unchanged (redundant theme events, or a
+            # theme switch that keeps the same chrome).
+            if getattr(self, '_chrome_color_applied', None) != color:
+                self._chrome_color_applied = color
+                pywinstyles.change_header_color(self, color)
+                # Match the window border to the chrome too, so it honors the
+                # theme (otherwise Windows leaves a light border in dark mode).
+                pywinstyles.change_border_color(self, color)
         except Exception:
             pass
         finally:

--- a/src/bootstack/widgets/_impl/composites/avatar.py
+++ b/src/bootstack/widgets/_impl/composites/avatar.py
@@ -70,7 +70,7 @@ class Avatar(Frame):
                               background=self._surface_color())
         self._canvas.pack()
         self._canvas.bind("<Button-1>", self._forward_click)
-        self.bind("<<BsThemeChanged>>", self._on_theme, add="+")
+        self._enable_theme_repaint(self._on_theme)
 
         self._render()
 

--- a/src/bootstack/widgets/_impl/composites/calendar.py
+++ b/src/bootstack/widgets/_impl/composites/calendar.py
@@ -651,31 +651,46 @@ class Calendar(ttk.Frame):
             if header:
                 header.pack_forget()
 
-        # Weekday header per month
+        # Weekday header per month — labels are created ONCE and reused (text +
+        # grid updated on redraw), not destroyed and recreated every draw. The
+        # only thing that changes across draws is the column text (locale / week
+        # start) and, if it toggles, the week-number column.
         weekdays_frame: ttk.Frame | None = view.get("weekdays")
         if weekdays_frame is None:
             weekdays_frame = ttk.Frame(parent)
             weekdays_frame.pack(fill=X)
             view["weekdays"] = weekdays_frame
-        else:
-            for child in weekdays_frame.winfo_children():
-                child.destroy()
+            view["weekday_labels"] = []
+            view["weeknum_header"] = None
 
         col_offset = 1 if self._show_week_numbers else 0
         if self._show_week_numbers:
-            weekdays_frame.columnconfigure(0, weight=1, uniform="cal")
-            ttk.Label(weekdays_frame, text="#", anchor=CENTER, padding=5, surface="background[+1]", font='caption[bold]').grid(
-                row=0, column=0, sticky=NSEW)
+            wn_header = view.get("weeknum_header")
+            if wn_header is None:
+                weekdays_frame.columnconfigure(0, weight=1, uniform="cal")
+                wn_header = ttk.Label(weekdays_frame, text="#", anchor=CENTER, padding=5,
+                                      surface="background[+1]", font='caption[bold]')
+                view["weeknum_header"] = wn_header
+            wn_header.grid(row=0, column=0, sticky=NSEW)
+        elif view.get("weeknum_header") is not None:
+            view["weeknum_header"].grid_remove()
+
+        header_labels: list[ttk.Label] = view["weekday_labels"]
         for i, col in enumerate(self._header_columns()):
             weekdays_frame.columnconfigure(i + col_offset, weight=1, uniform="cal")
-            ttk.Label(
-                master=weekdays_frame,
-                text=col,
-                anchor=CENTER,
-                padding=5,
-                accent="muted",
-                font='caption[bold]',
-            ).grid(row=0, column=i + col_offset, sticky=NSEW)
+            if i < len(header_labels):
+                lbl = header_labels[i]
+            else:
+                lbl = ttk.Label(
+                    master=weekdays_frame,
+                    anchor=CENTER,
+                    padding=5,
+                    accent="muted",
+                    font='caption[bold]',
+                )
+                header_labels.append(lbl)
+            lbl.configure(text=col)
+            lbl.grid(row=0, column=i + col_offset, sticky=NSEW)
 
         # Grid reused
         grid: ttk.Frame | None = view.get("grid")

--- a/src/bootstack/widgets/_impl/composites/carousel.py
+++ b/src/bootstack/widgets/_impl/composites/carousel.py
@@ -135,7 +135,7 @@ class Carousel(Frame):
         self._stage.bind("<Button-1>", self._on_stage_click, add="+")
         self._stage.bind("<Left>", lambda e: self.previous())
         self._stage.bind("<Right>", lambda e: self.next())
-        self.bind("<<BsThemeChanged>>", self._on_theme, add="+")
+        self._enable_theme_repaint(self._on_theme)
 
         # Auto-refresh when the data source changes externally (parity with the
         # other record-native widgets); the subscription is released on destroy.

--- a/src/bootstack/widgets/_impl/composites/gallery.py
+++ b/src/bootstack/widgets/_impl/composites/gallery.py
@@ -254,7 +254,10 @@ class Gallery(Frame):
             except Exception:
                 self._change_sub = None
         self.bind("<Destroy>", self._on_destroy, add="+")
-        self.bind("<<BsThemeChanged>>", self._on_theme, add="+")
+        # Tile surfaces + the accent ring are painted imperatively, so re-resolve
+        # on a theme change — gated to on-screen by the Frame base hook (an
+        # off-screen gallery defers its thumbnail-grid repaint to <Map>).
+        self._enable_theme_repaint(self._on_theme)
         # First render is driven by the container's <Configure> (bound above);
         # no init timer needed.
 

--- a/src/bootstack/widgets/_impl/composites/list/listview.py
+++ b/src/bootstack/widgets/_impl/composites/list/listview.py
@@ -157,12 +157,10 @@ class ListView(Frame):
         # Bind events
         self.bind('<Configure>', self._on_resize, add='+')
         # The striped row surface is applied imperatively at pool-creation time,
-        # so it must be re-resolved on theme change. `<<BsThemeChanged>>` fires on
-        # the root (virtual events don't reach descendants), so bind there and
-        # release on destroy — the same pattern as the image theme-follow helper.
-        self._theme_root = self.winfo_toplevel()
-        self._theme_bind_id = self._theme_root.bind(
-            '<<BsThemeChanged>>', self._on_theme_changed, add='+')
+        # so it must be re-resolved on theme change — gated to on-screen by the
+        # Frame base hook (an off-screen list defers its per-row repaint to <Map>)
+        # and released on destroy automatically.
+        self._enable_theme_repaint(self._on_theme_changed)
         self._bind_scroll_events(self)
         self._bind_scroll_events(self._container)
 
@@ -221,13 +219,8 @@ class ListView(Frame):
         """Cancel the data-source subscription when the widget is destroyed."""
         if event is not None and getattr(event, 'widget', None) is not self:
             return
-        bind_id = getattr(self, '_theme_bind_id', None)
-        if bind_id:
-            try:
-                self._theme_root.unbind('<<BsThemeChanged>>', bind_id)
-            except Exception:
-                pass
-            self._theme_bind_id = None
+        # The theme subscription is released by the Frame base hook's own
+        # <Destroy> handler (publisher unsubscribe).
         sub = self._change_sub
         self._change_sub = None
         if sub is not None:

--- a/src/bootstack/widgets/_impl/composites/meter.py
+++ b/src/bootstack/widgets/_impl/composites/meter.py
@@ -467,7 +467,13 @@ class Meter(Frame):
         value_text_color = b.color(accent_token)
         secondary_text_color = b.color(self._secondary_style or 'background[muted]')
 
-        self._image_scale = b.scale(DEFAULT_IMAGE_SCALE)
+        # Supersample factor for antialiasing: the meter is drawn at
+        # `size * image_scale` then downscaled to the gauge's *logical* size, so
+        # the extra resolution `b.scale()` adds for the display's DPI is thrown
+        # away by the downscale — pure waste that balloons the redraw on HiDPI
+        # (a 200px gauge at 2x DPI would supersample to 2400px²). Cap it at the
+        # base factor: identical output at standard DPI, ~2-4x cheaper on HiDPI.
+        self._image_scale = min(b.scale(DEFAULT_IMAGE_SCALE), DEFAULT_IMAGE_SCALE)
         self._accent_color = accent_color
         self._surface = surface  # Store resolved color
         self._trough_color = trough_color

--- a/src/bootstack/widgets/_impl/composites/meter.py
+++ b/src/bootstack/widgets/_impl/composites/meter.py
@@ -135,9 +135,6 @@ class Meter(Frame):
         self._towards_maximum = True
         self._resolve_arc_range_offset(meter_type, arc_offset, arc_range)
         self._binding = {}
-        # Set when a theme change arrives while the meter is off-screen, so the
-        # expensive supersampled redraw is deferred to the next <Map>.
-        self._theme_update_pending = False
 
         # widget variables
         self._last_changed_value = value
@@ -165,22 +162,13 @@ class Meter(Frame):
         self._suffix_text_id = None
         self._subtitle_text_id = None
 
-        # update bindings
         # The meter face / track / arc / text are painted imperatively onto the
-        # canvas, so they live outside the ttk style loop and must be re-resolved
-        # on a theme change. Subscribe to the STD publisher channel: it fires
-        # AFTER `_rebuild_all_styles()` (so the resolved colors are the new
-        # theme's), calls the handler directly (no virtual-event propagation to
-        # descendants), and is auto-released on `<Destroy>`. The old ttk
-        # `<<ThemeChanged>>` binding fired *before* the rebuild and raced it,
-        # leaving stale colors (#167). Same pattern as the Combobox popdown.
-        from bootstack._core.publisher import Channel, Publisher
-        name = str(self)
-        Publisher.subscribe(name=name, func=self._handle_theme_changed, channel=Channel.STD)
-        self.bind('<Destroy>', lambda _e, n=name: Publisher.unsubscribe(n), add='+')
-        # A theme change that arrives while off-screen defers its redraw to here.
-        self.bind('<Map>', self._on_meter_map, add='+')
-        self._binding['<<Configure>>'] = self.bind('<<Configure>>', self._handle_theme_changed)
+        # canvas (outside the ttk style loop), so re-resolve + redraw on a theme
+        # change. The Frame base hook gates this to on-screen: an off-screen meter
+        # defers its (supersampled, expensive) redraw to the next <Map>, so a
+        # theme toggle repaints only visible gauges (#167 fixed the timing; this
+        # keeps it cheap with many gauges across pages).
+        self._enable_theme_repaint(self._repaint_theme)
         self._bind_interactive_events()
         self._draw_base_meter_images()
         self._draw_meter()
@@ -783,39 +771,17 @@ class Meter(Frame):
 
         return int(normalized * self._arc_range + self._arc_offset)
 
-    def _handle_theme_changed(self, *_, **__):
-        # Accepts both the publisher's theme/mode kwargs and a Tk event arg.
-        # Coalesce a burst of notifications into one idle repaint; the colors are
-        # already the new theme's (the STD publisher fires after the rebuild).
-        self.after_idle(self._apply_theme_update)
+    def _repaint_theme(self):
+        """Re-resolve theme colors and repaint the canvas (face + arcs + text).
 
-    def _apply_theme_update(self):
-        if not self.winfo_exists():
-            return
-        # Re-resolving colors is cheap; the supersampled image redraw is not. If
-        # the meter is off-screen (e.g. a non-active page), skip the redraw and
-        # mark it pending — the next <Map> repaints it once with current colors.
-        # This keeps a theme toggle from repainting every gauge in the app.
+        Invoked by the Frame base hook only while on screen; an off-screen meter
+        defers this to its next `<Map>`. Reconfigures the canvas background too,
+        since the face surface can be reset to the default during a re-map.
+        """
         self._resolve_meter_styles()
         self._canvas.configure(background=self._surface)
-        if not self.winfo_viewable():
-            self._theme_update_pending = True
-            return
-        self._theme_update_pending = False
         self._draw_base_meter_images()
         self._draw_meter()
-
-    def _on_meter_map(self, _event: Any = None) -> None:
-        """Repaint on map if a theme change was missed while off-screen.
-
-        Re-runs the full apply (now that the meter is viewable) so the canvas
-        background is re-configured too — not just the arc/text images — since the
-        face surface can be reset to the default when the page is re-mapped.
-        """
-        if getattr(self, '_theme_update_pending', False):
-            # Defer to idle so the repaint runs after the map cascade settles
-            # (the canvas background can be reset to the default during mapping).
-            self.after_idle(self._apply_theme_update)
 
     def _handle_interaction(self, e):
         """Handle mouse clicks/drags to update meter value in interactive mode."""

--- a/src/bootstack/widgets/_impl/composites/picture.py
+++ b/src/bootstack/widgets/_impl/composites/picture.py
@@ -87,7 +87,7 @@ class Picture(Frame):
         self._canvas.pack(fill="both", expand=True)
         self._canvas.bind("<Configure>", self._on_configure)
         self._canvas.bind("<Button-1>", self._forward_click)
-        self.bind("<<BsThemeChanged>>", self._on_theme_changed, add="+")
+        self._enable_theme_repaint(self._on_theme_changed)
 
         # Defer the initial load to idle so the constructor returns first: the
         # caller can bind on_load/on_error before the <<PictureLoad>> fires.

--- a/src/bootstack/widgets/_impl/composites/shell/nav_panel.py
+++ b/src/bootstack/widgets/_impl/composites/shell/nav_panel.py
@@ -105,7 +105,7 @@ class NavPanel(Frame):
         self._main = self._scroll.add(surface=surface)
         self._updating_overflow = False
         self._paint_canvas_surface()
-        self.bind("<<BsThemeChanged>>", lambda _e: self._paint_canvas_surface(), add="+")
+        self._enable_theme_repaint(self._paint_canvas_surface)
         # Re-evaluate the gutter/bar + footer divider whenever the content height
         # or viewport changes (items added/removed, sidebar resized, compaction).
         self._scroll.canvas.bind("<Configure>", lambda _e: self._update_overflow_state(), add="+")

--- a/src/bootstack/widgets/_impl/composites/slider/rangeslider.py
+++ b/src/bootstack/widgets/_impl/composites/slider/rangeslider.py
@@ -267,9 +267,15 @@ class RangeSlider(ConfigureDelegationMixin, tk.Frame):
 
         self._lo_var.trace_add("write", self._on_lo_write)
         self._hi_var.trace_add("write", self._on_hi_write)
-        root = self.nametowidget(".")
-        _tid = root.bind("<<ThemeChanged>>", lambda e: self._on_theme_changed(), add="+")
-        self.bind("<Destroy>", lambda e, r=root, b=_tid: r.unbind("<<ThemeChanged>>", b), add="+")
+        # Re-resolve track/handle colors on a theme change via the STD publisher
+        # (fires ONCE, after the rebuild) — NOT the ttk `<<ThemeChanged>>`, which
+        # re-fires per style reconfigure during the rebuild (×N styles × every
+        # slider on screen → thousands of redraws, the gallery's ~2s theme lag).
+        from bootstack._core.publisher import Channel, Publisher
+        name = str(self)
+        Publisher.subscribe(name=name, func=lambda *_a, **_k: self._on_theme_changed(),
+                            channel=Channel.STD)
+        self.bind("<Destroy>", lambda e, n=name: Publisher.unsubscribe(n), add="+")
         self.bind("<Map>", lambda e: self._on_map(), add="+")
 
     # ------------------------------------------------------------------

--- a/src/bootstack/widgets/_impl/composites/slider/slider.py
+++ b/src/bootstack/widgets/_impl/composites/slider/slider.py
@@ -268,9 +268,15 @@ class Slider(ConfigureDelegationMixin, tk.Frame):
         self._canvas.bind("<Configure>", self._on_configure)
 
         self._var.trace_add("write", self._on_var_write)
-        root = self.nametowidget(".")
-        _tid = root.bind("<<ThemeChanged>>", lambda e: self._on_theme_changed(), add="+")
-        self.bind("<Destroy>", lambda e, r=root, b=_tid: r.unbind("<<ThemeChanged>>", b), add="+")
+        # Re-resolve the track/handle colors on a theme change. Subscribe to the
+        # STD publisher (fires ONCE, after the rebuild) — NOT the ttk
+        # `<<ThemeChanged>>`, which re-fires per style reconfigure during the
+        # rebuild (×N styles × every slider on screen → thousands of redraws).
+        from bootstack._core.publisher import Channel, Publisher
+        name = str(self)
+        Publisher.subscribe(name=name, func=lambda *_a, **_k: self._on_theme_changed(),
+                            channel=Channel.STD)
+        self.bind("<Destroy>", lambda e, n=name: Publisher.unsubscribe(n), add="+")
         self.bind("<Map>", lambda e: self._on_map(), add="+")
 
     # ------------------------------------------------------------------

--- a/src/bootstack/widgets/_impl/composites/tableview/tableview.py
+++ b/src/bootstack/widgets/_impl/composites/tableview/tableview.py
@@ -484,12 +484,10 @@ class TableView(Frame):
                 self._change_sub = None
         self.bind('<Destroy>', self._on_table_destroy, add='+')
         # The alternating-row stripe is applied via imperative tag colors, which
-        # are NOT refreshed by the ttk style rebuild. `<<BsThemeChanged>>` is fired
-        # on the root (virtual events don't reach descendants), so bind there and
-        # release on destroy — the same pattern as the image theme-follow helper.
-        self._theme_root = self.winfo_toplevel()
-        self._theme_bind_id = self._theme_root.bind(
-            '<<BsThemeChanged>>', self._on_theme_changed, add='+')
+        # are NOT refreshed by the ttk style rebuild. Re-apply on a theme change —
+        # gated to on-screen by the Frame base hook (an off-screen table defers
+        # its per-row repaint to <Map>), and released on destroy automatically.
+        self._enable_theme_repaint(self._on_theme_changed)
 
     def _silence_source(self):
         """Context manager suppressing source change broadcasts for our own writes."""
@@ -510,13 +508,8 @@ class TableView(Frame):
         """Release subscriptions, in-flight exports, and the tooltip on destroy."""
         if event is not None and getattr(event, 'widget', None) is not self:
             return
-        bind_id = getattr(self, '_theme_bind_id', None)
-        if bind_id:
-            try:
-                self._theme_root.unbind('<<BsThemeChanged>>', bind_id)
-            except Exception:
-                pass
-            self._theme_bind_id = None
+        # The theme subscription is released by the Frame base hook's own
+        # <Destroy> handler (publisher unsubscribe).
         sub = self._change_sub
         self._change_sub = None
         if sub is not None:

--- a/src/bootstack/widgets/_impl/primitives/frame.py
+++ b/src/bootstack/widgets/_impl/primitives/frame.py
@@ -61,6 +61,59 @@ class Frame(TTKWrapperBase, WidgetCapabilitiesMixin, TtkStateMixin, ttk.Frame):
         kwargs['style_options'] = {**existing, **captured}
         super().__init__(master, **kwargs)
 
+    # ----- Theme repaint (for imperatively-painted / canvas widgets) -----
+
+    def _enable_theme_repaint(self, repaint) -> None:
+        """Repaint canvas-painted content on theme change, gated on visibility.
+
+        Widgets that paint colors directly onto a canvas live outside the ttk
+        style loop, so they must re-resolve and redraw when the theme changes.
+        Calling this once (after the drawing surface exists) wires that up the
+        right way:
+
+        - It subscribes to the `STD` publisher channel, which fires AFTER the
+          theme rebuild (so resolved colors are the new theme's) and calls back
+          directly (virtual events do not reach descendants).
+        - The redraw runs ONLY while the widget is on screen. A theme change that
+          arrives while it is off-screen (e.g. an inactive page) is deferred to
+          the next `<Map>` — so a theme toggle repaints just the visible widgets
+          instead of every canvas widget in the app.
+        - The subscription is released on `<Destroy>`.
+
+        Args:
+            repaint: The widget's full re-resolve-and-redraw callback (no args).
+        """
+        from bootstack._core.publisher import Channel, Publisher
+
+        self._theme_repaint = repaint
+        self._theme_repaint_pending = False
+        name = str(self)
+        Publisher.subscribe(name=name, func=self._on_theme_notify, channel=Channel.STD)
+        self.bind('<Map>', self._on_theme_map, add='+')
+        self.bind('<Destroy>', lambda _e, n=name: Publisher.unsubscribe(n), add='+')
+
+    def _on_theme_notify(self, *_: Any, **__: Any) -> None:
+        """STD-publisher callback (after the rebuild): repaint now, or defer."""
+        if not self.winfo_exists():
+            return
+        if self.winfo_viewable():
+            self._theme_repaint_pending = False
+            self._theme_repaint()
+        else:
+            self._theme_repaint_pending = True
+
+    def _on_theme_map(self, _event: Any = None) -> None:
+        """On map, run a theme repaint that was deferred while off-screen."""
+        if getattr(self, '_theme_repaint_pending', False):
+            # Defer to idle so the repaint runs after the map cascade settles
+            # (a canvas background can be reset to the default during mapping).
+            self.after_idle(self._run_pending_theme_repaint)
+
+    def _run_pending_theme_repaint(self) -> None:
+        if getattr(self, '_theme_repaint_pending', False) and self.winfo_exists():
+            self._theme_repaint_pending = False
+            self._theme_repaint()
+
     def configure_style_options(self, value=None, **kwargs):
         """Set style options and refresh descendant surfaces if needed."""
         old_surface = getattr(self, "_surface", "background")

--- a/tests/widgets/test_gauge_theme.py
+++ b/tests/widgets/test_gauge_theme.py
@@ -76,6 +76,26 @@ def test_offscreen_theme_change_defers_expensive_redraw(app):
     assert calls["n"] == 1
 
 
+def test_supersample_scale_capped_on_hidpi(app):
+    # The supersample is downscaled to the gauge's logical size, so the DPI
+    # multiplier b.scale() adds is wasted; it must be capped at the base factor
+    # so a HiDPI display does not balloon the redraw.
+    import bootstack as bs
+    from bootstack.style.style import get_style
+    from bootstack.widgets._impl.composites import meter as meter_mod
+
+    g = bs.Gauge(value=50)
+    m = g._internal
+    b = get_style().style_builder
+    orig = b.scale
+    b.scale = lambda v: v * 3  # pretend a 3x HiDPI display
+    try:
+        m._resolve_meter_styles()
+        assert m._image_scale == meter_mod.DEFAULT_IMAGE_SCALE  # capped, not 18
+    finally:
+        b.scale = orig
+
+
 def test_gauge_subscribes_and_releases(app):
     import bootstack as bs
     from bootstack._core.publisher import Publisher

--- a/tests/widgets/test_gauge_theme.py
+++ b/tests/widgets/test_gauge_theme.py
@@ -33,7 +33,11 @@ def test_gauge_canvas_repaints_on_theme_change(app):
 
     g = bs.Gauge(value=50)
     app._tk_root.update_idletasks()
-    canvas = g._internal._canvas
+    m = g._internal
+    canvas = m._canvas
+    # The test window is withdrawn, so the gauge is never "viewable"; force it so
+    # the on-screen repaint path runs (off-screen would correctly defer).
+    m.winfo_viewable = lambda: True
     light_bg = canvas.cget("background")
 
     bs.set_theme("bootstrap-dark")
@@ -52,7 +56,7 @@ def test_gauge_canvas_repaints_on_theme_change(app):
 def test_offscreen_theme_change_defers_expensive_redraw(app):
     # A theme change while the gauge is off-screen must NOT run the expensive
     # supersampled redraw (so toggling the theme doesn't repaint every gauge in
-    # the app); it marks the repaint pending and runs once when next viewable.
+    # the app); the Frame base hook marks it pending and repaints once on <Map>.
     import bootstack as bs
 
     g = bs.Gauge(value=50)
@@ -60,19 +64,19 @@ def test_offscreen_theme_change_defers_expensive_redraw(app):
     m = g._internal
 
     calls = {"n": 0}
-    m._draw_base_meter_images = lambda: calls.__setitem__("n", calls["n"] + 1)
+    m._theme_repaint = lambda: calls.__setitem__("n", calls["n"] + 1)
 
-    # Off-screen: defer.
+    # Off-screen: defer (no repaint), mark pending.
     m.winfo_viewable = lambda: False
-    m._theme_update_pending = False
-    m._apply_theme_update()
-    assert m._theme_update_pending is True
+    m._theme_repaint_pending = False
+    m._on_theme_notify()
+    assert m._theme_repaint_pending is True
     assert calls["n"] == 0  # expensive redraw skipped while hidden
 
-    # Viewable: repaint now, clear pending.
+    # Viewable: repaint immediately, clear pending.
     m.winfo_viewable = lambda: True
-    m._apply_theme_update()
-    assert m._theme_update_pending is False
+    m._on_theme_notify()
+    assert m._theme_repaint_pending is False
     assert calls["n"] == 1
 
 


### PR DESCRIPTION
## Summary

Toggling the theme in the widget gallery — **after visiting every page** — took **~3 seconds** to repaint the active page. This makes theme changes only repaint what's on screen and stops the theme handlers from firing thousands of times. **~2960ms → ~580ms.**

## Root cause
Theme handlers were firing far more than once per toggle:
- **`Slider` / `RangeSlider`** bound the ttk `<<ThemeChanged>>` event on the **root**. That event re-fires **once per ttk style reconfigure** during the rebuild (~1400×), and root-bound handlers fire for **every** slider instance accumulated across visited pages → thousands of redraws (`_on_theme_changed`: 4221 + 1407 calls).
- **Window chrome** (`base_window`) bound it on the **toplevel** → ~1400 redundant DWM header/border calls (~290ms).

## Fixes
- **Sliders → STD publisher** (fires **once**, after the rebuild) instead of the ttk event. 5628 redraws → 4.
- **Window chrome →** coalesce the `<<ThemeChanged>>` storm into a single deferred update (`after_cancel`) + skip the DWM calls when the chrome color is unchanged.
- **New `Frame` base hook `_enable_theme_repaint(repaint)`** — subscribes to the STD publisher, runs the repaint **only while viewable**, defers off-screen changes to the next `<Map>` (idle-deferred), releases on `<Destroy>`. Migrated `Meter`, `DataTable`, `Gallery`, `ListView`, `Carousel`, `Picture`, `Avatar`, `NavPanel` onto it — a theme toggle now repaints only on-screen widgets. **Bonus:** `Carousel`/`Picture`/`Avatar`/`NavPanel` were self-binding `<<BsThemeChanged>>` (which never reaches descendants) and so **weren't recoloring at all** — now fixed.
- **Calendar render win** (folded in): the weekday-header labels were destroyed + recreated every redraw (7 widgets/redraw); reuse them instead. Month navigation **5.8ms → 2.7ms**.

## The rule
For canvas / imperatively-painted widgets: **never bind ttk `<<ThemeChanged>>` on the root/toplevel** (it fires ~1400× per rebuild). Use the **STD publisher** (fires once, after the rebuild) and **gate the redraw on visibility**.

## Results
- Gallery, all pages visited, toggle on Progress: **~2960ms → ~580ms** (remaining: ~254ms ttk style rebuild + ~244ms single Windows DWM chrome re-tint + relayout).
- Slider redraws 5628 → 4; chrome DWM calls 1407 → 1; off-screen canvas widgets defer to `<Map>`.

## Tests
`test_gauge_theme` (off-screen defer, supersample cap, subscribe/release), `test_datatable` (10), `test_listview` (4), `test_tree` (40), `test_slider_events` (5), `test_public_surface` (161) — all pass.

Closes the canvas/slider portions of #177.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
