### PR TITLE
fix(overlay): ContextMenu/Tooltip cover container target children (#166)

### DIFF
--- a/src/bootstack/_runtime/utility.py
+++ b/src/bootstack/_runtime/utility.py
@@ -356,6 +356,51 @@ def bind_right_click(widget, handler, add: str | bool = '+'):
         widget.bind('<Control-Button-1>', handler, add=add)
 
 
+def propagate_target_bindings(target) -> None:
+    """Make events on `target`'s descendants also fire `target`'s own bindings.
+
+    Tk events do not bubble up the widget hierarchy — the widget directly under
+    the pointer receives the event — so a gesture (right-click, hover, ...) bound
+    to a *container* never fires when the pointer is over one of the container's
+    children. This adds the container's own bindtag (its Tk path name, the tag
+    that `widget.bind(...)` registers under) to every descendant in the same
+    toplevel, so the container's binding fires for events anywhere inside it.
+
+    The tag is inserted just after each descendant's own path-name tag, so the
+    child's own bindings still take precedence. The call is idempotent, so it is
+    safe to run again after the container gains new children. Nested toplevels
+    (popups, menus, dialogs parented to the target) are skipped.
+
+    Args:
+        target: The container widget whose bindings should cover its descendants.
+    """
+    try:
+        tag = str(target)
+        top = str(target.winfo_toplevel())
+    except Exception:
+        return
+
+    def visit(widget):
+        try:
+            children = widget.winfo_children()
+        except Exception:
+            return
+        for child in children:
+            try:
+                # Don't cross into nested toplevels (the menu/tooltip popup
+                # itself is parented to the target and would be walked here).
+                if str(child.winfo_toplevel()) != top:
+                    continue
+                tags = list(child.bindtags())
+                if tag not in tags:
+                    child.bindtags([tags[0], tag, *tags[1:]] if tags else [tag])
+            except Exception:
+                continue
+            visit(child)
+
+    visit(target)
+
+
 def clamp(value, min_val, max_val):
     """Return a value that is bounded by a minimum and maximum.
 

--- a/src/bootstack/widgets/_impl/composites/contextmenu.py
+++ b/src/bootstack/widgets/_impl/composites/contextmenu.py
@@ -1697,7 +1697,7 @@ class ContextMenu:
 
     def _bind_trigger(self, target: Misc, trigger: str) -> None:
         """Bind `target`'s activation event to show this menu at the click."""
-        from bootstack._runtime.utility import bind_right_click
+        from bootstack._runtime.utility import bind_right_click, propagate_target_bindings
 
         def show_at(event):
             self.show(position=(event.x_root, event.y_root))
@@ -1718,6 +1718,10 @@ class ContextMenu:
                 f"Unknown trigger {trigger!r}. Use 'right-click', 'click', "
                 f"'double-click', 'shift-click', 'ctrl-click', or 'manual'."
             )
+
+        # Tk events don't bubble, so a gesture over the target's children would
+        # otherwise never reach this binding. Extend it across the subtree.
+        propagate_target_bindings(target)
 
     # ── Public API stubs ──────────────────────────────────────────────────────
     # Explicit method definitions so griffe and IDEs can see the API.

--- a/src/bootstack/widgets/_impl/composites/tooltip.py
+++ b/src/bootstack/widgets/_impl/composites/tooltip.py
@@ -116,7 +116,13 @@ class ToolTip:
         self._widget.bind("<Enter>", self._on_enter)
         self._widget.bind("<Leave>", self._on_leave)
         self._widget.bind("<Motion>", self._move_tip)
-        self._widget.bind("<ButtonPress>", self._on_leave)
+        self._widget.bind("<ButtonPress>", self._on_button_press)
+
+        # Tk events don't bubble, so hovering a child of a container target
+        # would otherwise never reach these bindings. Extend them across the
+        # subtree so the tip shows anywhere inside the container.
+        from bootstack._runtime.utility import propagate_target_bindings
+        propagate_target_bindings(self._widget)
 
     def destroy(self) -> None:
         """Cleanup tooltip resources and unbind all event handlers.
@@ -137,9 +143,36 @@ class ToolTip:
         self._schedule()
 
     def _on_leave(self, _) -> None:
-        """Handle mouse leave event by canceling and hiding tooltip."""
+        """Handle mouse leave event by canceling and hiding tooltip.
+
+        When the target is a container, crossing from the container onto one of
+        its children fires a `<Leave>` on the container even though the pointer
+        is still inside it. Keep the tip in that case so it doesn't flicker as
+        the pointer moves over child widgets.
+        """
+        if self._pointer_within_target():
+            return
         self._unschedule()
         self._hide_tip()
+
+    def _on_button_press(self, _) -> None:
+        """Hide the tooltip on any button press inside the target subtree."""
+        self._unschedule()
+        self._hide_tip()
+
+    def _pointer_within_target(self) -> bool:
+        """Return True if the pointer is over the target or one of its children."""
+        try:
+            x = self._widget.winfo_pointerx()
+            y = self._widget.winfo_pointery()
+            under = self._widget.winfo_containing(x, y)
+        except tk.TclError:
+            return False
+        if under is None:
+            return False
+        target_path = str(self._widget)
+        under_path = str(under)
+        return under_path == target_path or under_path.startswith(target_path + ".")
 
     def _schedule(self) -> None:
         """Schedule the tooltip to appear after the configured delay."""

--- a/src/bootstack/widgets/contextmenu.py
+++ b/src/bootstack/widgets/contextmenu.py
@@ -69,7 +69,9 @@ class ContextMenu:
 
     Args:
         target: Widget the menu attaches to for positioning and auto-trigger
-            binding. Accepts any bootstack widget. If omitted, call
+            binding. Accepts any bootstack widget. When the target is a
+            container, the trigger fires anywhere inside it, including over its
+            children present at attach time. If omitted, call
             `show(position=(x, y))` manually.
         min_width: Minimum menu width in pixels. Default `150`.
         width: Fixed menu width in pixels. Defaults to auto (uses `min_width`).

--- a/src/bootstack/widgets/tooltip.py
+++ b/src/bootstack/widgets/tooltip.py
@@ -17,6 +17,9 @@ class Tooltip:
 
     Args:
         target: Widget to attach the tooltip to. Accepts any bootstack widget.
+            When the target is a container, the tooltip shows while hovering
+            anywhere inside it, including over its children present at attach
+            time.
         text: Tooltip text content. Defaults to `''`.
         delay: Milliseconds before the tooltip appears on mouse enter. Defaults
             to `250`.

--- a/tests/widgets/public/test_overlay_container_coverage.py
+++ b/tests/widgets/public/test_overlay_container_coverage.py
@@ -1,0 +1,110 @@
+"""ContextMenu/Tooltip cover a container target's children (issue #166).
+
+Tk events don't bubble, so a gesture bound to a container never fires when the
+pointer is over a child. `propagate_target_bindings` adds the container's own
+bindtag to its descendants so the gesture/hover triggers anywhere inside it.
+
+Structural only — asserts the child widgets carry the container's bindtag after
+attach (no synthetic event delivery, which is flaky headless). One module-scoped
+App (creating several Apps crashes Tk).
+"""
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.gui
+
+
+@pytest.fixture(scope="module")
+def app():
+    import bootstack as bs
+
+    app = bs.App()
+    app._tk_root.withdraw()
+    try:
+        yield app
+    finally:
+        try:
+            app._tk_root.destroy()
+        except Exception:
+            pass
+
+
+def _build_card_with_children(bs):
+    """Return (card, [child tk widgets]) — a Card holding a nested Label."""
+    with bs.Card() as card:
+        with bs.Column():
+            label = bs.Label("Right-click me")
+    card.tk.update_idletasks()
+    return card, label
+
+
+def test_context_menu_tag_reaches_container_children(app):
+    import bootstack as bs
+    from bootstack.widgets.contextmenu import _resolve_tk
+
+    card, label = _build_card_with_children(bs)
+    menu = bs.ContextMenu(target=card, trigger="right_click")
+    menu.add_item("Edit")
+
+    tag = str(_resolve_tk(card))
+    assert tag in label.tk.bindtags()
+    menu.destroy()
+
+
+def test_tooltip_tag_reaches_container_children(app):
+    import bootstack as bs
+
+    card, label = _build_card_with_children(bs)
+    tip = bs.Tooltip(card, "Container tip")
+
+    # Tooltip resolves the target via `.tk`; that is the tag its hover bindings
+    # are registered under, and it must reach the nested child.
+    tag = str(card.tk)
+    assert tag in label.tk.bindtags()
+    tip.destroy()
+
+
+def test_propagate_is_idempotent(app):
+    import bootstack as bs
+    from bootstack._runtime.utility import propagate_target_bindings
+
+    card, label = _build_card_with_children(bs)
+    target = card.tk
+    propagate_target_bindings(target)
+    propagate_target_bindings(target)
+
+    tag = str(target)
+    # The tag appears exactly once, not duplicated per call.
+    assert label.tk.bindtags().count(tag) == 1
+
+
+def test_propagate_skips_nested_toplevels(app):
+    import bootstack as bs
+    from bootstack._runtime.utility import propagate_target_bindings
+
+    # A ContextMenu parented to the card creates its own Toplevel under it; the
+    # walk must not tag the popup's own widgets.
+    card, _label = _build_card_with_children(bs)
+    menu = bs.ContextMenu(target=card, trigger="manual")
+    menu.add_item("Edit")
+    propagate_target_bindings(card.tk)
+
+    tag = str(card.tk)
+    popup = menu._internal._impl._toplevel
+    frame = popup.winfo_children()[0]
+    assert tag not in frame.bindtags()
+    menu.destroy()
+
+
+def test_child_own_pathtag_keeps_precedence(app):
+    import bootstack as bs
+    from bootstack._runtime.utility import propagate_target_bindings
+
+    card, label = _build_card_with_children(bs)
+    propagate_target_bindings(card.tk)
+
+    tags = label.tk.bindtags()
+    # The child's own path-name tag still runs before the injected container tag.
+    assert tags[0] == str(label.tk)
+    assert tags.index(str(label.tk)) < tags.index(str(card.tk))


### PR DESCRIPTION
Closes #166.

## Problem

Tk events don't bubble, so a `ContextMenu`/`Tooltip` gesture bound to a **container** target (e.g. a `Card`) only fired over the container's bare area — never over its children. Right-clicking a `Label` inside the card did nothing; you had to hit the card's padding.

## Fix

New shared helper **`propagate_target_bindings(target)`** in `_runtime/utility.py` (the bindtags approach from the issue):

- Adds the container's own path-name bindtag — the tag `widget.bind(...)` registers under — to every descendant in the same toplevel, so the trigger/hover fires anywhere inside the container.
- Inserted **after** each child's own path tag, so child bindings keep precedence.
- **Idempotent** (safe to re-run) and **skips nested toplevels** — important because the menu's own popup `Toplevel` is parented under the target and would otherwise get tagged.

Wired into `ContextMenu._bind_trigger` (covers all platform gesture variants at once, since it's tag-based) and `Tooltip.__init__`.

`Tooltip` also gains a **crossing-aware `<Leave>`** (`_pointer_within_target` via `winfo_containing`): moving from the container onto a child fires a `<Leave>` on the container even though the pointer is still inside it, which would otherwise flicker the tip. `<ButtonPress>` is split into its own unconditional-hide handler.

Public `target` docstrings note the new container coverage.

## Limitation

Children added **after** attach aren't auto-tagged (re-attach covers it). The common case — content built before the menu/tooltip is created — works, since those children already exist at attach time.

## Tests

`tests/widgets/public/test_overlay_container_coverage.py` (5, passing): tag reaches nested children for both widgets, idempotency, nested-toplevel skip, child-precedence ordering. Existing native-contextmenu tests still green. Both behaviors verified manually in the demo (right-click + hover over a card's child label).

🤖 Generated with [Claude Code](https://claude.com/claude-code)