### PR TITLE
fix(fields): placeholder renders unmasked under an input mask (#195)

### DIFF
--- a/src/bootstack/widgets/_impl/_parts/textentry_part.py
+++ b/src/bootstack/widgets/_impl/_parts/textentry_part.py
@@ -107,6 +107,9 @@ class TextEntryPart(ValidationMixin, Entry):
         # so the Signal is never set to the placeholder text
         if placeholder:
             self._default_fg = self.cget("foreground")
+            # remember any masking char so the placeholder can render unmasked
+            # (a password '•'/'*' mask must not turn the placeholder into bullets)
+            self._show_char = self.cget("show")
             if not self.textsignal():
                 self._show_placeholder()
             self.bind('<FocusIn>', self._on_focus_in_placeholder, add=True)
@@ -115,6 +118,9 @@ class TextEntryPart(ValidationMixin, Entry):
     def _show_placeholder(self) -> None:
         self._showing_placeholder = True
         self.configure(textvariable='')
+        # render the placeholder unmasked even when an input mask is active
+        if getattr(self, '_show_char', ''):
+            self.configure(show='')
         self.insert(0, self._placeholder_text)
         self.configure(foreground='grey')
 
@@ -122,6 +128,9 @@ class TextEntryPart(ValidationMixin, Entry):
         self._showing_placeholder = False
         self.delete(0, 'end')
         self.configure(textvariable=self.textsignal.var)
+        # restore the input mask now that real input is shown
+        if getattr(self, '_show_char', ''):
+            self.configure(show=self._show_char)
         self.configure(foreground=self._default_fg)
 
     def _on_focus_in_placeholder(self, _event) -> None:

--- a/src/bootstack/widgets/_impl/composites/passwordentry.py
+++ b/src/bootstack/widgets/_impl/composites/passwordentry.py
@@ -94,6 +94,9 @@ class PasswordEntry(Field):
 
     def _hide_password(self, _):
         """Hide the password by restoring character masking."""
+        # leave an unmasked placeholder alone — it is not real input to mask
+        if getattr(self.entry_widget, '_showing_placeholder', False):
+            return
         self.entry_widget['show'] = self._show_indicator
 
     # ------ Configuration Delegates ------
@@ -127,5 +130,8 @@ class PasswordEntry(Field):
 
     def hide(self) -> None:
         """Restore character masking."""
+        # leave an unmasked placeholder alone — it is not real input to mask
+        if getattr(self.entry_widget, '_showing_placeholder', False):
+            return
         self.entry_widget['show'] = self._show_indicator
 

--- a/tests/widgets/public/test_field_placeholder_mask.py
+++ b/tests/widgets/public/test_field_placeholder_mask.py
@@ -1,0 +1,102 @@
+"""Regression guard for #195 — an input mask (`show=`, e.g. a password bullet)
+must NOT mask the placeholder text. The placeholder is a readable hint, not user
+input: it renders unmasked, and the mask reappears only for real, committed input.
+"""
+import pytest
+
+import bootstack as bs
+
+
+@pytest.fixture(scope="module")
+def app():
+    a = bs.App()
+    a.__enter__()
+    a._tk_root.deiconify()
+    a._tk_root.update_idletasks()
+    try:
+        yield a
+    finally:
+        try:
+            a.__exit__(None, None, None)
+        except Exception:
+            pass
+        try:
+            a._tk_root.destroy()
+        except Exception:
+            pass
+
+
+def test_password_placeholder_renders_unmasked(app):
+    pf = bs.PasswordField(placeholder="Enter password")
+    app._tk_root.update_idletasks()
+    entry = pf._internal._entry
+
+    # Empty + unfocused: placeholder shows in plain text, mask is suppressed.
+    assert entry._showing_placeholder is True
+    assert entry.cget("show") == ""
+    assert entry.get() == "Enter password"
+
+
+def test_password_mask_restored_for_real_input(app):
+    pf = bs.PasswordField(placeholder="Enter password")
+    app._tk_root.update_idletasks()
+    entry = pf._internal._entry
+
+    # Focus + type: placeholder is gone and the mask is back.
+    entry.event_generate("<FocusIn>")
+    entry.insert(0, "hunter2")
+    app._tk_root.update_idletasks()
+    assert entry._showing_placeholder is False
+    assert entry.cget("show") == "•"  # the bullet mask
+    assert entry.get() == "hunter2"
+
+
+def test_password_placeholder_returns_unmasked_after_clearing(app):
+    pf = bs.PasswordField(placeholder="Enter password")
+    app._tk_root.update_idletasks()
+    entry = pf._internal._entry
+
+    entry.event_generate("<FocusIn>")
+    entry.insert(0, "abc")
+    app._tk_root.update_idletasks()
+    entry.delete(0, "end")
+    entry.event_generate("<FocusOut>")
+    app._tk_root.update_idletasks()
+
+    # Empty again: placeholder is back and unmasked.
+    assert entry._showing_placeholder is True
+    assert entry.cget("show") == ""
+    assert entry.get() == "Enter password"
+
+
+def test_visibility_toggle_does_not_mask_placeholder(app):
+    # Pressing the eye toggle while the placeholder is showing must not re-mask it.
+    pf = bs.PasswordField(placeholder="Enter password")
+    app._tk_root.update_idletasks()
+    entry = pf._internal._entry
+
+    pf._internal._show_password(None)
+    pf._internal._hide_password(None)
+    app._tk_root.update_idletasks()
+
+    assert entry._showing_placeholder is True
+    assert entry.cget("show") == ""
+    assert entry.get() == "Enter password"
+
+
+def test_textfield_placeholder_unaffected_without_mask(app):
+    # A plain field has no mask; placeholder still shows and clears normally.
+    tf = bs.TextField(placeholder="Search...")
+    app._tk_root.update_idletasks()
+    entry = tf._internal._entry
+
+    assert entry._showing_placeholder is True
+    assert entry.cget("show") == ""
+    assert entry.get() == "Search..."
+
+    entry.event_generate("<FocusIn>")
+    entry.insert(0, "query")
+    app._tk_root.update_idletasks()
+    assert entry._showing_placeholder is False
+    assert entry.cget("show") == ""
+    assert entry.get() == "query"


### PR DESCRIPTION
Closes #195.

### Problem
A field with an input mask (`show=` internally, `mask=` on `TextField`; `PasswordField` masks with a bullet by default) also masked its **placeholder** — the readable hint rendered as `••••`. The placeholder is inserted as live entry text, so the ttk `show` mask applied to it too.

### Fix
- `_parts/textentry_part.py` — capture the mask char once at init; clear `show` while the placeholder is displayed (`_show_placeholder`) and restore it once real input is shown (`_hide_placeholder`).
- `composites/passwordentry.py` — the visibility (eye) toggle's hide path no-ops while the placeholder is showing, so it can't re-mask an unmasked placeholder.

### Tests
`tests/widgets/public/test_field_placeholder_mask.py` (5):
- placeholder renders unmasked initially
- mask restored for real input
- placeholder returns unmasked after clearing + blur
- eye toggle doesn't mask a shown placeholder
- plain `TextField` (no mask) unaffected

Verified visually (empty fields show readable ghost text, not bullets) and via the suite. Existing field tests pass in isolation; the combined-run errors are the pre-existing one-App-per-process harness issue (#150), not this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
