### PR TITLE
fix: context-menu dismissal, DataTable right-click/selection behavior, and FormDialog action results

### DIFF
--- a/docs/examples/contextmenu.py
+++ b/docs/examples/contextmenu.py
@@ -29,7 +29,7 @@ with bs.App(title="ContextMenu Demo", padding=20, gap=16) as app:
         bs.Label("Right-click for a menu with a shared callback.")
 
     def on_action(event):
-        print("selected:", event["text"])
+        print("selected:", event.text)
 
     menu2 = bs.ContextMenu(card2, on_select=on_action)
     menu2.add_item("Archive")

--- a/docs/widgets/contextmenu.rst
+++ b/docs/widgets/contextmenu.rst
@@ -62,12 +62,13 @@ Global callback
 ~~~~~~~~~~~~~~~
 
 Pass ``on_select=`` to register a single handler for all item activations.
-The callback receives a dict with ``'type'``, ``'text'``, and ``'value'`` keys.
+The callback receives a :class:`~bootstack.events.MenuSelectEvent` with
+``type``, ``text``, and ``value`` attributes.
 
 .. code-block:: python
 
    def on_action(event):
-       print("selected:", event["text"])
+       print("selected:", event.text)
 
    menu = bs.ContextMenu(card, on_select=on_action)
    menu.add_item("Archive")

--- a/docs/widgets/menubutton.rst
+++ b/docs/widgets/menubutton.rst
@@ -60,12 +60,13 @@ Global item callback
 ~~~~~~~~~~~~~~~~~~~~
 
 Pass ``on_select=`` to register a single callback for every item click.
-The callback receives a dict with ``type``, ``text``, and ``value`` keys.
+The callback receives a :class:`~bootstack.events.MenuSelectEvent` with
+``type``, ``text``, and ``value`` attributes.
 
 .. code-block:: python
 
    def on_action(event):
-       print("selected:", event["text"], "→", event["value"])
+       print("selected:", event.text, "→", event.value)
 
    mb = bs.MenuButton("Actions", on_select=on_action)
    mb.add_item("Delete", value="delete")

--- a/src/bootstack/dialogs/_impl/formdialog.py
+++ b/src/bootstack/dialogs/_impl/formdialog.py
@@ -26,7 +26,9 @@ class FormDialog:
     dialogs for data entry with automatic field generation or explicit layouts.
 
     Attributes:
-        result: The form data returned after closing (dict), or None if cancelled.
+        result: After closing — the entered form data (dict) for a submit
+            button (ok/submit/save), the button's own result value for a custom
+            action button (e.g. "delete"), or None if cancelled.
         form: The embedded Form widget instance, accessible for advanced usage.
 
     Args:
@@ -204,11 +206,27 @@ class FormDialog:
             auto_flip=auto_flip
         )
 
-        # Transfer the result from dialog to FormDialog
-        if self._dialog.result is not None:
-            self.result = self.form.data if self.form else None
-        else:
-            self.result = None
+        # Transfer the result from dialog to FormDialog.
+        self.result = self._resolve_result(self._dialog.result)
+
+    # Submit-style button results that mean "return the entered form data".
+    _DATA_RESULTS = frozenset({"ok", "submit", "save"})
+
+    def _resolve_result(self, dialog_result: Any) -> Any:
+        """Map the closing button's dialog result to the FormDialog result.
+
+        A data-submit button (ok / submit / save) yields the entered form data;
+        a custom action button (e.g. a `'delete'` result) yields its own result
+        value so callers can tell the action apart from the data. A cancel /
+        unset result (`None`) yields `None`.
+        """
+        if dialog_result is None:
+            return None
+        if isinstance(dialog_result, str) and dialog_result.lower() in self._DATA_RESULTS:
+            return self.form.data if self.form else None
+        # A non-cancel button with no explicit result already carries the form
+        # data (set in `_wrap_button_commands`); anything else is an action token.
+        return dialog_result
 
 
     def _build_form_content(self, parent):

--- a/src/bootstack/widgets/_impl/composites/contextmenu.py
+++ b/src/bootstack/widgets/_impl/composites/contextmenu.py
@@ -157,9 +157,14 @@ class _ToplevelContextMenu(CustomConfigMixin):
         self._hide_on_outside_click = hide_on_outside_click
         self._density = density
         self._command = command
-        self._click_handler_id = None
+        self._click_handler_ids: list[tuple[str, str]] = []
         self._click_binding_root = None
         self._click_bind_after_id = None
+        # One-shot guard: the click that (re)opens the menu reaches the
+        # already-bound outside handler on the same event (the trigger binding
+        # fires `show()` before the toplevel's outside handler). Without this
+        # the reopen click would immediately dismiss the menu it just opened.
+        self._suppress_next_outside = False
 
         # Create toplevel window. This backend is selected on Win/Linux only;
         # Aqua dispatches to `_NativeContextMenu` to avoid the key-window
@@ -629,9 +634,22 @@ class _ToplevelContextMenu(CustomConfigMixin):
         # Start with no item highlighted (keyboard nav will highlight on first arrow key)
         self._highlighted_index = -1
 
+        # Ignore the outside click that triggered this (re)open. It is consumed
+        # synchronously by the already-bound handler on the same event; the idle
+        # callback clears it so a genuine later outside click still dismisses.
+        self._suppress_next_outside = True
+        try:
+            self._toplevel.after_idle(self._clear_suppress_outside)
+        except TclError:
+            self._suppress_next_outside = False
+
         # Setup click outside handler if enabled
         if self._hide_on_outside_click:
             self._setup_click_outside_handler()
+
+    def _clear_suppress_outside(self) -> None:
+        """Drop the one-shot outside-click guard set on show()."""
+        self._suppress_next_outside = False
 
     def _setup_keyboard_bindings(self) -> None:
         """Setup keyboard navigation bindings on the toplevel."""
@@ -744,6 +762,11 @@ class _ToplevelContextMenu(CustomConfigMixin):
             'value': value
         }
 
+        # Hide the menu before running any handler. A handler may open a modal
+        # dialog (which blocks here until it is closed), so hiding afterward
+        # would leave the menu visible for the whole dialog interaction.
+        self.hide()
+
         # Call registered callback
         if self._command:
             self._command(data)
@@ -751,9 +774,6 @@ class _ToplevelContextMenu(CustomConfigMixin):
         # Execute item command
         if command:
             command()
-
-        # Hide menu after item click
-        self.hide()
 
     def _compute_position(self, position: tuple[int, int] | None) -> tuple[int, int] | None:
         """Compute screen coordinates for the menu based on anchor/attach/offset."""
@@ -820,6 +840,12 @@ class _ToplevelContextMenu(CustomConfigMixin):
             if not self._toplevel.winfo_viewable():
                 return
 
+            # Swallow the click that just (re)opened this menu so it doesn't
+            # dismiss it on the very same event.
+            if self._suppress_next_outside:
+                self._suppress_next_outside = False
+                return
+
             # Check if click is inside the menu
             try:
                 x, y = event.x_root, event.y_root
@@ -848,7 +874,13 @@ class _ToplevelContextMenu(CustomConfigMixin):
                 root = self._get_binding_root()
                 if root and root.winfo_exists():
                     self._click_binding_root = root
-                    self._click_handler_id = root.bind('<Button-1>', on_click, add='+')
+                    # Watch every mouse button. A menu is opened with a
+                    # right-click, so right-clicking outside (e.g. to open a
+                    # different menu) must dismiss this one too — a left-click-only
+                    # handler misses that gesture and leaves both menus open.
+                    for seq in ('<Button-1>', '<Button-2>', '<Button-3>'):
+                        handler_id = root.bind(seq, on_click, add='+')
+                        self._click_handler_ids.append((seq, handler_id))
 
         # Delay binding to avoid capturing the click that shows the menu
         self._cancel_click_outside_after()
@@ -865,17 +897,18 @@ class _ToplevelContextMenu(CustomConfigMixin):
         return None
 
     def _unbind_click_outside_handler(self) -> None:
-        """Remove the click-outside binding if present."""
-        if not self._click_handler_id or not self._click_binding_root:
+        """Remove the click-outside bindings if present."""
+        if not self._click_handler_ids or not self._click_binding_root:
             return
 
         try:
             if self._click_binding_root.winfo_exists():
-                self._click_binding_root.unbind('<Button-1>', self._click_handler_id)
+                for seq, handler_id in self._click_handler_ids:
+                    self._click_binding_root.unbind(seq, handler_id)
         except TclError:
             pass
         finally:
-            self._click_handler_id = None
+            self._click_handler_ids = []
             self._click_binding_root = None
 
     def _cancel_click_outside_after(self) -> None:

--- a/src/bootstack/widgets/_impl/composites/tableview/tableview.py
+++ b/src/bootstack/widgets/_impl/composites/tableview/tableview.py
@@ -427,6 +427,10 @@ class TableView(Frame):
         self._alignment_sample: list[dict] | None = None
         self._row_map: dict[str, dict] = {}
         self._row_menu: ContextMenu | None = None
+        # The row a right-click context menu targets. Right-click never changes
+        # the selection (that is a left-click affordance), so the row menu acts
+        # on this clicked row instead — see `_context_iids`.
+        self._context_iid: str | None = None
         self._display_columns: list[int] = []
         self._header_menu: ContextMenu | None = None
         self._header_menu_col: int | None = None
@@ -1298,6 +1302,14 @@ class TableView(Frame):
         return records
 
     def _refresh_tree(self, records: list[dict]) -> None:
+        # Preserve the selection across the rebuild for rows that remain visible.
+        # Selection is view/page-scoped: a sort keeps every row (selection fully
+        # preserved), a search keeps the still-matching rows, and rows no longer
+        # shown drop out. Captured by record id since the row handles are rebuilt.
+        prev_selected_ids = {
+            self._record_id(self._row_map[iid])
+            for iid in self._tree.selection() if iid in self._row_map
+        }
         self._tree.delete(*self._tree.get_children())
         self._row_map.clear()
         if not self._column_keys and records:
@@ -1309,6 +1321,11 @@ class TableView(Frame):
         else:
             self._render_flat(records)
         self._apply_row_alternation()
+        if prev_selected_ids:
+            restore = [iid for iid, rec in self._row_map.items()
+                       if self._record_id(rec) in prev_selected_ids]
+            if restore:
+                self._tree.selection_set(restore)
         self._update_selection_markers()
 
     def _append_tree(self, records: list[dict]) -> None:
@@ -1565,6 +1582,15 @@ class TableView(Frame):
         self._update_footer_visibility()
 
     # ------------------------------------------------------------------ Row context menu
+    def _dismiss_context_menus(self) -> None:
+        """Hide any open built-in row/header context menu (idempotent)."""
+        for menu in (self._row_menu, self._header_menu):
+            if menu is not None:
+                try:
+                    menu.hide()
+                except Exception:
+                    pass
+
     def _ensure_row_menu(self) -> None:
         if not self._row_context_enabled():
             return
@@ -1607,13 +1633,13 @@ class TableView(Frame):
             col_idx = int(col_id.strip("#")) - 1
         except Exception:
             col_idx = 0
-        if iid:
-            if iid not in self._tree.selection():
-                self._tree.selection_set(iid)
-            rec = self._row_map.get(iid, {})
-            self.event_generate("<<RowRightClick>>", data=RowEvent(record=self._public_record(rec), id=self._record_id(rec)))
-        if not self._tree.selection():
-            return
+        # Right-click does not alter the selection (left-click owns that); it
+        # only records which row the menu targets and opens the menu there.
+        self._context_iid = iid or None
+        if not iid:
+            return  # empty space or a group-header row — no row menu
+        rec = self._row_map.get(iid, {})
+        self.event_generate("<<RowRightClick>>", data=RowEvent(record=self._public_record(rec), id=self._record_id(rec)))
         self._row_menu_col = col_idx
         self._ensure_row_menu()
         self._row_menu.show(position=(event.x_root, event.y_root))
@@ -1781,8 +1807,24 @@ class TableView(Frame):
             )
         return items
 
+    def _context_iids(self) -> tuple[str, ...]:
+        """Row id(s) a row-menu command acts on.
+
+        The menu targets the right-clicked row. When that row is part of the
+        current (left-click) selection, the whole selection is the target — the
+        intuitive multi-select behavior — otherwise just the clicked row. Either
+        way the selection itself is left unchanged.
+        """
+        clicked = self._context_iid
+        selection = tuple(self._tree.selection())
+        if clicked and clicked in selection:
+            return selection
+        if clicked:
+            return (clicked,)
+        return selection
+
     def _filter_by_value(self) -> None:
-        selection = self._tree.selection()
+        selection = self._context_iids()
         if not selection:
             return
         iid = selection[0]
@@ -1797,7 +1839,7 @@ class TableView(Frame):
         self._apply_where()
 
     def _sort_selection(self, ascending: bool) -> None:
-        selection = self._tree.selection()
+        selection = self._context_iids()
         if not selection:
             return
         iid = selection[0]
@@ -1832,7 +1874,7 @@ class TableView(Frame):
             self._move_row_absolute(len(children) - 1)
 
     def _move_row_relative(self, delta: int) -> None:
-        sel = list(self._tree.selection())
+        sel = list(self._context_iids())
         if not sel:
             return
         target_iid = sel[0]
@@ -1851,7 +1893,7 @@ class TableView(Frame):
             self.event_generate("<<RowsMove>>", data=RowsEvent(records=[self._public_record(rec)]))
 
     def _move_row_absolute(self, new_idx: int) -> None:
-        sel = list(self._tree.selection())
+        sel = list(self._context_iids())
         if not sel:
             return
         target_iid = sel[0]
@@ -1864,14 +1906,14 @@ class TableView(Frame):
             self.event_generate("<<RowsMove>>", data=RowsEvent(records=[self._public_record(rec)]))
 
     def _hide_selection(self) -> None:
-        sel = list(self._tree.selection())
+        sel = list(self._context_iids())
         for iid in sel:
             self._tree.delete(iid)
             self._row_map.pop(iid, None)
 
     def _edit_selected_row(self) -> None:
-        """Open the form dialog for the first selected row."""
-        sel = list(self._tree.selection())
+        """Open the form dialog for the right-clicked row."""
+        sel = list(self._context_iids())
         if not sel:
             return
         iid = sel[0]
@@ -1879,8 +1921,8 @@ class TableView(Frame):
         self._open_form_dialog(rec)
 
     def _delete_selected_row(self) -> None:
-        """Delete the first selected row from the datasource."""
-        sel = list(self._tree.selection())
+        """Delete the right-clicked row from the datasource."""
+        sel = list(self._context_iids())
         if not sel:
             return
         iid = sel[0]
@@ -2729,6 +2771,11 @@ class TableView(Frame):
 
     def _on_header_click(self, event):
         """Handle left-click: header sorting, or toggle-select with checkboxes."""
+        # A left-click on the tree dismisses an open context menu. Do it
+        # explicitly: the toggle-select and group-row branches below return
+        # 'break', which stops the event before it reaches the window-level
+        # outside-click handler that would otherwise close the menu.
+        self._dismiss_context_menus()
         region = self._tree.identify_region(event.x, event.y)
         if region == "heading":
             if self._sorting == 'none':


### PR DESCRIPTION
## Summary

A batch of related fixes surfaced while testing context menus and the `DataTable` edit/delete flow.

### ContextMenu (`contextmenu.py`)
- **Dismiss on any mouse button** — the outside-click handler now watches `<Button-1/2/3>`, not just left-click. A menu is opened with a right-click, so right-clicking elsewhere (e.g. to open another menu) must dismiss the current one; the left-click-only handler left both open. Also covers the macOS right-click variants (Button-2 / Control-click).
- **Reopen-race guard** — a one-shot `_suppress_next_outside` flag set in `show()` swallows exactly the click that (re)opened the menu, so repositioning it (right-click another row/column) no longer dismisses it on the same event. Clears on idle, leaving normal outside-dismiss intact.
- **Hide before running an item handler** — was after. A handler may open a modal dialog (which blocks until closed); hiding afterward left the menu visible for the whole interaction.

### DataTable (`tableview.py`)
- **Right-click no longer changes the selection** — selection is now a left-click-only affordance. `_on_row_context` records the clicked row; the row-menu commands target it via the new `_context_iids()` (clicked row, or the whole selection when the clicked row is part of a multi-selection) without altering the selection.
- **Left-click dismisses an open menu through a `break`** — with checkbox toggle-select / group rows, `_on_header_click` returns `'break'`, which stopped the click before the window-level outside handler could dismiss the menu. The built-in menus are now dismissed explicitly. (General case for user-attached menus: #207.)
- **Selection survives a rebuild** — `_refresh_tree` previously cleared selection on every search/sort/page. It now re-selects the still-visible rows: a sort keeps the full selection, a search narrows it to the matching rows. (Cross-page persist-by-id: #208.)

### FormDialog (`formdialog.py`)
- **Honor a custom action button's result** — `show()` overwrote `result` with the form data for any non-cancel close, discarding a button's explicit `result`. The DataTable edit dialog's Delete (`{"result": "delete"}`) therefore returned form data instead of `"delete"`, so the record was updated rather than deleted. `_resolve_result` now maps submit buttons → form data, action buttons → their result value, cancel → None.

### Docs
- Fixed stale `event["text"]` (dict-subscript) usage in the ContextMenu/MenuButton examples and guides — `on_select` receives a `MenuSelectEvent` dataclass, so attribute access (`event.text`) is correct.

## Test plan
- `tests/widgets/public/test_datatable.py` — 10 passed.
- Functional checks (scripted): outside-dismiss on every button; reopen keeps the menu open while a later outside click still dismisses; menu hidden before a (blocking) item handler runs; right-click leaves selection untouched while the menu targets the clicked row; a left-click on a checkbox table dismisses the open menu; selection preserved across sort and narrowed on search; FormDialog result mapping across button types; source-backed delete removes the row.
- Visual verification (right-click/edit/delete/search interactions) left for the maintainer.

## Follow-ups
- #207 — general grab-based dismiss so user-attached menus also dismiss when a host widget returns `break`.
- #208 — persist DataTable selection by record id across pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)