### PR TITLE
test(media): regression test + cleanup for Gallery/Carousel height floor (#160)

### DIFF
--- a/src/bootstack/widgets/_impl/composites/carousel.py
+++ b/src/bootstack/widgets/_impl/composites/carousel.py
@@ -39,6 +39,11 @@ _DOT_GAP = 6
 _DOTS_MAX = 8            # above this, 'dots' auto-switches to a 'count' label
 _CAPTION_INSET = 14      # caption baseline inset from the bottom
 _FRAME_MS = 16
+# Nominal stage width (px) behind the aspect-ratio height floor: with no explicit
+# `height`, the minimum stage height is `_FLOOR_STAGE_WIDTH / aspect_ratio`
+# (e.g. 400 / 1.5 ≈ 267). A floor, not a cap — `fill`/`expand` grow it past this,
+# and a larger `aspect_ratio` (wider slide) yields a shorter floor.
+_FLOOR_STAGE_WIDTH = 400
 
 
 def _hex_rgb(color: str) -> tuple[int, int, int]:
@@ -127,7 +132,7 @@ class Carousel(Frame):
         # public wrapper freezes this frame with `pack_propagate(False)`, so its
         # own configured `height` is its requested height; `fill`/`expand` still
         # grow it past this floor when the parent has room.
-        floor_h = height if height else round(400 / max(0.1, aspect_ratio))
+        floor_h = height if height else round(_FLOOR_STAGE_WIDTH / max(0.1, aspect_ratio))
         self.configure(height=floor_h)
         self._stage = Canvas(self, highlightthickness=0, bd=0, background=surface)
         self._stage.pack(fill="both", expand=True)

--- a/src/bootstack/widgets/_impl/composites/gallery.py
+++ b/src/bootstack/widgets/_impl/composites/gallery.py
@@ -34,6 +34,7 @@ OVERSCAN_ROWS = 1
 _RING_THICKNESS = 3
 _RING_GAP = 3                       # separation between the image and the ring
 _RING_PAD = _RING_GAP + _RING_THICKNESS   # margin reserved around the image
+_CAPTION_H = 24            # vertical space reserved per caption row in the height floor
 EMPTY = {"__empty__": True, "id": "__empty__"}
 
 
@@ -221,7 +222,7 @@ class Gallery(Frame):
         self._pool_rows = 1
         self._start_row = 0
         self._ring_photo: PhotoImage | None = None
-        self._row_h = self._th + 2 * _RING_PAD + (24 if caption_field else 0) + gap
+        self._row_h = self._th + 2 * _RING_PAD + (_CAPTION_H if caption_field else 0) + gap
 
         sb_surface = getattr(self, '_surface', None)
         sb_kw = {'surface': sb_surface} if sb_surface else {}

--- a/src/bootstack/widgets/carousel.py
+++ b/src/bootstack/widgets/carousel.py
@@ -52,8 +52,9 @@ class Carousel(PublicWidgetBase):
             Default `0`.
         aspect_ratio: Width-to-height ratio used to derive the carousel's minimum
             height when it sits in a container that doesn't impose one (a scroll
-            view, an auto-fit window). Default `1.5`. Ignored when `height` is
-            set. `fill`/`expand` still grow the stage past this floor.
+            view, an auto-fit window) — a larger ratio gives a wider, shorter
+            floor. Default `1.5`. Ignored when `height` is set. `fill`/`expand`
+            still grow the stage past this floor.
         height: Explicit minimum height for the slide stage, in pixels. Overrides
             `aspect_ratio`. Default `None` (derive from `aspect_ratio`).
         accent: Color intent token to brand the active indicator dot. By default

--- a/tests/widgets/public/test_media_height_floor.py
+++ b/tests/widgets/public/test_media_height_floor.py
@@ -1,0 +1,131 @@
+"""Gallery/Carousel keep a height floor in non-expanding parents (issue #160).
+
+Gallery and Carousel are fill-driven and request ~0 height on their own, so in a
+container that hands children their requested size — a ScrollView, an auto-fit
+window — they used to collapse to a sliver and drag the surrounding group down
+with them. PR #161 gave each a requested-height floor (a true minimum: `grow`/
+`expand` still grow past it). These guard that the floor exists, is honored inside
+a ScrollView, reflects the sizing knobs, and does not freeze growth.
+
+One shown, module-scoped App (children only map under a shown App; multiple Apps
+per process crash Tk).
+"""
+from __future__ import annotations
+
+import pytest
+
+import bootstack as bs
+
+pytestmark = pytest.mark.gui
+
+
+@pytest.fixture(scope="module")
+def shown_app():
+    app = bs.App()
+    app.__enter__()
+    root = app._tk_root
+    root.geometry("440x640")
+    root.deiconify()
+    root.update_idletasks()
+    try:
+        yield app
+    finally:
+        try:
+            app.__exit__(None, None, None)
+        except Exception:
+            pass
+        try:
+            root.destroy()
+        except Exception:
+            pass
+
+
+def _pump(app):
+    app._tk_root.update_idletasks()
+    app._tk_root.update()
+
+
+# ----- The floor exists (requested height is non-zero) -----------------------
+
+
+def test_gallery_requests_a_height_floor(shown_app):
+    g = bs.Gallery(grow=True)
+    _pump(shown_app)
+    # Default rows=2, tile 160, ring pad 2x6, gap 8 -> 2 * 180 = 360.
+    assert g._internal.winfo_reqheight() == 360
+    g.destroy()
+
+
+def test_carousel_requests_a_height_floor(shown_app):
+    c = bs.Carousel(grow=True)
+    _pump(shown_app)
+    # Default aspect_ratio 1.5 -> round(400 / 1.5) = 267.
+    assert c._internal.winfo_reqheight() == 267
+    c.destroy()
+
+
+# ----- The issue's literal case: non-zero height inside a ScrollView ----------
+
+
+def test_gallery_in_scrollview_does_not_collapse(shown_app):
+    with bs.ScrollView(scroll_direction="vertical", height=240, grow=True) as sv:
+        g = bs.Gallery(grow=True)
+    _pump(shown_app)
+    assert g._internal.winfo_reqheight() > 1
+    assert g._internal.winfo_height() > 1  # actually rendered, not a sliver
+    sv.destroy()  # also destroys the gallery inside
+
+
+def test_carousel_in_scrollview_does_not_collapse(shown_app):
+    with bs.ScrollView(scroll_direction="vertical", height=240, grow=True) as sv:
+        c = bs.Carousel(grow=True)
+    _pump(shown_app)
+    assert c._internal.winfo_reqheight() > 1
+    assert c._internal.winfo_height() > 1
+    sv.destroy()
+
+
+# ----- The floor is a minimum, not a freeze ----------------------------------
+
+
+def test_floor_is_a_minimum_not_a_fixed_size(shown_app):
+    # The floor must be a requested MINIMUM the parent can grow past, not a hard
+    # freeze. The public wrappers achieve this by freezing the frame at the floor
+    # while packing the inner canvas with expand, so a larger allocation flows
+    # into the canvas. Assert that growth path so a future change that re-breaks
+    # it is caught. (Actual grow-past-floor allocation is exercised in the demo.)
+    g = bs.Gallery(grow=True)
+    c = bs.Carousel(grow=True)
+    _pump(shown_app)
+    assert g._internal._container.pack_info().get("expand") in (1, "1", True)
+    assert c._internal._stage.pack_info().get("expand") in (1, "1", True)
+    g.destroy()
+    c.destroy()
+
+
+# ----- The sizing knobs move the floor ---------------------------------------
+
+
+def test_gallery_rows_scale_the_floor(shown_app):
+    g2 = bs.Gallery(rows=2, grow=True)
+    g4 = bs.Gallery(rows=4, grow=True)
+    _pump(shown_app)
+    assert g4._internal.winfo_reqheight() > g2._internal.winfo_reqheight()
+    g2.destroy()
+    g4.destroy()
+
+
+def test_carousel_height_overrides_aspect_ratio(shown_app):
+    c = bs.Carousel(height=200, grow=True)
+    _pump(shown_app)
+    assert c._internal.winfo_reqheight() == 200
+    c.destroy()
+
+
+def test_carousel_lower_aspect_ratio_is_taller(shown_app):
+    wide = bs.Carousel(aspect_ratio=2.0, grow=True)   # shorter floor
+    tall = bs.Carousel(aspect_ratio=1.0, grow=True)   # taller floor
+    _pump(shown_app)
+    assert tall._internal.winfo_reqheight() > wide._internal.winfo_reqheight()
+    wide.destroy()
+    tall.destroy()


### PR DESCRIPTION
Closes #160.

## Background

#160 reported that `Gallery` and `Carousel` collapse to zero height in a non-expanding container (a scrollable page / auto-fit window) — they're fill-driven and request ~0 height, so a container that hands children their *requested* size gives them a sliver, collapsing the surrounding group too. **PR #161 already fixed this** with a requested-height floor. This PR closes the issue out: the fix was sound but **untested**, and carried two unexplained magic numbers.

## What this does

The #161 floor mechanism is **sound and untouched** — `pack_propagate(False)` on the outer frame + `configure(height=floor)`, with the inner canvas `fill="both", expand=True` so it's a true *minimum* that `grow`/`expand` still grows past.

- **Regression test** — `tests/widgets/public/test_media_height_floor.py` (8):
  - the floor reqheight is non-zero (Gallery `360`, Carousel `267`)
  - neither collapses inside a `ScrollView` (the literal issue scenario — `winfo_height() > 1`)
  - the floor is a *minimum, not a freeze* (the inner canvas is expand-packed, so a larger allocation flows in)
  - the sizing knobs move the floor (`rows` / `height` / `aspect_ratio`)
- **Harden the magic numbers** into named, documented constants — `carousel._FLOOR_STAGE_WIDTH = 400` (the assumed stage width behind `400/aspect_ratio`; comment notes a larger ratio → shorter floor) and `gallery._CAPTION_H = 24` (the per-caption-row allowance in the height floor). Value-preserving — the exact `360`/`267` assertions pin the result.
- **Docstring** — Carousel `aspect_ratio` now states a larger ratio gives a wider, shorter floor.

## Deliberately not changed

API symmetry: Gallery sizes by `rows=`, Carousel by `aspect_ratio=`/`height=`. Each is the natural knob for its widget (a grid thinks in rows, a slide in aspect); a unified `min_height=` would be scope creep. Left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)