### PR TITLE
feat(tabs): tab overflow handling — scrolling strip + overflow menu (#168)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,50 @@ Go from nothing to something fast. The user should never need to `import tkinter
 Pointers only — these shipped; rationale, detail, and gotchas live in the linked
 memories and git history.
 
+- **Tab overflow handling (#168)** (this session; branch `feat/tabs-overflow`,
+  3 commits — **committed, not yet PR'd**) — tabs that exceed the strip now stay
+  in a **scrollbar-less scrolling line** (wheel scrolls along the axis; the
+  selected tab auto-scrolls into view) with a trailing **chevron overflow menu**
+  listing the off-screen tabs (with icons) that scrolls the picked one into view.
+  `⌄`/`+` are pinned outside the scroll region (`+` outermost, `⌄` next), ghost
+  buttons with a gap before them: horizontal = compact icon-only `⌄`; vertical =
+  full-width left-aligned **`⌄ More`** matching the rows + **`+ New`**.
+  **Always-on — NO `overflow=` option** (clipped tabs are never desirable; the
+  plain non-scrolling strip is kept ONLY for `tab_width='stretch'`, which always
+  fits). New **`max_tabs=`** disables the add button at the limit (re-enables on
+  removal). Axis-aware (both orientations); built on the existing `ScrollView`
+  (`scrollbar_visibility='never'`). **Three framework fixes surfaced while
+  building:** (a) **`PackFrame` skips the full forget/repack on child removal
+  when `gap==0`** (Tk keeps sibling order on its own) — kills a tab-close
+  **flash**; a win for any gap-less PackFrame. (b) **`PageStack.navigate`
+  pre-sizes the target page before a SWAP** (`update_idletasks`, guarded to
+  `self._current is not None` so the initial build — all first-mounts — isn't
+  serialized into a visible **slow-motion** render) — kills the add+select
+  content-area **jump** (a pre-existing PageStack quirk, reproduced in the old
+  non-scrolling path too). (c) **`_scroll_into_view` defers via retry** until the
+  new tab is positioned (winfo_x ready) instead of a forced synchronous flush.
+  Demo Navigation page wires `+` to add+select and showcases H/V overflow + the
+  `max_tabs` limit. Tests `tests/widgets/public/test_tabs_overflow.py` (10). The
+  `+` only fires a `tab_add` event — the app supplies the new tab (it never
+  "did nothing"; the demo simply hadn't wired a handler).
+- **ContextMenu/Tooltip cover container children (#166)** (this session; PR
+  **#183**, MERGED to `main`) — Tk events don't bubble, so a gesture bound to a
+  **container** target (e.g. a `Card`) only fired over the container's bare area,
+  never over its children. Fix = new shared helper **`propagate_target_bindings(target)`**
+  in `_runtime/utility.py`: adds the container's own **path-name bindtag** (the tag
+  `widget.bind(...)` registers under) to every descendant in the same toplevel, so the
+  trigger/hover fires anywhere inside. Inserted **after** each child's own path tag
+  (child bindings keep precedence); **idempotent**; **skips nested toplevels** (the
+  menu's own popup is parented under the target). Wired into
+  `ContextMenu._bind_trigger` (covers all platform gesture variants at once — it's
+  tag-based) + `Tooltip.__init__`. `Tooltip` also gained a **crossing-aware `<Leave>`**
+  (`_pointer_within_target` via `winfo_containing`) so moving container→child doesn't
+  flicker the tip; `<ButtonPress>` split into its own unconditional-hide handler.
+  **Limitation:** children added *after* attach aren't auto-tagged (re-attach covers
+  it). Tests `tests/widgets/public/test_overlay_container_coverage.py` (5). Memory
+  `reference_bindtags_underused` — **bindtags are underused in the architecture;
+  TODO: an eval pass to find recursive/duplicated `.bind()` a shared bindtag could
+  simplify** (a `BindtagsMixin` already exists, barely used).
 - **Theme-repaint cleanup (#177) + docstring-backtick sweep** (this session; PRs
   **#181**/**#182**, both MERGED to `main`) — **#181**
   (`fix/theme-repaint-cleanup`, closes #177): migrated the code-editor's
@@ -457,9 +501,11 @@ geometry manager. Merged to `main` via **PR #170** (the long-running
   keyboard focus, NOT hover. Memory `project_gallery_focus_ring`.
 - **`add_spacer()`→public `Spacer`** still deferred — entangled with
   `feat/unified-toolbars` (internal `Toolbar` is pack-based). Memory `project_unified_toolbars`.
-- Demo bugs (pre-existing, NOT layout-caused): **#166 ContextMenu/Tooltip don't
-  cover container children — NEXT UP** · ~~#167 Gauge theme repaint~~ (resolved by
-  the theme-repaint perf work, PR #180) · #168 Tabs overflow.
+- Demo bugs (pre-existing, NOT layout-caused): ~~#166 ContextMenu/Tooltip don't
+  cover container children~~ (DONE, PR #183 — see top of "Recently completed") ·
+  ~~#167 Gauge theme repaint~~ (resolved by the theme-repaint perf work, PR #180) ·
+  ~~#168 Tabs overflow~~ (DONE, branch `feat/tabs-overflow`, 3 commits — committed,
+  not yet PR'd; see top of "Recently completed").
 
 ### ✅ SHIPPED — Undecorated window controls + border + maximized-drag (#162, #165) — MERGED #175
 

--- a/docs/widgets/tabs.rst
+++ b/docs/widgets/tabs.rst
@@ -144,6 +144,37 @@ programmatically.
 
    tabs.on_tab_add(add_tab)
 
+Overflow
+~~~~~~~~
+
+When the tabs exceed the strip, ``overflow='scroll'`` (the default) keeps them in
+a single scrolling line — there is no scrollbar; the mouse wheel scrolls along
+the strip, and selecting a tab scrolls it into view. A trailing chevron button
+appears only while tabs overflow: it lists the off-screen tabs and scrolls the
+one you pick into view. This works the same in both orientations — horizontal
+scrolls left and right, vertical scrolls up and down.
+
+.. code-block:: python
+
+   tabs = bs.Tabs(allow_add=True)          # overflow='scroll' by default
+   for i in range(20):
+       with tabs.add(f"file{i}", label=f"source-file-{i}.py", icon="file-earmark-code"):
+           bs.Label(f"Contents of source-file-{i}.py")
+
+Pass ``overflow='clip'`` to keep the older behavior, where tabs past the edge are
+clipped. Overflow scrolling does not apply when ``tab_width='stretch'`` — stretched
+tabs always fit.
+
+Limiting the tab count
+~~~~~~~~~~~~~~~~~~~~~~~
+
+``max_tabs=`` caps how many tabs can be open. When the count reaches the limit the
+add button is disabled; it re-enables when a tab is removed.
+
+.. code-block:: python
+
+   tabs = bs.Tabs(allow_add=True, max_tabs=8)
+
 Page layout modes
 ~~~~~~~~~~~~~~~~~
 

--- a/docs/widgets/tabs.rst
+++ b/docs/widgets/tabs.rst
@@ -147,23 +147,21 @@ programmatically.
 Overflow
 ~~~~~~~~
 
-When the tabs exceed the strip, ``overflow='scroll'`` (the default) keeps them in
-a single scrolling line — there is no scrollbar; the mouse wheel scrolls along
-the strip, and selecting a tab scrolls it into view. A trailing chevron button
-appears only while tabs overflow: it lists the off-screen tabs and scrolls the
-one you pick into view. This works the same in both orientations — horizontal
-scrolls left and right, vertical scrolls up and down.
+When the tabs exceed the strip, they stay in a single scrolling line — there is
+no scrollbar; the mouse wheel scrolls along the strip, and selecting a tab scrolls
+it into view. A trailing chevron button appears only while tabs overflow: it lists
+the off-screen tabs and scrolls the one you pick into view. This works the same in
+both orientations — horizontal scrolls left and right, vertical scrolls up and
+down. No configuration is needed; it just works.
 
 .. code-block:: python
 
-   tabs = bs.Tabs(allow_add=True)          # overflow='scroll' by default
+   tabs = bs.Tabs(allow_add=True)
    for i in range(20):
        with tabs.add(f"file{i}", label=f"source-file-{i}.py", icon="file-earmark-code"):
            bs.Label(f"Contents of source-file-{i}.py")
 
-Pass ``overflow='clip'`` to keep the older behavior, where tabs past the edge are
-clipped. Overflow scrolling does not apply when ``tab_width='stretch'`` — stretched
-tabs always fit.
+(``tab_width='stretch'`` never overflows — those tabs always fit the bar.)
 
 Limiting the tab count
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/bootstack/cli/demo.py
+++ b/src/bootstack/cli/demo.py
@@ -621,7 +621,7 @@ def _build_navigation_page():
 
             tabs2.on_tab_add(lambda e: _add_doc())
 
-        with bs.GroupBox("Tabs (overflow → scroll + menu, max 16)", horizontal_items="stretch", grow=True):
+        with bs.GroupBox("Tabs (overflow scrolls + menu, max 16)", horizontal_items="stretch", grow=True):
             tabs3 = bs.Tabs(allow_close="hover", allow_add=True, max_tabs=16, grow=True)
             _file_n = [0]
 

--- a/src/bootstack/cli/demo.py
+++ b/src/bootstack/cli/demo.py
@@ -607,8 +607,42 @@ def _build_navigation_page():
 
         with bs.GroupBox("Tabs (closable + addable)", horizontal_items="stretch", grow=True):
             tabs2 = bs.Tabs(allow_close=True, allow_add=True, grow=True)
+            _doc_n = [1]
             with tabs2.add("doc1", label="Document 1", icon="file-text"):
                 bs.Label("Content for Document 1.", padding=20)
+
+            def _add_doc():
+                _doc_n[0] += 1
+                n = _doc_n[0]
+                page = tabs2.add(f"doc{n}", label=f"Document {n}", icon="file-text")
+                with page:
+                    bs.Label(f"Content for Document {n}.", padding=20)
+                page.select()  # newly added tab becomes active (and scrolls into view)
+
+            tabs2.on_tab_add(lambda e: _add_doc())
+
+        with bs.GroupBox("Tabs (overflow → scroll + menu, max 16)", horizontal_items="stretch", grow=True):
+            tabs3 = bs.Tabs(allow_close="hover", allow_add=True, max_tabs=16, grow=True)
+            _file_n = [0]
+
+            def _add_file(select=True):
+                _file_n[0] += 1
+                n = _file_n[0]
+                page = tabs3.add(f"file{n}", label=f"source-file-{n}.py", icon="file-earmark-code")
+                with page:
+                    bs.Label(f"Contents of source-file-{n}.py", padding=20)
+                if select:
+                    page.select()
+
+            for _ in range(12):
+                _add_file(select=False)
+            tabs3.on_tab_add(lambda e: _add_file())
+
+        with bs.GroupBox("Tabs (vertical overflow)", horizontal_items="stretch", grow=True):
+            tabs4 = bs.Tabs(orient="vertical", grow=True)
+            for n in range(1, 13):
+                with tabs4.add(f"sec{n}", label=f"Section {n}", icon="bookmark"):
+                    bs.Label(f"Section {n} body", padding=20)
 
         with bs.GroupBox("PageStack (swap content in place)", horizontal_items="stretch", grow=True):
             ps = bs.PageStack(grow=True)

--- a/src/bootstack/widgets/_impl/composites/pagestack.py
+++ b/src/bootstack/widgets/_impl/composites/pagestack.py
@@ -163,6 +163,13 @@ class PageStack(Frame):
 
         # Unmount previous page
         if self._current is not None:
+            # Pre-size the target page while the current one is still mounted, so
+            # the swap doesn't briefly collapse the content area (a freshly built
+            # page is otherwise unsized at mount time and the view jumps when it
+            # settles). Only needed for a real swap — the initial mount has
+            # nothing to collapse from, and forcing layout there would serialize
+            # the first render (a visible "slow-motion" build of the page).
+            self._pages[key].update_idletasks()
             self._pages[self._current].event_generate('<<PageUnmount>>', when="tail")
             self._pages[self._current].pack_forget()
 

--- a/src/bootstack/widgets/_impl/composites/tabs/tabs.py
+++ b/src/bootstack/widgets/_impl/composites/tabs/tabs.py
@@ -43,7 +43,6 @@ class Tabs(Frame):
         tab_min_width: int = 80,
         tab_padding: tuple = (12, 8),
         tab_anchor: str = None,
-        overflow: Literal['scroll', 'clip'] = 'scroll',
         enable_closing: bool | Literal['hover'] = False,
         enable_adding: bool = False,
         max_tabs: int | None = None,
@@ -72,15 +71,6 @@ class Tabs(Frame):
                 Default is (12, 8).
             tab_anchor: Anchor for tab text/icon alignment. If None, defaults
                 to 'w' for vertical orientation, 'center' for horizontal.
-            overflow: How to handle tabs that exceed the strip's length.
-                'scroll' (default) keeps the tabs in a single scrolling line
-                (no scrollbar; the wheel scrolls along the strip) with a
-                trailing chevron button that lists the off-screen tabs and
-                scrolls the chosen one into view. 'clip' keeps the legacy
-                behavior (tabs past the edge are clipped). Ignored when
-                `tab_width='stretch'` (tabs always fit). Applies to both
-                horizontal (scrolls left/right) and vertical (scrolls
-                up/down) orientations.
             enable_closing: Default close button visibility for all tabs.
                 True=always visible, False=hidden, 'hover'=visible on hover.
                 Can be overridden per-tab via `closable` in add_tab().
@@ -158,10 +148,9 @@ class Tabs(Frame):
         self._hidden: set[str] = set()
         self._counter = 0  # For auto-generating keys
 
-        # Overflow handling. Only meaningful when tabs are content-sized;
-        # 'stretch' always fits, so it disables scrolling.
-        self._overflow = overflow
-        self._scrollable = overflow == 'scroll' and tab_width != 'stretch'
+        # Tabs scroll when they exceed the strip. 'stretch' always fits, so it
+        # uses the plain non-scrolling strip instead.
+        self._scrollable = tab_width != 'stretch'
         self._axis = 'x' if orient == 'horizontal' else 'y'
         self._scroll: ScrollView | None = None
         self._strip_row: Frame | None = None
@@ -189,7 +178,7 @@ class Tabs(Frame):
             self.bind('<Destroy>', self._on_overflow_destroy, add='+')
 
     def _build_static_strip(self, orient: str, direction: str, gap: int) -> None:
-        """Build the legacy non-scrolling tab strip (tabs may clip)."""
+        """Build the plain non-scrolling strip (used when `tab_width='stretch'`)."""
         self._tab_bar = PackFrame(self, direction=direction, gap=gap)
         if orient == 'horizontal':
             self._tab_bar.pack(side='top', fill='x')

--- a/src/bootstack/widgets/_impl/composites/tabs/tabs.py
+++ b/src/bootstack/widgets/_impl/composites/tabs/tabs.py
@@ -12,6 +12,7 @@ from bootstack.widgets._impl.primitives.packframe import PackFrame
 from bootstack.widgets._impl.primitives.frame import Frame, FrameKwargs
 from bootstack.widgets._impl.primitives.separator import Separator
 from bootstack.widgets._impl.primitives.button import Button
+from bootstack.widgets._impl.composites.scrollview import ScrollView
 from bootstack.widgets._impl.composites.tabs.tabitem import TabItem
 from bootstack.widgets._impl.mixins.configure_mixin import configure_delegate
 from bootstack.widgets.types import Master
@@ -42,8 +43,10 @@ class Tabs(Frame):
         tab_min_width: int = 80,
         tab_padding: tuple = (12, 8),
         tab_anchor: str = None,
+        overflow: Literal['scroll', 'clip'] = 'scroll',
         enable_closing: bool | Literal['hover'] = False,
         enable_adding: bool = False,
+        max_tabs: int | None = None,
         variable: Variable = None,
         signal: 'Signal[Any]' = None,
         accent: str = None,
@@ -69,6 +72,15 @@ class Tabs(Frame):
                 Default is (12, 8).
             tab_anchor: Anchor for tab text/icon alignment. If None, defaults
                 to 'w' for vertical orientation, 'center' for horizontal.
+            overflow: How to handle tabs that exceed the strip's length.
+                'scroll' (default) keeps the tabs in a single scrolling line
+                (no scrollbar; the wheel scrolls along the strip) with a
+                trailing chevron button that lists the off-screen tabs and
+                scrolls the chosen one into view. 'clip' keeps the legacy
+                behavior (tabs past the edge are clipped). Ignored when
+                `tab_width='stretch'` (tabs always fit). Applies to both
+                horizontal (scrolls left/right) and vertical (scrolls
+                up/down) orientations.
             enable_closing: Default close button visibility for all tabs.
                 True=always visible, False=hidden, 'hover'=visible on hover.
                 Can be overridden per-tab via `closable` in add_tab().
@@ -76,6 +88,9 @@ class Tabs(Frame):
                 orientation, shows a plus icon on the right. In vertical
                 orientation, shows "New Tab" at the bottom. Fires `<<TabAdd>>`
                 event when clicked.
+            max_tabs: Maximum number of tabs allowed. When the tab count
+                reaches this value the add button is disabled (and re-enabled
+                when a tab is removed). None (default) means no limit.
             variable: Tk variable for tracking selected tab value.
                 See [tkinter Variables](https://docs.python.org/3/library/tkinter.html#tkinter-variables).
             signal: Reactive Signal for tracking selected tab value.
@@ -92,6 +107,7 @@ class Tabs(Frame):
         self._tab_padding = tab_padding
         self._enable_closing = enable_closing
         self._enable_adding = enable_adding
+        self._max_tabs = max_tabs
         self._accent = accent
 
         # Handle variable/signal setup
@@ -134,14 +150,47 @@ class Tabs(Frame):
         # Internal add button
         self._add_button: Button | None = None
 
-        # Create internal PackFrame for tabs
-        self._tab_bar = PackFrame(
-            self,
-            direction=direction,
-            gap=gap,
-        )
+        # Tab tracking by key
+        self._tabs: dict[str, TabItem] = {}
+        self._tab_order: list[str] = []
+        self._tab_values: dict[str, Any] = {}
+        self._tab_icons: dict[str, Any] = {}
+        self._hidden: set[str] = set()
+        self._counter = 0  # For auto-generating keys
 
-        # Layout tab bar and divider
+        # Overflow handling. Only meaningful when tabs are content-sized;
+        # 'stretch' always fits, so it disables scrolling.
+        self._overflow = overflow
+        self._scrollable = overflow == 'scroll' and tab_width != 'stretch'
+        self._axis = 'x' if orient == 'horizontal' else 'y'
+        self._scroll: ScrollView | None = None
+        self._strip_row: Frame | None = None
+        self._overflow_button: Button | None = None
+        self._overflow_menu = None
+        self._overflow_visible = False
+        self._overflow_after: str | None = None
+        self._canvas_cross = 0
+        self._wheel_tag = f'TabStripWheel_{id(self)}'
+
+        # Build the tab strip (scrollable or static) + divider
+        if self._scrollable:
+            self._build_scrollable_strip(orient, direction, gap)
+        else:
+            self._build_static_strip(orient, direction, gap)
+
+        # Create add button if enabled (must be after the strip is built)
+        if enable_adding:
+            self._create_add_button()
+
+        # Wire scroll behavior once everything exists
+        if self._scrollable:
+            self._setup_wheel_bindings()
+            self._signal.subscribe(self._on_selection_scroll)
+            self.bind('<Destroy>', self._on_overflow_destroy, add='+')
+
+    def _build_static_strip(self, orient: str, direction: str, gap: int) -> None:
+        """Build the legacy non-scrolling tab strip (tabs may clip)."""
+        self._tab_bar = PackFrame(self, direction=direction, gap=gap)
         if orient == 'horizontal':
             self._tab_bar.pack(side='top', fill='x')
             if self._show_divider:
@@ -153,15 +202,49 @@ class Tabs(Frame):
                 self._divider = Separator(self, orient='vertical')
                 self._divider.pack(side='left', fill='y')
 
-        # Create add button if enabled (must be after tab_bar is created)
-        if enable_adding:
-            self._create_add_button()
+    def _build_scrollable_strip(self, orient: str, direction: str, gap: int) -> None:
+        """Build a scrollbar-less scrolling strip with a trailing overflow menu.
 
-        # Tab tracking by key
-        self._tabs: dict[str, TabItem] = {}
-        self._tab_order: list[str] = []
-        self._hidden: set[str] = set()
-        self._counter = 0  # For auto-generating keys
+        The tab `PackFrame` lives inside a `ScrollView`; the add and overflow
+        buttons are pinned outside the scroll region (right edge for horizontal,
+        bottom for vertical) so they stay reachable while the tabs scroll.
+        """
+        if orient == 'horizontal':
+            self._strip_row = Frame(self)
+            self._strip_row.pack(side='top', fill='x')
+            self._scroll = ScrollView(
+                self._strip_row,
+                scroll_direction='horizontal',
+                scrollbar_visibility='never',
+            )
+            # Small gap between the scrolling tabs and the pinned add/overflow buttons.
+            self._scroll.pack(side='left', fill='x', expand=True, padx=(0, 6))
+        else:
+            self._strip_row = Frame(self)
+            self._strip_row.pack(side='left', fill='y')
+            self._scroll = ScrollView(
+                self._strip_row,
+                scroll_direction='vertical',
+                scrollbar_visibility='never',
+            )
+            # Small gap between the scrolling tabs and the pinned add/overflow buttons.
+            self._scroll.pack(side='top', fill='y', expand=True, pady=(0, 6))
+
+        self._tab_bar = PackFrame(self._scroll.canvas, direction=direction, gap=gap)
+        self._scroll.add(self._tab_bar)
+
+        # Match the canvas cross-size to the strip and re-evaluate overflow on
+        # any size change (ScrollView's own <Configure> bindings are kept via +).
+        self._tab_bar.bind('<Configure>', self._on_tabbar_configure, add='+')
+        self._scroll.canvas.bind('<Configure>', self._on_viewport_configure, add='+')
+
+        if self._show_divider:
+            if orient == 'horizontal':
+                self._divider = Separator(self, orient='horizontal')
+                self._divider.pack(side='top', fill='x')
+            else:
+                self._divider = Separator(self, orient='vertical')
+                self._divider.pack(side='left', fill='y')
 
     def _create_divider(self):
         """Create the divider separator widget."""
@@ -186,23 +269,26 @@ class Tabs(Frame):
         if self._add_button is not None:
             return
 
+        # When scrolling, the add button is pinned outside the scroll region
+        # (right edge for horizontal, bottom for vertical) so it stays put.
+        parent = self._strip_row if self._scrollable else self._tab_bar
+
         if self._orient == 'horizontal':
-            # Use TabItem.TButton so the button sizes to content (no button_height
-            # constraint), naturally matching the tab item's content-driven height
             self._add_button = Button(
-                self._tab_bar,
+                parent,
                 icon={'name': 'plus-lg', 'size': 16},
                 icon_only=True,
-                ttk_class='TabItem.TButton',
-                variant='icon',
-                padding=(8, 8),
+                variant='ghost',
                 command=self._on_add_click,
             )
-            self._add_button.pack()
+            if self._scrollable:
+                self._add_button.pack(side='right')
+            else:
+                self._add_button.pack()
         else:
             # "New Tab" with plus icon
             self._add_button = Button(
-                self._tab_bar,
+                parent,
                 text='New',
                 icon='plus-lg',
                 variant='ghost',
@@ -210,7 +296,12 @@ class Tabs(Frame):
                 command=self._on_add_click,
                 anchor='w',
             )
-            self._add_button.pack(fill='x')
+            if self._scrollable:
+                self._add_button.pack(side='bottom', fill='x')
+            else:
+                self._add_button.pack(fill='x')
+
+        self._update_add_button_state()
 
     def _destroy_add_button(self):
         """Remove the add button widget."""
@@ -219,8 +310,21 @@ class Tabs(Frame):
             self._add_button.destroy()
             self._add_button = None
 
+    def _update_add_button_state(self):
+        """Disable the add button when the tab count reaches `max_tabs`."""
+        if self._add_button is None:
+            return
+        at_limit = self._max_tabs is not None and len(self._tabs) >= self._max_tabs
+        if at_limit:
+            self._add_button.state(['disabled'])
+        else:
+            self._add_button.state(['!disabled'])
+
     def _on_add_click(self):
         """Handle add button click."""
+        # Guard against a queued click that lands after the limit is reached.
+        if self._max_tabs is not None and len(self._tabs) >= self._max_tabs:
+            return
         self.event_generate('<<TabAdd>>')
 
     def on_tab_added(self, callback: Callable) -> str:
@@ -348,8 +452,13 @@ class Tabs(Frame):
         if self._tab_width == 'stretch' and self._orient == 'horizontal':
             pack_opts['expand'] = True
 
-        # Insert before add button if it exists, otherwise append
-        if self._add_button is not None:
+        if self._scrollable:
+            # Tabs live inside the scroll region; the add/overflow buttons are
+            # pinned outside it, so just append in order.
+            tab.pack(**pack_opts)
+            self._add_wheel_binding(tab)
+            self._schedule_overflow_update()
+        elif self._add_button is not None:
             tab.pack(before=self._add_button, **pack_opts)
         else:
             tab.pack(**pack_opts)
@@ -357,11 +466,14 @@ class Tabs(Frame):
         # Track tab by key
         self._tabs[key] = tab
         self._tab_order.append(key)
+        self._tab_values[key] = value
+        self._tab_icons[key] = icon
 
         # Auto-select first tab
         if len(self._tabs) == 1:
             self._variable.set(value)
 
+        self._update_add_button_state()
         return tab
 
     def remove(self, key: str) -> None:
@@ -378,8 +490,12 @@ class Tabs(Frame):
 
         tab = self._tabs.pop(key)
         self._tab_order.remove(key)
+        self._tab_values.pop(key, None)
+        self._tab_icons.pop(key, None)
         tab.pack_forget()
         tab.destroy()
+        self._update_add_button_state()
+        self._schedule_overflow_update()
 
     def hide(self, key: str) -> None:
         """Hide a tab without removing it from the registry.
@@ -397,6 +513,7 @@ class Tabs(Frame):
         if key not in self._hidden:
             self._hidden.add(key)
             self._tabs[key].pack_forget()
+            self._schedule_overflow_update()
 
     def show(self, key: str) -> None:
         """Restore a previously hidden tab to the bar.
@@ -419,10 +536,13 @@ class Tabs(Frame):
             next_visible = self._next_visible_tab_after(key)
             if next_visible is not None:
                 tab.pack(before=self._tabs[next_visible], **pack_opts)
-            elif self._add_button is not None:
+            elif self._add_button is not None and not self._scrollable:
                 tab.pack(before=self._add_button, **pack_opts)
             else:
                 tab.pack(**pack_opts)
+            if self._scrollable:
+                self._add_wheel_binding(tab)
+                self._schedule_overflow_update()
 
     def _next_visible_tab_after(self, key: str) -> str | None:
         """Return the key of the next visible tab after *key* in tab order."""
@@ -433,6 +553,304 @@ class Tabs(Frame):
             if k == key:
                 found = True
         return None
+
+    # -------------------------------------------------------------------------
+    # Overflow scrolling (scrollbar-less strip + trailing overflow menu)
+    # -------------------------------------------------------------------------
+
+    def _on_tabbar_configure(self, _event=None) -> None:
+        """Keep the canvas cross-size matched to the strip; recheck overflow."""
+        if not self._scrollable:
+            return
+        if self._axis == 'x':
+            cross = self._tab_bar.winfo_reqheight()
+        else:
+            cross = self._tab_bar.winfo_reqwidth()
+        if cross > 1 and cross != self._canvas_cross:
+            self._canvas_cross = cross
+            if self._axis == 'x':
+                self._scroll.canvas.configure(height=cross)
+            else:
+                self._scroll.canvas.configure(width=cross)
+        self._schedule_overflow_update()
+
+    def _on_viewport_configure(self, _event=None) -> None:
+        """Re-evaluate overflow when the visible viewport is resized."""
+        self._schedule_overflow_update()
+
+    def _content_size(self) -> int:
+        """Total length of the tab strip along the scroll axis (pixels)."""
+        if self._axis == 'x':
+            return self._tab_bar.winfo_reqwidth()
+        return self._tab_bar.winfo_reqheight()
+
+    def _viewport_size(self) -> int:
+        """Visible length of the scroll viewport along the scroll axis (pixels)."""
+        canvas = self._scroll.canvas
+        return canvas.winfo_width() if self._axis == 'x' else canvas.winfo_height()
+
+    def _content_overflows(self) -> bool:
+        """Whether the strip is longer than the viewport (tabs are off-screen)."""
+        if not self._scrollable:
+            return False
+        view = self._viewport_size()
+        return view > 1 and self._content_size() > view + 1
+
+    def _view_first(self) -> float:
+        """First-visible fraction (0..1) of the scroll axis."""
+        view = self._scroll.xview() if self._axis == 'x' else self._scroll.yview()
+        return view[0]
+
+    def _view_moveto(self, fraction: float) -> None:
+        """Scroll so *fraction* (0..1) of the content is at the leading edge."""
+        if self._axis == 'x':
+            self._scroll.xview_moveto(fraction)
+        else:
+            self._scroll.yview_moveto(fraction)
+
+    def _tab_start(self, tab: TabItem) -> int:
+        """Leading-edge offset of *tab* within the strip along the scroll axis."""
+        return tab.winfo_x() if self._axis == 'x' else tab.winfo_y()
+
+    def _tab_extent(self, tab: TabItem) -> int:
+        """Length of *tab* along the scroll axis (pixels)."""
+        return tab.winfo_width() if self._axis == 'x' else tab.winfo_height()
+
+    def _schedule_overflow_update(self) -> None:
+        """Coalesce overflow re-evaluation to the next idle moment."""
+        if not self._scrollable or self._overflow_after is not None:
+            return
+        try:
+            self._overflow_after = self.after_idle(self._update_overflow)
+        except Exception:
+            self._overflow_after = None
+
+    def _update_overflow(self) -> None:
+        """Show or hide the trailing overflow button to match overflow state."""
+        self._overflow_after = None
+        if not self._scrollable or not self.winfo_exists():
+            return
+        overflow = self._content_overflows()
+        if overflow and not self._overflow_visible:
+            self._show_overflow_button()
+        elif not overflow and self._overflow_visible:
+            self._hide_overflow_button()
+
+    def _show_overflow_button(self) -> None:
+        """Create (once) and pin the trailing overflow button.
+
+        Horizontal uses a compact icon-only chevron; vertical uses a full-width,
+        left-aligned `⌄ More` to match the tab rows and the `+ New` button.
+        """
+        if self._overflow_button is None:
+            if self._axis == 'x':
+                self._overflow_button = Button(
+                    self._strip_row,
+                    icon={'name': 'chevron-down', 'size': 16},
+                    icon_only=True,
+                    variant='ghost',
+                    command=self._on_overflow_click,
+                )
+            else:
+                self._overflow_button = Button(
+                    self._strip_row,
+                    text='More',
+                    icon='chevron-down',
+                    variant='ghost',
+                    anchor='w',
+                    command=self._on_overflow_click,
+                )
+        if self._axis == 'x':
+            self._overflow_button.pack(side='right')
+        else:
+            self._overflow_button.pack(side='bottom', fill='x')
+        self._overflow_visible = True
+
+    def _hide_overflow_button(self) -> None:
+        """Unpin the trailing overflow button (kept for reuse)."""
+        if self._overflow_button is not None:
+            self._overflow_button.pack_forget()
+        self._overflow_visible = False
+
+    def _offscreen_tab_keys(self) -> list[str]:
+        """Keys of visible tabs that are not fully within the viewport."""
+        if not self._scrollable:
+            return []
+        content = self._content_size()
+        view = self._viewport_size()
+        lead = self._view_first() * content
+        trail = lead + view
+        keys: list[str] = []
+        for key in self._tab_order:
+            if key in self._hidden:
+                continue
+            tab = self._tabs[key]
+            start = self._tab_start(tab)
+            end = start + self._tab_extent(tab)
+            if start < lead - 1 or end > trail + 1:
+                keys.append(key)
+        return keys
+
+    def _scroll_into_view(self, key: str, _retries: int = 3) -> None:
+        """Scroll the strip so the tab for *key* is fully visible."""
+        if not self._scrollable or key not in self._tabs or key in self._hidden:
+            return
+        if not self.winfo_exists():
+            return
+        tab = self._tabs[key]
+        # A just-added tab may not be laid out yet (winfo_x/y still 0). Re-defer
+        # rather than force a synchronous flush, which would paint a half-settled
+        # layout and make the page visibly jump. Only the first tab legitimately
+        # sits at offset 0.
+        if _retries > 0 and key != self._tab_order[0] and self._tab_start(tab) == 0:
+            self.after_idle(lambda: self._scroll_into_view(key, _retries - 1))
+            return
+        content = self._content_size()
+        view = self._viewport_size()
+        if view <= 1 or content <= view:
+            return
+        start = self._tab_start(tab)
+        end = start + self._tab_extent(tab)
+        lead = self._view_first() * content
+        trail = lead + view
+        if start < lead:
+            new_lead = start
+        elif end > trail:
+            new_lead = end - view
+        else:
+            return
+        new_lead = max(0, min(new_lead, content - view))
+        self._view_moveto(new_lead / content)
+
+    def _on_selection_scroll(self, value: Any) -> None:
+        """Auto-scroll the newly selected tab into view (signal subscriber)."""
+        if not self._scrollable:
+            return
+        key = self._key_for_value(value)
+        if key is not None:
+            self.after_idle(lambda: self._scroll_into_view(key))
+
+    def _key_for_value(self, value: Any) -> str | None:
+        """Reverse-map a selection value back to a tab key."""
+        for key, val in self._tab_values.items():
+            if val == value:
+                return key
+        return None
+
+    def _ensure_overflow_menu(self):
+        """Create (once) the dropdown used by the overflow button."""
+        if self._overflow_menu is None:
+            from bootstack.widgets._impl.composites.contextmenu import ContextMenu
+            if self._axis == 'x':
+                anchor, attach = 'ne', 'se'
+            else:
+                anchor, attach = 'sw', 'nw'
+            self._overflow_menu = ContextMenu(
+                self._overflow_button,
+                target=self._overflow_button,
+                trigger='manual',
+                anchor=anchor,
+                attach=attach,
+                offset=(0, 2),
+            )
+        return self._overflow_menu
+
+    def _on_overflow_click(self) -> None:
+        """Populate and show the overflow dropdown with the off-screen tabs."""
+        keys = self._offscreen_tab_keys()
+        menu = self._ensure_overflow_menu()
+        menu.items([])  # clear previous contents
+        for key in keys:
+            tab = self._tabs[key]
+            try:
+                label = tab.cget('text') or key
+            except Exception:
+                label = key
+            icon = self._tab_icons.get(key)
+            kw = {'text': label, 'command': lambda k=key: self._on_overflow_select(k)}
+            if icon:
+                kw['icon'] = icon
+            menu.add_command(**kw)
+        menu.show()
+
+    def _on_overflow_select(self, key: str) -> None:
+        """Select a tab chosen from the overflow menu and reveal it."""
+        if key not in self._tab_values:
+            return
+        self._variable.set(self._tab_values[key])
+        # Selection scroll also fires via the signal, but request it explicitly
+        # too in case the value did not actually change.
+        self.after_idle(lambda: self._scroll_into_view(key))
+
+    def _setup_wheel_bindings(self) -> None:
+        """Bind wheel scrolling along the strip axis via a private bindtag."""
+        winsys = self.tk.call('tk', 'windowingsystem')
+        if winsys == 'x11':
+            self.bind_class(self._wheel_tag, '<Button-4>', self._on_strip_wheel, add='+')
+            self.bind_class(self._wheel_tag, '<Button-5>', self._on_strip_wheel, add='+')
+        else:
+            self.bind_class(self._wheel_tag, '<MouseWheel>', self._on_strip_wheel, add='+')
+        self._add_wheel_binding(self._tab_bar)
+
+    def _add_wheel_binding(self, widget) -> None:
+        """Add the wheel bindtag to *widget* and its descendants (idempotent)."""
+        try:
+            tags = list(widget.bindtags())
+            if self._wheel_tag not in tags:
+                tags.insert(1 if len(tags) > 1 else len(tags), self._wheel_tag)
+                widget.bindtags(tuple(tags))
+        except Exception:
+            pass
+        try:
+            children = widget.winfo_children()
+        except Exception:
+            return
+        for child in children:
+            self._add_wheel_binding(child)
+
+    def _on_strip_wheel(self, event) -> str | None:
+        """Scroll the strip along its axis in response to the mouse wheel."""
+        if not self._scrollable or not self._content_overflows():
+            return None
+        winsys = self.tk.call('tk', 'windowingsystem')
+        if winsys == 'win32':
+            notches = -event.delta / 120
+        elif winsys == 'aqua':
+            notches = -event.delta
+        elif getattr(event, 'num', None) == 4:
+            notches = -1
+        elif getattr(event, 'num', None) == 5:
+            notches = 1
+        else:
+            notches = 0
+        if not notches:
+            return 'break'
+        content = self._content_size()
+        view = self._viewport_size()
+        if content <= view:
+            return 'break'
+        step = 60 * notches
+        lead = self._view_first() * content
+        lead = max(0, min(lead + step, content - view))
+        self._view_moveto(lead / content)
+        return 'break'
+
+    def _on_overflow_destroy(self, event) -> None:
+        """Release overflow resources when the tab strip is destroyed."""
+        if event.widget is not self:
+            return
+        if self._overflow_after is not None:
+            try:
+                self.after_cancel(self._overflow_after)
+            except Exception:
+                pass
+            self._overflow_after = None
+        if self._overflow_menu is not None:
+            try:
+                self._overflow_menu.destroy()
+            except Exception:
+                pass
+            self._overflow_menu = None
 
     def item(self, key: str) -> TabItem:
         """Get a tab by its key.

--- a/src/bootstack/widgets/_impl/composites/tabs/tabview.py
+++ b/src/bootstack/widgets/_impl/composites/tabs/tabview.py
@@ -37,7 +37,6 @@ class TabView(Frame):
         tab_width: None | int | Literal['stretch'] = None,
         tab_padding: tuple = (12, 8),
         tab_anchor: str = None,
-        overflow: Literal['scroll', 'clip'] = 'scroll',
         enable_closing: bool | Literal['hover'] = False,
         enable_adding: bool = False,
         max_tabs: int | None = None,
@@ -56,10 +55,6 @@ class TabView(Frame):
             tab_padding: Padding for all tabs as (horizontal, vertical).
             tab_anchor: Anchor for tab text/icon alignment. If None, defaults
                 to 'w' for vertical orientation, 'center' for horizontal.
-            overflow: How to handle tabs that exceed the strip — 'scroll'
-                (default; scrollbar-less scrolling strip with a trailing
-                overflow menu) or 'clip' (legacy clipping). Ignored when
-                `tab_width='stretch'`.
             enable_closing: Default close button visibility for all tabs.
                 True=always visible, False=hidden, 'hover'=visible on hover.
                 Can be overridden per-tab via `closable` in add().
@@ -86,7 +81,6 @@ class TabView(Frame):
             tab_width=tab_width,
             tab_padding=tab_padding,
             tab_anchor=tab_anchor,
-            overflow=overflow,
             enable_closing=enable_closing,
             enable_adding=enable_adding,
             max_tabs=max_tabs,

--- a/src/bootstack/widgets/_impl/composites/tabs/tabview.py
+++ b/src/bootstack/widgets/_impl/composites/tabs/tabview.py
@@ -37,8 +37,10 @@ class TabView(Frame):
         tab_width: None | int | Literal['stretch'] = None,
         tab_padding: tuple = (12, 8),
         tab_anchor: str = None,
+        overflow: Literal['scroll', 'clip'] = 'scroll',
         enable_closing: bool | Literal['hover'] = False,
         enable_adding: bool = False,
+        max_tabs: int | None = None,
         accent: str = None,
         **kwargs: Unpack[FrameKwargs]
     ):
@@ -54,10 +56,16 @@ class TabView(Frame):
             tab_padding: Padding for all tabs as (horizontal, vertical).
             tab_anchor: Anchor for tab text/icon alignment. If None, defaults
                 to 'w' for vertical orientation, 'center' for horizontal.
+            overflow: How to handle tabs that exceed the strip — 'scroll'
+                (default; scrollbar-less scrolling strip with a trailing
+                overflow menu) or 'clip' (legacy clipping). Ignored when
+                `tab_width='stretch'`.
             enable_closing: Default close button visibility for all tabs.
                 True=always visible, False=hidden, 'hover'=visible on hover.
                 Can be overridden per-tab via `closable` in add().
             enable_adding: If True, shows an "add" button that fires `<<TabAdd>>`.
+            max_tabs: Maximum tab count; the add button disables at the limit.
+                None (default) means no limit.
             accent: Accent token for styling.
             **kwargs: Additional arguments passed to Frame.
         """
@@ -78,8 +86,10 @@ class TabView(Frame):
             tab_width=tab_width,
             tab_padding=tab_padding,
             tab_anchor=tab_anchor,
+            overflow=overflow,
             enable_closing=enable_closing,
             enable_adding=enable_adding,
+            max_tabs=max_tabs,
             variable=self._tab_variable,
             accent=accent,
         )

--- a/src/bootstack/widgets/_impl/primitives/packframe.py
+++ b/src/bootstack/widgets/_impl/primitives/packframe.py
@@ -219,6 +219,9 @@ class PackFrame(Frame):
         tk.Pack.forget(widget)
         self._managed.pop(idx)
 
-        # Only repack if we removed something that affects gaps (not the last item)
-        if idx < len(self._managed):
+        # Only repack if we removed something that affects gaps (not the last
+        # item). With no gap, Tk preserves the order of the remaining children
+        # on its own, so a full forget/repack is pure churn (it briefly clears
+        # the whole row — a visible flash) and is skipped.
+        if self._gap and idx < len(self._managed):
             self._repack_all()

--- a/src/bootstack/widgets/tabs.py
+++ b/src/bootstack/widgets/tabs.py
@@ -170,13 +170,10 @@ class Tabs(PublicWidgetBase):
         orient: `'horizontal'` (default, tabs above content) or `'vertical'` (tabs left).
         show_divider: Show a divider line between the tab bar and the page area.
         tab_width: Fixed tab width in pixels, `'stretch'` to fill available space, or
-            `None` (default, size to content).
-        overflow: How tabs that exceed the strip are handled. `'scroll'` (default)
-            keeps them in one scrolling line — no scrollbar, the wheel scrolls
-            along the strip, and a trailing chevron lists the off-screen tabs and
-            scrolls the chosen one into view. `'clip'` keeps the legacy behavior
-            (overflowing tabs are clipped). Works for both horizontal and vertical
-            orientations; ignored when `tab_width='stretch'`.
+            `None` (default, size to content). When tabs exceed the strip they
+            scroll — no scrollbar, the wheel scrolls along the strip, and a
+            trailing chevron lists the off-screen tabs and scrolls the chosen one
+            into view (both orientations). `'stretch'` tabs always fit.
         allow_close: Show close buttons on tabs. `True` = always, `False` = never,
             `'hover'` = on hover. Defaults to `False`.
         allow_add: Show an add-tab button that fires the `tab_add` event.
@@ -196,7 +193,6 @@ class Tabs(PublicWidgetBase):
         orient: Orient = "horizontal",
         show_divider: bool | None = None,
         tab_width: int | Literal["stretch"] | None = None,
-        overflow: Literal["scroll", "clip"] = "scroll",
         allow_close: bool | Literal["hover"] = False,
         allow_add: bool = False,
         max_tabs: int | None = None,
@@ -211,7 +207,6 @@ class Tabs(PublicWidgetBase):
 
         internal_kwargs: dict[str, Any] = {
             "orient": orient,
-            "overflow": overflow,
             "enable_closing": allow_close,
             "enable_adding": allow_add,
             "max_tabs": max_tabs,

--- a/src/bootstack/widgets/tabs.py
+++ b/src/bootstack/widgets/tabs.py
@@ -171,9 +171,18 @@ class Tabs(PublicWidgetBase):
         show_divider: Show a divider line between the tab bar and the page area.
         tab_width: Fixed tab width in pixels, `'stretch'` to fill available space, or
             `None` (default, size to content).
+        overflow: How tabs that exceed the strip are handled. `'scroll'` (default)
+            keeps them in one scrolling line — no scrollbar, the wheel scrolls
+            along the strip, and a trailing chevron lists the off-screen tabs and
+            scrolls the chosen one into view. `'clip'` keeps the legacy behavior
+            (overflowing tabs are clipped). Works for both horizontal and vertical
+            orientations; ignored when `tab_width='stretch'`.
         allow_close: Show close buttons on tabs. `True` = always, `False` = never,
             `'hover'` = on hover. Defaults to `False`.
         allow_add: Show an add-tab button that fires the `tab_add` event.
+        max_tabs: Maximum number of tabs. When reached, the add button is
+            disabled (and re-enabled when a tab is removed). `None` (default)
+            means no limit. Pairs with `allow_add`.
         accent: Accent token for the tab bar. Defaults to the theme accent.
         parent: Override the context-stack parent.
         **kwargs: Layout placement options applied by the parent container —
@@ -187,8 +196,10 @@ class Tabs(PublicWidgetBase):
         orient: Orient = "horizontal",
         show_divider: bool | None = None,
         tab_width: int | Literal["stretch"] | None = None,
+        overflow: Literal["scroll", "clip"] = "scroll",
         allow_close: bool | Literal["hover"] = False,
         allow_add: bool = False,
+        max_tabs: int | None = None,
         accent: AccentToken | str | None = None,
         parent: Any = None,
         **kwargs: Any,
@@ -200,8 +211,10 @@ class Tabs(PublicWidgetBase):
 
         internal_kwargs: dict[str, Any] = {
             "orient": orient,
+            "overflow": overflow,
             "enable_closing": allow_close,
             "enable_adding": allow_add,
+            "max_tabs": max_tabs,
         }
         if show_divider is not None:
             internal_kwargs["show_divider"] = show_divider

--- a/tests/widgets/public/test_tabs_overflow.py
+++ b/tests/widgets/public/test_tabs_overflow.py
@@ -1,0 +1,188 @@
+"""Tab overflow handling (issue #168).
+
+When tab headers exceed the strip length, `overflow='scroll'` (the default)
+hosts them in a scrollbar-less scrolling strip with a trailing chevron that
+lists the off-screen tabs. These assert the structural behavior — the scrollable
+wiring, overflow detection, the off-screen set, and scroll-into-view — for both
+orientations. Visual polish is verified by hand. One shown, module-scoped App
+(child widgets only map under a shown App; multiple Apps per process crash Tk).
+"""
+from __future__ import annotations
+
+import pytest
+
+import bootstack as bs
+
+pytestmark = pytest.mark.gui
+
+
+@pytest.fixture(scope="module")
+def shown_app():
+    app = bs.App()
+    app.__enter__()
+    root = app._tk_root
+    root.geometry("380x260")
+    root.deiconify()
+    root.update_idletasks()
+    try:
+        yield app
+    finally:
+        try:
+            app.__exit__(None, None, None)
+        except Exception:
+            pass
+        try:
+            root.destroy()
+        except Exception:
+            pass
+
+
+def _pump(app):
+    app._tk_root.update_idletasks()
+    app._tk_root.update()
+
+
+def _build(app, *, orient, count, label, **kw):
+    tabs = bs.Tabs(orient=orient, grow=True, **kw)
+    for i in range(count):
+        with tabs.add(f"k{i}", label=label.format(i=i)):
+            bs.Label(f"body {i}")
+    _pump(app)
+    inner = tabs._internal._tabs
+    inner._update_overflow()
+    _pump(app)
+    return tabs, inner
+
+
+def test_scroll_is_default_and_clip_opts_out(shown_app):
+    tabs, inner = _build(shown_app, orient="horizontal", count=2, label="Tab {i}")
+    assert inner._scrollable is True
+    assert inner._scroll is not None
+    tabs.destroy()
+
+    clip, clip_inner = _build(
+        shown_app, orient="horizontal", count=2, label="Tab {i}", overflow="clip"
+    )
+    assert clip_inner._scrollable is False
+    assert clip_inner._scroll is None
+    clip.destroy()
+
+
+def test_stretch_disables_scrolling(shown_app):
+    tabs, inner = _build(
+        shown_app, orient="horizontal", count=2, label="Tab {i}", tab_width="stretch"
+    )
+    assert inner._scrollable is False
+    tabs.destroy()
+
+
+def test_horizontal_overflow_shows_button_and_lists_offscreen(shown_app):
+    tabs, inner = _build(
+        shown_app, orient="horizontal", count=12, label="Document number {i}"
+    )
+    assert inner._axis == "x"
+    assert inner._content_size() > inner._viewport_size()
+    assert inner._content_overflows() is True
+    assert inner._overflow_visible is True
+    assert inner._overflow_button is not None
+    # Most tabs are off-screen; the first remains visible.
+    offscreen = inner._offscreen_tab_keys()
+    assert "k0" not in offscreen
+    assert len(offscreen) >= 8
+    tabs.destroy()
+
+
+def test_scroll_into_view_moves_the_strip(shown_app):
+    tabs, inner = _build(
+        shown_app, orient="horizontal", count=12, label="Document number {i}"
+    )
+    before = inner._view_first()
+    inner._scroll_into_view("k11")
+    _pump(shown_app)
+    after = inner._view_first()
+    assert after > before  # scrolled right to reveal the last tab
+    # And the revealed tab is no longer reported off-screen.
+    assert "k11" not in inner._offscreen_tab_keys()
+    tabs.destroy()
+
+
+def test_add_then_select_reveals_new_tab(shown_app):
+    # Regression: add+select must scroll the new (rightmost) tab into view, not
+    # snap to the left because the new tab's geometry wasn't yet computed.
+    tabs, inner = _build(
+        shown_app, orient="horizontal", count=12, label="source-file-{i}.py"
+    )
+    inner._scroll_into_view("k6")  # scroll to the middle first
+    _pump(shown_app)
+    with tabs.add("knew", label="source-file-new.py"):
+        bs.Label("new")
+    tabs.select("knew")
+    _pump(shown_app)
+    # The newly selected tab is fully visible.
+    assert "knew" not in inner._offscreen_tab_keys()
+    assert inner._view_first() > 0.5  # scrolled toward the right end
+    tabs.destroy()
+
+
+def test_remove_middle_tab_preserves_order(shown_app):
+    # With gap=0 the strip no longer full-repacks on removal (no flash); the
+    # remaining tabs keep their order.
+    tabs, inner = _build(shown_app, orient="horizontal", count=6, label="T{i}")
+    tabs.forget_tab("k2")
+    _pump(shown_app)
+    assert inner._tab_order == ["k0", "k1", "k3", "k4", "k5"]
+    tabs.destroy()
+
+
+def test_no_overflow_when_few_tabs(shown_app):
+    tabs, inner = _build(shown_app, orient="horizontal", count=2, label="T{i}")
+    assert inner._content_overflows() is False
+    assert inner._overflow_visible is False
+    tabs.destroy()
+
+
+def test_max_tabs_disables_add_button(shown_app):
+    tabs = bs.Tabs(allow_add=True, max_tabs=4, grow=True)
+    inner = tabs._internal._tabs
+    for i in range(3):
+        with tabs.add(f"k{i}", label=f"T{i}"):
+            bs.Label("x")
+    _pump(shown_app)
+    assert inner._add_button.instate(["!disabled"])  # 3 < 4 → enabled
+    with tabs.add("k3", label="T3"):
+        bs.Label("x")
+    _pump(shown_app)
+    assert inner._add_button.instate(["disabled"])  # 4 == max → disabled
+    tabs.forget_tab("k3")
+    _pump(shown_app)
+    assert inner._add_button.instate(["!disabled"])  # back under the limit
+    tabs.destroy()
+
+
+def test_overflow_menu_tracks_tab_icons(shown_app):
+    tabs, inner = _build(
+        shown_app, orient="horizontal", count=6, label="File {i}", allow_close="hover"
+    )
+    # rebuild with explicit icons
+    tabs.destroy()
+    tabs = bs.Tabs(orient="horizontal", grow=True)
+    inner = tabs._internal._tabs
+    for i in range(6):
+        with tabs.add(f"k{i}", label=f"File {i}", icon="file-earmark-code"):
+            bs.Label("x")
+    _pump(shown_app)
+    assert inner._tab_icons["k0"] == "file-earmark-code"
+    assert len(inner._tab_icons) == 6
+    tabs.destroy()
+
+
+def test_vertical_overflow_and_scroll(shown_app):
+    tabs, inner = _build(shown_app, orient="vertical", count=18, label="Section {i}")
+    assert inner._axis == "y"
+    assert inner._content_overflows() is True
+    assert inner._overflow_visible is True
+    before = inner._view_first()
+    inner._scroll_into_view("k17")
+    _pump(shown_app)
+    assert inner._view_first() > before
+    tabs.destroy()

--- a/tests/widgets/public/test_tabs_overflow.py
+++ b/tests/widgets/public/test_tabs_overflow.py
@@ -1,8 +1,9 @@
 """Tab overflow handling (issue #168).
 
-When tab headers exceed the strip length, `overflow='scroll'` (the default)
-hosts them in a scrollbar-less scrolling strip with a trailing chevron that
-lists the off-screen tabs. These assert the structural behavior — the scrollable
+When tab headers exceed the strip length, they are hosted in a scrollbar-less
+scrolling strip with a trailing chevron that lists the off-screen tabs (the
+plain non-scrolling strip is used only for `tab_width='stretch'`, which always
+fits). These assert the structural behavior — the scrollable
 wiring, overflow detection, the off-screen set, and scroll-into-view — for both
 orientations. Visual polish is verified by hand. One shown, module-scoped App
 (child widgets only map under a shown App; multiple Apps per process crash Tk).
@@ -54,25 +55,20 @@ def _build(app, *, orient, count, label, **kw):
     return tabs, inner
 
 
-def test_scroll_is_default_and_clip_opts_out(shown_app):
+def test_scrolling_enabled_by_default(shown_app):
     tabs, inner = _build(shown_app, orient="horizontal", count=2, label="Tab {i}")
     assert inner._scrollable is True
     assert inner._scroll is not None
     tabs.destroy()
 
-    clip, clip_inner = _build(
-        shown_app, orient="horizontal", count=2, label="Tab {i}", overflow="clip"
-    )
-    assert clip_inner._scrollable is False
-    assert clip_inner._scroll is None
-    clip.destroy()
 
-
-def test_stretch_disables_scrolling(shown_app):
+def test_stretch_uses_plain_strip(shown_app):
+    # Stretched tabs always fit, so they use the plain non-scrolling strip.
     tabs, inner = _build(
         shown_app, orient="horizontal", count=2, label="Tab {i}", tab_width="stretch"
     )
     assert inner._scrollable is False
+    assert inner._scroll is None
     tabs.destroy()
 
 


### PR DESCRIPTION
Closes #168.

## Problem

When tab headers exceeded the strip, they were clipped and **unreachable** — no way to scroll or reach the off-screen tabs.

## Solution

Tabs that exceed the strip now stay in a **scrollbar-less scrolling line**, axis-aware so it works in both orientations (horizontal scrolls left/right, vertical up/down):

- **No scrollbar** — the mouse wheel scrolls along the strip; selecting a tab auto-scrolls it into view.
- **Trailing `⌄` overflow menu** — appears *only while tabs overflow*; lists the off-screen tabs (with their icons) and scrolls the chosen one into view.
- Affordances pinned **outside** the scroll region with the add button (`+` outermost, `⌄` next), as **ghost** buttons with a gap before them. Horizontal: compact icon-only `⌄`. Vertical: full-width left-aligned **`⌄ More`** to match the rows and the **`+ New`** button.
- New **`max_tabs=`** disables the add button at the limit (re-enabled on removal).

Built on the existing `ScrollView` (`scrollbar_visibility='never'`).

### Always-on (no `overflow=` option)

Initially added an `overflow='scroll'|'clip'` param, then **removed it**: clipped tabs are never desirable (inaccessible = the bug, not a feature), and there's no prior behavior to preserve pre-release. Scrolling is always-on; the plain non-scrolling strip is kept only for `tab_width='stretch'` (always fits). If a genuinely different strategy ever lands (e.g. a menu-only collapse), `overflow=` can return with values that actually differ.

## Three framework fixes surfaced while building

- **`PackFrame` skips the full forget/repack on child removal when `gap==0`** — Tk preserves sibling order on its own, so the repack is pure churn that briefly clears the row (a visible **flash** on tab close). A win for any gap-less PackFrame.
- **`PageStack.navigate` pre-sizes the target page before a swap** (guarded to `self._current is not None`) — navigating to a *freshly built* page otherwise collapses the content area for a frame and the view **jumps**. A pre-existing quirk (reproduced in the non-scrolling path too). The guard keeps the initial build — all first-mounts — from being serialized into a **slow-motion** render.
- **`_scroll_into_view` defers via retry** until the new tab is positioned (`winfo_x` ready) instead of forcing a synchronous layout flush (which painted a half-settled frame).

## Notes

- The `+` button only fires a `tab_add` event — the app supplies the new tab's content (it never "did nothing"; the demo simply hadn't wired a handler). Demo Navigation page now wires `+` to add+select and showcases horizontal (max 16) and vertical overflow.

## Tests / docs

- `tests/widgets/public/test_tabs_overflow.py` — 10 passing (scrollable wiring, overflow detection, off-screen set, scroll-into-view, add-reveal, remove-order, `max_tabs` cycle, icon tracking, both orientations).
- `docs/widgets/tabs.rst` — Overflow + "Limiting the tab count" sections; `-W` build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)