### PR TITLE
fix(toolbar): make add_widget class-only on Toolbar + StatusBar (#187)

### DIFF
--- a/docs/tasks/composing-fields.rst
+++ b/docs/tasks/composing-fields.rst
@@ -179,9 +179,8 @@ when you need a widget directly.
 Reusable fields
 ---------------
 
-bootstack has no public base class for authoring an entirely new field *type* —
-but you rarely need one. A configured field is an ordinary object, so the
-practical way to ship a custom input is to wrap a recipe in a function:
+A configured field is an ordinary object, so the simplest way to ship a custom
+input is to wrap a recipe in a function:
 
 .. code-block:: python
 
@@ -203,6 +202,41 @@ practical way to ship a custom input is to wrap a recipe in a function:
 `search_field()` returns a real :class:`~bootstack.TextField`, so `.value`,
 validation, and signal binding all work on it exactly as they would on a plain
 field. Call it wherever you would build one.
+
+Subclassing for a reusable type
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When you want a named field *type* — one you instantiate by class, or hand to a
+container that builds widgets for you — subclass the field instead of wrapping
+it in a function:
+
+.. code-block:: python
+
+   class SearchField(bs.TextField):
+       def __init__(self, *, on_search=None, **kwargs):
+           kwargs.setdefault("placeholder", "Search")
+           super().__init__(**kwargs)
+           self.insert_addon("label", "before", icon="search")
+           self.insert_addon("button", "after", icon="x-lg", on_click=self.clear)
+           if on_search:
+               self.on_submit(lambda e: on_search(self.value))
+
+`SearchField` is a real :class:`~bootstack.TextField`, so everything a field
+offers — `.value`, validation, signal binding — carries over unchanged.
+
+The reason to reach for a subclass over a function is when something needs the
+*class*, not a built instance. A :class:`~bootstack.Toolbar` or
+:class:`~bootstack.StatusBar` builds the widgets you add to it — you give
+:meth:`~bootstack.Toolbar.add_widget` the class and the bar constructs it,
+applying its own density and surface:
+
+.. code-block:: python
+
+   with app.add_toolbar() as tb:
+       tb.add_widget(SearchField, on_search=run_query)
+
+A function recipe can't drop in there (it returns an already-built field the bar
+can't restyle); a subclass can.
 
 See also
 --------

--- a/docs/widgets/statusbar.rst
+++ b/docs/widgets/statusbar.rst
@@ -74,9 +74,9 @@ running count or sync state.
 Embedding widgets
 ~~~~~~~~~~~~~~~~~~~
 
-Create any widget with ``parent=statusbar`` to add it to the left cluster, or
-pass a pre-parented widget to ``add_widget()`` (with ``side=`` to choose the
-cluster). Useful for a slim progress indicator or a badge.
+Pass a widget **class** to ``add_widget()`` (with ``side=`` to choose the
+cluster) and the band builds it, or create any widget with ``parent=statusbar``
+to add it to the left cluster. Useful for a slim progress indicator or a badge.
 
 .. code-block:: python
 

--- a/docs/widgets/toolbar.rst
+++ b/docs/widgets/toolbar.rst
@@ -203,8 +203,9 @@ the class accepts), so the widget matches the rest of the bar:
    tb.add_widget(bs.Select, options=["main", "dev", "feat/new-ui"], value="main")
    tb.add_widget(bs.TextField, placeholder="Search", width=24)
 
-(An already-built *instance* — ``tb.add_widget(my_widget)`` — is added as-is and
-does **not** inherit the bar's density/surface; prefer the class form for that.)
+To add a widget you have already built yourself, parent it onto the bar directly
+— ``bs.MyCustomWidget(parent=tb)`` — and it attaches automatically, keeping
+whatever you configured.
 
 .. _toolbars-in-a-window:
 

--- a/src/bootstack/widgets/statusbar.py
+++ b/src/bootstack/widgets/statusbar.py
@@ -21,11 +21,12 @@ class StatusBar(PublicWidgetBase):
     left-to-right; an `add_spacer()` (or `side='right'`) pushes the following
     segments to the right cluster.
 
-    Use it standalone — `bs.StatusBar(fill="x", side="bottom")` pins one to the
-    bottom of any `App`/`Window` — or read `shell.statusbar` for the one built
-    into an :class:`AppShell <bootstack.AppShell>`. Create custom widgets with
-    `parent=statusbar` (they add to the left cluster automatically) or pass a
-    pre-parented widget to `add_widget()`.
+    Use it standalone — `bs.StatusBar(horizontal="stretch")` spans the bottom of
+    any `App`/`Window` (place it last and let the content above `grow`) — or read
+    `shell.statusbar` for the one built
+    into an :class:`AppShell <bootstack.AppShell>`. Add widgets by class with
+    `add_widget()`, or create custom widgets with `parent=statusbar` (they add to
+    the left cluster automatically).
 
     Args:
         surface: Background surface token. Defaults to the theme's `'chrome'`
@@ -97,31 +98,50 @@ class StatusBar(PublicWidgetBase):
             self._internal.add_spacer()
             self._has_right_spacer = True
 
-    def add_widget(self, widget: Any, *, side: Literal["left", "right"] = "left", **kwargs: Any) -> Any:
-        """Add a widget to the left or right cluster.
+    def add_widget(
+        self, widget_cls: Any, *, side: Literal["left", "right"] = "left", **kwargs: Any
+    ) -> Any:
+        """Build a widget on the left or right cluster from its class.
 
-        Pass a widget **class** to have the bar build it (`kwargs` go to its
-        constructor), or an existing widget **instance**:
+        Pass a widget **class** — the bar builds it, applying its own `density`
+        and `surface` (for any the class accepts) so the widget matches the band,
+        and forwarding `kwargs` to the constructor:
 
             status.add_widget(bs.ThemeToggle, side="right")
-            status.add_widget(my_label)
+            status.add_widget(bs.ProgressBar, value=65)
+
+        To add a widget you have already built yourself, parent it onto the bar
+        directly (it lands in the left cluster):
+
+            bs.MyCustomWidget(parent=status)
 
         Args:
-            widget: A widget class or instance.
+            widget_cls: The widget class to build on the band.
             side: `'left'` (default) or `'right'` (after the spacer).
-            **kwargs: Constructor arguments, used only when `widget` is a class.
+            **kwargs: Constructor arguments for the widget.
 
         Returns:
-            The widget (the new instance when a class is given).
+            The new widget instance.
         """
         if side == "right":
             self._ensure_right()
-        if isinstance(widget, type):
-            return widget(parent=self, **kwargs)
-        tk_widget = getattr(widget, "_internal", widget)
-        self._internal.add_widget(tk_widget)
-        self._show()
-        return widget
+        self._apply_bar_defaults(widget_cls, kwargs)
+        return widget_cls(parent=self, **kwargs)
+
+    def _apply_bar_defaults(self, widget_cls: type, kwargs: dict[str, Any]) -> None:
+        """Default `density`/`surface` from the band onto a class being built, but
+        only for parameters the widget actually accepts (and not if the caller
+        already passed them)."""
+        import inspect
+
+        try:
+            params = inspect.signature(widget_cls).parameters
+        except (TypeError, ValueError):
+            return
+        if "density" in params:
+            kwargs.setdefault("density", self._internal.density)
+        if "surface" in params:
+            kwargs.setdefault("surface", self._internal._surface)
 
     def add_text(
         self,

--- a/src/bootstack/widgets/toolbar.py
+++ b/src/bootstack/widgets/toolbar.py
@@ -197,32 +197,31 @@ class Toolbar(PublicWidgetBase):
         """Add a flexible spacer that pushes subsequent items to the right."""
         self._internal.add_spacer()
 
-    def add_widget(self, widget: Any, **kwargs: Any) -> Any:
-        """Add a widget to the toolbar.
+    def add_widget(self, widget_cls: Any, **kwargs: Any) -> Any:
+        """Build a widget on the toolbar from its class.
 
-        Pass a widget **class** to have the bar build it for you — the bar's
-        `density` and `surface` are applied (for any the class accepts) so the
-        widget matches the rest of the bar, and `kwargs` are forwarded to its
-        constructor (overriding those defaults):
+        Pass a widget **class** — the bar builds it, applying its own `density`
+        and `surface` (for any the class accepts) so the widget matches the rest
+        of the bar, and forwarding `kwargs` to the constructor (overriding those
+        defaults):
 
             bar.add_widget(bs.ThemeToggle)
             bar.add_widget(bs.TextField, placeholder="Search", width=24)
 
-        Or pass an existing widget **instance** — `kwargs` are pack options. (An
-        instance is built before it reaches the bar, so it does NOT inherit the
-        bar's density/surface; prefer the class form for that.)
+        To add a widget you have already built yourself, parent it onto the bar
+        directly — it attaches automatically and keeps whatever you configured:
 
-            bar.add_widget(my_widget, padx=4)
+            bs.MyCustomWidget(parent=bar)
+
+        Args:
+            widget_cls: The widget class to build on the bar.
+            **kwargs: Constructor arguments for the widget.
 
         Returns:
-            The widget (the new instance when a class is given).
+            The new widget instance.
         """
-        if isinstance(widget, type):
-            self._apply_bar_defaults(widget, kwargs)
-            return widget(parent=self, **kwargs)
-        tk_widget = getattr(widget, "_internal", widget)
-        self._internal.add_widget(tk_widget, **kwargs)
-        return widget
+        self._apply_bar_defaults(widget_cls, kwargs)
+        return widget_cls(parent=self, **kwargs)
 
     def _apply_bar_defaults(self, widget_cls: type, kwargs: dict[str, Any]) -> None:
         """Default `density`/`surface` from the bar onto a class being built, but

--- a/tests/widgets/public/test_statusbar.py
+++ b/tests/widgets/public/test_statusbar.py
@@ -1,0 +1,54 @@
+"""Tests for the public StatusBar — class-only add_widget + bar defaults.
+
+`add_widget()` is class-only (the band builds the widget, applying its own
+density/surface). A self-built widget is added via `parent=statusbar`. One
+module-scoped App (creating several Apps crashes Tk).
+"""
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.gui
+
+
+@pytest.fixture(scope="module")
+def app():
+    import bootstack as bs
+
+    app = bs.App()
+    app._tk_root.withdraw()
+    try:
+        yield app
+    finally:
+        try:
+            app._tk_root.destroy()
+        except Exception:
+            pass
+
+
+def test_add_widget_builds_class_and_returns_instance(app):
+    import bootstack as bs
+
+    sb = bs.StatusBar(density="compact")
+    pb = sb.add_widget(bs.ProgressBar, value=65)
+    assert isinstance(pb, bs.ProgressBar)
+    app._internal.update_idletasks()
+    assert len(sb._internal.content.winfo_children()) == 1
+
+
+def test_add_widget_class_inherits_band_density_skips_unsupported_surface(app):
+    import bootstack as bs
+
+    sb = bs.StatusBar(density="compact")
+    kw: dict = {}
+    sb._apply_bar_defaults(bs.TextField, kw)
+    # density is injected (TextField accepts it); surface is skipped (it does not).
+    assert kw == {"density": "compact"}
+
+
+def test_add_widget_right_side_adds_spacer(app):
+    import bootstack as bs
+
+    sb = bs.StatusBar()
+    sb.add_widget(bs.ProgressBar, value=10, side="right")
+    assert sb._has_right_spacer is True


### PR DESCRIPTION
Closes #187.

## What

`Toolbar.add_widget` and `StatusBar.add_widget` are now **class-only** — `add_widget(WidgetClass, **kwargs)`. The bar builds the widget from its class and applies its own `density`/`surface` to it.

## Why

The issue asked whether to make `StatusBar.add_widget` class-only "for consistency." But its actual sibling — `Toolbar.add_widget` — was *also* polymorphic (class **or** instance), so the two were already consistent. Going class-only on **both** keeps them aligned while removing the redundant instance branch (the one that couldn't inherit the bar's density/surface, and required a manual `getattr(_internal)` attach).

No flexibility is lost: a widget you build yourself drops in via the container protocol — `bs.MyWidget(parent=bar)` — which auto-attaches. Every add path on the bar (`add_button`/`add_label`/`add_menu`/`add_theme_toggle`/`add_widget`) is now class-based.

## Changes

- `toolbar.py` / `statusbar.py` — `add_widget` class-only; `StatusBar` gains the `_apply_bar_defaults` helper it lacked (so a class it builds inherits the band's density/surface).
- Fixed a stale `StatusBar(fill="x", side="bottom")` docstring example that would **raise** under the grid layout engine → `horizontal="stretch"`.
- `docs/widgets/{toolbar,statusbar}.rst` — replaced "pass an already-built instance" prose with the `parent=bar` self-built path.
- `docs/tasks/composing-fields.rst` — new **"Subclassing for a reusable type"** section: a `SearchField(bs.TextField)` subclass (in-field search icon + clear button via `insert_addon`), justified by exactly this change — a toolbar/status bar can only build your field if it's a class.
- `tests/widgets/public/test_statusbar.py` — new (3 tests).

## Verification

- `test_statusbar.py` (3) + `test_add_toolbar.py` (8) pass, each in its own process.
- Docs clean build (`-W --keep-going`): 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)