### PR TITLE
fix(numberfield): represent an empty field at construction (#216)

### DIFF
--- a/src/bootstack/widgets/_impl/_parts/numberentry_part.py
+++ b/src/bootstack/widgets/_impl/_parts/numberentry_part.py
@@ -90,8 +90,15 @@ class NumberEntryPart(TextEntryPart):
             **kwargs
         )
 
-        # Apply bounds to initial value
-        if self._value is not None:
+        # Apply bounds to the initial value. An empty/blank field has no numeric
+        # value — it arrives here as '' (a number field with no format stores its
+        # text verbatim) — so normalize it to None and skip bounds, mirroring how
+        # clear()/commit represent an empty field. (Without this, float('') raises
+        # at construction for NumberField(value=None) or value="".)
+        if self._value is None or self._value == "":
+            self._value = None
+            self._prev_changed_value = None
+        else:
             self._value = self._apply_bounds(float(self._value))
             if self._num_type is int:
                 self._value = int(round(self._value))

--- a/tests/widgets/public/test_numberfield_empty.py
+++ b/tests/widgets/public/test_numberfield_empty.py
@@ -1,0 +1,61 @@
+"""Regression guard for #216 — an empty NumberField is representable at
+construction. `NumberField(value=None)` (and `value=""`) used to raise
+`ValueError: could not convert string to float: ''` while applying bounds to the
+initial value: `None`/`""` flowed through to an empty string, then `float("")`
+blew up. An empty numeric field must construct cleanly (it already did
+post-construction — `clear()` sets `value` to `None`).
+"""
+import pytest
+
+import bootstack as bs
+
+
+@pytest.fixture(scope="module")
+def app():
+    a = bs.App()
+    a.__enter__()
+    a._tk_root.deiconify()
+    a._tk_root.update_idletasks()
+    try:
+        yield a
+    finally:
+        try:
+            a.__exit__(None, None, None)
+        except Exception:
+            pass
+        try:
+            a._tk_root.destroy()
+        except Exception:
+            pass
+
+
+@pytest.mark.parametrize("empty", [None, ""])
+def test_numberfield_empty_constructs(app, empty):
+    """Constructing an empty field does not raise; value reads back as None."""
+    nf = bs.NumberField(value=empty)
+    app._tk_root.update_idletasks()
+    assert nf.value is None
+    assert nf.text == ""
+
+
+def test_numberfield_empty_with_bounds_constructs(app):
+    """Bounds must not be applied to an empty value (the crash site)."""
+    nf = bs.NumberField(value=None, min_value=1, max_value=10)
+    app._tk_root.update_idletasks()
+    assert nf.value is None
+
+
+def test_numberfield_empty_then_step_uses_min(app):
+    """An empty field still steps off its min/zero base — value is usable after."""
+    nf = bs.NumberField(value=None, min_value=5, max_value=10)
+    app._tk_root.update_idletasks()
+    nf.increment()
+    app._tk_root.update_idletasks()
+    assert nf.value == 6  # base min (5) + one step
+
+
+def test_numberfield_value_still_constructs(app):
+    """A real initial value is unaffected by the empty-value guard."""
+    nf = bs.NumberField(value=42, min_value=0, max_value=100)
+    app._tk_root.update_idletasks()
+    assert nf.value == 42


### PR DESCRIPTION
Fixes #216.

## Problem

`bs.NumberField(value=None)` (and `value=""`) raised at construction:

```
ValueError: could not convert string to float: ''
  src/bootstack/widgets/_impl/_parts/numberentry_part.py
      self._value = self._apply_bounds(float(self._value))
```

An empty numeric field should be representable at construction — it already is post-construction (`clear()` correctly sets `value` to `None`).

## Root cause

`value=None` flows into `TextEntryPart`, which stores an empty field's value as `''` (a number field with no format keeps its text verbatim). Back in `NumberEntryPart.__init__`, the initial-bounds guard was `if self._value is not None:` — `''` isn't `None`, so it entered and ran `float('')`.

## Fix

Normalize empty (`None` or `''`) to `None` and skip bounds, mirroring how `clear()`/`commit` represent an empty field. The public `value` property already coerces `''` → `None` via `_as_number`, so construction was the only gap.

## Test

`tests/widgets/public/test_numberfield_empty.py` (5 cases): `None`/`""` construct cleanly, empty-with-bounds, step-from-empty uses the min base, and a real initial value is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
