### PR TITLE
docs(src): convert RST double-backticks to single backticks in docstrings

### DIFF
--- a/src/bootstack/__init__.py
+++ b/src/bootstack/__init__.py
@@ -11,9 +11,9 @@ Example:
     app.run()
     ```
 
-The top-level ``bootstack`` namespace holds what you *compose a UI* with: every
-widget, ``App``/``AppShell``/``Window``, ``Signal``, the dialog verbs
-(``alert``/``confirm``/``ask_*``/``toast``), and ``set_theme``/``toggle_theme``.
+The top-level `bootstack` namespace holds what you *compose a UI* with: every
+widget, `App`/`AppShell`/`Window`, `Signal`, the dialog verbs
+(`alert`/`confirm`/`ask_*`/`toast`), and `set_theme`/`toggle_theme`.
 Framework primitives you reference *by type to configure behavior* live in
 submodules — for example::
 

--- a/src/bootstack/_core/images.py
+++ b/src/bootstack/_core/images.py
@@ -354,9 +354,9 @@ class _ImageService:
         LANCZOS blur at non-integer DPI scale factors (e.g., 125%, 150%).
 
         Args:
-            name: Bootstrap icon name (e.g., ``"house"``, ``"arrow-right-fill"``).
+            name: Bootstrap icon name (e.g., `"house"`, `"arrow-right-fill"`).
             size: Requested pixel size. Snapped to the nearest even integer.
-            color: Foreground color as a hex string (e.g., ``"#ffffff"``).
+            color: Foreground color as a hex string (e.g., `"#ffffff"`).
 
         Returns:
             A cached Tk-compatible PhotoImage for the icon.

--- a/src/bootstack/_runtime/app.py
+++ b/src/bootstack/_runtime/app.py
@@ -476,10 +476,10 @@ class App(BaseWindow, WidgetCapabilitiesMixin, tkinter.Tk):
             override_redirect: If `True`, creates a window without standard
                 decorations (title bar, borders, etc.).
             center_on_screen: If True (default), center the app window on
-                the screen when ``mainloop()`` starts.
+                the screen when `mainloop()` starts.
             on_close: Callback invoked when the user clicks the close button.
-                Return ``False`` to veto the close; return ``None`` or ``True``
-                to allow it. Equivalent to calling ``add_close_handler(fn)``
+                Return `False` to veto the close; return `None` or `True`
+                to allow it. Equivalent to calling `add_close_handler(fn)`
                 after construction.
             **kwargs: Additional keyword arguments to pass to the
                 underlying `tkinter.Tk` constructor.

--- a/src/bootstack/_runtime/base_window.py
+++ b/src/bootstack/_runtime/base_window.py
@@ -342,9 +342,9 @@ class BaseWindow:
     def _close_dispatch(self) -> None:
         """WM_DELETE_WINDOW handler that runs registered close handlers.
 
-        Runs each handler in registration order. If any returns ``False`` the
-        close is vetoed and the window stays open. If all pass (return ``None``
-        or ``True``), ``_do_close()`` is called to perform the actual close.
+        Runs each handler in registration order. If any returns `False` the
+        close is vetoed and the window stays open. If all pass (return `None`
+        or `True`), `_do_close()` is called to perform the actual close.
         """
         for handler in list(getattr(self, '_close_handlers', [])):
             try:
@@ -359,7 +359,7 @@ class BaseWindow:
         """Perform the default close action.
 
         Subclasses may override this to change what happens after all handlers
-        pass. The default is ``self.destroy()``.
+        pass. The default is `self.destroy()`.
         """
         try:
             self.destroy()
@@ -370,8 +370,8 @@ class BaseWindow:
         """Close the window programmatically, bypassing the close handlers.
 
         This is the uniform close contract every top-level window honors. It
-        performs the default close action directly (``_do_close()``), so the
-        veto handlers registered with ``add_close_handler()`` — which guard the
+        performs the default close action directly (`_do_close()`), so the
+        veto handlers registered with `add_close_handler()` — which guard the
         user clicking the window's close button — are not run. The application
         root overrides this to quit its event loop instead.
         """
@@ -380,13 +380,13 @@ class BaseWindow:
     def add_close_handler(self, callback: Callable[[], bool | None]) -> None:
         """Register a callback invoked when the window's close button is clicked.
 
-        Handlers are called in registration order. Return ``False`` from a
-        handler to veto the close; return ``None`` or ``True`` to allow it.
+        Handlers are called in registration order. Return `False` from a
+        handler to veto the close; return `None` or `True` to allow it.
         All handlers that pass are run before the window closes.
 
         Args:
             callback: Called with no arguments when close is requested.
-                Return ``False`` to cancel the close, ``None`` or ``True`` to proceed.
+                Return `False` to cancel the close, `None` or `True` to proceed.
         """
         self._init_close_handlers()
         self._close_handlers.append(callback)
@@ -645,12 +645,12 @@ class BaseWindow:
     def on_close(self, handler: Callable[[], bool | None]) -> None:
         """Register a handler for the window close button.
 
-        Equivalent to ``add_close_handler(handler)``. Handlers are called in
-        registration order; return ``False`` to veto the close.
+        Equivalent to `add_close_handler(handler)`. Handlers are called in
+        registration order; return `False` to veto the close.
 
         Args:
             handler: Called with no arguments when close is requested.
-                Return ``False`` to cancel, ``None`` or ``True`` to proceed.
+                Return `False` to cancel, `None` or `True` to proceed.
         """
         self.add_close_handler(handler)
 

--- a/src/bootstack/_runtime/toplevel.py
+++ b/src/bootstack/_runtime/toplevel.py
@@ -69,9 +69,9 @@ class Toplevel(BaseWindow, WidgetCapabilitiesMixin, tkinter.Toplevel):
             window_style: Windows-only pywinstyles effect. Options include
                 'mica', 'acrylic', 'aero', 'transparent', 'win7', etc.
                 Defaults to 'mica'. Set to None to disable.
-            modal: Modality level. ``False`` (default) — non-modal. ``True`` or
-                ``"window"`` — window-level modal: grabs input from parent only.
-                ``"app"`` — app-level modal: grabs input from all windows.
+            modal: Modality level. `False` (default) — non-modal. `True` or
+                `"window"` — window-level modal: grabs input from parent only.
+                `"app"` — app-level modal: grabs input from all windows.
                 When modal is truthy and `transient` is not set, a transient
                 parent is inferred from `master` or the current app.
             center_on_parent: If True, center this window over its transient
@@ -81,8 +81,8 @@ class Toplevel(BaseWindow, WidgetCapabilitiesMixin, tkinter.Toplevel):
             center_on_screen: If True, center this window on the screen.
                 Ignored when `position` or `center_on_parent` is given.
             on_close: Callback invoked when the user clicks the close button.
-                Return ``False`` to veto the close; return ``None`` or ``True``
-                to allow it. Equivalent to calling ``add_close_handler(fn)``
+                Return `False` to veto the close; return `None` or `True`
+                to allow it. Equivalent to calling `add_close_handler(fn)`
                 after construction.
             **kwargs: Other keyword arguments passed to `tkinter.Toplevel`.
         """
@@ -220,8 +220,8 @@ class Toplevel(BaseWindow, WidgetCapabilitiesMixin, tkinter.Toplevel):
     def result(self) -> Any:
         """Value set by the window's content before it closes.
 
-        Defaults to ``None``. Set this attribute before calling
-        ``destroy()`` to return a value from ``block_until_closed()``.
+        Defaults to `None`. Set this attribute before calling
+        `destroy()` to return a value from `block_until_closed()`.
 
         See [block_until_closed()][bootstack.Toplevel.block_until_closed].
         """
@@ -234,18 +234,18 @@ class Toplevel(BaseWindow, WidgetCapabilitiesMixin, tkinter.Toplevel):
     def block_until_closed(self) -> Any:
         """Show this window and block until it is destroyed.
 
-        Calls ``show()`` to make the window visible, then enters a nested
-        event loop via ``wait_window()`` that blocks until the window is
-        destroyed. Returns ``self.result``.
+        Calls `show()` to make the window visible, then enters a nested
+        event loop via `wait_window()` that blocks until the window is
+        destroyed. Returns `self.result`.
 
-        Set ``self.result`` (or ``self.result = value``) before calling
-        ``destroy()`` to pass a return value back to the caller.
+        Set `self.result` (or `self.result = value`) before calling
+        `destroy()` to pass a return value back to the caller.
 
         Returns:
-            The value of ``self.result`` at the time the window was destroyed.
+            The value of `self.result` at the time the window was destroyed.
 
         Note:
-            Do not call this from within an existing ``block_until_closed()``
+            Do not call this from within an existing `block_until_closed()`
             chain unless you understand the implications of nested event loops.
         """
         self.show()

--- a/src/bootstack/cli/add.py
+++ b/src/bootstack/cli/add.py
@@ -261,8 +261,8 @@ def run_add_i18n(args: argparse.Namespace) -> None:
     """Add internationalization support to the project.
 
     By default this scaffolds a Python translations module (the simplest path -
-    no tooling, bundled with your code). With ``--po`` it scaffolds ``.po``
-    catalog files in ``assets/`` for a file-based workflow.
+    no tooling, bundled with your code). With `--po` it scaffolds `.po`
+    catalog files in `assets/` for a file-based workflow.
     """
     languages = args.languages
 

--- a/src/bootstack/cli/appicon.py
+++ b/src/bootstack/cli/appicon.py
@@ -2,7 +2,7 @@
 
 Launches a small bootstack app that previews an `AppIcon` live as you adjust the
 glyph, colors, and corner radius, then exports it (`.ico`/`.icns`/`.png`) or
-copies a ready-to-paste ``[build.icon]`` snippet for ``bootstack.toml``.
+copies a ready-to-paste `[build.icon]` snippet for `bootstack.toml`.
 """
 from __future__ import annotations
 

--- a/src/bootstack/constants.py
+++ b/src/bootstack/constants.py
@@ -4,7 +4,7 @@ This module provides symbolic string constants for use with tkinter geometry
 managers, widget states, and other APIs that accept fixed string values.
 
 Type aliases (Literal types for type checking) live in
-``bootstack.widgets.types`` and are re-exported here for convenience.
+`bootstack.widgets.types` and are re-exported here for convenience.
 
 Example::
 
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 from typing import Final, Literal
 
-# Re-export type aliases from widgets.types so ``from bootstack.constants import *``
+# Re-export type aliases from widgets.types so `from bootstack.constants import *`
 # continues to work as before.
 from bootstack.widgets.types import (
     Anchor,
@@ -44,18 +44,18 @@ TkBoolean = Literal[0, 1, True, False]
 """Tk-style boolean: 0/1 or True/False."""
 
 State = Literal['normal', 'disabled', 'active', 'hidden', 'readonly']
-"""Full widget state set including ``'hidden'`` (Canvas) and ``'readonly'`` (ttk).
-For ttk widget construction kwargs prefer ``WidgetState`` from ``bootstack.widgets.types``.
+"""Full widget state set including `'hidden'` (Canvas) and `'readonly'` (ttk).
+For ttk widget construction kwargs prefer `WidgetState` from `bootstack.widgets.types`.
 """
 
 MenuItemType = Literal['cascade', 'checkbutton', 'command', 'radiobutton', 'separator']
-"""Menu item type for ``tk.Menu.add_*`` calls."""
+"""Menu item type for `tk.Menu.add_*` calls."""
 
 ActiveStyle = Literal['none', 'dotbox', 'underline']
-"""Active-item highlight style for ``tk.Listbox``."""
+"""Active-item highlight style for `tk.Listbox`."""
 
 PieStyle = Literal['pieslice', 'chord', 'arc']
-"""Arc/pie style for ``Canvas.create_arc``."""
+"""Arc/pie style for `Canvas.create_arc`."""
 
 LineCap = Literal['butt', 'projecting', 'round']
 """Line cap style for Canvas lines."""
@@ -67,7 +67,7 @@ IndexPos = Literal['first', 'last']
 """Named index positions used by several widget methods."""
 
 ViewArg = Literal['moveto', 'scroll', 'units', 'pages']
-"""Arguments accepted by ``xview()`` / ``yview()`` scroll methods."""
+"""Arguments accepted by `xview()` / `yview()` scroll methods."""
 
 TtkTheme = Literal['clam', 'alt', 'default']
 """Built-in base ttk theme names."""
@@ -79,10 +79,10 @@ Align = Literal['baseline']
 """Text alignment for embedded windows/images in the Text widget."""
 
 Wrap = Literal['none', 'char', 'word']
-"""Text wrapping mode for the ``tk.Text`` widget."""
+"""Text wrapping mode for the `tk.Text` widget."""
 
 SelectMode = Literal['single', 'browse', 'multiple', 'extended']
-"""Item selection mode for ``tk.Listbox``."""
+"""Item selection mode for `tk.Listbox`."""
 
 ProgressMode = Literal['determinate', 'indeterminate']
 """Progress mode for the Progressbar widget."""

--- a/src/bootstack/data/file_source.py
+++ b/src/bootstack/data/file_source.py
@@ -12,9 +12,9 @@ store, never written back. Save changes by exporting to a new file.
 Working store (where the ingested data lives):
     - default: a temporary on-disk SQLite file, removed on `close()` — bounded
       memory even for millions of rows.
-    - ``cache="path.db"``: a named, persistent store. Edits survive restarts, and
+    - `cache="path.db"`: a named, persistent store. Edits survive restarts, and
       re-opening skips re-ingest while the cache is newer than the source file.
-    - ``cache=":memory:"``: an in-memory store — compact, but RAM-bound.
+    - `cache=":memory:"`: an in-memory store — compact, but RAM-bound.
 
 Transformation pipeline (applied per record during ingest):
     column selection / renames / default values / type conversions / per-column
@@ -160,7 +160,7 @@ class FileDataSource(SqliteDataSource):
         cache: Working store location. None (default) uses a temporary on-disk
             file removed on `close()`. A path names a persistent store whose data
             survives restarts (and is reused without re-ingest while it is newer
-            than the source). ``":memory:"`` keeps the store in memory.
+            than the source). `":memory:"` keeps the store in memory.
         id_field: Record field used as the stable row identity.
 
     Attributes:

--- a/src/bootstack/data/writers.py
+++ b/src/bootstack/data/writers.py
@@ -187,7 +187,7 @@ def write_json(path: "str | Path", records: "Iterable[Record]", config: "Optiona
 def write_xml(path: "str | Path", records: "Iterable[Record]", config: "Optional[FileSourceConfig]" = None) -> None:
     """Write records as XML, streaming one record element at a time.
 
-    Each record becomes a ``<record>`` element (or ``config.xml_record_tag``) whose
+    Each record becomes a `<record>` element (or `config.xml_record_tag`) whose
     child elements are the record's fields.
     """
     record_tag = getattr(config, "xml_record_tag", None) or "record"

--- a/src/bootstack/dialogs/_impl/__init__.py
+++ b/src/bootstack/dialogs/_impl/__init__.py
@@ -1,20 +1,20 @@
 """Internal dialog implementations.
 
 The Bootstrap-styled dialog building blocks behind the public dialog API. The
-curated public surface — the ``alert`` / ``confirm`` / ``ask_*`` verbs and the
-``Dialog`` / ``FormDialog`` / ``FontDialog`` / ``ColorChooserDialog`` /
-``FilterDialog`` classes — lives in ``bootstack.dialogs``; import from there, not
+curated public surface — the `alert` / `confirm` / `ask_*` verbs and the
+`Dialog` / `FormDialog` / `FontDialog` / `ColorChooserDialog` /
+`FilterDialog` classes — lives in `bootstack.dialogs`; import from there, not
 from this package.
 
 Modules here:
 
-- ``message`` (MessageBox/MessageDialog): info/warning/error/question prompts
-- ``query`` (QueryBox/QueryDialog): collect input (string, number, date, item, …)
-- ``colorchooser`` / ``colordropper``: color picker and screen dropper
-- ``datedialog``: calendar date picker
-- ``fontdialog``: font selection
-- ``filterdialog``: multi-select filter dialog with search
-- ``dialog``: the base ``Dialog`` / ``DialogButton``
+- `message` (MessageBox/MessageDialog): info/warning/error/question prompts
+- `query` (QueryBox/QueryDialog): collect input (string, number, date, item, …)
+- `colorchooser` / `colordropper`: color picker and screen dropper
+- `datedialog`: calendar date picker
+- `fontdialog`: font selection
+- `filterdialog`: multi-select filter dialog with search
+- `dialog`: the base `Dialog` / `DialogButton`
 """
 from .colorchooser import (
     ColorChooser,

--- a/src/bootstack/i18n/__init__.py
+++ b/src/bootstack/i18n/__init__.py
@@ -1,8 +1,8 @@
 """Localization for bootstack.
 
-Public API: ``L`` (lazy translated text) and ``LV`` (lazy locale-formatted
-value), used wherever a widget takes text. ``MessageCatalog`` (the gettext /
-Tcl-msgcat bridge) and ``IntlFormatter`` (the Babel value formatter) are the
+Public API: `L` (lazy translated text) and `LV` (lazy locale-formatted
+value), used wherever a widget takes text. `MessageCatalog` (the gettext /
+Tcl-msgcat bridge) and `IntlFormatter` (the Babel value formatter) are the
 internal engines behind them — importable for internal use but not part of the
 public API.
 """

--- a/src/bootstack/i18n/catalog.py
+++ b/src/bootstack/i18n/catalog.py
@@ -1,7 +1,7 @@
 """Public helpers for extending the runtime translation catalog.
 
-Widget text is localized automatically: in the default ``localize_mode="auto"``,
-a plain string such as ``bs.Label("Save")`` is translated through the catalog
+Widget text is localized automatically: in the default `localize_mode="auto"`,
+a plain string such as `bs.Label("Save")` is translated through the catalog
 when a translation is registered for the current locale, and left as-is
 otherwise. These functions register your own strings so that auto-localization
 (and the explicit :func:`~bootstack.i18n.L` spec) can resolve them.
@@ -25,7 +25,7 @@ __all__ = ["add_translation", "add_translations", "load_po", "load_translations"
 def _resolve_asset(path: Union[str, PathLike[str]]) -> Path:
     """Resolve a project asset path in both a dev run and a packaged build.
 
-    A relative path is tried under the PyInstaller bundle (``sys._MEIPASS``)
+    A relative path is tried under the PyInstaller bundle (`sys._MEIPASS`)
     first, then relative to the working directory (the dev case).
     """
     p = Path(path)

--- a/src/bootstack/i18n/specs.py
+++ b/src/bootstack/i18n/specs.py
@@ -56,9 +56,9 @@ class LocalizedTextSpec(LocalizedSpec):
     def resolve(self, locale: str) -> str:
         """Resolve to translated text using MessageCatalog.
 
-        Looks the key up in the catalog, then applies Python ``str.format``
+        Looks the key up in the catalog, then applies Python `str.format`
         interpolation with any positional/keyword arguments — so placeholders use
-        ``{0}`` / ``{name}`` style.
+        `{0}` / `{name}` style.
 
         Args:
             locale: The locale code (unused, MessageCatalog uses its own state).

--- a/src/bootstack/images.py
+++ b/src/bootstack/images.py
@@ -277,7 +277,7 @@ class Image:
     def _materialize(self, master=None) -> "_Photo":
         """Render the source to a cached display image and return it.
 
-        The ``master`` is accepted for interface symmetry; the backing service
+        The `master` is accepted for interface symmetry; the backing service
         renders against the default application root, which exists by the time a
         handle is bound to a widget.
         """

--- a/src/bootstack/scheduling/__init__.py
+++ b/src/bootstack/scheduling/__init__.py
@@ -1,7 +1,7 @@
 """Deferred and repeating task scheduling tied to a widget's lifetime.
 
-Every public widget exposes a ``Schedule`` via its ``schedule`` property; each
-scheduling call returns a cancellable ``Job``.
+Every public widget exposes a `Schedule` via its `schedule` property; each
+scheduling call returns a cancellable `Job`.
 """
 from bootstack.scheduling._schedule import Job, Schedule
 

--- a/src/bootstack/shortcuts.py
+++ b/src/bootstack/shortcuts.py
@@ -1,7 +1,7 @@
 """Cross-platform keyboard shortcuts — the public home for the shortcut service.
 
-Register named shortcuts with platform-agnostic patterns (``Mod+S`` becomes
-``Ctrl+S`` on Windows/Linux and ``⌘S`` on macOS), bind them to an app, and let
+Register named shortcuts with platform-agnostic patterns (`Mod+S` becomes
+`Ctrl+S` on Windows/Linux and `⌘S` on macOS), bind them to an app, and let
 menus display the resolved shortcut text automatically.
 
 Usage::

--- a/src/bootstack/streams/__init__.py
+++ b/src/bootstack/streams/__init__.py
@@ -1,8 +1,8 @@
 """Composable event-stream pipelines for bootstack widgets.
 
-Call an ``on_*()`` shorthand with no handler to get a ``Stream``; chain
-operators (``map``, ``filter``, ``debounce``, …) and finish with ``listen()``,
-which returns a cancellable ``Handle``.
+Call an `on_*()` shorthand with no handler to get a `Stream`; chain
+operators (`map`, `filter`, `debounce`, …) and finish with `listen()`,
+which returns a cancellable `Handle`.
 """
 from bootstack.streams._stream import Handle, Stream
 

--- a/src/bootstack/style/typography.py
+++ b/src/bootstack/style/typography.py
@@ -459,7 +459,7 @@ class Font:
     """
     Resolves a font token string to a live Tk font object.
 
-    Accepts the same token syntax as the ``font=`` argument on any widget:
+    Accepts the same token syntax as the `font=` argument on any widget:
       Font("body[bold]")
       Font("heading-lg[+1][italic]")
       Font("[16][bold]")            # default token + size/mods
@@ -467,8 +467,8 @@ class Font:
     Use it for text measurement or to pass a resolved font to a raw Tk widget.
 
     Args:
-        value: Font token string (e.g. ``'body[bold]'``, ``'heading-md[italic]'``).
-        default_token: Token to use when ``value`` has no token prefix. Defaults to ``'body'``.
+        value: Font token string (e.g. `'body[bold]'`, `'heading-md[italic]'`).
+        default_token: Token to use when `value` has no token prefix. Defaults to `'body'`.
     """
 
     __slots__ = ("spec", "_tkfont")

--- a/src/bootstack/widgets/__init__.py
+++ b/src/bootstack/widgets/__init__.py
@@ -1,8 +1,8 @@
 """Widget package for bootstack.
 
 Public widgets are lazily importable from this package — e.g.
-``from bootstack.widgets import Button`` — mirroring the canonical
-``import bootstack as bs; bs.Button`` access. Resolution is lazy (PEP 562)
+`from bootstack.widgets import Button` — mirroring the canonical
+`import bootstack as bs; bs.Button` access. Resolution is lazy (PEP 562)
 so importing the package does not eagerly pull in every widget module.
 """
 from typing import Any

--- a/src/bootstack/widgets/_core/base.py
+++ b/src/bootstack/widgets/_core/base.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 def adapt_handler(handler: Callable[[Any], Any]) -> Callable[[Any], Any]:
     """Wrap a public handler so it receives a bootstack event, not a raw one.
 
-    Data-carrying events (emitted with ``data=<payload>``) deliver the payload
+    Data-carrying events (emitted with `data=<payload>`) deliver the payload
     object directly — the handler argument *is* the payload. Native/context
     events carry no payload, so the raw toolkit event is curated into a clean
     :class:`~bootstack.events.Event` first.

--- a/src/bootstack/widgets/_core/field_mixin.py
+++ b/src/bootstack/widgets/_core/field_mixin.py
@@ -167,21 +167,21 @@ class FieldAddonMixin:
         """Add a validation rule to the field.
 
         Rules run automatically on blur or key events depending on the rule
-        type, or manually via ``validate()``. Multiple rules can be added;
+        type, or manually via `validate()`. Multiple rules can be added;
         they are evaluated in order and stop at the first failure.
 
         Args:
             rule_type: The kind of validation rule to apply.
             **kwargs: Rule-specific options:
 
-                - ``message`` *(all rules)* — override the default error message.
-                - ``trigger`` *(all rules)* — when to run: ``'always'`` (key and
-                  blur), ``'key'``, ``'blur'``, or ``'manual'``. Each rule type
+                - `message` *(all rules)* — override the default error message.
+                - `trigger` *(all rules)* — when to run: `'always'` (key and
+                  blur), `'key'`, `'blur'`, or `'manual'`. Each rule type
                   has its own sensible default (see the Validation reference).
-                - ``min``, ``max`` *(stringLength)* — minimum/maximum character count.
-                - ``pattern`` *(pattern)* — regex string the value must match.
-                - ``other_field`` *(compare)* — field whose value must match.
-                - ``func`` *(custom)* — callable ``(value: str) -> bool``.
+                - `min`, `max` *(stringLength)* — minimum/maximum character count.
+                - `pattern` *(pattern)* — regex string the value must match.
+                - `other_field` *(compare)* — field whose value must match.
+                - `func` *(custom)* — callable `(value: str) -> bool`.
 
         Example::
 

--- a/src/bootstack/widgets/_impl/composites/compositeframe.py
+++ b/src/bootstack/widgets/_impl/composites/compositeframe.py
@@ -98,8 +98,8 @@ class Composite:
         """Remove a widget from state synchronization.
 
         Call this before destroying a registered child so that later state
-        updates do not touch a dead widget (which raises ``TclError: invalid
-        command name``).
+        updates do not touch a dead widget (which raises `TclError: invalid
+        command name`).
 
         Args:
             widget: A previously registered widget.

--- a/src/bootstack/widgets/_impl/composites/picture.py
+++ b/src/bootstack/widgets/_impl/composites/picture.py
@@ -1,12 +1,12 @@
 """Internal Picture composite — a canvas-backed image display.
 
 Renders a single image (or an animated sequence) into a themed canvas, fitting
-it to the canvas's allocated size with a CSS ``object-fit``-style policy. The
+it to the canvas's allocated size with a CSS `object-fit`-style policy. The
 public `bootstack.Picture` wrapper drives this; nothing here is public.
 
 The canvas (not a Label) is the backing widget on purpose: it does not
 shrink-wrap to the image, it reports its allocated pixel size through
-``<Configure>``, and it letterboxes cleanly behind a fitted image.
+`<Configure>`, and it letterboxes cleanly behind a fitted image.
 """
 
 from __future__ import annotations

--- a/src/bootstack/widgets/_impl/composites/slider/_shared.py
+++ b/src/bootstack/widgets/_impl/composites/slider/_shared.py
@@ -68,7 +68,7 @@ def _make_track(
 ) -> PhotoImage | None:
     """Render a slider track (trough + fill region) as a PhotoImage.
 
-    When ``vertical=True`` the image is rotated 90° CCW so the fill region
+    When `vertical=True` the image is rotated 90° CCW so the fill region
     appears at the bottom of the returned (tall) image.
     """
     if track_w < 1:
@@ -93,10 +93,10 @@ def _make_track(
 
 
 def get_widget_bg(widget: object) -> str | None:
-    """Return a widget's rendered background as a ``#rrggbb`` hex string.
+    """Return a widget's rendered background as a `#rrggbb` hex string.
 
-    Tries ``cget('background')`` first (tk widgets), then falls back to the
-    ttk Style lookup (ttk widgets). Returns ``None`` when neither works.
+    Tries `cget('background')` first (tk widgets), then falls back to the
+    ttk Style lookup (ttk widgets). Returns `None` when neither works.
     """
     if widget is None:
         return None
@@ -129,11 +129,11 @@ def resolve_colors(accent: str, surface: str, bg_override: str | None = None) ->
     """Resolve all slider colors from theme tokens.
 
     Args:
-        accent: Accent token (e.g., ``'primary'``, ``'success'``).
-        surface: Surface token (e.g., ``'content'``, ``'card'``).
-        bg_override: Explicit hex background color (``'#rrggbb'``) to use
+        accent: Accent token (e.g., `'primary'`, `'success'`).
+        surface: Surface token (e.g., `'content'`, `'card'`).
+        bg_override: Explicit hex background color (`'#rrggbb'`) to use
             instead of the theme default. Pass the result of
-            ``get_widget_bg(master)`` to make the slider blend with its
+            `get_widget_bg(master)` to make the slider blend with its
             container surface.
 
     Returns:

--- a/src/bootstack/widgets/_impl/composites/slider/rangeslider.py
+++ b/src/bootstack/widgets/_impl/composites/slider/rangeslider.py
@@ -24,12 +24,12 @@ class RangeSlider(ConfigureDelegationMixin, tk.Frame):
     """A themed two-handle range slider widget.
 
     Provides a low-value and high-value handle that define a selected range
-    within ``[minvalue, maxvalue]``.  Both handles are keyboard-accessible
-    and cycle with ``Tab``.
+    within `[minvalue, maxvalue]`.  Both handles are keyboard-accessible
+    and cycle with `Tab`.
 
-    Current range is accessible via ``lovalue`` / ``hivalue`` properties,
-    ``get_lo()`` / ``get_hi()`` / ``set_lo()`` / ``set_hi()`` methods, or
-    bound ``lo_variable`` / ``hi_variable`` / ``lo_signal`` / ``hi_signal``.
+    Current range is accessible via `lovalue` / `hivalue` properties,
+    `get_lo()` / `get_hi()` / `set_lo()` / `set_hi()` methods, or
+    bound `lo_variable` / `hi_variable` / `lo_signal` / `hi_signal`.
     """
 
     def __init__(
@@ -61,11 +61,11 @@ class RangeSlider(ConfigureDelegationMixin, tk.Frame):
             master: Parent widget.
             minvalue: Minimum bound of the slider range.
             maxvalue: Maximum bound of the slider range.
-            lovalue: Initial low-handle value. Ignored when ``lo_variable``
-                or ``lo_signal`` is provided.
-            hivalue: Initial high-handle value. Ignored when ``hi_variable``
-                or ``hi_signal`` is provided.
-            orient: Orientation — ``'horizontal'`` or ``'vertical'``.
+            lovalue: Initial low-handle value. Ignored when `lo_variable`
+                or `lo_signal` is provided.
+            hivalue: Initial high-handle value. Ignored when `hi_variable`
+                or `hi_signal` is provided.
+            orient: Orientation — `'horizontal'` or `'vertical'`.
             accent: Accent token controlling fill, handles, and focus ring color.
             surface: Surface token for trough and background color context.
             lo_variable: Tkinter DoubleVar bound to the low-handle value.
@@ -74,13 +74,13 @@ class RangeSlider(ConfigureDelegationMixin, tk.Frame):
                 See [tkinter Variables](https://docs.python.org/3/library/tkinter.html#tkinter-variables).
             lo_signal: Reactive Signal linked to the low-handle value.
             hi_signal: Reactive Signal linked to the high-handle value.
-            state: Widget state — ``'normal'`` or ``'disabled'``.
+            state: Widget state — `'normal'` or `'disabled'`.
             show_value: Show floating badges above/beside each handle displaying
                 their current values.
-            tick_interval: Spacing between major tick marks. ``None`` disables ticks.
+            tick_interval: Spacing between major tick marks. `None` disables ticks.
             minor_ticks: Number of minor tick marks between each major tick.
             tick_labels: Show numeric labels at major tick positions.
-            tick_format: Format string for tick and badge labels (e.g. ``"{:.1f}°C"``).
+            tick_format: Format string for tick and badge labels (e.g. `"{:.1f}°C"`).
         """
         self._minvalue = float(minvalue)
         self._maxvalue = float(maxvalue)
@@ -715,12 +715,12 @@ class RangeSlider(ConfigureDelegationMixin, tk.Frame):
         self._hi_var.set(min(self._maxvalue, max(float(value), self._lo_var.get())))
 
     def on_changed(self, callback: Callable[[RangeSliderEvent], None]) -> str:
-        """Register a callback for ``<<Change>>`` events.
+        """Register a callback for `<<Change>>` events.
 
         Args:
-            callback: Called with a Tkinter event; ``event.low_value``
-                and ``event.high_value`` are the current handle values;
-                ``event.prev_low_value`` and ``event.prev_high_value``
+            callback: Called with a Tkinter event; `event.low_value`
+                and `event.high_value` are the current handle values;
+                `event.prev_low_value` and `event.prev_high_value`
                 are the values before the change.
 
         Returns:
@@ -729,7 +729,7 @@ class RangeSlider(ConfigureDelegationMixin, tk.Frame):
         return self.bind("<<Change>>", callback, add="+")
 
     def off_changed(self, bind_id: str | None = None) -> None:
-        """Unsubscribe from ``<<Change>>``.
+        """Unsubscribe from `<<Change>>`.
 
         Args:
             bind_id: ID returned by `on_changed()`. If None, removes all.
@@ -737,14 +737,14 @@ class RangeSlider(ConfigureDelegationMixin, tk.Frame):
         self.unbind("<<Change>>", bind_id)
 
     def on_commit(self, callback: Callable[[RangeSliderCommitEvent], None]) -> str:
-        """Register a callback for ``<<Commit>>`` events.
+        """Register a callback for `<<Commit>>` events.
 
         Fires on mouse release and keyboard commit. Use for expensive
         downstream operations.
 
         Args:
-            callback: Called with a Tkinter event; ``event.low_value``
-                and ``event.high_value`` are the committed values.
+            callback: Called with a Tkinter event; `event.low_value`
+                and `event.high_value` are the committed values.
 
         Returns:
             Bind ID — pass to `off_commit()` to unsubscribe.
@@ -752,7 +752,7 @@ class RangeSlider(ConfigureDelegationMixin, tk.Frame):
         return self.bind("<<Commit>>", callback, add="+")
 
     def off_commit(self, bind_id: str | None = None) -> None:
-        """Unsubscribe from ``<<Commit>>``.
+        """Unsubscribe from `<<Commit>>`.
 
         Args:
             bind_id: ID returned by `on_commit()`. If None, removes all.

--- a/src/bootstack/widgets/_impl/composites/slider/slider.py
+++ b/src/bootstack/widgets/_impl/composites/slider/slider.py
@@ -25,13 +25,13 @@ class Slider(ConfigureDelegationMixin, tk.Frame):
 
     """A themed horizontal or vertical slider widget.
 
-    Replaces ``ttk.Scale`` with full theming support, optional tick marks,
+    Replaces `ttk.Scale` with full theming support, optional tick marks,
     value badge, min/max labels, and reactive signal/variable
     binding.
 
-    The current value is accessible via the ``value`` property, ``get()`` /
-    ``set()`` methods, ``configure(value=x)``, or a bound ``variable`` /
-    ``signal``.
+    The current value is accessible via the `value` property, `get()` /
+    `set()` methods, `configure(value=x)`, or a bound `variable` /
+    `signal`.
     """
 
     def __init__(
@@ -61,22 +61,22 @@ class Slider(ConfigureDelegationMixin, tk.Frame):
             master: Parent widget.
             minvalue: Minimum value of the slider range.
             maxvalue: Maximum value of the slider range.
-            value: Initial value. Ignored when ``variable`` or ``signal`` is provided.
-            orient: Orientation — ``'horizontal'`` or ``'vertical'``.
+            value: Initial value. Ignored when `variable` or `signal` is provided.
+            orient: Orientation — `'horizontal'` or `'vertical'`.
             accent: Accent token controlling fill, handle, and focus ring color.
             surface: Surface token for trough and background color context.
             variable: Tkinter DoubleVar to bind to the slider value.
                 See [tkinter Variables](https://docs.python.org/3/library/tkinter.html#tkinter-variables).
             signal: Reactive Signal linked to the slider value.
-            state: Widget state — ``'normal'`` or ``'disabled'``.
+            state: Widget state — `'normal'` or `'disabled'`.
             show_value: Show a floating badge above (horizontal) or beside
                 (vertical) the handle displaying the current value.
-            show_minmax: Show ``minvalue`` and ``maxvalue`` labels at the
-                track ends. Redundant when ``tick_interval`` is set.
-            tick_interval: Spacing between major tick marks. ``None`` disables ticks.
+            show_minmax: Show `minvalue` and `maxvalue` labels at the
+                track ends. Redundant when `tick_interval` is set.
+            tick_interval: Spacing between major tick marks. `None` disables ticks.
             minor_ticks: Number of minor tick marks between each major tick.
             tick_labels: Show numeric labels at major tick positions.
-            tick_format: Format string for tick and badge labels (e.g. ``"{:.1f}°C"``).
+            tick_format: Format string for tick and badge labels (e.g. `"{:.1f}°C"`).
         """
         self._minvalue = float(minvalue)
         self._maxvalue = float(maxvalue)
@@ -612,11 +612,11 @@ class Slider(ConfigureDelegationMixin, tk.Frame):
         self._var.set(max(self._minvalue, min(self._maxvalue, float(value))))
 
     def on_changed(self, callback: Callable[[SliderEvent], None]) -> str:
-        """Register a callback for ``<<Change>>`` events.
+        """Register a callback for `<<Change>>` events.
 
         Args:
-            callback: Called with a Tkinter event; ``event.value`` is
-                the current value and ``event.prev_value`` is the
+            callback: Called with a Tkinter event; `event.value` is
+                the current value and `event.prev_value` is the
                 value before the change.
 
         Returns:
@@ -625,7 +625,7 @@ class Slider(ConfigureDelegationMixin, tk.Frame):
         return self.bind("<<Change>>", callback, add="+")
 
     def off_changed(self, bind_id: str | None = None) -> None:
-        """Unsubscribe from ``<<Change>>``.
+        """Unsubscribe from `<<Change>>`.
 
         Args:
             bind_id: ID returned by `on_changed()`. If None, removes all.
@@ -633,13 +633,13 @@ class Slider(ConfigureDelegationMixin, tk.Frame):
         self.unbind("<<Change>>", bind_id)
 
     def on_commit(self, callback: Callable[[SliderCommitEvent], None]) -> str:
-        """Register a callback for ``<<Commit>>`` events.
+        """Register a callback for `<<Commit>>` events.
 
         Fires on mouse release and keyboard commit, not continuously during drag.
         Use for expensive downstream operations.
 
         Args:
-            callback: Called with a Tkinter event; ``event.value`` is
+            callback: Called with a Tkinter event; `event.value` is
                 the committed value.
 
         Returns:
@@ -648,7 +648,7 @@ class Slider(ConfigureDelegationMixin, tk.Frame):
         return self.bind("<<Commit>>", callback, add="+")
 
     def off_commit(self, bind_id: str | None = None) -> None:
-        """Unsubscribe from ``<<Commit>>``.
+        """Unsubscribe from `<<Commit>>`.
 
         Args:
             bind_id: ID returned by `on_commit()`. If None, removes all.

--- a/src/bootstack/widgets/_impl/composites/tableview/tableview.py
+++ b/src/bootstack/widgets/_impl/composites/tableview/tableview.py
@@ -2497,7 +2497,7 @@ class TableView(Frame):
         Records are projected to the exported columns (what the table shows) and
         streamed through `bootstack.data.writers`, so the export carries the same
         columns as CSV/XLSX. (For the full record set, use
-        ``table.data_source.save(path)``.)
+        `table.data_source.save(path)`.)
         """
         from bootstack.data.writers import write_records
 

--- a/src/bootstack/widgets/_impl/composites/tabs/tabs.py
+++ b/src/bootstack/widgets/_impl/composites/tabs/tabs.py
@@ -384,7 +384,7 @@ class Tabs(Frame):
     def hide(self, key: str) -> None:
         """Hide a tab without removing it from the registry.
 
-        The tab disappears from the bar but can be restored with ``show()``.
+        The tab disappears from the bar but can be restored with `show()`.
 
         Args:
             key: Key of the tab to hide.

--- a/src/bootstack/widgets/_impl/composites/tabs/tabview.py
+++ b/src/bootstack/widgets/_impl/composites/tabs/tabview.py
@@ -319,7 +319,7 @@ class TabView(Frame):
         """Hide a tab without removing it from the registry.
 
         The tab disappears from the bar but remains registered. Restore it
-        with ``show_tab()``. If the hidden tab was selected, the next
+        with `show_tab()`. If the hidden tab was selected, the next
         available visible tab is selected automatically.
 
         Args:
@@ -362,7 +362,7 @@ class TabView(Frame):
     def forget_tab(self, key: str) -> None:
         """Remove a tab and its page entirely.
 
-        Unlike ``hide_tab()``, the tab is unregistered and cannot be restored.
+        Unlike `hide_tab()`, the tab is unregistered and cannot be restored.
         If the removed tab was selected, the next available tab is selected.
 
         Args:
@@ -396,7 +396,7 @@ class TabView(Frame):
     def remove(self, key: str) -> None:
         """Remove a tab and its associated page.
 
-        Alias for ``forget_tab()``.
+        Alias for `forget_tab()`.
 
         Args:
             key: The identifier of the tab/page to remove.
@@ -495,7 +495,7 @@ class TabView(Frame):
     def keys(self) -> tuple[str, ...]:
         """Get all tab keys.
 
-        Alias for ``tab_keys()``.
+        Alias for `tab_keys()`.
 
         Returns:
             A tuple of all tab keys in the order they were added.
@@ -566,8 +566,8 @@ class TabView(Frame):
 
         Args:
             callback: Receives a `TabChangeEvent` payload with attributes
-                ``current`` (`TabRef`), ``previous`` (`TabRef | None`),
-                ``reason`` (`ChangeReason`), and ``via`` (`ChangeMethod`).
+                `current` (`TabRef`), `previous` (`TabRef | None`),
+                `reason` (`ChangeReason`), and `via` (`ChangeMethod`).
 
         Returns:
             Bind ID — pass to `off_tab_changed()` to unsubscribe.
@@ -589,7 +589,7 @@ class TabView(Frame):
 
         Args:
             callback: Receives a `TabActivateEvent` payload with attributes
-                ``key`` and ``text``.
+                `key` and `text`.
 
         Returns:
             Bind ID — pass to `off_tab_activated()` to unsubscribe.
@@ -611,7 +611,7 @@ class TabView(Frame):
 
         Args:
             callback: Receives a `TabDeactivateEvent` payload with attributes
-                ``key`` and ``text``.
+                `key` and `text`.
 
         Returns:
             Bind ID — pass to `off_tab_deactivated()` to unsubscribe.

--- a/src/bootstack/widgets/_impl/mixins/configure_mixin.py
+++ b/src/bootstack/widgets/_impl/mixins/configure_mixin.py
@@ -65,7 +65,7 @@ class ConfigureDelegationMixin:
         """Query the delegate handler for `key`.
 
         Returns:
-            A ``(handled, value)`` tuple. ``handled`` is False if no handler
+            A `(handled, value)` tuple. `handled` is False if no handler
             exists for the key.
         """
         method_name = self._configure_delegate_map.get(key)
@@ -82,9 +82,9 @@ class ConfigureDelegationMixin:
         """Set one or more widget options, or query the current value of a named option.
 
         Args:
-            cnf: Option name to query (e.g. ``'accent'``), a dict of options to
+            cnf: Option name to query (e.g. `'accent'`), a dict of options to
                 set, or None when passing options as keyword arguments.
-            **kwargs: Option names and values to set (e.g. ``accent='primary'``).
+            **kwargs: Option names and values to set (e.g. `accent='primary'`).
         """
         if kwargs:
             for _k in list(kwargs.keys()):
@@ -103,14 +103,14 @@ class ConfigureDelegationMixin:
     config = configure
 
     def __setitem__(self, key: str, value: Any) -> None:
-        """Set a configuration option using ``widget[key] = value`` syntax."""
+        """Set a configuration option using `widget[key] = value` syntax."""
         if key in self._configure_delegate_map:
             self._config_delegate_set(key, value)
             return
         return super().__setitem__(key, value)
 
     def __getitem__(self, key: str) -> Any:
-        """Return the current value of a configuration option using ``widget[key]`` syntax."""
+        """Return the current value of a configuration option using `widget[key]` syntax."""
         if key in self._configure_delegate_map:
             handled, value = self._config_delegate_get(key)
             if handled:
@@ -121,7 +121,7 @@ class ConfigureDelegationMixin:
         """Return the current value of a configuration option.
 
         Args:
-            key: Option name, e.g. ``'accent'``, ``'icon'``.
+            key: Option name, e.g. `'accent'`, `'icon'`.
         """
         if key in self._configure_delegate_map:
             handled, value = self._config_delegate_get(key)
@@ -150,13 +150,13 @@ class CustomConfigMixin(ConfigureDelegationMixin):
         """Set one or more widget options, or query the current value of a named option.
 
         Args:
-            cnf: Option name to query (e.g. ``'accent'``), a dict of options to
+            cnf: Option name to query (e.g. `'accent'`), a dict of options to
                 set, or None when passing options as keyword arguments.
-            **kwargs: Option names and values to set (e.g. ``accent='primary'``).
+            **kwargs: Option names and values to set (e.g. `accent='primary'`).
 
         Returns:
-            When ``cnf`` is None, a dict of all options in tkinter tuple format.
-            When ``cnf`` is a string, a ``(name, dbName, dbClass, default, current)``
+            When `cnf` is None, a dict of all options in tkinter tuple format.
+            When `cnf` is a string, a `(name, dbName, dbClass, default, current)`
             tuple. None when setting options.
         """
         if isinstance(cnf, dict):
@@ -186,14 +186,14 @@ class CustomConfigMixin(ConfigureDelegationMixin):
     config = configure
 
     def __setitem__(self, key: str, value: Any) -> None:
-        """Set an option using ``obj[key] = value`` syntax."""
+        """Set an option using `obj[key] = value` syntax."""
         if key in self._configure_delegate_map:
             if self._config_delegate_set(key, value):
                 return
         self._custom_config_store[key] = value
 
     def __getitem__(self, key: str) -> Any:
-        """Return an option value using ``obj[key]`` syntax."""
+        """Return an option value using `obj[key]` syntax."""
         if key in self._configure_delegate_map:
             handled, value = self._config_delegate_get(key)
             if handled:

--- a/src/bootstack/widgets/_impl/mixins/font_mixin.py
+++ b/src/bootstack/widgets/_impl/mixins/font_mixin.py
@@ -333,9 +333,9 @@ class FontMixin:
     def _delegate_font(self, value: Any = None) -> Any:
         """Get or set the widget font, resolving bootstack modifier syntax.
 
-        Accepts a plain font name, a token name (e.g. ``'body'``,
-        ``'heading-lg'``), a modifier expression (e.g. ``'body[bold]'``,
-        ``'[16][italic]'``), or a Tk font tuple. Modifier expressions are
+        Accepts a plain font name, a token name (e.g. `'body'`,
+        `'heading-lg'`), a modifier expression (e.g. `'body[bold]'`,
+        `'[16][italic]'`), or a Tk font tuple. Modifier expressions are
         merged with the widget's current font so only the specified
         attributes change.
 
@@ -344,7 +344,7 @@ class FontMixin:
 
         Returns:
             Current font value when querying, otherwise the result of
-            the underlying ``configure(font=...)`` call.
+            the underlying `configure(font=...)` call.
         """
         if value is None:
             return self._ttk_base.cget(self, "font")  # type: ignore[misc]

--- a/src/bootstack/widgets/_impl/mixins/icon_mixin.py
+++ b/src/bootstack/widgets/_impl/mixins/icon_mixin.py
@@ -27,7 +27,7 @@ class IconMixin:
                 current value.
 
         Returns:
-            Current icon value when querying (``value`` is None), otherwise
+            Current icon value when querying (`value` is None), otherwise
             the result of rebuilding the widget style.
         """
         if value is None:
@@ -40,15 +40,15 @@ class IconMixin:
     def _delegate_icon_only(self, value: Any = None) -> Any:
         """Get or set icon-only display mode.
 
-        When ``True``, removes the extra padding reserved for text so the
+        When `True`, removes the extra padding reserved for text so the
         icon fills the available space without a label gap.
 
         Args:
-            value: ``True`` to enable icon-only mode, ``False`` to disable,
+            value: `True` to enable icon-only mode, `False` to disable,
                 or None to query the current value.
 
         Returns:
-            Current ``icon_only`` value when querying, otherwise the result
+            Current `icon_only` value when querying, otherwise the result
             of rebuilding the widget style.
         """
         if value is None:

--- a/src/bootstack/widgets/_impl/mixins/validation_mixin.py
+++ b/src/bootstack/widgets/_impl/mixins/validation_mixin.py
@@ -34,7 +34,7 @@ class ValidationMixin(Widget):
         """Set up validation state before the widget is fully initialized.
 
         Initialises the rule list, debounce tracking, and optional convenience
-        callbacks. Binds ``<<KeyRelease>>`` and ``<<FocusOut>>`` to trigger
+        callbacks. Binds `<<KeyRelease>>` and `<<FocusOut>>` to trigger
         debounced validation automatically.
         """
         # Validation rules

--- a/src/bootstack/widgets/appshell.py
+++ b/src/bootstack/widgets/appshell.py
@@ -35,7 +35,7 @@ class Page:
     """Context-manager proxy returned by `add_page()` / `panel()`.
 
     Pushes onto the context stack so widgets created inside
-    ``with shell.add_page(...):`` are automatically parented to the page. When
+    `with shell.add_page(...):` are automatically parented to the page. When
     `scrollable=True`, children parent into an internal vertical `ScrollView`.
     """
 
@@ -144,7 +144,7 @@ class Workspace:
     def content(self) -> Page:
         """The workspace's content region as a container for hand-driven content.
 
-        Use with ``with ws.content:`` or ``parent=ws.content`` to place widgets
+        Use with `with ws.content:` or `parent=ws.content` to place widgets
         in the content area directly — the escape hatch for custom (`panel`) mode.
         """
         host = getattr(self, "_content_host", None)
@@ -278,7 +278,7 @@ class AppShell(AppConfigMixin, WindowControlsMixin, ChromeHostMixin, PublicWidge
     Fill the (implicit) sidebar with `add_page()` for static authored pages, or
     `list_nav()` / `tree_nav()` for data-bound master-detail. For a multi-section
     app, add named `add_workspace()` workspaces — each is authored with the same
-    page API. Pages support context-manager syntax so widgets inside the ``with``
+    page API. Pages support context-manager syntax so widgets inside the `with`
     block are parented to that page automatically.
 
     Like `App`, configuration is a single flat path: pass options as constructor
@@ -508,7 +508,7 @@ class AppShell(AppConfigMixin, WindowControlsMixin, ChromeHostMixin, PublicWidge
             scrollable: If `True`, wrap the page in a vertical `ScrollView`.
 
         Returns:
-            A `Page` context manager. Use with ``with`` to parent child
+            A `Page` context manager. Use with `with` to parent child
             widgets into the page automatically.
         """
         frame = self._internal.add_page(key, text=text, icon=icon)
@@ -748,7 +748,7 @@ class AppShell(AppConfigMixin, WindowControlsMixin, ChromeHostMixin, PublicWidge
     def content(self) -> Page:
         """The content region as a container for hand-driven content.
 
-        Use with ``with shell.content:`` or ``parent=shell.content`` to place
+        Use with `with shell.content:` or `parent=shell.content` to place
         widgets in the content area directly — the escape hatch for custom
         (`panel`) mode. Targets the active workspace's content frame, not the
         layout region (which hosts the page deck).

--- a/src/bootstack/widgets/button.py
+++ b/src/bootstack/widgets/button.py
@@ -23,7 +23,7 @@ class Button(IconProperty, ImageProperty, PublicWidgetBase):
     Args:
         text: Text displayed on the button.
         on_click: Called with no arguments when the button is clicked.
-            Equivalent to subscribing to the ``'click'`` event.
+            Equivalent to subscribing to the `'click'` event.
         accent: Color intent token. Defaults to the theme's default button color.
         variant: Visual weight token. Default `'solid'`.
         icon: Bootstrap Icons name (e.g. `'save'`, `'trash'`) — see the full

--- a/src/bootstack/widgets/buttongroup.py
+++ b/src/bootstack/widgets/buttongroup.py
@@ -169,7 +169,7 @@ class ButtonGroup(PublicWidgetBase):
 
         Args:
             key: Key returned by `add()`.
-            option: Option name to query (e.g. ``'text'``, ``'state'``).
+            option: Option name to query (e.g. `'text'`, `'state'`).
         """
         return self._internal.configure_item(key, option)
 

--- a/src/bootstack/widgets/expander.py
+++ b/src/bootstack/widgets/expander.py
@@ -39,40 +39,40 @@ class Expander(PublicContainer):
 
     Args:
         title: Header text shown in the clickable header bar.
-        layout: Internal layout for the body. One of ``'column'`` (default),
-            ``'row'``, or ``'grid'``.
+        layout: Internal layout for the body. One of `'column'` (default),
+            `'row'`, or `'grid'`.
         padding: Space between the expander border and its body content, in
-            pixels. Accepts a single int or a ``(x, y)`` tuple.
-        gap: Space between body children in pixels. Default ``0``.
+            pixels. Accepts a single int or a `(x, y)` tuple.
+        gap: Space between body children in pixels. Default `0`.
         horizontal_items: How body children sit on the horizontal axis — edge
-            values ``'left'``/``'center'``/``'right'``/``'stretch'``, plus
-            ``'space-*'`` when horizontal is the stacking axis. Default
-            ``'stretch'`` for ``'grid'``, else ``'left'``.
+            values `'left'`/`'center'`/`'right'`/`'stretch'`, plus
+            `'space-*'` when horizontal is the stacking axis. Default
+            `'stretch'` for `'grid'`, else `'left'`.
         vertical_items: How body children sit on the vertical axis — edge values
-            ``'top'``/``'center'``/``'bottom'``/``'stretch'``, plus ``'space-*'``
-            when vertical is the stacking axis. Default ``'stretch'`` for
-            ``'grid'``, else ``'top'``.
-        grow_items: For ``'column'``/``'row'``, when ``True`` every body
-            child grows equally to share the main axis. Default ``False``.
-        columns: Column size definitions for ``'grid'`` layout. An integer
+            `'top'`/`'center'`/`'bottom'`/`'stretch'`, plus `'space-*'`
+            when vertical is the stacking axis. Default `'stretch'` for
+            `'grid'`, else `'top'`.
+        grow_items: For `'column'`/`'row'`, when `True` every body
+            child grows equally to share the main axis. Default `False`.
+        columns: Column size definitions for `'grid'` layout. An integer
             creates that many equal-weight columns; a list of ints sets
-            per-column weights. Default ``None``.
-        rows: Row size definitions for ``'grid'`` layout. Same format as
-            ``columns``. Default ``None``.
-        auto_flow: Grid placement direction — ``'row'`` (default) or
-            ``'column'``.
-        expanded: If ``True`` (default), the body is visible on creation.
-        collapsible: If ``True`` (default), clicking the header toggles the
-            body. If ``False``, the chevron is hidden and the body stays open.
-        show_border: If ``True``, draws a border around the entire widget.
-            Default ``False``.
+            per-column weights. Default `None`.
+        rows: Row size definitions for `'grid'` layout. Same format as
+            `columns`. Default `None`.
+        auto_flow: Grid placement direction — `'row'` (default) or
+            `'column'`.
+        expanded: If `True` (default), the body is visible on creation.
+        collapsible: If `True` (default), clicking the header toggles the
+            body. If `False`, the chevron is hidden and the body stays open.
+        show_border: If `True`, draws a border around the entire widget.
+            Default `False`.
         variant: Header style. Defaults to `None` (the default header reads
             as a ghost/transparent bar).
         icon: Icon name or spec displayed to the left of the title.
         icon_position: Side on which the collapse chevron appears —
-            ``'after'`` (default, right of title) or ``'before'`` (left).
-        highlight: If ``True``, the header shows a selected visual state while
-            the body is expanded. Default ``False``.
+            `'after'` (default, right of title) or `'before'` (left).
+        highlight: If `True`, the header shows a selected visual state while
+            the body is expanded. Default `False`.
         accent: Color intent token for the header. Defaults to `None`
             (theme default).
         parent: Explicit parent container. Omit to use the current context.
@@ -488,11 +488,11 @@ class Accordion(PublicWidgetBase):
     def on_change(self, handler: Callable[[AccordionChangeEvent], Any] | None = None) -> Stream | Subscription:
         """Register a callback fired when any section expands or collapses.
 
-        The handler receives an `AccordionChangeEvent`; ``e.expanded`` is the
+        The handler receives an `AccordionChangeEvent`; `e.expanded` is the
         tuple of currently expanded sections.
 
         Returns:
-            ``Subscription`` (with handler) or ``Stream`` (without handler).
+            `Subscription` (with handler) or `Stream` (without handler).
         """
         return self.on("change", handler)
 

--- a/src/bootstack/widgets/menubutton.py
+++ b/src/bootstack/widgets/menubutton.py
@@ -60,29 +60,29 @@ _RESERVED_INTERNAL_KEYS = frozenset({
 class MenuButton(IconProperty, PublicWidgetBase):
     """A button that opens a dropdown menu when clicked.
 
-    Items are added at construction via ``items=`` or dynamically with
-    ``add_item()``. The ``on_select`` callback fires for every item click,
-    receiving a dict with ``type``, ``text``, and ``value`` keys.
+    Items are added at construction via `items=` or dynamically with
+    `add_item()`. The `on_select` callback fires for every item click,
+    receiving a dict with `type`, `text`, and `value` keys.
 
     Args:
         text: Button text. Defaults to an empty string.
-        items: Initial list of item dicts. Each dict must have a ``type``
-            key (``'command'``, ``'check'``, ``'radio'``, or
-            ``'divider'``) plus item-specific keys such as ``text``,
-            ``icon``, ``value``, and ``on_click`` (the per-item callback).
+        items: Initial list of item dicts. Each dict must have a `type`
+            key (`'command'`, `'check'`, `'radio'`, or
+            `'divider'`) plus item-specific keys such as `text`,
+            `icon`, `value`, and `on_click` (the per-item callback).
         on_select: Callback fired when any menu item is activated. Called with
             a :class:`~bootstack.events.MenuSelectEvent` (`type`, `text`,
             `value` of the activated item).
         icon: Icon name shown on the button face.
-        icon_only: If ``True``, hides the label and shows only the icon.
-            Inferred automatically when ``icon=`` is set and ``label`` is
-            empty. Defaults to ``False``.
-        show_arrow: If ``True`` (default), shows the dropdown chevron arrow.
-            Pass ``False`` to hide it (useful when the icon implies the action).
-        menu_options: Extra options forwarded to the underlying ``ContextMenu``
-            at construction (e.g. ``{'anchor': 'se', 'offset': 4}``).
-        disabled: If ``True``, button is shown but non-interactive. Defaults
-            to ``False``.
+        icon_only: If `True`, hides the label and shows only the icon.
+            Inferred automatically when `icon=` is set and `label` is
+            empty. Defaults to `False`.
+        show_arrow: If `True` (default), shows the dropdown chevron arrow.
+            Pass `False` to hide it (useful when the icon implies the action).
+        menu_options: Extra options forwarded to the underlying `ContextMenu`
+            at construction (e.g. `{'anchor': 'se', 'offset': 4}`).
+        disabled: If `True`, button is shown but non-interactive. Defaults
+            to `False`.
         accent: Color intent token. Defaults to the theme default.
         variant: Style variant. Default `'ghost'`.
         density: Layout density.
@@ -182,7 +182,7 @@ class MenuButton(IconProperty, PublicWidgetBase):
             on_click: Callback fired when the item is clicked.
             icon: Icon name shown beside the label.
             shortcut: Keyboard shortcut hint displayed on the right. Accepts a
-                modifier pattern (``"Mod+S"`` → ``"Ctrl+S"`` / ``"⌘S"``), a
+                modifier pattern (`"Mod+S"` → `"Ctrl+S"` / `"⌘S"`), a
                 registered shortcut key name, or a literal display string.
             disabled: If True, item is shown but non-interactive.
             key: Unique string key. Auto-generated if omitted.
@@ -240,21 +240,21 @@ class MenuButton(IconProperty, PublicWidgetBase):
     ) -> str:
         """Add a radio-button item to the dropdown.
 
-        All radio items in a ``MenuButton`` share one group variable
-        automatically. Pass ``selected=True`` on the item that should be
+        All radio items in a `MenuButton` share one group variable
+        automatically. Pass `selected=True` on the item that should be
         pre-selected on first open.
 
         Note:
             Values are stored as strings internally. Pass string values
-            (e.g. ``value="100%"``) for predictable comparisons when reading
-            the group selection via ``menu``.
+            (e.g. `value="100%"`) for predictable comparisons when reading
+            the group selection via `menu`.
 
         Args:
             label: Item label text.
             value: Value associated with this radio item. Stored as a string
-                internally; defaults to ``label`` when omitted.
-            selected: If ``True``, this item is the initial selection.
-                Defaults to ``False``.
+                internally; defaults to `label` when omitted.
+            selected: If `True`, this item is the initial selection.
+                Defaults to `False`.
             on_click: Callback fired on selection.
             key: Unique string key. Auto-generated if omitted.
 
@@ -289,7 +289,7 @@ class MenuButton(IconProperty, PublicWidgetBase):
     def add_items(self, items: list[Any]) -> None:
         """Add multiple items at once from a list of item dicts.
 
-        Each dict must have a ``type`` key plus item-specific keys:
+        Each dict must have a `type` key plus item-specific keys:
 
         .. code-block:: python
 
@@ -302,9 +302,9 @@ class MenuButton(IconProperty, PublicWidgetBase):
            ])
 
         Args:
-            items: List of item dicts. ``type`` accepts ``'command'``,
-                ``'check'``, ``'radio'``, or ``'divider'``; an item's
-                ``on_click`` key sets its per-item callback.
+            items: List of item dicts. `type` accepts `'command'`,
+                `'check'`, `'radio'`, or `'divider'`; an item's
+                `on_click` key sets its per-item callback.
         """
         self._internal.add_items([_translate_item(it) for it in items])
 
@@ -313,9 +313,9 @@ class MenuButton(IconProperty, PublicWidgetBase):
 
         Args:
             index: Zero-based position to insert at.
-            type: Item type — ``'command'``, ``'check'``, ``'radio'``,
-                or ``'divider'``.
-            **kwargs: Forwarded to the matching ``add_*`` method.
+            type: Item type — `'command'`, `'check'`, `'radio'`,
+                or `'divider'`.
+            **kwargs: Forwarded to the matching `add_*` method.
 
         Returns:
             The key assigned to the new item.
@@ -338,7 +338,7 @@ class MenuButton(IconProperty, PublicWidgetBase):
         """Reconfigure a dropdown item after creation.
 
         Args:
-            key: Key returned by an ``add_*`` method.
+            key: Key returned by an `add_*` method.
             **kwargs: Options forwarded to the item's configure method.
         """
         self._internal.configure_item(key, **kwargs)
@@ -347,7 +347,7 @@ class MenuButton(IconProperty, PublicWidgetBase):
         """Remove a dropdown item by key.
 
         Args:
-            key: Key returned by an ``add_*`` method.
+            key: Key returned by an `add_*` method.
         """
         self._internal.remove_item(key)
 
@@ -363,10 +363,10 @@ class MenuButton(IconProperty, PublicWidgetBase):
     # ----- Properties -----
 
     def item(self, key: str) -> Any:
-        """Return the item object for ``key``.
+        """Return the item object for `key`.
 
         Args:
-            key: Key returned by an ``add_*`` method.
+            key: Key returned by an `add_*` method.
         """
         return self._internal.context_menu.item(key)
 
@@ -382,7 +382,7 @@ class MenuButton(IconProperty, PublicWidgetBase):
 
     @property
     def menu(self) -> Any:
-        """The underlying ``ContextMenu`` — for advanced programmatic access."""
+        """The underlying `ContextMenu` — for advanced programmatic access."""
         return self._internal.context_menu
 
     @property

--- a/src/bootstack/widgets/statusbar.py
+++ b/src/bootstack/widgets/statusbar.py
@@ -21,10 +21,10 @@ class StatusBar(PublicWidgetBase):
     left-to-right; an `add_spacer()` (or `side='right'`) pushes the following
     segments to the right cluster.
 
-    Use it standalone — ``bs.StatusBar(fill="x", side="bottom")`` pins one to the
+    Use it standalone — `bs.StatusBar(fill="x", side="bottom")` pins one to the
     bottom of any `App`/`Window` — or read `shell.statusbar` for the one built
     into an :class:`AppShell <bootstack.AppShell>`. Create custom widgets with
-    ``parent=statusbar`` (they add to the left cluster automatically) or pass a
+    `parent=statusbar` (they add to the left cluster automatically) or pass a
     pre-parented widget to `add_widget()`.
 
     Args:

--- a/src/bootstack/widgets/toolbar.py
+++ b/src/bootstack/widgets/toolbar.py
@@ -151,12 +151,12 @@ class Toolbar(PublicWidgetBase):
         window's chrome).
 
         Args:
-            text: The menu's label (e.g. ``'File'``).
-            key: Optional stable identifier; defaults to ``text``.
+            text: The menu's label (e.g. `'File'`).
+            key: Optional stable identifier; defaults to `text`.
 
         Returns:
-            The menu's `MenuGroup` builder (``add_action`` / ``add_check`` /
-            ``add_radio`` / ``add_separator``; usable as a context manager).
+            The menu's `MenuGroup` builder (`add_action` / `add_check` /
+            `add_radio` / `add_separator`; usable as a context manager).
         """
         return self._internal.add_menu(text, key=key)
 
@@ -173,7 +173,7 @@ class Toolbar(PublicWidgetBase):
         Args:
             text: Label text.
             icon: Icon name displayed alongside the text.
-            font: Font token, e.g. ``'heading-md'`` or ``'caption'``.
+            font: Font token, e.g. `'heading-md'` or `'caption'`.
         """
         kw: dict[str, Any] = {}
         if text is not None:
@@ -189,7 +189,7 @@ class Toolbar(PublicWidgetBase):
         """Add a vertical divider.
 
         Args:
-            length: Divider height in pixels. Defaults to ``16``.
+            length: Divider height in pixels. Defaults to `16`.
         """
         self._internal.add_separator(length=length)
 

--- a/src/bootstack/widgets/types.py
+++ b/src/bootstack/widgets/types.py
@@ -87,7 +87,7 @@ Fill = Literal['none', 'x', 'y', 'both', 'horizontal', 'vertical', 'all']
 aliases for `'x'`/`'y'`/`'both'`."""
 
 Sticky = Literal['n', 's', 'e', 'w', 'ns', 'ew', 'nsew', 'ne', 'nw', 'se', 'sw', 'nse', 'nsw', 'new', 'sew', '']
-"""Cell alignment for Grid layout. Any combination of ``'n'``, ``'s'``, ``'e'``, ``'w'``."""
+"""Cell alignment for Grid layout. Any combination of `'n'`, `'s'`, `'e'`, `'w'`."""
 
 Side = Literal['left', 'top', 'right', 'bottom']
 """Side placement for stack layout."""

--- a/src/bootstack/widgets/window.py
+++ b/src/bootstack/widgets/window.py
@@ -57,7 +57,7 @@ class Window(WindowControlsMixin, ChromeHostMixin, FlexContainer):
     """A secondary top-level window.
 
     Behaves as an implicit `Column` from the user's perspective: children
-    created inside a ``with`` block are automatically packed into its content
+    created inside a `with` block are automatically packed into its content
     frame top-to-bottom.  Call `show()` to display the window after building
     its content, or `block_until_closed()` to show it and wait for the user
     to close it.
@@ -256,7 +256,7 @@ class Window(WindowControlsMixin, ChromeHostMixin, FlexContainer):
                 off-screen. Defaults to `True`.
 
         Returns:
-            `self` — allows chaining: ``win = Window(...).show()``.
+            `self` — allows chaining: `win = Window(...).show()`.
         """
         self._ensure_default_titlebar()
         if anchor_to is not None:


### PR DESCRIPTION
Clears the standing `project_docstring_backticks` backlog item.

## What

Sweeps `src/` docstrings onto the Google-style **single-backtick** convention (de-risked by `default_role="code"`): **754 RST double-backtick literals (` ``X`` `) across 43 files** become single backticks (` `X` `).

- Only **runs of exactly two backticks** are converted (lookaround-guarded), so the 70 ` ```python ` code fences in docstrings are left intact.
- **RST cross-reference roles untouched** (`:class:` / `:doc:` / `:ref:`) — they use single backticks and are the deliberate links added by the typing sweep, not stray double-backticks.
- CRLF line endings and BOMs preserved (byte-safe write, no blanket `sed`).

Pure mechanical docstring change — no code or behavior change.

## Verification

- `compileall` clean; all public submodules import OK
- **Clean warning-free docs build** (`sphinx-build -W --keep-going`, fresh temp dir)
- Confirmed rendered output: pages show proper `<code>` spans with **0 literal backtick leakage**
- No file overlap with #181 → no merge-conflict risk

🤖 Generated with [Claude Code](https://claude.com/claude-code)