### PR TITLE
feat(slider): add step= for value snapping + keyboard increment (#210)

### DIFF
--- a/docs/examples/rangeslider.py
+++ b/docs/examples/rangeslider.py
@@ -1,7 +1,7 @@
 """RangeSlider — full feature demo.
 
 Demonstrates basic usage, value badges, tick marks, accent colors,
-and disabled state.
+step snapping, and disabled state.
 
 Run with:
     python docs/examples/rangeslider.py
@@ -29,6 +29,10 @@ with bs.App(title="RangeSlider Demo", padding=20, gap=16, minsize=(400, 200)) as
     with bs.Column(gap=6, horizontal="stretch", horizontal_items="stretch"):
         for accent in ("primary", "secondary", "info", "success", "warning", "danger"):
             bs.RangeSlider(20, 80, accent=accent)
+
+    # Step snapping (both handles snap to 0, 5, 10, … 100)
+    bs.Label("Step Snapping", font="heading-sm")
+    bs.RangeSlider(20, 80, step=5, tick_step=5, horizontal="stretch")
 
     # Disabled
     bs.Label("Disabled", font="heading-sm")

--- a/docs/examples/slider.py
+++ b/docs/examples/slider.py
@@ -1,7 +1,7 @@
 """Slider — full feature demo.
 
 Demonstrates accent colors, value badge, min/max labels, tick marks,
-custom tick format, and disabled state.
+custom tick format, step snapping, and disabled state.
 
 Run with:
     python docs/examples/slider.py
@@ -46,6 +46,10 @@ with bs.App(title="Slider Demo", padding=20, gap=16, min_size=(400, 1)) as app:
         show_value=True,
         horizontal="stretch",
     )
+
+    # Step snapping (only 0, 5, 10, … 100)
+    bs.Label("Step Snapping", font="heading-sm")
+    bs.Slider(50, step=5, tick_step=5, horizontal="stretch")
 
     # Disabled
     bs.Label("Disabled", font="heading-sm")

--- a/docs/widgets/rangeslider.rst
+++ b/docs/widgets/rangeslider.rst
@@ -58,6 +58,12 @@ subdivisions between them.
    :class: bs-screenshot-dark
    :alt: RangeSlider tick marks — dark theme
 
+.. note::
+
+   ``tick_step`` only *draws* the marks — the handles still move continuously.
+   To make the handles snap to those increments, use ``step=`` (see
+   `Snapping to steps`_).
+
 Accent colors
 ~~~~~~~~~~~~~
 
@@ -104,6 +110,22 @@ Access both handles at once via ``.value``, or individually via
    rs.low_value  = 30     # move low handle (clamped to [min, high])
    rs.high_value = 70     # move high handle (clamped to [low, max])
 
+Snapping to steps
+~~~~~~~~~~~~~~~~~
+
+Set ``step=`` to constrain both handles to discrete increments. Click and drag
+values snap to the nearest multiple of ``step`` (measured from ``min_value``),
+and the arrow keys move by ``step``. It is independent of ``tick_step`` — set
+both for a stepped range with matching marks, or ``step`` alone to snap without
+drawing ticks.
+
+.. code-block:: python
+
+   # Both handles snap to 0, 5, 10, … 100
+   bs.RangeSlider(20, 80, min_value=0, max_value=100, step=5, tick_step=5)
+
+When the range is not an even multiple of ``step``, the maximum stays reachable.
+
 Events
 ~~~~~~
 
@@ -133,8 +155,9 @@ Keyboard
 ~~~~~~~~
 
 When focused, ``Tab`` switches between the low and high handle. The active
-handle responds to the arrow keys (±1), ``Shift`` + arrow (±10), and ``Home`` /
-``End`` (minimum / maximum). Every keyboard change also emits ``on_commit``.
+handle responds to the arrow keys (±1, or ±``step`` when ``step`` is set),
+``Shift`` + arrow (a larger jump), and ``Home`` / ``End`` (minimum / maximum).
+Every keyboard change also emits ``on_commit``.
 
 Disabled
 ~~~~~~~~

--- a/docs/widgets/slider.rst
+++ b/docs/widgets/slider.rst
@@ -78,6 +78,11 @@ track ends.
    :class: bs-screenshot-dark
    :alt: Slider min/max labels — dark theme
 
+.. note::
+
+   When ``tick_step`` is set with labels, the range ends are already labeled —
+   ``show_minmax`` is mainly for a slider without tick marks.
+
 Tick marks
 ~~~~~~~~~~
 
@@ -98,6 +103,28 @@ subdivisions between them. ``tick_labels=False`` hides the numeric labels.
 .. image:: /_static/examples/slider-ticks-dark.png
    :class: bs-screenshot-dark
    :alt: Slider tick marks — dark theme
+
+.. note::
+
+   ``tick_step`` only *draws* the marks — the value still moves continuously.
+   To make the slider snap to those increments, use ``step=`` (see
+   `Snapping to steps`_).
+
+Snapping to steps
+~~~~~~~~~~~~~~~~~
+
+Set ``step=`` to constrain the value to discrete increments. Click and drag
+values snap to the nearest multiple of ``step`` (measured from ``min_value``),
+and the arrow keys move by ``step``. It is independent of ``tick_step`` — set
+both for a stepped slider with matching marks, or ``step`` alone to snap without
+drawing ticks.
+
+.. code-block:: python
+
+   # Only 0, 5, 10, … 100 — with ticks drawn at the same increments
+   bs.Slider(50, min_value=0, max_value=100, step=5, tick_step=5)
+
+When the range is not an even multiple of ``step``, the maximum stays reachable.
 
 Reactive binding
 ~~~~~~~~~~~~~~~~
@@ -137,9 +164,9 @@ holds the current value.
 Keyboard
 ~~~~~~~~
 
-When focused, the slider responds to the arrow keys (±1), ``Shift`` + arrow
-(±10), and ``Home`` / ``End`` (minimum / maximum). Every keyboard change also
-emits ``on_commit``.
+When focused, the slider responds to the arrow keys (±1, or ±``step`` when
+``step`` is set), ``Shift`` + arrow (a larger jump), and ``Home`` / ``End``
+(minimum / maximum). Every keyboard change also emits ``on_commit``.
 
 Disabled
 ~~~~~~~~

--- a/src/bootstack/widgets/_impl/composites/slider/rangeslider.py
+++ b/src/bootstack/widgets/_impl/composites/slider/rangeslider.py
@@ -53,6 +53,7 @@ class RangeSlider(ConfigureDelegationMixin, tk.Frame):
         minor_ticks: int = 0,
         tick_labels: bool = True,
         tick_format: str = "{:.0f}",
+        step: float | None = None,
         **kw: Any,
     ) -> None:
         """Create a RangeSlider widget.
@@ -81,9 +82,15 @@ class RangeSlider(ConfigureDelegationMixin, tk.Frame):
             minor_ticks: Number of minor tick marks between each major tick.
             tick_labels: Show numeric labels at major tick positions.
             tick_format: Format string for tick and badge labels (e.g. `"{:.1f}°C"`).
+            step: Snap increment. When set, handle values snap to multiples of
+                `step` (measured from `minvalue`) and arrow keys move by `step`.
+                `None` leaves the values continuous. Independent of `tick_interval`.
         """
         self._minvalue = float(minvalue)
         self._maxvalue = float(maxvalue)
+        self._step_size = float(step) if step else None
+        self._kbd_step = self._step_size if self._step_size else float(STEP)
+        self._kbd_step_large = self._step_size * 10 if self._step_size else float(STEP_LARGE)
         self._orient = orient
         self._accent = accent
         self._surface = surface
@@ -120,7 +127,7 @@ class RangeSlider(ConfigureDelegationMixin, tk.Frame):
             lo_variable.trace_add(
                 "write", lambda *_: self._lo_signal.var.set(lo_variable.get()))
         else:
-            self._lo_signal = Signal(float(lovalue))
+            self._lo_signal = Signal(self._snap(float(lovalue)))
         self._lo_var = self._lo_signal.var
 
         if hi_signal is not None:
@@ -132,7 +139,7 @@ class RangeSlider(ConfigureDelegationMixin, tk.Frame):
             hi_variable.trace_add(
                 "write", lambda *_: self._hi_signal.var.set(hi_variable.get()))
         else:
-            self._hi_signal = Signal(float(hivalue))
+            self._hi_signal = Signal(self._snap(float(hivalue)))
         self._hi_var = self._hi_signal.var
 
         self._prev_lovalue: float = self._lo_var.get()
@@ -254,12 +261,12 @@ class RangeSlider(ConfigureDelegationMixin, tk.Frame):
 
         self.bind("<FocusIn>",     self._on_focus_in)
         self.bind("<FocusOut>",    self._on_focus_out)
-        self.bind("<Left>",        lambda e: self._step(-STEP))
-        self.bind("<Right>",       lambda e: self._step(+STEP))
-        self.bind("<Down>",        lambda e: self._step(-STEP))
-        self.bind("<Up>",          lambda e: self._step(+STEP))
-        self.bind("<Shift-Left>",  lambda e: self._step(-STEP_LARGE))
-        self.bind("<Shift-Right>", lambda e: self._step(+STEP_LARGE))
+        self.bind("<Left>",        lambda e: self._step(-self._kbd_step))
+        self.bind("<Right>",       lambda e: self._step(+self._kbd_step))
+        self.bind("<Down>",        lambda e: self._step(-self._kbd_step))
+        self.bind("<Up>",          lambda e: self._step(+self._kbd_step))
+        self.bind("<Shift-Left>",  lambda e: self._step(-self._kbd_step_large))
+        self.bind("<Shift-Right>", lambda e: self._step(+self._kbd_step_large))
         self.bind("<Home>",        lambda e: self._jump(self._minvalue))
         self.bind("<End>",         lambda e: self._jump(self._maxvalue))
         self.bind("<Tab>",         self._cycle_handle)
@@ -332,6 +339,19 @@ class RangeSlider(ConfigureDelegationMixin, tk.Frame):
         if self._orient == "horizontal":
             return event.x
         return event.y
+
+    def _snap(self, v: float) -> float:
+        """Clamp `v` to [min, max] and, when `step` is set, snap it to the
+        nearest grid point (measured from `minvalue`). `maxvalue` stays reachable
+        even when the range is not an exact multiple of `step`."""
+        v = max(self._minvalue, min(self._maxvalue, float(v)))
+        if not self._step_size:
+            return v
+        grid = self._minvalue + round((v - self._minvalue) / self._step_size) * self._step_size
+        grid = max(self._minvalue, min(self._maxvalue, grid))
+        if abs(v - self._maxvalue) < abs(v - grid):
+            return self._maxvalue
+        return grid
 
     # ------------------------------------------------------------------
     # Rendering helpers
@@ -575,7 +595,7 @@ class RangeSlider(ConfigureDelegationMixin, tk.Frame):
         ))
 
     def _move(self, pos: int) -> None:
-        value = self._pos_to_value(pos)
+        value = self._snap(self._pos_to_value(pos))
         if self._dragging == "lo":
             self._lo_var.set(max(self._minvalue, min(value, self._hi_var.get())))
         else:
@@ -593,7 +613,7 @@ class RangeSlider(ConfigureDelegationMixin, tk.Frame):
         ))
 
     def _set_focused(self, value: float) -> None:
-        value = max(self._minvalue, min(self._maxvalue, value))
+        value = self._snap(value)
         if self._focus_handle == "lo":
             self._lo_var.set(min(value, self._hi_var.get()))
         else:
@@ -613,8 +633,8 @@ class RangeSlider(ConfigureDelegationMixin, tk.Frame):
         """Pull both handles back into [min, max] (and lo <= hi) after a range
         change, emitting <<Change>> only for handles that actually move."""
         lo, hi = self._lo_var.get(), self._hi_var.get()
-        nlo = max(self._minvalue, min(lo, self._maxvalue))
-        nhi = max(self._minvalue, min(hi, self._maxvalue))
+        nlo = self._snap(lo)
+        nhi = self._snap(hi)
         nlo = min(nlo, nhi)
         changed = False
         if nlo != lo:
@@ -726,20 +746,22 @@ class RangeSlider(ConfigureDelegationMixin, tk.Frame):
         return self._hi_var.get()
 
     def set_lo(self, value: float) -> None:
-        """Set the low handle to a new value, clamped to [minvalue, hivalue].
+        """Set the low handle to a new value, clamped to [minvalue, hivalue] and
+        snapped to the step grid when `step` is set.
 
         Args:
             value: New low-handle value.
         """
-        self._lo_var.set(max(self._minvalue, min(float(value), self._hi_var.get())))
+        self._lo_var.set(min(self._snap(value), self._hi_var.get()))
 
     def set_hi(self, value: float) -> None:
-        """Set the high handle to a new value, clamped to [lovalue, maxvalue].
+        """Set the high handle to a new value, clamped to [lovalue, maxvalue] and
+        snapped to the step grid when `step` is set.
 
         Args:
             value: New high-handle value.
         """
-        self._hi_var.set(min(self._maxvalue, max(float(value), self._lo_var.get())))
+        self._hi_var.set(max(self._snap(value), self._lo_var.get()))
 
     def on_changed(self, callback: Callable[[RangeSliderEvent], None]) -> str:
         """Register a callback for `<<Change>>` events.
@@ -817,6 +839,15 @@ class RangeSlider(ConfigureDelegationMixin, tk.Frame):
         self._maxvalue = float(value)
         self._setup_ticks()
         self._reclamp()
+
+    @configure_delegate('step')
+    def _delegate_step(self, value=None):
+        if value is None:
+            return self._step_size
+        self._step_size = float(value) if value else None
+        self._kbd_step = self._step_size if self._step_size else float(STEP)
+        self._kbd_step_large = self._step_size * 10 if self._step_size else float(STEP_LARGE)
+        self._reclamp()   # re-snap both handles onto the new grid
 
     @configure_delegate('accent')
     def _delegate_accent(self, value=None):

--- a/src/bootstack/widgets/_impl/composites/slider/slider.py
+++ b/src/bootstack/widgets/_impl/composites/slider/slider.py
@@ -53,6 +53,7 @@ class Slider(ConfigureDelegationMixin, tk.Frame):
         minor_ticks: int = 0,
         tick_labels: bool = True,
         tick_format: str = "{:.0f}",
+        step: float | None = None,
         **kw: Any,
     ) -> None:
         """Create a Slider widget.
@@ -77,9 +78,15 @@ class Slider(ConfigureDelegationMixin, tk.Frame):
             minor_ticks: Number of minor tick marks between each major tick.
             tick_labels: Show numeric labels at major tick positions.
             tick_format: Format string for tick and badge labels (e.g. `"{:.1f}°C"`).
+            step: Snap increment. When set, click/drag values snap to multiples
+                of `step` (measured from `minvalue`) and arrow keys move by `step`.
+                `None` leaves the value continuous. Independent of `tick_interval`.
         """
         self._minvalue = float(minvalue)
         self._maxvalue = float(maxvalue)
+        self._step_size = float(step) if step else None
+        self._kbd_step = self._step_size if self._step_size else float(STEP)
+        self._kbd_step_large = self._step_size * 10 if self._step_size else float(STEP_LARGE)
         self._orient = orient
         self._accent = accent
         self._surface = surface
@@ -121,7 +128,7 @@ class Slider(ConfigureDelegationMixin, tk.Frame):
             variable.trace_add(
                 "write", lambda *_: self._signal.var.set(variable.get()))
         else:
-            self._signal = Signal(float(value))
+            self._signal = Signal(self._snap(float(value)))
         self._var = self._signal.var
         self._prev_value: float = self._var.get()
 
@@ -257,12 +264,12 @@ class Slider(ConfigureDelegationMixin, tk.Frame):
 
         self.bind("<FocusIn>",     self._on_focus_in)
         self.bind("<FocusOut>",    self._on_focus_out)
-        self.bind("<Left>",        lambda e: self._step(-STEP))
-        self.bind("<Right>",       lambda e: self._step(+STEP))
-        self.bind("<Down>",        lambda e: self._step(-STEP))
-        self.bind("<Up>",          lambda e: self._step(+STEP))
-        self.bind("<Shift-Left>",  lambda e: self._step(-STEP_LARGE))
-        self.bind("<Shift-Right>", lambda e: self._step(+STEP_LARGE))
+        self.bind("<Left>",        lambda e: self._step(-self._kbd_step))
+        self.bind("<Right>",       lambda e: self._step(+self._kbd_step))
+        self.bind("<Down>",        lambda e: self._step(-self._kbd_step))
+        self.bind("<Up>",          lambda e: self._step(+self._kbd_step))
+        self.bind("<Shift-Left>",  lambda e: self._step(-self._kbd_step_large))
+        self.bind("<Shift-Right>", lambda e: self._step(+self._kbd_step_large))
         self.bind("<Home>",        lambda e: self._jump(self._minvalue))
         self.bind("<End>",         lambda e: self._jump(self._maxvalue))
         self._canvas.bind("<Configure>", self._on_configure)
@@ -338,6 +345,21 @@ class Slider(ConfigureDelegationMixin, tk.Frame):
         if self._orient == "vertical":
             ratio = 1.0 - ratio
         return self._minvalue + ratio * (self._maxvalue - self._minvalue)
+
+    def _snap(self, v: float) -> float:
+        """Clamp `v` to [min, max] and, when `step` is set, snap it to the
+        nearest grid point (measured from `minvalue`). `maxvalue` stays reachable
+        even when the range is not an exact multiple of `step`."""
+        v = max(self._minvalue, min(self._maxvalue, float(v)))
+        if not self._step_size:
+            return v
+        grid = self._minvalue + round((v - self._minvalue) / self._step_size) * self._step_size
+        grid = max(self._minvalue, min(self._maxvalue, grid))
+        # Let the exact maximum win when the value is closer to it than to the
+        # last grid point (an off-grid max would otherwise be unreachable).
+        if abs(v - self._maxvalue) < abs(v - grid):
+            return self._maxvalue
+        return grid
 
     # ------------------------------------------------------------------
     # Rendering helpers
@@ -540,9 +562,9 @@ class Slider(ConfigureDelegationMixin, tk.Frame):
             return
         # event.x/y are already in canvas coordinates — no winfo_x/y offset needed.
         if self._orient == "horizontal":
-            self._var.set(self._pos_to_value(event.x))
+            self._var.set(self._snap(self._pos_to_value(event.x)))
         else:
-            self._var.set(self._pos_to_value(event.y))
+            self._var.set(self._snap(self._pos_to_value(event.y)))
 
     def _on_drag(self, event: tk.Event) -> None:
         self._on_click(event)
@@ -556,7 +578,7 @@ class Slider(ConfigureDelegationMixin, tk.Frame):
     def _step(self, amount: float) -> None:
         if self._state == "disabled":
             return
-        new = max(self._minvalue, min(self._maxvalue, self._var.get() + amount))
+        new = self._snap(self._var.get() + amount)
         self._var.set(new)
         self.event_generate("<<Commit>>", data=SliderCommitEvent(value=new))
 
@@ -569,9 +591,10 @@ class Slider(ConfigureDelegationMixin, tk.Frame):
         self.event_generate("<<Commit>>", data=SliderCommitEvent(value=new))
 
     def _reclamp(self) -> None:
-        """Pull the current value back into [min, max] after a range change."""
+        """Pull the current value back into [min, max] (and onto the step grid)
+        after a range or step change."""
         cur = self._var.get()
-        clamped = max(self._minvalue, min(self._maxvalue, cur))
+        clamped = self._snap(cur)
         if clamped != cur:
             self._var.set(clamped)   # trace fires _sync + <<Change>>
         else:
@@ -621,12 +644,13 @@ class Slider(ConfigureDelegationMixin, tk.Frame):
         return self._var.get()
 
     def set(self, value: float) -> None:
-        """Set the slider to a new value, clamped to [minvalue, maxvalue].
+        """Set the slider to a new value, clamped to [minvalue, maxvalue] and
+        snapped to the step grid when `step` is set.
 
         Args:
             value: New value to set.
         """
-        self._var.set(max(self._minvalue, min(self._maxvalue, float(value))))
+        self._var.set(self._snap(float(value)))
 
     def on_changed(self, callback: Callable[[SliderEvent], None]) -> str:
         """Register a callback for `<<Change>>` events.
@@ -705,6 +729,15 @@ class Slider(ConfigureDelegationMixin, tk.Frame):
         self._maxvalue = float(value)
         self._setup_ticks()
         self._reclamp()
+
+    @configure_delegate('step')
+    def _delegate_step(self, value=None):
+        if value is None:
+            return self._step_size
+        self._step_size = float(value) if value else None
+        self._kbd_step = self._step_size if self._step_size else float(STEP)
+        self._kbd_step_large = self._step_size * 10 if self._step_size else float(STEP_LARGE)
+        self._reclamp()   # re-snap the current value onto the new grid
 
     @configure_delegate('accent')
     def _delegate_accent(self, value=None):

--- a/src/bootstack/widgets/slider.py
+++ b/src/bootstack/widgets/slider.py
@@ -44,6 +44,10 @@ class Slider(PublicWidgetBase):
             positions. Defaults to `True`.
         tick_format: Python format string applied to tick and badge labels.
             Defaults to `'{:.0f}'`.
+        step: Snap increment. When set, click/drag values snap to multiples of
+            `step` (measured from `min_value`) and the arrow keys move by `step`.
+            `None` (the default) leaves the value continuous. Independent of
+            `tick_step`, which only places tick marks.
         accent: Accent token controlling the fill, handle, and focus ring
             color. Defaults to `'primary'`.
         disabled: If `True`, slider is non-interactive. Defaults to
@@ -69,6 +73,7 @@ class Slider(PublicWidgetBase):
         minor_ticks: int = 0,
         tick_labels: bool = True,
         tick_format: str = "{:.0f}",
+        step: float | None = None,
         accent: AccentToken | str | None = None,
         disabled: bool = False,
         parent: Any = None,
@@ -89,6 +94,7 @@ class Slider(PublicWidgetBase):
             "minor_ticks":  minor_ticks,
             "tick_labels":  tick_labels,
             "tick_format":  tick_format,
+            "step":         step,
         }
         if signal is not None:
             internal_kwargs["signal"] = signal
@@ -135,6 +141,15 @@ class Slider(PublicWidgetBase):
     @max_value.setter
     def max_value(self, v: float) -> None:
         self._internal.configure(maxvalue=float(v))
+
+    @property
+    def step(self) -> float | None:
+        """Snap increment, or `None` when the value is continuous."""
+        return self._internal._step_size
+
+    @step.setter
+    def step(self, v: float | None) -> None:
+        self._internal.configure(step=v)
 
     @property
     def disabled(self) -> bool:
@@ -211,6 +226,10 @@ class RangeSlider(PublicWidgetBase):
             positions. Defaults to `True`.
         tick_format: Python format string applied to tick and badge labels.
             Defaults to `'{:.0f}'`.
+        step: Snap increment. When set, handle values snap to multiples of
+            `step` (measured from `min_value`) and the arrow keys move by `step`.
+            `None` (the default) leaves the values continuous. Independent of
+            `tick_step`, which only places tick marks.
         accent: Accent token controlling the fill, handles, and focus ring
             color. Defaults to `'primary'`.
         disabled: If `True`, slider is non-interactive. Defaults to
@@ -237,6 +256,7 @@ class RangeSlider(PublicWidgetBase):
         minor_ticks: int = 0,
         tick_labels: bool = True,
         tick_format: str = "{:.0f}",
+        step: float | None = None,
         accent: AccentToken | str | None = None,
         disabled: bool = False,
         parent: Any = None,
@@ -257,6 +277,7 @@ class RangeSlider(PublicWidgetBase):
             "minor_ticks":   minor_ticks,
             "tick_labels":   tick_labels,
             "tick_format":   tick_format,
+            "step":          step,
         }
         if low_signal is not None:
             internal_kwargs["lo_signal"] = low_signal
@@ -325,6 +346,15 @@ class RangeSlider(PublicWidgetBase):
     @max_value.setter
     def max_value(self, v: float) -> None:
         self._internal.configure(maxvalue=float(v))
+
+    @property
+    def step(self) -> float | None:
+        """Snap increment, or `None` when the values are continuous."""
+        return self._internal._step_size
+
+    @step.setter
+    def step(self, v: float | None) -> None:
+        self._internal.configure(step=v)
 
     @property
     def disabled(self) -> bool:

--- a/tests/widgets/public/test_slider_step.py
+++ b/tests/widgets/public/test_slider_step.py
@@ -1,0 +1,98 @@
+"""Snapping tests for the Slider / RangeSlider ``step`` parameter.
+
+``step`` snaps values to multiples of the increment (measured from ``min_value``)
+and clamps to the range; the exact maximum stays reachable when the range is not
+an even multiple of ``step``. These are pure value reads (Tk traces fire on
+``set``), so no event-loop pumping is needed.
+"""
+from __future__ import annotations
+
+import pytest
+
+import bootstack as bs
+
+
+@pytest.fixture(scope="module")
+def app():
+    a = bs.App()
+    a.__enter__()
+    try:
+        yield a
+    finally:
+        try:
+            a.__exit__(None, None, None)
+        except Exception:
+            pass
+        try:
+            a._tk_root.destroy()
+        except Exception:
+            pass
+
+
+# --- Slider --------------------------------------------------------------
+
+def test_slider_initial_value_snaps(app):
+    s = bs.Slider(33, min_value=0, max_value=100, step=5)
+    assert s.value == 35.0
+
+
+def test_slider_set_snaps_to_nearest(app):
+    s = bs.Slider(0, min_value=0, max_value=100, step=5)
+    s.value = 37          # → 35
+    assert s.value == 35.0
+    s.value = 38          # → 40
+    assert s.value == 40.0
+
+
+def test_slider_step_none_is_continuous(app):
+    s = bs.Slider(0, min_value=0, max_value=100)
+    s.value = 33.3
+    assert s.value == pytest.approx(33.3)
+
+
+def test_slider_offgrid_max_is_reachable(app):
+    s = bs.Slider(0, min_value=0, max_value=100, step=3)
+    s.value = 100         # exact max wins even though 100 is off-grid
+    assert s.value == 100.0
+    s.value = 98          # closer to the 99 grid point
+    assert s.value == 99.0
+
+
+def test_slider_step_property_resnaps(app):
+    s = bs.Slider(0, min_value=0, max_value=100)
+    s.value = 37
+    assert s.value == 37.0
+    s.step = 10           # applying a grid re-snaps the current value
+    assert s.value == 40.0
+    assert s.step == 10.0
+
+
+def test_slider_range_change_resnaps_onto_grid(app):
+    s = bs.Slider(40, min_value=0, max_value=100, step=10)
+    s.min_value = 5       # grid now 5, 15, 25, … ; 40 → 45
+    assert s.value == 45.0
+
+
+# --- RangeSlider ---------------------------------------------------------
+
+def test_rangeslider_initial_values_snap(app):
+    rs = bs.RangeSlider(22, 78, min_value=0, max_value=100, step=5)
+    assert rs.low_value == 20.0
+    assert rs.high_value == 80.0
+
+
+def test_rangeslider_setters_snap(app):
+    rs = bs.RangeSlider(20, 80, min_value=0, max_value=100, step=5)
+    rs.low_value = 23     # → 25
+    rs.high_value = 67    # → 65
+    assert rs.low_value == 25.0
+    assert rs.high_value == 65.0
+
+
+def test_rangeslider_step_property_resnaps(app):
+    rs = bs.RangeSlider(0, 100, min_value=0, max_value=100)
+    rs.low_value = 12
+    rs.high_value = 87
+    rs.step = 25          # grid 0,25,50,75,100
+    assert rs.low_value == 0.0     # 12 → 0
+    assert rs.high_value == 75.0   # 87 → 75


### PR DESCRIPTION
Closes #210.

Adds a `step=` parameter to `Slider` and `RangeSlider` that constrains the value(s) to discrete increments — the snapping/keyboard counterpart to `tick_step` (which only draws marks).

## Behavior
- **Snapping.** A central `_snap()` clamps to `[min, max]` and snaps to the nearest grid point (measured from `min_value`). Applied at every value-commit site: click/drag, keyboard step, `set()` / `set_lo()` / `set_hi()`, the initial value (when the widget owns its `Signal`), and on range/step change via `_reclamp()`.
- **Keyboard.** The arrow increment derives from `step` when set (Shift+arrow = a larger jump); `Home`/`End` still go to the exact `min`/`max`.
- **Off-grid max stays reachable** when the range isn't an even multiple of `step` (e.g. `max=100, step=3` → the exact max wins when the value is closest to it).
- **Independent of `tick_step`.** Live `step` configure-delegate + public `step` property on both widgets. `step=None` (default) keeps the value continuous — fully backward compatible.

## Docs
- A **"Snapping to steps"** section on both widget pages (its own heading/TOC entry).
- Two **adjacency `.. note::`** annotations placed at the point of confusion: `tick_step`→`step` (below the tick-marks screenshot) and `show_minmax`→ticks (below the min/max screenshot).
- `step` demos added to both Full Examples; Keyboard sections note the step-derived increment.

## Tests
`tests/widgets/public/test_slider_step.py` (9): initial-value snap, set snapping, continuous default, off-grid max reachable, live `step` re-snap, range-change re-snap, both RangeSlider handles.

Builds on the merged slider review (#212). Clean `-W` docs build; 23 slider tests pass (run per-file due to the one-App-per-process harness limitation, #150).