### PR TITLE
feat(shell): persistent chrome-to-content border + softer inter-toolbar divider

### DIFF
--- a/docs/widgets/appshell.rst
+++ b/docs/widgets/appshell.rst
@@ -224,6 +224,10 @@ widgets, **and menus** (``toolbar.add_menu(...)``); each ``add_toolbar()`` call
 stacks a new full-width band above the sidebar / content body. On macOS a
 toolbar's menus bridge to the native global menu bar.
 
+The shell always draws a quiet hairline between the chrome stack and the
+workspace below it, so a single toolbar needs no divider of its own. Reserve
+``add_toolbar(divider=True)`` for separating one stacked band from the next.
+
 .. code-block:: python
 
    with bs.AppShell(title="My App") as shell:

--- a/src/bootstack/widgets/_core/window_menu.py
+++ b/src/bootstack/widgets/_core/window_menu.py
@@ -10,6 +10,11 @@ from __future__ import annotations
 
 from typing import Any
 
+# Softness for a chrome divider, matching the shell's region dividers: the stroke
+# blends close to its surface for a quiet hairline rather than the default
+# separator border (which blends harder toward the semantic border color).
+_CHROME_DIVIDER_BORDER_STRENGTH = 0.90
+
 
 class _ToolbarStackContainer:
     """Public-container shim so an `add_toolbar()` toolbar packs into the host's
@@ -87,7 +92,8 @@ class ChromeHostMixin:
             # surface leaks below the line when this is the last band before the
             # content (the window's content surface starts right after the line).
             Separator(
-                stack, orient="horizontal", surface=toolbar_kwargs["surface"]
+                stack, orient="horizontal", surface=toolbar_kwargs["surface"],
+                border_strength=_CHROME_DIVIDER_BORDER_STRENGTH,
             ).pack(side="top", fill="x")
         self._register_chrome_toolbar(tb, use_macos_menus)
         return tb

--- a/src/bootstack/widgets/_impl/composites/shell/layout.py
+++ b/src/bootstack/widgets/_impl/composites/shell/layout.py
@@ -155,6 +155,12 @@ class ShellLayout(App):
         self._toolbar_stack = PackFrame(root, direction="vertical", surface="chrome")
         self._statusbar = Toolbar(root, surface=self._statusbar_surface, draggable=False)
         self._status_sep = Separator(root, orient="horizontal", border_strength=DIVIDER_BORDER_STRENGTH)
+        # A persistent hairline at the top edge of the body (above the rail +
+        # sidebar + content), derived against the content surface. This is the
+        # always-on boundary between the window's top chrome and the workspace,
+        # regardless of whether any toolbar is present. Stacked toolbars can still
+        # add their own dividers (`add_toolbar(divider=True)`) to separate bars.
+        self._body_sep = Separator(root, orient="horizontal", border_strength=DIVIDER_BORDER_STRENGTH)
 
         # Body row + its slots.
         self._body = Frame(root)
@@ -187,11 +193,13 @@ class ShellLayout(App):
 
     def _relayout_window(self) -> None:
         """Re-pack the full-width toolbar / status bands and the body."""
-        for child in (self._toolbar_stack, self._status_sep,
+        for child in (self._toolbar_stack, self._body_sep, self._status_sep,
                       self._statusbar, self._body):
             child.pack_forget()
         # The stacked-toolbar region — full width, at the very top, above the body.
         self._toolbar_stack.pack(side="top", fill="x")
+        # Persistent boundary between the top chrome and the workspace below it.
+        self._body_sep.pack(side="top", fill="x")
         if self._show_statusbar:
             # Band at the very bottom; its hairline just above it (both full width).
             self._statusbar.pack(side="bottom", fill="x")


### PR DESCRIPTION
## Summary

The boundary between the top chrome stack and the workspace was being drawn by
`add_toolbar(divider=True)` using the default (heavy) separator stroke, which
read noticeably heavier than every other divider in the shell. This makes the
boundary a property of the layout instead, and softens the per-toolbar divider
to match.

- **Persistent chrome→content border** — `ShellLayout` always draws a
  content-surfaced hairline at the soft `DIVIDER_BORDER_STRENGTH` (0.90) between
  the chrome stack and the body (rail + sidebar + content), mirroring the bottom
  status hairline. Present regardless of whether any toolbar exists, so authors
  no longer rely on `add_toolbar(divider=True)` for the chrome/workspace edge,
  and the stroke matches the rail/sidebar/status dividers.
- **Softer inter-toolbar divider** — `add_toolbar(divider=True)` now passes the
  same soft `border_strength` (0.90) the shell's region dividers use, so a
  divider between two stacked bars is a quiet hairline. The surface stays the
  bar's own (`chrome` by default), keeping the stroke derived against the
  surface it sits between.
- **Docs** — `appshell.rst` notes the shell auto-draws the chrome→workspace
  hairline and that `divider=True` is now for separating stacked bars.

`add_toolbar(divider=True)` on a plain `App` is unchanged — an `App` has no
shell layout, so the divider is still its way to separate chrome from content.

## Test plan

- Smoke-tested shell construction through `navigate` (single toolbar, and two
  stacked toolbars with `divider=True`) — no errors; the body divider maps.
- Verified visually via a scratch demo (light + dark): the persistent border and
  inter-bar divider both read as quiet hairlines consistent with the
  rail/sidebar/status strokes.

Follow-up: re-shoot the AppShell screenshots (deferred to a separate pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)