### PR TITLE
Field validation: validate the typed value, type-aware rules, reactive surface

### DIFF
--- a/docs/_dev/field-validation-system.md
+++ b/docs/_dev/field-validation-system.md
@@ -190,7 +190,15 @@ no second object-taking door.
 2. **Rule taxonomy** — value-rule vs text-rule split; `range` rule; attach-time
    dtype rejection.
 3. **Reactive surface** — `valid`/`error` signals; declarative message label;
-   `Form` aggregates; events become derived.
+   `Form` aggregates; events become derived. **DONE (field-level):** the engine
+   owns `_valid_signal`/`_error_signal` (source of truth, set on every run);
+   `field.valid`/`field.error` expose them; the message label is bound to the
+   error signal (imperative `_show_error`/`_clear_error` gone); `Form.validate()`
+   now routes through the entry's validator (typed value + signal update).
+   **Deferred to 3b:** a reactive `Form.valid`/`Form.errors` *computed* aggregate
+   over the field signals, and the stream-based trigger mechanism (the current
+   `_setup_validation_binds`/`after()` debounce works and is not Tk-coupled, so
+   rewriting it as streams is internal churn — done only if it earns its risk).
 4. **Docs + tests** — per-widget validation sections; validation topic-guide
    rewrite; headless rule tests + GUI delivery tests (one App per process, #150).
 

--- a/docs/_dev/field-validation-system.md
+++ b/docs/_dev/field-validation-system.md
@@ -1,0 +1,212 @@
+# Field Validation System — Redesign Brief
+
+Status: **proposed** (design approved; implementation not started)
+Branch: `feat/field-validation-system`
+Surfaced by: the TextField widget review (audit → the validation path is broken
+for typed fields).
+
+---
+
+## 1. The problem
+
+Field validation does not work as expected for typed (numeric / date / time)
+fields, and the engine is a hand-rolled imperative version of mechanisms the
+framework already provides natively (signals, streams, events).
+
+Two concrete defects, both proven empirically during the TextField review:
+
+1. **Validation runs against the wrong thing, inconsistently.** The seven field
+   wrappers split on what they hand the rule engine:
+
+   | Field | passes to `validate()` | result |
+   |-------|------------------------|--------|
+   | DateField, TimeField | `entry.get()` — display **text** | string rules run on `"Jan 2, 2024"` |
+   | TextField | `entry.value()` — committed value | stale; not the live input |
+   | NumberField, SpinnerField, PathField, PasswordField | `entry.value()` — raw datum | **`TypeError`** on a `float`/`date` |
+
+   A `stringLength`/`pattern`/`custom` rule on a NumberField raises
+   `TypeError: object of type 'float' has no len()` /
+   `expected string or bytes-like object, got 'float'`. So a NumberField with
+   *any* string rule attached crashes on `validate()`.
+
+2. **No type-aware behavior and no rule for what typed fields need.** The rule
+   catalog is string-only (`required`, `email`, `stringLength`, `pattern`,
+   `compare`, `custom`). There is no `range`/bounds **validation** rule — numeric
+   and date bounds are enforced only by silent `min_value`/`max_value` clamping,
+   which is a different UX from validating with a message ("must be ≥ 18").
+
+Supporting evidence that the *intended* model is value-based and type-aware:
+
+- The `required` rule body is already written to accept any type
+  (`# Everything else is valid (non-empty string, number, date, etc.)`).
+- `Form.validate()` already validates `widget.value` (the raw typed value,
+  `form.py:289`) — so the form aggregator assumes value-based validation and
+  hits the same crash.
+
+## 2. What exists today (and is *not* the coupling we feared)
+
+The rule engine is **already event-driven** — it does **not** use Tkinter's
+built-in input validation (`validatecommand`/`-validate`). Those options appear
+only as unused passthrough annotations on the primitive `Entry`
+(`entry.py:26-27,58-59`) and can be dropped.
+
+The current engine (`widgets/_impl/mixins/validation_mixin.py`):
+
+- Hand-binds `<KeyRelease>` and `<FocusOut>`, debounces with `after()`
+  (`_setup_validation_binds`, `_debounced`).
+- Resolves the value to validate via `_get_validation_value()` → prefers
+  `get()` (text) with a `value()` fallback.
+- Runs `ValidationRule.validate(value)` per rule, honoring each rule's trigger
+  policy.
+- Emits `<<Valid>>` / `<<Invalid>>` / `<<Validate>>` with a `ValidationEvent`
+  payload (`value`, `is_valid`, `message`).
+
+Error display is **imperative**: `Field._dispatch_invalid` pokes
+`_message_lbl['text']` and sets accent `danger`; `_dispatch_valid` resets it.
+
+So there is nothing to *un*-bind from Tk. The work is to re-ground the engine on
+the reactive layer and make it type-aware.
+
+## 3. Goals / non-goals
+
+**Goals**
+- Validate the field's **typed value**, with **type-appropriate** rule logic.
+- Re-ground the engine on **signals + streams + events** — the trigger policy is
+  expressed as streams, validity is reactive state, no hand-rolled `after()`
+  debounce or raw `<KeyRelease>` binding in the rules layer.
+- Validity is **reactive state** a UI binds to (`field.valid`, `field.error`);
+  the existing `on_valid`/`on_invalid`/`on_validate` events become a thin derived
+  layer.
+- Add the missing **`range`** rule (numeric / date / time bounds → message).
+- A rule that cannot apply to a field's dtype is **rejected at attach time** with
+  a clear error — not silently coerced.
+- One consistent path: a field's own `validate()`, the auto blur/key path, and
+  `Form.validate()` all agree.
+
+**Non-goals**
+- Reworking `min_value`/`max_value` **clamping** (that stays; `range` is the
+  *validation message* counterpart, opt-in).
+- A general constraint solver / cross-field rule DSL beyond the existing
+  `compare`.
+- Async / IO-backed validation (future; the stream shape leaves room).
+
+## 4. Design
+
+### 4.1 Validate the typed value
+
+The value handed to rules is the field's parsed, typed value — `str` for
+TextField/PasswordField/PathField, `int`/`float` for Number/Spinner, `date`/
+`time` for Date/Time. The single lever is the live parse the entry already owns
+(`TextEntryPart._parse_or_none(get())` and subclass parses); the resolver returns
+the parsed live value, not the display text or the stale committed value.
+
+### 4.2 Reactive engine (signals / streams / events)
+
+A `FieldValidator` owns a field's rule list and its validity state. It depends
+only on the reactive layer — it is handed value updates; it never touches
+`get()` / `state()` / `after()` / `<KeyRelease>`.
+
+- **Trigger policy is streams**, replacing `_setup_validation_binds` +
+  `_debounced`:
+  - key-trigger rules → the field's input stream
+    (`on_input().map(parse).debounce(ms)`)
+  - blur-trigger rules → the commit stream (`on_change()`)
+  - manual → `field.validate()`
+- **Validity is state** → two reactive signals, kept consistent from one result:
+  - `valid: Signal[bool]`
+  - `error: Signal[str]` (empty string when valid)
+- **Events are derived** — `<<Valid>>`/`<<Invalid>>`/`<<Validate>>` fire off the
+  signal transition, preserving the `on_valid`/`on_invalid`/`on_validate` API and
+  the `ValidationEvent` payload. Good for "the moment it became invalid" cases.
+- **Error display becomes declarative** — the field's message label binds the
+  `error` signal (text) and a danger accent; the imperative `_dispatch_invalid`/
+  `_dispatch_valid` poking goes away.
+
+### 4.3 Rule taxonomy (type-aware)
+
+Two honest families. A rule declares which it is; the field knows its dtype and
+rejects an inapplicable rule when it is attached.
+
+- **value-rules** (any typed value): `required`, `compare`, `custom`, **`range`**
+  — operate on the parsed value. `custom`'s `func` now receives the **typed**
+  value (`lambda v: v >= 18` on a NumberField — clean, no string parsing).
+- **text-rules** (string fields only): `stringLength`, `pattern`, `email` — and
+  `add_validation_rule("stringLength", …)` on a non-text field raises a clear
+  `BootstackError`/`ValueError` ("`stringLength` applies to text fields").
+
+New **`range`** rule: comparable bounds (`min=`, `max=`) over `int`/`float`/
+`date`/`time` — one rule covers all three since they are orderable. Produces a
+message ("must be between …"); distinct from silent clamping.
+
+### 4.4 Forms integration
+
+`Form.valid` becomes a computed signal AND-ing the fields' `valid` signals;
+`Form.error`(s) surface from the field `error` signals. `Form.validate()` (manual,
+run-all) stays, but routes through the same typed-value engine, so it stops
+double-implementing rule iteration and stops crashing on typed fields.
+
+## 5. Public API surface (proposed)
+
+- `field.valid` → `Signal[bool]` (read; reactive).
+- `field.error` → `Signal[str]` (read; reactive; `""` when valid).
+- `field.validate()` → `bool` (manual, runs all rules against the typed value).
+- `field.add_validation_rule(rule_type: str, **kwargs)` — unchanged signature;
+  now (a) guards non-string `rule_type` with a clear `TypeError` (no more silent
+  double-wrap of a `ValidationRule` object), and (b) rejects a text-rule on a
+  non-text field at attach time.
+- `on_valid` / `on_invalid` / `on_validate` — retained, derived from `valid`.
+- New `RuleType` member: `"range"`.
+- `Form.valid` / `Form.error` reactive aggregates.
+
+`add_validation_rule` stays **string-only** (decided during the review): a
+`ValidationRule` object carries no information the string form lacks, so there is
+no second object-taking door.
+
+## 6. Blast radius
+
+- `validation/validation_rules.py` — type-aware rule application; `range` rule;
+  value-rule vs text-rule classification.
+- `widgets/_impl/mixins/validation_mixin.py` — replace imperative bind/debounce
+  with the stream-driven `FieldValidator`; expose `valid`/`error` signals; emit
+  events as derived.
+- `widgets/_impl/_parts/textentry_part.py` (+ `numberentry_part.py`,
+  spinner/date/time parse paths) — the typed live-value resolver.
+- `widgets/_impl/composites/field.py` — bind the message label to `error`; drop
+  imperative dispatch.
+- `widgets/_impl/composites/form.py` — route through the engine; reactive
+  aggregates.
+- `widgets/_core/field_mixin.py` — `add_validation_rule` guards; expose
+  `valid`/`error`.
+- The 7 public field wrappers — drop the divergent `validate()` bodies; inherit
+  one correct path.
+- Tests + docs (TextField/NumberField/DateField validation sections; the
+  `/reference/validation` topic guide).
+
+## 7. Staging
+
+1. **Engine + typed value** — typed live-value resolver; unify all wrappers and
+   the auto path on it; make string rules type-safe enough not to crash. Fixes
+   the crash and the value/text inconsistency. *(Smallest correct slice.)*
+2. **Rule taxonomy** — value-rule vs text-rule split; `range` rule; attach-time
+   dtype rejection.
+3. **Reactive surface** — `valid`/`error` signals; declarative message label;
+   `Form` aggregates; events become derived.
+4. **Docs + tests** — per-widget validation sections; validation topic-guide
+   rewrite; headless rule tests + GUI delivery tests (one App per process, #150).
+
+## 8. Decisions locked
+
+- Validate the **typed value**, not display text or committed value.
+- **Signals primary** for validity state; events derived.
+- **Split** value-rules / text-rules; add **`range`**; **reject** inapplicable
+  rules at attach time (no silent coercion).
+- `add_validation_rule` stays **string-only**, with a guard.
+- Drop the unused Tk `validatecommand`/`invalidcommand` passthrough on `Entry`.
+
+## 9. Open questions
+
+- `valid`/`error` as two signals vs one `Signal[ValidationResult]` exposing
+  `.valid`/`.message` — leaning two for binding ergonomics.
+- Whether `range` on a string field is an error or maps to `stringLength`
+  (leaning: error — keep the families clean).
+- Debounce default for key-trigger streams (current code uses 50 ms).

--- a/docs/api-reference/validation.rst
+++ b/docs/api-reference/validation.rst
@@ -26,4 +26,4 @@ The rule names accepted by ``ValidationRule`` and a field's
 .. py:type:: RuleType
 
    A built-in validation rule name — `'required'`, `'email'`, `'pattern'`,
-   `'stringLength'`, `'custom'`, `'compare'`.
+   `'stringLength'`, `'range'`, `'custom'`, `'compare'`.

--- a/docs/examples/textfield.py
+++ b/docs/examples/textfield.py
@@ -65,13 +65,12 @@ with bs.App(title="TextField Demo", padding=20, gap=16) as app:
 
     # Validation
     bs.Label("Validation", font="heading-sm")
-    from bootstack.validation import ValidationRule
     vf = bs.TextField(label="Min 3 characters", placeholder="Enter text…", horizontal="stretch")
-    vf.add_validation_rule(ValidationRule(
+    vf.add_validation_rule(
         "stringLength",
         message="Must be at least 3 characters.",
         min=3,
         trigger="blur",
-    ))
+    )
 
 app.run()

--- a/docs/reference/validation.rst
+++ b/docs/reference/validation.rst
@@ -4,8 +4,21 @@ Validation
 Input fields can check what the user types against a set of rules. A rule has a
 type (``'required'``, ``'email'``, …), an optional custom message, and a
 *trigger* that decides when it runs. Rules run in the order you add them and stop
-at the first failure, and the field emits ``valid`` / ``invalid`` events you can
-listen to. The same rule engine also works standalone, with no widget attached.
+at the first failure. The same rule engine also works standalone, with no widget
+attached.
+
+Rules validate the field's **typed value** — a ``custom`` rule on a
+:class:`~bootstack.NumberField` receives a number, on a
+:class:`~bootstack.DateField` a ``date``. So the rule *kind* matches the value
+kind: the text rules (``'stringLength'``, ``'pattern'``, ``'email'``) apply to
+text fields, ``'range'`` applies to numeric and date/time fields, and the rest
+(``'required'``, ``'compare'``, ``'custom'``) apply anywhere. Attaching a rule to
+a field whose value it can't validate raises an error, so the mismatch surfaces
+when you write the code, not when the user types.
+
+A field's validity is **reactive state** you can read, bind, or subscribe to
+(``field.valid`` / ``field.error``), and it still emits ``valid`` / ``invalid``
+events.
 
 Adding rules to a field
 -----------------------
@@ -48,13 +61,17 @@ Built-in rule types
      - is not empty or whitespace.
    * - ``'email'``
      - —
-     - looks like an email address.
+     - looks like an email address. *(text fields)*
    * - ``'stringLength'``
      - ``min``, ``max``
-     - has a length within the given bounds.
+     - has a length within the given bounds. *(text fields)*
    * - ``'pattern'``
      - ``pattern`` (regex)
-     - matches the regular expression.
+     - matches the regular expression. *(text fields)*
+   * - ``'range'``
+     - ``min``, ``max``
+     - falls within the given bounds — a number, or a ``date``/``time``.
+       *(numeric and date/time fields)*
    * - ``'compare'``
      - ``other_field``
      - equals another field's value (confirm-password, etc.).
@@ -65,11 +82,41 @@ Built-in rule types
 Every rule also accepts ``message`` (override the default text) and ``trigger``
 (see below).
 
+Numeric and date bounds
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A ``'range'`` rule bounds an ordered value — a number, a ``date``, or a
+``time`` — with ``min`` and/or ``max``. Unlike a field's ``min_value`` /
+``max_value`` (which *clamp* the input silently), a rule *reports* an
+out-of-range value with a message:
+
+.. code-block:: python
+
+   age = bs.NumberField(label="Age")
+   age.add_validation_rule("range", min=18, message="You must be 18 or older.")
+
+   import datetime
+   start = bs.DateField(label="Start date")
+   start.add_validation_rule("range", min=datetime.date.today())
+
+An empty field is not out of range — pair ``'range'`` with ``'required'`` if the
+field must also be filled in.
+
+.. note::
+
+   ``'range'`` is for numeric and date/time fields; ``'stringLength'`` bounds the
+   length of a **text** field. Each rule applies only where it makes sense, so
+   ``age.add_validation_rule("stringLength", …)`` raises rather than silently
+   measuring the number's digits.
+
 Custom rules
 ~~~~~~~~~~~~
 
-A ``'custom'`` rule runs any predicate that takes the value and returns a bool.
-Pair it with a ``message`` so the user knows what went wrong:
+A ``'custom'`` rule runs any predicate that takes the field's typed value and
+returns a bool — a string for a text field, a number for a
+:class:`~bootstack.NumberField`, a ``date`` for a
+:class:`~bootstack.DateField`. Pair it with a ``message`` so the user knows what
+went wrong:
 
 .. code-block:: python
 
@@ -78,6 +125,13 @@ Pair it with a ``message`` so the user knows what went wrong:
        "custom",
        func=lambda v: v.isdigit() and len(v) == 6,
        message="The code is 6 digits.",
+   )
+
+   amount = bs.NumberField(label="Amount")
+   amount.add_validation_rule(            # v is a number here, not text
+       "custom",
+       func=lambda v: v % 5 == 0,
+       message="Enter a multiple of 5.",
    )
 
 Confirming a second field
@@ -125,8 +179,9 @@ has a sensible default, which you can override per rule:
    * - ``'key'``
      - only as the user types.
    * - ``'blur'``
-     - only when the field loses focus. Default for ``'stringLength'`` and
-       ``'compare'`` — they read better once the user has finished a field.
+     - only when the field loses focus. Default for ``'stringLength'``,
+       ``'range'``, and ``'compare'`` — they read better once the user has
+       finished a field.
    * - ``'manual'``
      - never automatically — only when you call ``validate()`` yourself.
        Default for ``'custom'``.
@@ -142,23 +197,36 @@ check a length rule live:
 Reacting to validation
 ----------------------
 
-Run every rule on demand with ``validate()`` (regardless of trigger); it returns
-``True`` when they all pass. Listen for outcomes with ``on_valid`` /
-``on_invalid`` — both receive a :class:`ValidationEvent
-<bootstack.events.ValidationEvent>` carrying ``value``, ``is_valid``, and
-``message``:
+A field's validity is reactive state. ``field.error`` is a ``Signal[str]`` — the
+current message, or ``""`` when valid — and ``field.valid`` is a ``Signal[bool]``.
+Bind the error straight to a label and it keeps itself in sync:
 
 .. code-block:: python
 
-   status = bs.Label("", accent="danger")
+   email = bs.TextField(label="Email")
+   email.add_validation_rule("email", message="Enter a valid email.")
 
-   def show(e):
-       status.text = e.message      # "" when valid
+   bs.Label(textsignal=email.error, accent="danger")   # shows and clears itself
 
-   email.on_invalid(show)
-   email.on_valid(show)
+Read either signal on demand by calling it (``email.valid()``), or ``subscribe``
+to run code on each change. The field already shows its own message below the
+input, so binding ``error`` is for surfacing the state somewhere else (a summary,
+a submit button's enabled state).
 
-   if email.validate():             # runs every rule, returns True if all pass
+For a one-off reaction, the ``on_valid`` / ``on_invalid`` events still fire — each
+receives a :class:`ValidationEvent <bootstack.events.ValidationEvent>` carrying
+``value``, ``is_valid``, and ``message``:
+
+.. code-block:: python
+
+   email.on_invalid(lambda e: toast(e.message))
+
+Run every rule on demand with ``validate()`` (regardless of trigger); it returns
+``True`` when they all pass:
+
+.. code-block:: python
+
+   if email.validate():
        submit()
 
 Validating a whole form before submit

--- a/src/bootstack/validation/types.py
+++ b/src/bootstack/validation/types.py
@@ -1,6 +1,6 @@
-from typing import Callable, Literal, Optional, TypedDict
+from typing import Any, Callable, Literal, Optional, TypedDict
 
-RuleType = Literal["required", "email", "pattern", "stringLength", "custom", "compare"]
+RuleType = Literal["required", "email", "pattern", "stringLength", "range", "custom", "compare"]
 """A built-in validation rule name."""
 
 RuleTriggerType = Literal['key', 'blur', 'always', 'manual']
@@ -9,7 +9,7 @@ RuleTriggerType = Literal['key', 'blur', 'always', 'manual']
 class ValidationOptions(TypedDict, total=False):
     pattern: str
     message: str
-    min: int
-    max: int
+    min: Any
+    max: Any
     trigger: Optional[Literal["key", "blur", "always", "manual"]]
     func: Callable[[str], bool]

--- a/src/bootstack/validation/validation_rules.py
+++ b/src/bootstack/validation/validation_rules.py
@@ -5,6 +5,19 @@ from bootstack.validation.types import RuleTriggerType, RuleType
 from bootstack.validation.validation_result import ValidationResult
 
 
+def _as_text(value: object) -> str:
+    """Coerce a value to text for the string rules.
+
+    The string rules (`stringLength`, `pattern`, `email`) operate on text. When
+    one is applied to a typed value (a number or date), coerce rather than crash;
+    the rule taxonomy rejects that misuse at attach time, this is the last-ditch
+    guard. `None` (an empty field) becomes the empty string.
+    """
+    if isinstance(value, str):
+        return value
+    return "" if value is None else str(value)
+
+
 class ValidationRule:
     """A single validation rule that can be applied to a string value.
 
@@ -64,16 +77,16 @@ class ValidationRule:
             return ValidationResult(True, "")
 
         elif self.type == "email":
-            if not re.match(r"[^@]+@[^@]+\.[^@]+", value):
+            if not re.match(r"[^@]+@[^@]+\.[^@]+", _as_text(value)):
                 return ValidationResult(False, msg)
         elif self.type == "stringLength":
             min_len = self.params.get("min", 0)
             max_len = self.params.get("max", float("inf"))
-            if not (min_len <= len(value) <= max_len):
+            if not (min_len <= len(_as_text(value)) <= max_len):
                 return ValidationResult(False, msg)
         elif self.type == "pattern":
             pattern = self.params.get("pattern", "")
-            if not re.match(pattern, value):
+            if not re.match(pattern, _as_text(value)):
                 return ValidationResult(False, msg)
         elif self.type == "compare":
             if value != self._read_other(self.params.get("other_field")):

--- a/src/bootstack/validation/validation_rules.py
+++ b/src/bootstack/validation/validation_rules.py
@@ -5,6 +5,34 @@ from bootstack.validation.types import RuleTriggerType, RuleType
 from bootstack.validation.validation_result import ValidationResult
 
 
+# Rules that operate on a text value; meaningless on a typed (number/date/time)
+# value. The field rejects these at attach time when it does not hold text.
+TEXT_RULES = frozenset({"stringLength", "pattern", "email"})
+
+# Rules that operate on an orderable typed value (number, date, or time).
+ORDERED_RULES = frozenset({"range"})
+
+
+def rule_applies_to_kind(rule_type: str, kind: str) -> bool:
+    """Whether a rule type can validate a field holding the given value kind.
+
+    Args:
+        rule_type: The rule name (e.g. `'stringLength'`, `'range'`).
+        kind: The field's value kind — `'text'`, `'number'`, `'date'`, or
+            `'time'`.
+
+    Returns:
+        `True` if the rule applies. Text rules apply only to text fields;
+        `'range'` applies only to ordered (number/date/time) fields; the
+        remaining rules (`'required'`, `'compare'`, `'custom'`) apply to any.
+    """
+    if rule_type in TEXT_RULES:
+        return kind == "text"
+    if rule_type in ORDERED_RULES:
+        return kind in ("number", "date", "time")
+    return True
+
+
 def _as_text(value: object) -> str:
     """Coerce a value to text for the string rules.
 
@@ -88,6 +116,21 @@ class ValidationRule:
             pattern = self.params.get("pattern", "")
             if not re.match(pattern, _as_text(value)):
                 return ValidationResult(False, msg)
+        elif self.type == "range":
+            # Bounds on an ordered value (number/date/time). An empty field is
+            # not out of range — use 'required' for presence.
+            if value is None or value == "":
+                return ValidationResult(True)
+            lo = self.params.get("min")
+            hi = self.params.get("max")
+            try:
+                if lo is not None and value < lo:
+                    return ValidationResult(False, msg)
+                if hi is not None and value > hi:
+                    return ValidationResult(False, msg)
+            except TypeError:
+                # Incomparable types (e.g. a string bound against a number).
+                return ValidationResult(False, msg)
         elif self.type == "compare":
             if value != self._read_other(self.params.get("other_field")):
                 return ValidationResult(False, msg)
@@ -133,6 +176,16 @@ class ValidationRule:
             return f"Enter between {min_len} and {max_len} characters."
         elif self.type == "pattern":
             return "Value does not match the required pattern."
+        elif self.type == "range":
+            lo = self.params.get("min")
+            hi = self.params.get("max")
+            if lo is not None and hi is not None:
+                return f"Enter a value between {lo} and {hi}."
+            if lo is not None:
+                return f"Enter a value of at least {lo}."
+            if hi is not None:
+                return f"Enter a value of at most {hi}."
+            return "Value is out of range."
         elif self.type == "compare":
             return "Values do not match."
         elif self.type == "custom":
@@ -143,7 +196,7 @@ class ValidationRule:
         """Return the default trigger policy for this rule type."""
         if self.type == "required":
             return "always"
-        elif self.type in {"stringLength", "compare"}:
+        elif self.type in {"stringLength", "compare", "range"}:
             return "blur"
         elif self.type in {"email", "pattern"}:
             return "always"

--- a/src/bootstack/widgets/_core/field_mixin.py
+++ b/src/bootstack/widgets/_core/field_mixin.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from typing import Any, Callable, Literal, TYPE_CHECKING
 
+from bootstack.errors import BootstackError
 from bootstack.validation import RuleType
+from bootstack.validation.validation_rules import rule_applies_to_kind
 from bootstack.widgets.types import AccentToken
 
 if TYPE_CHECKING:
@@ -15,6 +17,11 @@ class FieldAddonMixin:
     Requires the inheriting class to have `self._internal` pointing to a
     `Field`-based composite that implements `insert_addon` / `addons`.
     """
+
+    #: The kind of value this field holds, used to reject inapplicable
+    #: validation rules at attach time. Text fields keep the default; typed
+    #: field wrappers override it (`'number'`, `'date'`, `'time'`).
+    _VALIDATION_KIND: str = "text"
 
     _ADDON_TYPES = {
         "button":  "bootstack.widgets._impl.primitives.button::Button",
@@ -170,6 +177,12 @@ class FieldAddonMixin:
         type, or manually via `validate()`. Multiple rules can be added;
         they are evaluated in order and stop at the first failure.
 
+        Rules validate the field's **typed value** — a `custom` rule on a
+        numeric field receives a number, on a date field a `date`. Text rules
+        (`stringLength`, `pattern`, `email`) apply only to text fields; `range`
+        applies only to numeric/date/time fields. Attaching a rule to a field
+        whose value kind it cannot validate raises `BootstackError`.
+
         Args:
             rule_type: The kind of validation rule to apply.
             **kwargs: Rule-specific options:
@@ -179,9 +192,12 @@ class FieldAddonMixin:
                   blur), `'key'`, `'blur'`, or `'manual'`. Each rule type
                   has its own sensible default (see the Validation reference).
                 - `min`, `max` *(stringLength)* — minimum/maximum character count.
+                - `min`, `max` *(range)* — lower/upper bound for the typed value
+                  (numbers, or `date`/`time` objects).
                 - `pattern` *(pattern)* — regex string the value must match.
                 - `other_field` *(compare)* — field whose value must match.
-                - `func` *(custom)* — callable `(value: str) -> bool`.
+                - `func` *(custom)* — callable `(value) -> bool` receiving the
+                  field's typed value.
 
         Example::
 
@@ -189,6 +205,8 @@ class FieldAddonMixin:
             field.add_validation_rule("stringLength", min=3, max=50)
             field.add_validation_rule("email", message="Enter a valid email.")
             field.add_validation_rule("custom", func=lambda v: v.isdigit())
+
+            age.add_validation_rule("range", min=18, message="Must be 18+.")
         """
         if not isinstance(rule_type, str):
             raise TypeError(
@@ -196,6 +214,16 @@ class FieldAddonMixin:
                 f"'stringLength'), not a {type(rule_type).__name__} object. Pass "
                 f"the rule's options as keyword arguments: "
                 f"field.add_validation_rule('stringLength', min=3)."
+            )
+        kind = self._VALIDATION_KIND
+        if not rule_applies_to_kind(rule_type, kind):
+            if kind == "text":
+                hint = "'stringLength' bounds text length."
+            else:
+                hint = f"'range' or 'custom' validates {kind} values."
+            raise BootstackError(
+                f"the {rule_type!r} rule does not apply to a {kind} field "
+                f"({type(self).__name__}). {hint}"
             )
         self._internal.add_validation_rule(rule_type, **kwargs)
 

--- a/src/bootstack/widgets/_core/field_mixin.py
+++ b/src/bootstack/widgets/_core/field_mixin.py
@@ -170,6 +170,25 @@ class FieldAddonMixin:
         """
         return self._internal.get()
 
+    @property
+    def valid(self) -> "Signal":
+        """Reactive `Signal[bool]` — whether the field currently passes validation.
+
+        Call it to read the current state (`field.valid()`), `subscribe` to
+        react, or bind it. Updated on every validation run — a blur, a keystroke
+        (for key-triggered rules), or a manual `validate()`.
+        """
+        return self._internal._entry._valid_signal
+
+    @property
+    def error(self) -> "Signal":
+        """Reactive `Signal[str]` — the current validation error, `''` when valid.
+
+        Bind it to surface the message anywhere, for example
+        `bs.Label(textsignal=field.error)`.
+        """
+        return self._internal._entry._error_signal
+
     def add_validation_rule(self, rule_type: RuleType, **kwargs: Any) -> None:
         """Add a validation rule to the field.
 

--- a/src/bootstack/widgets/_core/field_mixin.py
+++ b/src/bootstack/widgets/_core/field_mixin.py
@@ -190,6 +190,13 @@ class FieldAddonMixin:
             field.add_validation_rule("email", message="Enter a valid email.")
             field.add_validation_rule("custom", func=lambda v: v.isdigit())
         """
+        if not isinstance(rule_type, str):
+            raise TypeError(
+                f"add_validation_rule() takes a rule-type string (e.g. "
+                f"'stringLength'), not a {type(rule_type).__name__} object. Pass "
+                f"the rule's options as keyword arguments: "
+                f"field.add_validation_rule('stringLength', min=3)."
+            )
         self._internal.add_validation_rule(rule_type, **kwargs)
 
 

--- a/src/bootstack/widgets/_impl/_parts/numberentry_part.py
+++ b/src/bootstack/widgets/_impl/_parts/numberentry_part.py
@@ -259,6 +259,27 @@ class NumberEntryPart(TextEntryPart):
 
         return self
 
+    def _get_validation_value(self):
+        """Return the current input coerced to its numeric type, for validation.
+
+        A plain numeric field parses to a string when no display format is set,
+        so coerce it the same way the public value does — validation rules and a
+        `custom` func receive a real `int`/`float` (or `None` for empty/invalid
+        input), never the display string.
+        """
+        text = self.get()
+        try:
+            raw = self._parse_or_none(text)
+        except Exception:
+            raw = text
+        if raw is None or raw == "":
+            return None
+        try:
+            number = float(raw)
+        except (TypeError, ValueError):
+            return None
+        return int(round(number)) if self._num_type is int else number
+
     def _normalize_display_from_value(self):
         """Update display text from internal value without triggering input events."""
         # Format the value

--- a/src/bootstack/widgets/_impl/_parts/textentry_part.py
+++ b/src/bootstack/widgets/_impl/_parts/textentry_part.py
@@ -279,6 +279,21 @@ class TextEntryPart(ValidationMixin, Entry):
             self.textsignal.set(formatted_text)
             return None
 
+    def _get_validation_value(self):
+        """Return the current input parsed to its typed value, for validation.
+
+        Validation runs against the field's typed value — the string itself for
+        a text field, a `date`/`time` for a date or time field — parsed from
+        what is currently shown, not the raw display text and not the
+        last-committed value. This keeps a manual `validate()`, the automatic
+        blur/key validation, and a form-level validate in agreement on the same
+        live, typed input.
+        """
+        try:
+            return self._parse_or_none(self.get())
+        except Exception:
+            return self.get()
+
     def text(self, value=None):
         """Get or set the raw display text without committing.
 

--- a/src/bootstack/widgets/_impl/composites/field.py
+++ b/src/bootstack/widgets/_impl/composites/field.py
@@ -228,8 +228,10 @@ class Field(EntryMixin, Frame):
         if self._show_messages:
             self._message_lbl.pack(side='top', fill='x', padx=4)
 
-        self._entry.bind('<<Invalid>>', self._show_error, add=True)
-        self._entry.bind('<<Valid>>', self._clear_error, add=True)
+        # The message label follows the entry's reactive error signal: a
+        # non-empty error shows in danger, an empty one restores the static
+        # helper message.
+        self._entry._error_signal.subscribe(self._on_validation_message)
 
         # bind focus styling to the field frame
         self._entry.bind('<FocusIn>', lambda _: self._field.state(['focus']), add=True)
@@ -619,16 +621,20 @@ class Field(EntryMixin, Frame):
             self._show_messages = True
             self._message_lbl.pack(side='top', fill='x', padx=4)
 
-    def _show_error(self, event: Any) -> None:
-        """Display a validation error message below the input field."""
-        self._message_lbl['text'] = event.data.message
-        self._message_lbl['accent'] = "danger"
-        self._message_lbl.pack(side='top', after=self._field, padx=4)
+    def _on_validation_message(self, message: str) -> None:
+        """React to the entry's error signal — show the error or restore helper text.
 
-    def _clear_error(self, _: Any) -> None:
-        """Clear the error message and restore the original message text."""
-        self._message_lbl['text'] = self._message_text or ''
-        self._message_lbl['accent'] = "secondary"
+        Args:
+            message: The current validation error, or an empty string when the
+                field is valid.
+        """
+        if message:
+            self._message_lbl['text'] = message
+            self._message_lbl['accent'] = "danger"
+            self._message_lbl.pack(side='top', after=self._field, padx=4)
+        else:
+            self._message_lbl['text'] = self._message_text or ''
+            self._message_lbl['accent'] = "secondary"
 
     def _set_addons_state(self, disabled: bool) -> None:
         """Configure addon widgets based on whether the entry is interactive."""

--- a/src/bootstack/widgets/_impl/composites/form.py
+++ b/src/bootstack/widgets/_impl/composites/form.py
@@ -8,7 +8,6 @@ from tkinter import BooleanVar, DoubleVar, IntVar, StringVar, Text, Variable
 from typing import Any, Callable, Iterable, Literal, Mapping, Sequence, TYPE_CHECKING
 
 from bootstack.constants import DEFAULT_MIN_COL_WIDTH
-from bootstack.events import ValidationEvent
 from bootstack.widgets._impl.primitives.button import Button
 from bootstack.widgets._impl.primitives.checkbutton import CheckButton
 from bootstack.widgets._impl.primitives.switch import Switch
@@ -25,7 +24,6 @@ from bootstack.widgets._impl.composites.slider.slider import Slider
 from bootstack.widgets._impl.composites.selectbox import SelectBox
 from bootstack.widgets._impl.primitives.spinbox import Spinbox
 from bootstack.widgets._impl.composites.textentry import TextEntry
-from bootstack.widgets._impl.mixins.validation_mixin import ValidationMixin
 from bootstack.widgets.types import EditorType, Master
 
 if TYPE_CHECKING:
@@ -278,32 +276,13 @@ class Form(Frame):
 
         def _validate_field(widget: Field) -> bool:
             entry = getattr(widget, "_entry", widget)
-            rules = getattr(entry, "_rules", [])
-            if not rules:
+            if not getattr(entry, "_rules", None):
                 return True
-            value = widget.value
-            is_valid = True
-            # An explicit form.validate() is a manual action, so run every rule
-            # regardless of its auto-trigger (matching a field's own validate()).
-            for rule in rules:
-                result = rule.validate(value)
-                if not result.is_valid:
-                    is_valid = False
-                    payload = ValidationEvent(value=value, is_valid=False, message=result.message)
-                    try:
-                        entry.event_generate(ValidationMixin.EVENT_INVALID, data=payload)
-                        entry.event_generate(ValidationMixin.EVENT_VALIDATED, data=payload)
-                    except Exception:
-                        pass
-                    break
-            if is_valid:
-                payload = ValidationEvent(value=value, is_valid=True, message="")
-                try:
-                    entry.event_generate(ValidationMixin.EVENT_VALID, data=payload)
-                    entry.event_generate(ValidationMixin.EVENT_VALIDATED, data=payload)
-                except Exception:
-                    pass
-            return is_valid
+            # Delegate to the entry's own validator. An explicit form.validate()
+            # is a manual action, so the "manual" trigger runs every rule; the
+            # entry validates its typed value, updates the field's reactive
+            # validity signals, and emits the validation events.
+            return entry.validate(entry._get_validation_value(), trigger="manual")
 
         for widget in self._widgets.values():
             if isinstance(widget, Field):

--- a/src/bootstack/widgets/_impl/mixins/validation_mixin.py
+++ b/src/bootstack/widgets/_impl/mixins/validation_mixin.py
@@ -12,6 +12,7 @@ from tkinter.ttk import Widget
 from typing import Any, Callable
 
 from bootstack.events import ValidationEvent
+from bootstack.signals import Signal
 from bootstack.validation import ValidationRule
 from bootstack.validation.types import RuleTriggerType, RuleType, ValidationOptions
 
@@ -49,7 +50,18 @@ class ValidationMixin(Widget):
         self._on_validated_command: Callable | None = None
 
         super().__init__(*args, **kwargs)  # next in MRO must be a Tk/ttk widget
+
+        # Reactive validity state — the source of truth for the field's display
+        # and for form-level aggregation. Updated on every validation run.
+        self._valid_signal: Signal = Signal(True)
+        self._error_signal: Signal = Signal("")
+
         self._setup_validation_binds()
+
+    def _set_validity(self, is_valid: bool, message: str) -> None:
+        """Update the reactive validity signals (the source of truth)."""
+        self._error_signal.set("" if is_valid else message)
+        self._valid_signal.set(is_valid)
 
     # ---------------- Public API ----------------
 
@@ -107,14 +119,16 @@ class ValidationMixin(Widget):
             result = rule.validate(value)
 
             if not result.is_valid:
-                # Emit invalid and validated events with data
+                # Update validity state, then emit invalid + validated events.
+                self._set_validity(False, result.message)
                 payload = ValidationEvent(value=value, is_valid=False, message=result.message)
                 self.event_generate(self.EVENT_INVALID, data=payload)
                 self.event_generate(self.EVENT_VALIDATED, data=payload)
                 return False
 
         if ran_rule:
-            # Emit valid and validated events with data
+            # Update validity state, then emit valid + validated events.
+            self._set_validity(True, "")
             payload = ValidationEvent(value=value, is_valid=True, message="")
             self.event_generate(self.EVENT_VALID, data=payload)
             self.event_generate(self.EVENT_VALIDATED, data=payload)

--- a/src/bootstack/widgets/datefield.py
+++ b/src/bootstack/widgets/datefield.py
@@ -256,9 +256,8 @@ class DateField(ValueSignalMixin, FieldAddonMixin, PublicWidgetBase):
         Returns:
             `True` if all rules pass, `False` otherwise.
         """
-        return self._internal._entry.validate(
-            self._internal._entry.get(), trigger="manual"
-        )
+        entry = self._internal._entry
+        return entry.validate(entry._get_validation_value(), trigger="manual")
 
     def focus(self) -> None:
         """Give keyboard focus to this field."""

--- a/src/bootstack/widgets/datefield.py
+++ b/src/bootstack/widgets/datefield.py
@@ -10,7 +10,6 @@ from bootstack.widgets._core.events import resolve_event, register_widget_events
 from bootstack.widgets._core.field_mixin import FieldAddonMixin, ValueSignalMixin
 from bootstack.events import ChangeEvent, Subscription, ValidationEvent
 from bootstack.streams import Stream
-from bootstack.validation import RuleType
 from bootstack.widgets.textfield import _INNER_ENTRY_SEQUENCES
 from bootstack.widgets.types import AccentToken, Event, WidgetDensity
 
@@ -70,6 +69,8 @@ class DateField(ValueSignalMixin, FieldAddonMixin, PublicWidgetBase):
             `fill`, `expand`, `anchor`, `margin`, `row`, `column`, `sticky`.
             See :doc:`/tasks/layout`.
     """
+
+    _VALIDATION_KIND = "date"
 
     def __init__(
         self,
@@ -266,14 +267,6 @@ class DateField(ValueSignalMixin, FieldAddonMixin, PublicWidgetBase):
     def clear(self) -> None:
         """Clear the field, setting the value to `None`."""
         self._internal.value = None
-
-    def add_validation_rule(self, rule_type: RuleType, **kwargs: Any) -> None:
-        """Add a validation rule to this field.
-
-        Args:
-            rule_type: The kind of validation rule to apply.
-        """
-        self._internal.add_validation_rule(rule_type, **kwargs)
 
     # ----- Event shorthands -----
 

--- a/src/bootstack/widgets/numberfield.py
+++ b/src/bootstack/widgets/numberfield.py
@@ -258,9 +258,8 @@ class NumberField(ValueSignalMixin, FieldAddonMixin, PublicWidgetBase):
         Returns:
             `True` if all rules pass, `False` otherwise.
         """
-        return self._internal._entry.validate(
-            self._internal._entry.value(), trigger="manual"
-        )
+        entry = self._internal._entry
+        return entry.validate(entry._get_validation_value(), trigger="manual")
 
     def focus(self) -> None:
         """Give keyboard focus to this field."""

--- a/src/bootstack/widgets/numberfield.py
+++ b/src/bootstack/widgets/numberfield.py
@@ -97,6 +97,8 @@ class NumberField(ValueSignalMixin, FieldAddonMixin, PublicWidgetBase):
             See :doc:`/tasks/layout`.
     """
 
+    _VALIDATION_KIND = "number"
+
     def __init__(
         self,
         value: int | float = 0,

--- a/src/bootstack/widgets/passwordfield.py
+++ b/src/bootstack/widgets/passwordfield.py
@@ -199,9 +199,8 @@ class PasswordField(FieldAddonMixin, PublicWidgetBase):
         Returns:
             `True` if all rules pass, `False` otherwise.
         """
-        return self._internal._entry.validate(
-            self._internal._entry.value(), trigger="manual"
-        )
+        entry = self._internal._entry
+        return entry.validate(entry._get_validation_value(), trigger="manual")
 
     def focus(self) -> None:
         """Give keyboard focus to this field."""

--- a/src/bootstack/widgets/pathfield.py
+++ b/src/bootstack/widgets/pathfield.py
@@ -219,9 +219,8 @@ class PathField(FieldAddonMixin, PublicWidgetBase):
         Returns:
             `True` if all rules pass, `False` otherwise.
         """
-        return self._internal._entry.validate(
-            self._internal._entry.value(), trigger="manual"
-        )
+        entry = self._internal._entry
+        return entry.validate(entry._get_validation_value(), trigger="manual")
 
     def select_all(self) -> None:
         """Select all text in the field."""

--- a/src/bootstack/widgets/spinnerfield.py
+++ b/src/bootstack/widgets/spinnerfield.py
@@ -231,9 +231,8 @@ class SpinnerField(FieldAddonMixin, PublicWidgetBase):
         Returns:
             `True` if all rules pass, `False` otherwise.
         """
-        return self._internal._entry.validate(
-            self._internal._entry.value(), trigger="manual"
-        )
+        entry = self._internal._entry
+        return entry.validate(entry._get_validation_value(), trigger="manual")
 
     def select_all(self) -> None:
         """Select all text in the field."""

--- a/src/bootstack/widgets/textfield.py
+++ b/src/bootstack/widgets/textfield.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import tkinter
 from typing import overload, Any, Callable, Literal, TYPE_CHECKING
 
 from bootstack.widgets._impl.composites.textentry import TextEntry as _InternalTextEntry
@@ -12,6 +11,8 @@ from bootstack.streams import Stream
 from bootstack.widgets.types import AccentToken, Event, Justify, WidgetDensity
 
 if TYPE_CHECKING:
+    import tkinter
+
     from bootstack.signals import Signal
 
 # Events that fire on the inner entry part, not the outer Frame.
@@ -210,14 +211,18 @@ class TextField(FieldAddonMixin, PublicWidgetBase):
     # ----- Methods -----
 
     def validate(self) -> bool:
-        """Run validation rules against the current value.
+        """Run validation rules against the current input text.
+
+        Validates what the user currently sees and is typing — the field's
+        display `text`, not its last-committed `value`. This matches the
+        automatic blur/key validation, so a manual check and an on-blur check
+        agree on the same input.
 
         Returns:
             `True` if all rules pass, `False` otherwise.
         """
-        return self._internal._entry.validate(
-            self._internal._entry.value(), trigger="manual"
-        )
+        entry = self._internal._entry
+        return entry.validate(entry._get_validation_value(), trigger="manual")
 
     def focus(self) -> None:
         """Give keyboard focus to this field."""

--- a/src/bootstack/widgets/timefield.py
+++ b/src/bootstack/widgets/timefield.py
@@ -10,7 +10,6 @@ from bootstack.widgets._core.events import resolve_event, register_widget_events
 from bootstack.widgets._core.field_mixin import FieldAddonMixin, ValueSignalMixin
 from bootstack.events import ChangeEvent, Subscription, ValidationEvent
 from bootstack.streams import Stream
-from bootstack.validation import RuleType
 from bootstack.widgets.textfield import _INNER_ENTRY_SEQUENCES
 from bootstack.widgets.types import AccentToken, Event, WidgetDensity
 
@@ -65,6 +64,8 @@ class TimeField(ValueSignalMixin, FieldAddonMixin, PublicWidgetBase):
             `fill`, `expand`, `anchor`, `margin`, `row`, `column`, `sticky`.
             See :doc:`/tasks/layout`.
     """
+
+    _VALIDATION_KIND = "time"
 
     def __init__(
         self,
@@ -211,14 +212,6 @@ class TimeField(ValueSignalMixin, FieldAddonMixin, PublicWidgetBase):
     def clear(self) -> None:
         """Clear the field, setting the value to `None`."""
         self._internal.value = None
-
-    def add_validation_rule(self, rule_type: RuleType, **kwargs: Any) -> None:
-        """Add a validation rule to this field.
-
-        Args:
-            rule_type: The kind of validation rule to apply.
-        """
-        self._internal.add_validation_rule(rule_type, **kwargs)
 
     # ----- Event shorthands -----
 

--- a/src/bootstack/widgets/timefield.py
+++ b/src/bootstack/widgets/timefield.py
@@ -201,9 +201,8 @@ class TimeField(ValueSignalMixin, FieldAddonMixin, PublicWidgetBase):
         Returns:
             `True` if all rules pass, `False` otherwise.
         """
-        return self._internal._entry.validate(
-            self._internal._entry.get(), trigger="manual"
-        )
+        entry = self._internal._entry
+        return entry.validate(entry._get_validation_value(), trigger="manual")
 
     def focus(self) -> None:
         """Give keyboard focus to this field."""

--- a/tests/widgets/public/test_field_validation_typed.py
+++ b/tests/widgets/public/test_field_validation_typed.py
@@ -36,12 +36,13 @@ def app():
             pass
 
 
-def test_numberfield_string_rule_does_not_crash(app):
-    # Was a hard TypeError: len() on a float / re.match on a float.
-    nf = bs.NumberField(value=1234.5, value_format="#,##0.00")
-    nf.add_validation_rule("stringLength", min=3, max=20, trigger="manual")
-    app._tk_root.update_idletasks()
-    assert nf.validate() is True  # no exception
+def test_string_rule_is_crash_safe_on_typed_value():
+    # Fields reject text rules on typed values at attach time (see the
+    # rejection test below), but the rule itself must still never crash if
+    # handed a non-string — the original bug was len()/re.match on a float.
+    assert ValidationRule("stringLength", min=3).validate(1234.5).is_valid in (True, False)
+    assert ValidationRule("pattern", pattern=r"\d+").validate(1234).is_valid in (True, False)
+    assert ValidationRule("email").validate(None).is_valid in (True, False)
 
 
 def test_numberfield_custom_rule_receives_number(app):
@@ -120,3 +121,70 @@ def test_add_validation_rule_rejects_rule_object(app):
     tf = bs.TextField()
     with pytest.raises(TypeError):
         tf.add_validation_rule(ValidationRule("stringLength", min=3))
+
+
+# --- Phase 2: range rule + attach-time dtype rejection ---
+
+
+def test_range_rule_on_numberfield(app):
+    nf = bs.NumberField(value=25)
+    nf.add_validation_rule("range", min=18, message="must be 18+")
+    app._tk_root.update_idletasks()
+    assert nf.validate() is True
+    nf.value = 10
+    app._tk_root.update_idletasks()
+    assert nf.validate() is False
+
+
+def test_range_rule_on_datefield_with_date_bounds(app):
+    df = bs.DateField(value="2024-06-01")
+    df.add_validation_rule(
+        "range", min=datetime.date(2024, 1, 1), max=datetime.date(2024, 12, 31)
+    )
+    app._tk_root.update_idletasks()
+    assert df.validate() is True
+
+
+def test_range_rule_empty_field_is_not_out_of_range(app):
+    # An empty field passes range; use 'required' to demand presence.
+    nf = bs.NumberField(value=5)
+    nf.add_validation_rule("range", min=1)
+    nf.clear()
+    app._tk_root.update_idletasks()
+    assert nf.validate() is True
+
+
+@pytest.mark.parametrize(
+    "factory, rule",
+    [
+        (lambda: bs.NumberField(value=1), "stringLength"),
+        (lambda: bs.NumberField(value=1), "email"),
+        (lambda: bs.NumberField(value=1), "pattern"),
+        (lambda: bs.DateField(value="2024-01-01"), "email"),
+        (lambda: bs.TextField(), "range"),
+    ],
+)
+def test_inapplicable_rule_rejected_at_attach(app, factory, rule):
+    from bootstack.errors import BootstackError
+
+    field = factory()
+    app._tk_root.update_idletasks()
+    with pytest.raises(BootstackError):
+        field.add_validation_rule(rule)
+
+
+@pytest.mark.parametrize(
+    "factory, rule, kwargs",
+    [
+        (lambda: bs.TextField(), "stringLength", {"min": 3}),
+        (lambda: bs.TextField(), "email", {}),
+        (lambda: bs.NumberField(value=1), "range", {"min": 0}),
+        (lambda: bs.NumberField(value=1), "custom", {"func": lambda v: v > 0}),
+        (lambda: bs.DateField(value="2024-01-01"), "required", {}),
+        (lambda: bs.TimeField(value="08:30"), "required", {}),
+    ],
+)
+def test_applicable_rule_attaches_cleanly(app, factory, rule, kwargs):
+    field = factory()
+    app._tk_root.update_idletasks()
+    field.add_validation_rule(rule, **kwargs)  # no exception

--- a/tests/widgets/public/test_field_validation_typed.py
+++ b/tests/widgets/public/test_field_validation_typed.py
@@ -188,3 +188,79 @@ def test_applicable_rule_attaches_cleanly(app, factory, rule, kwargs):
     field = factory()
     app._tk_root.update_idletasks()
     field.add_validation_rule(rule, **kwargs)  # no exception
+
+
+# --- Phase 3: reactive validity surface ---
+
+
+def test_valid_and_error_signals_track_validation(app):
+    tf = bs.TextField(value="ab", message="helper")
+    tf.add_validation_rule("stringLength", min=3, message="need 3+")
+    app._tk_root.update_idletasks()
+
+    assert tf.valid() is True  # nothing run yet
+    assert tf.error() == ""
+
+    assert tf.validate() is False
+    app._tk_root.update_idletasks()
+    assert tf.valid() is False
+    assert tf.error() == "need 3+"
+
+    tf.value = "abcd"
+    app._tk_root.update_idletasks()
+    assert tf.validate() is True
+    app._tk_root.update_idletasks()
+    assert tf.valid() is True
+    assert tf.error() == ""
+
+
+def test_error_signal_is_subscribable(app):
+    tf = bs.TextField(value="x")
+    tf.add_validation_rule("stringLength", min=3, message="too short")
+    app._tk_root.update_idletasks()
+    seen = []
+    tf.error.subscribe(seen.append)
+    tf.validate()
+    app._tk_root.update_idletasks()
+    assert seen == ["too short"]
+
+
+def test_error_signal_binds_to_a_label(app):
+    tf = bs.TextField(value="x")
+    tf.add_validation_rule("stringLength", min=3, message="too short")
+    app._tk_root.update_idletasks()
+    lbl = bs.Label(textsignal=tf.error)
+    tf.validate()
+    app._tk_root.update_idletasks()
+    assert lbl.text == "too short"
+
+
+def test_on_invalid_event_still_fires(app):
+    # The event API stays alongside the signals.
+    tf = bs.TextField(value="x")
+    tf.add_validation_rule("stringLength", min=3, message="too short")
+    app._tk_root.update_idletasks()
+    fired = []
+    tf.on_invalid(lambda e: fired.append(e.message))
+    tf.validate()
+    app._tk_root.update_idletasks()
+    assert fired == ["too short"]
+
+
+def test_form_validate_updates_field_validity_signal(app):
+    # Regression: the message label follows the error signal, so a form-level
+    # validate must update it (not just emit events).
+    form = bs.Form(items=[bs.FieldItem(key="name", label="Name", required=True)])
+    app._tk_root.update_idletasks()
+    entry = form.field("name")._entry
+
+    assert form.validate() is False
+    app._tk_root.update_idletasks()
+    assert entry._error_signal() == "This field is required."
+    assert entry._valid_signal() is False
+
+    form.field("name").value = "Alice"
+    app._tk_root.update_idletasks()
+    assert form.validate() is True
+    app._tk_root.update_idletasks()
+    assert entry._error_signal() == ""

--- a/tests/widgets/public/test_field_validation_typed.py
+++ b/tests/widgets/public/test_field_validation_typed.py
@@ -1,0 +1,122 @@
+"""Field validation runs against the field's typed value.
+
+Phase 1 of the validation-system redesign (docs/_dev/field-validation-system.md):
+validation resolves the current input to its typed value — a number for a
+numeric field, a date for a date field, the string itself for a text field —
+and all seven field wrappers route their `validate()` through the same resolver.
+
+Regression guard for the bug surfaced by the TextField review: a string rule on
+a NumberField used to crash (`validate()` passed the raw `float` into `len()`),
+and `custom` rules received the display text instead of the typed value.
+"""
+import datetime
+
+import pytest
+
+import bootstack as bs
+from bootstack.validation import ValidationRule
+
+
+@pytest.fixture(scope="module")
+def app():
+    a = bs.App()
+    a.__enter__()
+    a._tk_root.deiconify()
+    a._tk_root.update_idletasks()
+    try:
+        yield a
+    finally:
+        try:
+            a.__exit__(None, None, None)
+        except Exception:
+            pass
+        try:
+            a._tk_root.destroy()
+        except Exception:
+            pass
+
+
+def test_numberfield_string_rule_does_not_crash(app):
+    # Was a hard TypeError: len() on a float / re.match on a float.
+    nf = bs.NumberField(value=1234.5, value_format="#,##0.00")
+    nf.add_validation_rule("stringLength", min=3, max=20, trigger="manual")
+    app._tk_root.update_idletasks()
+    assert nf.validate() is True  # no exception
+
+
+def test_numberfield_custom_rule_receives_number(app):
+    seen = {}
+    nf = bs.NumberField(value=1500, value_format="#,##0.00")
+    nf.add_validation_rule(
+        "custom",
+        func=lambda v: seen.update(type=type(v).__name__, value=v) or v >= 1000,
+    )
+    app._tk_root.update_idletasks()
+    assert nf.validate() is True
+    assert seen["type"] in ("int", "float")
+    assert seen["value"] == 1500
+
+
+def test_plain_numberfield_custom_gets_numeric_not_string(app):
+    # No value_format: the internal parse yields a string; the resolver must
+    # still coerce it to a number for the rule.
+    got = {}
+    nf = bs.NumberField(value=42)
+    nf.add_validation_rule(
+        "custom",
+        func=lambda v: got.update(type=type(v).__name__, value=v) or v >= 100,
+    )
+    app._tk_root.update_idletasks()
+    assert nf.validate() is False
+    assert got["type"] in ("int", "float")
+    assert got["value"] == 42
+
+
+def test_datefield_custom_rule_receives_date(app):
+    seen = {}
+    df = bs.DateField(value="2024-06-01")
+    df.add_validation_rule("custom", func=lambda v: seen.update(t=type(v).__name__) or True)
+    app._tk_root.update_idletasks()
+    df.validate()
+    assert seen["t"] in ("date", "datetime")
+
+
+def test_textfield_string_length_still_works(app):
+    tf = bs.TextField(value="ab")
+    tf.add_validation_rule("stringLength", min=3, message="need 3")
+    app._tk_root.update_idletasks()
+    assert tf.validate() is False
+    tf.value = "abcd"
+    app._tk_root.update_idletasks()
+    assert tf.validate() is True
+
+
+def test_textfield_validates_live_input_not_committed(app):
+    # Manual validate() must see what is currently typed, not the last commit.
+    tf = bs.TextField(value="ab")
+    tf.add_validation_rule("stringLength", min=3, trigger="manual")
+    app._tk_root.update_idletasks()
+    assert tf.validate() is False
+    # Change the displayed text without committing (no blur / Enter).
+    tf._internal._entry.text("abcd")
+    app._tk_root.update_idletasks()
+    assert tf.validate() is True
+
+
+def test_required_rule_is_type_agnostic(app):
+    # `required` runs against the typed value (the number 5), no string ops.
+    nf = bs.NumberField(value=5)
+    nf.add_validation_rule("required")
+    app._tk_root.update_idletasks()
+    assert nf.validate() is True
+    nf.clear()  # value becomes None (an empty field)
+    app._tk_root.update_idletasks()
+    assert nf.validate() is False
+
+
+def test_add_validation_rule_rejects_rule_object(app):
+    # The silent double-wrap (ValidationRule inside ValidationRule -> never
+    # validates) now raises a clear TypeError instead.
+    tf = bs.TextField()
+    with pytest.raises(TypeError):
+        tf.add_validation_rule(ValidationRule("stringLength", min=3))


### PR DESCRIPTION
## Summary

What started as a `TextField` review surfaced a fundamental flaw: field validation didn't work for typed (numeric/date) fields — it crashed or validated the wrong thing. This redesigns the field-validation system around the framework's own architecture. Design brief: `docs/_dev/field-validation-system.md`.

### The bug
The seven field wrappers split on what they handed the string-rule engine: 4 passed the raw datum (`TypeError` on a `float`/`date`), 2 passed display text. A string rule on a `NumberField` crashed `validate()`; `custom` rules received formatted text instead of the typed value.

## What changed (4 phases)

**Phase 1 — validate the typed value, consistently** (`6842a7e9`)
- One resolver (`_get_validation_value`) returns the live, typed value; all 7 wrappers route through it. `custom` on a NumberField gets a real number; on a DateField, a `date`.
- Guard the `add_validation_rule` double-wrap (passing a `ValidationRule` object silently never-validated) with a clear `TypeError`.

**Phase 2 — type-aware taxonomy + `range`** (`c2ebd107`)
- New **`range`** rule: bounds over number/date/time, with a message (vs silent `min_value`/`max_value` clamping).
- Rules classified by value kind; an inapplicable rule (e.g. `stringLength` on a NumberField, `range` on text) is **rejected at attach time** with a `BootstackError` rather than silently coerced.

**Phase 3 — reactive validity surface** (`8486aad6`)
- The engine owns `valid: Signal[bool]` / `error: Signal[str]` as the source of truth; public `field.valid` / `field.error` expose them (`bs.Label(textsignal=field.error)`).
- The message label is bound to the error signal (imperative `_show_error`/`_clear_error` removed).
- `Form.validate()` routed through the engine (typed value + signal update); `on_valid`/`on_invalid` events preserved.

**Phase 4 — docs** (`c36c71d4`)
- Validation topic guide leads with the typed-value model; documents `range`, the type-aware behavior, and the reactive signals. API-ref `RuleType` updated.

## Testing
- `tests/widgets/public/test_field_validation_typed.py` — **27** cases (typed value, range, attach-time rejection, reactive signals, form-level).
- Field / validation-rules / public-surface suites green; examples construct; clean `-W` docs build.
- Manually verified on screen via a scratch demo (range/custom on numbers, date bounds, reactive error label).

## Follow-ups
- #216 — `NumberField(value=None)` crashes at construction (pre-existing, surfaced here).
- #217 — deferred 3b: reactive `Form.valid`/`Form.errors` computed aggregate + stream-based triggers (additive polish, not correctness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)