### PR TITLE
feat(appshell): sidebar hamburger via Toolbar.add_sidebar_toggle() (#201)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,8 +46,38 @@ memories and git history.
   (PR #199, MERGED) was folded in** — `nav_variant` ctor kwarg → `page_nav(variant=)`;
   its `test_nav_selection.py` removed (superseded by `test_appshell_reshape.py`).
   Tests: `test_appshell_reshape.py` (6) + `test_workbench.py` (2). Memory
-  `project_navigation_api_reshape`. **Follow-up: #201** (expandable menu group for
-  the single-tier page nav — future).
+  `project_navigation_api_reshape`. **Follow-up: #201 — SHIPPED (sidebar
+  hamburger, see top of this list).**
+- **Sidebar hamburger toggle — `Toolbar.add_sidebar_toggle()` (#201)** (this
+  session; on `feat/nav-expandable-group`) — #201 was filed as an *expandable
+  sub-item nav group*, but the maintainer **reinterpreted it** as a built-in
+  **hamburger that collapses/expands the AppShell sidebar** (the accordion-style
+  sub-items stay parked per the nav-spec Revision-4 cut — compose `bs.Accordion`
+  in a `custom_nav`). The collapse machinery already existed (`toggle_sidebar()`/
+  `show_sidebar()`/`hide_sidebar()`/`sidebar_mode`, Ctrl-B); what was missing was
+  a control. Modeled on `ThemeToggle`/`add_theme_toggle()` but **NOT standalone**
+  (a sidebar toggle is meaningless outside one shell): an internal
+  `SidebarToggle(Button)` (`widgets/sidebar_toggle.py`, **not** in `bs.*`) built by
+  **`Toolbar.add_sidebar_toggle(**kwargs)`**, which wires it to the owning shell.
+  **AppShell-only** — the guard is `isinstance(host, AppShell)` (a `_SidebarHost`;
+  `Workbench` inherits `toggle_sidebar` from `_ShellBase` so a `hasattr` check is
+  too loose), raising `BootstackError` on `Workbench`/`App`/`Window`. Enabler:
+  `add_toolbar()` (ChromeHostMixin) now passes `_host=self` into the `Toolbar`;
+  `Toolbar.__init__` stores `self._host`. **Author places it wherever they want in
+  the bar — no auto-injection.** `collapse='compact'` is the **default** (the
+  desktop/Fluent convention: shrink to the icon rail, reusing the shell's
+  `_can_compact_active()` so it **falls back to hidden** for non-compactable
+  data-bound navs); `collapse='hidden'` always fully hides. **Mode-dependent
+  default icon** (`icon=None` resolves to `layout-sidebar` for compact, `list` for
+  hidden); single steady glyph unless the author passes a stateful pair
+  (`collapse_icon` shown while expanded, `expand_icon` while collapsed, each
+  falling back to `icon`). A ~6px toggle-vs-rail offset in compact is **left as-is
+  by decision** (only visible compacted; aligning would couple toolbar padding to
+  rail width). Tests `tests/widgets/public/test_sidebar_toggle.py` (8). Docs:
+  "Sidebar toggle" section in `docs/widgets/toolbar.rst` (full detail) + the
+  AppShell page's "Sidebar visibility" section (the user-facing control,
+  cross-linked). StatusBar deliberately **not** given the method (scope creep — a
+  hamburger belongs in a toolbar).
 - **Gallery/Carousel height-floor cleanup (#160)** (this session; PR **#185**,
   MERGED to `main`) — closed out #160 (Gallery/Carousel collapse to ~0 height in a
   non-expanding/scrollable parent). The floor itself shipped in **PR #161** and is

--- a/docs/widgets/appshell.rst
+++ b/docs/widgets/appshell.rst
@@ -273,6 +273,21 @@ live. ``Ctrl/Cmd-B`` toggles it (when ``collapsible=True``), and the explicit
 ``toggle_sidebar()`` / ``show_sidebar()`` / ``hide_sidebar()`` verbs control
 visibility directly.
 
+To give users a visible control, add a **hamburger toggle** to a toolbar with
+``add_sidebar_toggle()`` (place it wherever you like — conventionally leftmost):
+
+.. code-block:: python
+
+   with shell.add_toolbar() as bar:
+       bar.add_sidebar_toggle()          # collapses to the icon rail by default
+       bar.add_spacer()
+       bar.add_theme_toggle()
+
+By default it shrinks the sidebar to the icon rail (falling back to hidden for a
+data-bound sidebar that can't show icons); pass ``collapse="hidden"`` to always
+fully hide. See :doc:`Toolbar </widgets/toolbar>` for the collapse modes and the
+icon customization (a single glyph, or a stateful open/closed pair).
+
 .. list-table::
    :header-rows: 1
    :widths: 20 80

--- a/docs/widgets/toolbar.rst
+++ b/docs/widgets/toolbar.rst
@@ -246,6 +246,42 @@ and lets the toolbar drag the window (double-click maximizes). This is how you
 build the title bar of an **undecorated window** — see the *Undecorated window*
 section on the :doc:`App </widgets/app>` page for the full example and screenshot.
 
+Sidebar toggle
+~~~~~~~~~~~~~~
+
+On a toolbar built into an :class:`AppShell <bootstack.AppShell>`,
+``add_sidebar_toggle()`` adds a hamburger button that collapses and expands the
+shell's sidebar. Place it wherever you like in the bar (conventionally
+leftmost). It is AppShell-only — calling it on a plain ``App``/``Window`` (or a
+``Workbench``) raises.
+
+.. code-block:: python
+
+   with shell.add_toolbar() as bar:
+       bar.add_sidebar_toggle()                 # leftmost hamburger
+       bar.add_spacer()
+       bar.add_theme_toggle()
+
+By default (``collapse="compact"``) it shrinks the sidebar to an **icon rail**
+when that sidebar can show icons (a static ``page_nav``) and falls back to fully
+**hiding** it when it can't (a data-bound ``list_nav`` / ``tree_nav``) — the
+standard desktop behavior. Pass ``collapse="hidden"`` to always fully hide.
+
+The glyph defaults by mode — a panel icon (``layout-sidebar``) for ``compact``, a
+hamburger (``list``) for ``hidden`` — and a single icon is shown in both the open
+and collapsed states. For a **stateful** button that swaps as the sidebar opens
+and closes, pass an open/closed pair: ``collapse_icon`` is shown while the
+sidebar is expanded (click to collapse) and ``expand_icon`` while it is collapsed
+(click to expand); each falls back to ``icon``.
+
+.. code-block:: python
+
+   # A stateful toggle that flips its chevron with the sidebar state.
+   bar.add_sidebar_toggle(
+       collapse_icon="chevron-double-left",   # shown while open
+       expand_icon="chevron-double-right",    # shown while collapsed
+   )
+
 Widget sizing
 ~~~~~~~~~~~~~
 

--- a/src/bootstack/widgets/_core/window_menu.py
+++ b/src/bootstack/widgets/_core/window_menu.py
@@ -80,7 +80,7 @@ class ChromeHostMixin:
         # Window chrome reads as a tight strip (menu bars, title bars, command
         # bars are all compact by convention) — default to compact, overridable.
         toolbar_kwargs.setdefault("density", "compact")
-        tb = Toolbar(parent=_ToolbarStackContainer(stack), **toolbar_kwargs)
+        tb = Toolbar(parent=_ToolbarStackContainer(stack), _host=self, **toolbar_kwargs)
         if divider:
             # A bare full-width hairline — no margin. The bar above provides any
             # spacing through its own (chrome) padding, so nothing of the stack

--- a/src/bootstack/widgets/sidebar_toggle.py
+++ b/src/bootstack/widgets/sidebar_toggle.py
@@ -1,0 +1,130 @@
+"""SidebarToggle — a hamburger button that collapses/expands an AppShell sidebar.
+
+This is not a standalone, place-anywhere widget like `ThemeToggle`: a sidebar
+toggle only means anything in the context of one shell's sidebar. It is built by
+`Toolbar.add_sidebar_toggle()` / `StatusBar.add_sidebar_toggle()`, which wire it
+to the owning `AppShell`; it is not exported at the `bootstack` top level.
+"""
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from bootstack.widgets.button import Button
+from bootstack.widgets.types import AccentToken, ButtonVariant, WidgetDensity
+
+
+class SidebarToggle(Button):
+    """A hamburger button that collapses and expands an AppShell's sidebar.
+
+    Clicking it toggles the shell's sidebar. With `collapse='compact'` (the
+    default — the desktop convention) it shrinks the sidebar to an icon rail when
+    that sidebar can show icons (a static `page_nav`), and falls back to fully
+    hiding it when it can't (a data-bound `list_nav`/`tree_nav`). With
+    `collapse='hidden'` it always toggles between hidden and expanded. Its icon
+    can reflect the current state — `expand_icon` is shown while the sidebar is
+    collapsed (clicking expands it) and `collapse_icon` while it is expanded
+    (clicking collapses it); each falls back to `icon` when not given.
+
+    Args:
+        shell: The `AppShell` whose sidebar this controls.
+        collapse: What "collapse" means — `'compact'` (shrink to the icon rail
+            where possible, else hide; the default) or `'hidden'` (always fully
+            hide).
+        icon: Base icon, used for both states unless a state-specific icon is
+            given. Defaults by mode — `'layout-sidebar'` (a panel glyph) for
+            `collapse='compact'`, `'list'` (a hamburger) for `collapse='hidden'`.
+        expand_icon: Icon shown while the sidebar is collapsed (the affordance to
+            expand it). Falls back to `icon`.
+        collapse_icon: Icon shown while the sidebar is expanded (the affordance to
+            collapse it). Falls back to `icon`.
+        variant: Button style variant. Default `'ghost'`.
+        density: Padding density — `'default'` or `'compact'`.
+        accent: Accent token applied to the icon. Defaults to the foreground.
+        parent: Explicit parent widget. If omitted, the current context-stack
+            container is used.
+        **kwargs: Layout placement options applied by the parent container.
+    """
+
+    def __init__(
+        self,
+        *,
+        shell: Any,
+        collapse: Literal["compact", "hidden"] = "compact",
+        icon: str | None = None,
+        expand_icon: str | None = None,
+        collapse_icon: str | None = None,
+        variant: ButtonVariant = "ghost",
+        density: WidgetDensity = "default",
+        accent: AccentToken | str | None = None,
+        parent: Any = None,
+        **kwargs: Any,
+    ) -> None:
+        self._shell = shell
+        self._collapse = collapse
+        # Default glyph follows the collapse mode: a panel for the icon rail, a
+        # hamburger for full hide.
+        if icon is None:
+            icon = "layout-sidebar" if collapse == "compact" else "list"
+        self._base_icon = icon
+        self._expand_icon = expand_icon
+        self._collapse_icon = collapse_icon
+        super().__init__(
+            on_click=self._toggle,
+            icon=self._state_icon(),
+            variant=variant,
+            density=density,
+            accent=accent,
+            parent=parent,
+            **kwargs,
+        )
+
+        # Keep the icon matching the live sidebar state — toggling here or
+        # elsewhere (Ctrl-B, another control) refreshes it. Setting the icon never
+        # fires a click, so there is no cycle.
+        self._subs = [
+            shell.on_sidebar_toggle(self._sync_icon),
+            shell.on_sidebar_mode_change(self._sync_icon),
+        ]
+        self.on_destroy(self._cleanup_sidebar_toggle)
+
+    def _is_expanded(self) -> bool:
+        return self._shell.sidebar_mode == "expanded"
+
+    def _state_icon(self) -> str:
+        if self._is_expanded():
+            return self._collapse_icon or self._base_icon
+        return self._expand_icon or self._base_icon
+
+    def _toggle(self) -> None:
+        if self._collapse == "hidden":
+            # Always fully hide (VS Code-style focus collapse).
+            self._shell.toggle_sidebar()
+            return
+        # "compact": collapse as far as is useful — to the icon rail when the
+        # active sidebar can show icons, otherwise hide it (a data list can't
+        # compact). Mirrors the shell's own Ctrl-B behavior.
+        if self._can_compact():
+            mode = self._shell.sidebar_mode
+            self._shell.sidebar_mode = "expanded" if mode == "compact" else "compact"
+        else:
+            self._shell.toggle_sidebar()
+
+    def _can_compact(self) -> bool:
+        """Whether the active sidebar can shrink to icons (vs. only hide)."""
+        try:
+            return bool(self._shell._internal._can_compact_active())
+        except Exception:
+            return False
+
+    def _sync_icon(self, _event: Any = None) -> None:
+        self.icon = self._state_icon()
+
+    def _cleanup_sidebar_toggle(self, _event: Any = None) -> None:
+        for sub in self._subs:
+            try:
+                sub.cancel()
+            except Exception:
+                pass
+
+
+__all__ = ["SidebarToggle"]

--- a/src/bootstack/widgets/toolbar.py
+++ b/src/bootstack/widgets/toolbar.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Callable
 
+from bootstack.errors import BootstackError
 from bootstack.widgets._impl.composites.toolbar import Toolbar as _InternalToolbar
 from bootstack.widgets._core.base import PublicWidgetBase
 from bootstack.widgets.types import AccentToken, WidgetDensity, SurfaceToken, ButtonVariant
@@ -55,8 +56,13 @@ class Toolbar(PublicWidgetBase):
         draggable: bool = False,
         parent: Any = None,
         _toolbar: Any = None,
+        _host: Any = None,
         **kwargs: Any,
     ) -> None:
+        # The chrome host (App/Window/AppShell) that owns this bar, when built via
+        # `host.add_toolbar()`. Lets shell-aware conveniences (add_sidebar_toggle)
+        # reach the sidebar; None for a standalone bar.
+        self._host = _host
         if _toolbar is not None:
             # Adoption: wrap a pre-built internal toolbar (e.g. an AppShell's
             # titlebar band, which already carries its window controls + drag).
@@ -277,3 +283,42 @@ class Toolbar(PublicWidgetBase):
 
         self._apply_bar_defaults(ThemeToggle, kwargs)
         return ThemeToggle(parent=self, **kwargs)
+
+    def add_sidebar_toggle(self, **kwargs: Any) -> Any:
+        """Add a hamburger button that collapses/expands the AppShell sidebar.
+
+        Only meaningful on a toolbar built into an `AppShell` (via
+        `shell.add_toolbar()`); raises on an `App`/`Window` toolbar, which has no
+        sidebar. Place it wherever you like in the bar.
+
+        Args:
+            **kwargs: Forwarded to the toggle button — e.g. `collapse`
+                (`'hidden'`/`'compact'`), `icon`, `expand_icon`, `collapse_icon`,
+                `variant`, `density`, `accent`.
+
+        Returns:
+            The created sidebar-toggle button.
+        """
+        from bootstack.widgets.sidebar_toggle import SidebarToggle
+
+        shell = self._sidebar_host()
+        self._apply_bar_defaults(SidebarToggle, kwargs)
+        return SidebarToggle(shell=shell, parent=self, **kwargs)
+
+    def _sidebar_host(self) -> Any:
+        """Return the owning `AppShell`, or raise if this bar has no sidebar.
+
+        Restricted to `AppShell` — the single-tier sidebar host. A `Workbench`
+        (two-tier, rail + per-workspace sidebars) inherits the shell sidebar
+        methods but is intentionally not supported here.
+        """
+        from bootstack.widgets.appshell import AppShell
+
+        host = getattr(self, "_host", None)
+        if not isinstance(host, AppShell):
+            raise BootstackError(
+                "add_sidebar_toggle() requires a toolbar built on an AppShell "
+                "(via shell.add_toolbar()); it is not supported on a Workbench or "
+                "a plain App/Window."
+            )
+        return host

--- a/tests/widgets/public/test_sidebar_toggle.py
+++ b/tests/widgets/public/test_sidebar_toggle.py
@@ -1,0 +1,111 @@
+"""Toolbar.add_sidebar_toggle() — the AppShell sidebar hamburger (#201).
+
+`add_sidebar_toggle()` builds a button that collapses/expands the AppShell
+sidebar. It defaults to `collapse='compact'` (shrink to the icon rail where the
+sidebar can show icons, else hide) with a panel glyph, and `collapse='hidden'`
+fully hides with a hamburger. It is AppShell-only — not a Workbench/App.
+
+Structural tests need no Tk; functional tests share one module-scoped AppShell.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+import bootstack as bs
+from bootstack.errors import BootstackError
+from bootstack.widgets.sidebar_toggle import SidebarToggle
+
+
+# ----- Structural (no Tk root) -----
+
+def test_toolbar_exposes_add_sidebar_toggle():
+    assert hasattr(bs.Toolbar, "add_sidebar_toggle")
+    # Not exported at the top level — it is shell-bound, not standalone.
+    assert not hasattr(bs, "SidebarToggle")
+
+
+def test_signature_defaults():
+    p = inspect.signature(SidebarToggle.__init__).parameters
+    for k in ("collapse", "icon", "expand_icon", "collapse_icon"):
+        assert k in p
+    assert p["collapse"].default == "compact"
+    assert p["icon"].default is None  # resolved by mode
+
+
+# ----- Functional (one module-scoped AppShell) -----
+
+@pytest.fixture(scope="module")
+def shell():
+    s = bs.AppShell(title="SidebarToggle", size=(800, 540))
+    s.__enter__()
+    with s.page_nav() as nav:
+        with nav.add_page("home", text="Home", icon="house"):
+            bs.Label("Home")
+        with nav.add_page("docs", text="Docs", icon="file-text"):
+            bs.Label("Docs")
+    s.navigate("home")
+    s._internal.update_idletasks()
+    try:
+        yield s
+    finally:
+        try:
+            s._internal.destroy()
+        except Exception:
+            pass
+
+
+def test_default_compact_panel_glyph(shell):
+    btn = shell.add_toolbar().add_sidebar_toggle()
+    assert isinstance(btn, SidebarToggle)
+    assert btn.icon == "layout-sidebar"
+
+
+def test_hidden_variant_hamburger_glyph(shell):
+    btn = shell.add_toolbar().add_sidebar_toggle(collapse="hidden")
+    assert btn.icon == "list"
+
+
+def test_compact_toggles_icon_rail(shell):
+    btn = shell.add_toolbar().add_sidebar_toggle()
+    shell.sidebar_mode = "expanded"
+    shell._internal.update_idletasks()
+    btn._toggle()
+    assert shell.sidebar_mode == "compact"
+    btn._toggle()
+    assert shell.sidebar_mode == "expanded"
+
+
+def test_hidden_toggles_visibility(shell):
+    btn = shell.add_toolbar().add_sidebar_toggle(collapse="hidden")
+    shell.sidebar_mode = "expanded"
+    shell._internal.update_idletasks()
+    btn._toggle()
+    assert shell.sidebar_mode == "hidden"
+    btn._toggle()
+    assert shell.sidebar_mode == "expanded"
+
+
+def test_stateful_icons_reflect_state(shell):
+    btn = shell.add_toolbar().add_sidebar_toggle(
+        expand_icon="chevron-right", collapse_icon="chevron-left"
+    )
+    shell.sidebar_mode = "expanded"
+    btn._sync_icon()
+    assert btn.icon == "chevron-left"   # expanded -> the collapse affordance
+    shell.sidebar_mode = "compact"
+    btn._sync_icon()
+    assert btn.icon == "chevron-right"  # collapsed -> the expand affordance
+    shell.sidebar_mode = "expanded"
+
+
+def test_rejects_non_appshell_host(shell):
+    bar = shell.add_toolbar()
+    bar._host = None
+    with pytest.raises(BootstackError):
+        bar.add_sidebar_toggle()
+    bar._host = object()
+    with pytest.raises(BootstackError):
+        bar.add_sidebar_toggle()


### PR DESCRIPTION
Addresses #201.

## Summary

Adds a built-in **hamburger button that collapses/expands the AppShell sidebar** — the control was missing, even though the collapse machinery (`toggle_sidebar()` / `show_sidebar()` / `hide_sidebar()` / `sidebar_mode`, Ctrl-B) already existed.

Built by **`Toolbar.add_sidebar_toggle(**kwargs)`**, mirroring `add_theme_toggle()`. The author places it anywhere in a toolbar; it wires to the owning shell. It is **not** a standalone top-level widget — a sidebar toggle is meaningless outside one shell — so the internal `SidebarToggle(Button)` is built by the bar, not exported in `bootstack.*`.

```python
with shell.add_toolbar() as bar:
    bar.add_sidebar_toggle()       # leftmost; collapses to the icon rail
    bar.add_spacer()
    bar.add_theme_toggle()
```

## Behavior

- **AppShell-only.** Guarded by `isinstance(host, AppShell)` (a `_SidebarHost`); `Workbench` inherits `toggle_sidebar` from `_ShellBase`, so a `hasattr` check would be too loose. Raises `BootstackError` on a `Workbench` / `App` / `Window` toolbar.
- **`collapse='compact'` (default)** — the desktop/Fluent convention: shrink to the **icon rail** where the sidebar can show icons (static `page_nav`), reusing the shell's `_can_compact_active()` to **fall back to hidden** for data-bound `list_nav`/`tree_nav`. `collapse='hidden'` always fully hides.
- **Mode-dependent default glyph** — `layout-sidebar` (panel) for compact, `list` (hamburger) for hidden. A single steady icon unless the author passes a **stateful** `collapse_icon`/`expand_icon` pair (shown while expanded / collapsed; each falls back to `icon`).

## Enabler

`add_toolbar()` (ChromeHostMixin) now threads `_host=self` into the `Toolbar`, which stores `self._host` so the method can reach the shell. `StatusBar` is intentionally **not** given the method (a hamburger belongs in a toolbar).

## Scope note

#201 was filed as an *expandable sub-item nav group*; reinterpreted with the maintainer as the **sidebar hamburger**. The accordion-style sub-items stay parked per the nav-spec **Revision 4** decision (compose `bs.Accordion` in a `custom_nav`).

## Docs / tests

- Docs: "Sidebar toggle" section in the Toolbar page (full detail) + the AppShell "Sidebar visibility" section (the user-facing control, cross-linked).
- `tests/widgets/public/test_sidebar_toggle.py` (8): default/compact/hidden behavior, mode-dependent icons, stateful icon swap, AppShell-only guard.

Affected suites pass; docs build clean with `-W`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)