### PR TITLE
fix(appshell): rename nav_selection → nav_variant; gate solid to standalone nav (#189)

### DIFF
--- a/docs/widgets/appshell.rst
+++ b/docs/widgets/appshell.rst
@@ -253,20 +253,22 @@ and the nav-item selection wash blend against these automatically.
      - The bottom status band.
 
 The selected nav item is **neutral** by default. Set ``nav_accent`` to tint the
-selection (and the rail's indicator) with an accent, and ``nav_selection`` to
+selection (and the rail's indicator) with an accent, and ``nav_variant`` to
 choose how the accent reads:
 
 .. code-block:: python
 
-   # subtle accent wash + accent text (the default emphasis)
+   # subtle accent wash behind full-strength text (the default emphasis)
    bs.AppShell(nav_accent="primary")
 
    # a filled accent pill with on-accent (white) text — higher emphasis
-   bs.AppShell(nav_accent="primary", nav_selection="solid")
+   bs.AppShell(nav_accent="primary", nav_variant="solid")
 
 ``nav_accent`` colors the rail indicator bar, the static nav pills/rows, and the
-``list_nav`` / ``tree_nav`` selection wash; ``nav_selection`` (``'ghost'`` default
-or ``'solid'``) applies to the static nav items.
+``list_nav`` / ``tree_nav`` selection wash. ``nav_variant`` (``'ghost'`` default
+or ``'solid'``) applies only to the **standalone** primary nav — the no-rail,
+single-tier sidebar built with ``add_page``. Under a workspace rail the sidebar
+navs always use the subtle wash (a solid fill would compete with the rail).
 
 Navigation
 ~~~~~~~~~~

--- a/src/bootstack/cli/demo.py
+++ b/src/bootstack/cli/demo.py
@@ -978,6 +978,7 @@ def run_demo():
         title="Widget Gallery",
         theme="bootstrap-light",
         size=(1100, 750),
+        nav_variant="solid"
     ) as shell:
         build_gallery_shell(shell)
     shell.run()

--- a/src/bootstack/widgets/_impl/composites/shell/shell.py
+++ b/src/bootstack/widgets/_impl/composites/shell/shell.py
@@ -48,6 +48,10 @@ class Shell(ShellLayout):
         remember_nav_state: Persist the sidebar mode + per-workspace active page
             across sessions, restoring them on the next launch.
         nav_accent: Accent token for the active nav item.
+        nav_selection: Accented-selection treatment for the standalone primary
+            nav (the no-rail `nav-pill` default workspace) — `'ghost'` (subtle
+            wash) or `'solid'` (filled accent + on-accent text). Under-rail
+            workspace navs always use the wash.
         **kwargs: Forwarded to `ShellLayout` / `App` (widths, position, etc.).
     """
 
@@ -121,6 +125,11 @@ class Shell(ShellLayout):
         # sits under the rail -> quiet rows. (list_nav/tree keep their own row
         # language regardless; only the static provider reads this.)
         nav_variant = "nav-pill" if key == _DEFAULT_WORKSPACE else "nav-quiet"
+        # The `'solid'` (filled-accent) selection is the standalone primary nav's
+        # higher-emphasis look ONLY (the no-rail `nav-pill` default workspace). A
+        # named workspace's nav sits under the rail as quiet rows — a solid fill
+        # there would compete with the rail, so it always uses the subtle wash.
+        nav_selection = self._nav_selection if key == _DEFAULT_WORKSPACE else "ghost"
         ws = Workspace(
             key, panel, content,
             nav_accent=self._nav_accent,
@@ -129,7 +138,7 @@ class Shell(ShellLayout):
             on_first_page=self._on_first_page,
             nav_variant=nav_variant,
             nav_surface=self.sidebar_surface,
-            nav_selection=self._nav_selection,
+            nav_selection=nav_selection,
         )
         self._workspaces[key] = ws
         # The implicit default workspace never gets a rail icon (single-tier).

--- a/src/bootstack/widgets/appshell.py
+++ b/src/bootstack/widgets/appshell.py
@@ -326,6 +326,14 @@ class AppShell(AppConfigMixin, WindowControlsMixin, ChromeHostMixin, PublicWidge
             selected nav item / rail indicator picks up the theme's primary
             accent); set another accent token to retint, or `None` for a neutral
             wash.
+        nav_variant: How an accented selection reads on the standalone primary
+            nav — `'ghost'` (default) is a subtle accent wash behind full-strength
+            text; `'solid'` fills the item with the accent and uses on-accent
+            (white) text for higher emphasis. Needs `nav_accent`; with
+            `nav_accent=None` it falls back to a neutral wash. Applies only to the
+            standalone static nav (`add_page`, the no-rail single-tier sidebar);
+            under-rail workspace navs and the `list_nav` / `tree_nav` providers
+            always use the wash.
         rail_labels: Show a caption under each rail icon (widens the rail).
         remember_nav_state: Persist the sidebar mode and per-workspace active page
             across sessions. Default `False`.
@@ -373,7 +381,7 @@ class AppShell(AppConfigMixin, WindowControlsMixin, ChromeHostMixin, PublicWidge
         rail_width: int | None = None,
         collapsible: bool = True,
         nav_accent: AccentToken | str | None = "primary",
-        nav_selection: Literal["ghost", "solid"] = "ghost",
+        nav_variant: Literal["ghost", "solid"] = "ghost",
         rail_labels: bool = False,
         remember_nav_state: bool = False,
         show_statusbar: bool = False,
@@ -405,7 +413,9 @@ class AppShell(AppConfigMixin, WindowControlsMixin, ChromeHostMixin, PublicWidge
             "sidebar_mode": sidebar_mode,
             "collapsible": collapsible,
             "nav_accent": nav_accent,
-            "nav_selection": nav_selection,
+            # Public `nav_variant` maps to the internal selection-style chain
+            # (`nav_variant` is taken internally for the pill/quiet tier).
+            "nav_selection": nav_variant,
             "rail_labels": rail_labels,
             "remember_nav_state": remember_nav_state,
             "rail_surface": rail_surface,

--- a/tests/widgets/public/test_nav_selection.py
+++ b/tests/widgets/public/test_nav_selection.py
@@ -1,0 +1,77 @@
+"""`nav_variant='solid'` — the standalone primary nav's filled-accent selection.
+
+`solid` fills the selected nav item with the accent (+ on-accent text) for a
+higher-emphasis look than the default `'ghost'` wash. It is the **standalone**
+(no-rail, single-tier `add_page`) nav's treatment ONLY — a named workspace's nav
+sits under the rail as quiet rows and always uses the wash, regardless of
+`nav_variant`. With no accent, `solid` falls back to the neutral wash.
+
+`nav_variant` is the public AppShell kwarg; it maps to the internal selection
+chain (`nav_variant` is taken internally for the pill/quiet tier).
+
+One App/process (an AppShell owns its own root window).
+"""
+
+from __future__ import annotations
+
+import bootstack as bs
+from bootstack.style.builders.sidenav import _selection_colors
+from bootstack.style.style_builder_ttk import StyleBuilderTtk
+
+
+def test_solid_selection_colors_differ_from_ghost():
+    """At the builder level, solid is a filled accent; ghost is a subtle wash."""
+    app = bs.App(title="Solid")
+    app.__enter__()
+    try:
+        bs.Label("hi")
+        app._tk_root.update_idletasks()
+        b = StyleBuilderTtk()
+        opts = {"surface": "raised"}
+        ghost_bg, ghost_fg = _selection_colors(b, "primary", {**opts, "selection_style": "ghost"})
+        solid_bg, solid_fg = _selection_colors(b, "primary", {**opts, "selection_style": "solid"})
+        # Solid fills with the accent itself; ghost is a tinted wash off the surface.
+        assert solid_bg.lower() == b.color("primary").lower()
+        assert solid_bg.lower() != ghost_bg.lower()
+        # Solid uses on-accent (white) text; ghost keeps full-strength surface text.
+        assert solid_fg.lower() != ghost_fg.lower()
+        # No accent -> solid falls back to the neutral wash (no filled accent).
+        none_bg, _ = _selection_colors(b, None, {**opts, "selection_style": "solid"})
+        assert none_bg.lower() != b.color("primary").lower()
+    finally:
+        app.__exit__(None, None, None)
+
+
+def test_solid_applies_to_standalone_nav():
+    """add_page (no rail) -> nav-pill -> the item carries the solid selection."""
+    shell = bs.AppShell(title="Standalone", size=(800, 540),
+                        nav_accent="primary", nav_variant="solid")
+    shell.__enter__()
+    try:
+        with shell.add_page("home", text="Home", icon="house"):
+            bs.Label("hi")
+        shell.navigate("home")
+        shell._internal.update_idletasks()
+        nav = shell._internal.nav
+        assert nav._variant == "nav-pill"
+        assert nav._selection == "solid"
+    finally:
+        shell.__exit__(None, None, None)
+
+
+def test_solid_does_not_leak_to_workspace_nav():
+    """A named workspace's under-rail nav stays ghost even with nav_variant='solid'."""
+    shell = bs.AppShell(title="Workspace", size=(800, 540),
+                        nav_accent="primary", nav_variant="solid")
+    shell.__enter__()
+    try:
+        ws = shell.add_workspace("a", text="A", icon="house")
+        with ws.add_page("p1", text="P1", icon="file"):
+            bs.Label("p")
+        shell._internal.update_idletasks()
+        nav = shell._internal.nav
+        assert nav._variant == "nav-quiet"
+        # The solid request does NOT reach the under-rail workspace nav.
+        assert nav._selection == "ghost"
+    finally:
+        shell.__exit__(None, None, None)


### PR DESCRIPTION
Closes #189.

## What

- **Rename** the public `AppShell` kwarg `nav_selection` → **`nav_variant`** (`'ghost'`/`'solid'`). It selects a *visual* treatment, so it now uses the framework's `variant` vocabulary (`'solid'`/`'ghost'` are already button-variant tokens) and pairs with `nav_accent`. The old name read like selection *behavior*.
- **Gate `solid` to the standalone primary nav** (the no-rail `nav-pill` default workspace). It was threaded to every workspace uniformly, so it leaked onto under-rail `nav-quiet` workspace navs — where a filled accent competes with the rail. Named workspaces now always use the subtle wash.
- The public `nav_variant` maps to the internal `nav_selection` chain (the name `nav_variant` is already taken internally for the pill/quiet tier).
- Doc fix: the ghost foreground is full-strength text, not "accent text". Gallery demo updated.

## Background

#189 asked to verify/expose the `solid` selection variant. The variant was already wired end-to-end and documented; the real gaps were (a) the leaky scope and (b) a name that didn't match the framework's terminology. Verified at the builder level: `ghost` → subtle wash (`#D7E5F9`), `solid` → filled accent (`#0A58CA`) + white text, no-accent+`solid` → neutral fallback.

The "standalone sidebar" in the issue text is stale post-rewrite (standalone `bs.SideNav` was dropped); it now means the AppShell's no-rail single-tier nav.

## Tests

`tests/widgets/public/test_nav_selection.py` — solid vs ghost colors differ; standalone nav carries `solid`; under-rail workspace nav stays `ghost`. (One App/process — run individually, per the GUI-suite limitation in #150.)

Public-surface guard passes (161); clean `-W` docs build.

## Follow-up

A broader navigation-API reshape (`AppShell` + `Workbench`, provider front doors, options-on-provider) is being filed as its own design issue. `nav_variant` is forward-compatible with it (it becomes `page_nav(variant=)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
