### PR TITLE
fix(passwordfield): keep the reveal toggle usable under read_only (#226)

### DIFF
--- a/docs/widgets/passwordfield.rst
+++ b/docs/widgets/passwordfield.rst
@@ -69,6 +69,10 @@ Disable it with ``show_visibility_toggle=False``.
    :class: bs-screenshot-dark
    :alt: PasswordField visibility toggle — dark theme
 
+The toggle stays usable on a **read-only** field — revealing only unmasks the
+text, it never changes the value (handy for a generated secret shown for the user
+to peek at and copy). A fully ``disabled`` field dims it along with everything else.
+
 Programmatic reveal / hide
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/bootstack/widgets/_impl/composites/passwordentry.py
+++ b/src/bootstack/widgets/_impl/composites/passwordentry.py
@@ -73,7 +73,12 @@ class PasswordEntry(Field):
             name="visibility",
             icon={"name": "eye", "state": [("pressed", "eye-slash")]},
             compound="image",
-            icon_only=True
+            icon_only=True,
+            # Revealing only flips the mask char — it never mutates the value —
+            # so the toggle stays usable on a read-only field (e.g. a generated
+            # secret shown for the user to peek at). A fully disabled field still
+            # dims it. (active_when_readonly postdates this widget, hence the gap.)
+            active_when_readonly=True,
         )
         addon = self.addons['visibility']
         addon.bind('<ButtonPress>', self._show_password, add=True)

--- a/tests/widgets/public/test_passwordfield_readonly_reveal.py
+++ b/tests/widgets/public/test_passwordfield_readonly_reveal.py
@@ -1,0 +1,77 @@
+"""The PasswordField reveal (eye) toggle stays usable on a read-only field.
+
+Revealing only flips the mask character — it never mutates the value — so a
+read-only password (e.g. a generated secret shown for the user to peek at) can
+still be revealed. A fully disabled field dims everything, including the toggle.
+
+The `active_when_readonly` addon flag postdates this widget, so the toggle never
+adopted it until this fix; this guards the wire-up.
+"""
+import pytest
+
+import bootstack as bs
+
+
+@pytest.fixture(scope="module")
+def app():
+    a = bs.App()
+    a.__enter__()
+    a._tk_root.deiconify()
+    a._tk_root.update_idletasks()
+    try:
+        yield a
+    finally:
+        try:
+            a.__exit__(None, None, None)
+        except Exception:
+            pass
+        try:
+            a._tk_root.destroy()
+        except Exception:
+            pass
+
+
+def _eye(pf):
+    return pf._internal.addons["visibility"]
+
+
+def test_reveal_toggle_active_when_readonly(app):
+    pf = bs.PasswordField(value="secret123", read_only=True)
+    app._tk_root.update_idletasks()
+    assert "disabled" not in _eye(pf).state()
+
+
+def test_reveal_toggle_disabled_when_field_disabled(app):
+    pf = bs.PasswordField(value="secret123", disabled=True)
+    app._tk_root.update_idletasks()
+    assert "disabled" in _eye(pf).state()
+
+
+def test_reveal_toggle_follows_live_readonly_toggle(app):
+    pf = bs.PasswordField(value="secret123")
+    app._tk_root.update_idletasks()
+    assert "disabled" not in _eye(pf).state()
+
+    pf.read_only = True
+    app._tk_root.update_idletasks()
+    assert "disabled" not in _eye(pf).state()  # stays active under read-only
+
+    pf.disabled = True
+    app._tk_root.update_idletasks()
+    assert "disabled" in _eye(pf).state()       # dims when fully disabled
+
+    pf.disabled = False
+    app._tk_root.update_idletasks()
+    assert "disabled" not in _eye(pf).state()
+
+
+def test_reveal_still_unmasks_under_readonly(app):
+    pf = bs.PasswordField(value="secret123", read_only=True)
+    app._tk_root.update_idletasks()
+    entry = pf._internal._entry
+    pf._internal.reveal()
+    app._tk_root.update_idletasks()
+    assert entry.cget("show") == ""     # unmasked
+    pf._internal.hide()
+    app._tk_root.update_idletasks()
+    assert entry.cget("show") != ""     # re-masked


### PR DESCRIPTION
Re-lands a fix that was stranded: it was pushed to `feat/passwordfield-review` **after** that branch's PR (#225) had already merged (docs only), so the fix never reached `main`. This PR carries just the fix.

Fixes #226.

## Problem

The PasswordField eye (reveal) toggle inherited the default Field-addon behavior of dimming when the field is `read_only`, so a read-only password couldn't be revealed. Revealing only flips the mask character — it never mutates the value — so the toggle is safe and useful on a read-only field (e.g. a generated secret shown to peek at and copy).

The `active_when_readonly` addon flag **postdates PasswordField**, so the toggle never adopted it.

## Fix

Pass `active_when_readonly=True` on the visibility addon's `insert_addon`. A fully `disabled` field still dims the toggle.

## Test / docs

- `tests/widgets/public/test_passwordfield_readonly_reveal.py` (4 cases — active under read-only, disabled under disabled, live state transitions, reveal still unmasks under read-only).
- A note in the Visibility-toggle section of the PasswordField page.

## Verification

Tests pass (4/4); clean `-W` docs build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
