### PR TITLE
feat(pathfield): expose dialog-config options as live properties (#232)

### DIFF
--- a/docs/widgets/pathfield.rst
+++ b/docs/widgets/pathfield.rst
@@ -42,6 +42,16 @@ clicked. The default is ``'open'``.
    bs.PathField(mode="save")           # save-file dialog
    bs.PathField(mode="directory")      # directory picker
 
+``mode`` and the other dialog options (``dialog_title``, ``start_dir``,
+``file_filters``, ``default_extension``, ``default_filename``) are also live
+properties — assign to them to reconfigure the picker after construction:
+
+.. code-block:: python
+
+   pf = bs.PathField(mode="open")
+   pf.mode = "save"                 # switch the dialog the button opens
+   pf.start_dir = last_used_folder  # open where the user last browsed
+
 File filters
 ~~~~~~~~~~~~
 

--- a/src/bootstack/widgets/pathfield.py
+++ b/src/bootstack/widgets/pathfield.py
@@ -180,6 +180,62 @@ class PathField(FieldAddonMixin, PublicWidgetBase):
         """Raw result from the most recent dialog (string or tuple of strings)."""
         return self._internal.dialog_result
 
+    # ----- Live dialog configuration -----
+
+    @property
+    def mode(self) -> Literal["open", "open_multiple", "save", "directory"]:
+        """Which native dialog the browse button opens."""
+        return self._internal.cget("mode")
+
+    @mode.setter
+    def mode(self, v: Literal["open", "open_multiple", "save", "directory"]) -> None:
+        self._internal.configure(mode=v)
+
+    @property
+    def dialog_title(self) -> str | None:
+        """Title shown in the native picker window."""
+        return self._internal.cget("dialog_title")
+
+    @dialog_title.setter
+    def dialog_title(self, v: str | None) -> None:
+        self._internal.configure(dialog_title=v)
+
+    @property
+    def start_dir(self) -> str | None:
+        """Directory the dialog opens in."""
+        return self._internal.cget("start_dir")
+
+    @start_dir.setter
+    def start_dir(self, v: str | None) -> None:
+        self._internal.configure(start_dir=v)
+
+    @property
+    def file_filters(self) -> "list[tuple[str, str]] | None":
+        """File-type filters, e.g. `[('Images', '*.png *.jpg')]`. Not used for `'directory'` mode."""
+        return self._internal.cget("file_filters")
+
+    @file_filters.setter
+    def file_filters(self, v: "list[tuple[str, str]] | None") -> None:
+        self._internal.configure(file_filters=v)
+
+    @property
+    def default_extension(self) -> str | None:
+        """Extension appended automatically when omitted (`'save'` mode only)."""
+        return self._internal.cget("default_extension")
+
+    @default_extension.setter
+    def default_extension(self, v: str | None) -> None:
+        self._internal.configure(default_extension=v)
+
+    @property
+    def default_filename(self) -> str | None:
+        """Suggested filename pre-filled in the dialog (`'save'` mode only)."""
+        return self._internal.cget("default_filename")
+
+    @default_filename.setter
+    def default_filename(self, v: str | None) -> None:
+        self._internal.configure(default_filename=v)
+
     @property
     def signal(self) -> "Signal[str] | None":
         """The reactive `Signal` bound to this field, or `None`."""

--- a/tests/widgets/public/test_pathfield_live_props.py
+++ b/tests/widgets/public/test_pathfield_live_props.py
@@ -1,0 +1,77 @@
+"""PathField dialog-config options are live properties (#232).
+
+`mode`, `dialog_title`, `start_dir`, `file_filters`, `default_extension`, and
+`default_filename` are construction kwargs that can also be read and reassigned
+at runtime — so a field can switch from, say, "open" to "save", or update its
+start directory based on a prior selection, without being recreated. They route
+through the internal PathEntry's configure-delegates.
+"""
+import pytest
+
+import bootstack as bs
+
+
+@pytest.fixture(scope="module")
+def app():
+    a = bs.App()
+    a.__enter__()
+    a._tk_root.deiconify()
+    a._tk_root.update_idletasks()
+    try:
+        yield a
+    finally:
+        try:
+            a.__exit__(None, None, None)
+        except Exception:
+            pass
+        try:
+            a._tk_root.destroy()
+        except Exception:
+            pass
+
+
+def test_dialog_props_read_construction_values(app):
+    pf = bs.PathField(
+        mode="save",
+        dialog_title="Save as",
+        start_dir="/tmp",
+        file_filters=[("CSV", "*.csv")],
+        default_extension=".csv",
+        default_filename="out.csv",
+    )
+    app._tk_root.update_idletasks()
+    assert pf.mode == "save"
+    assert pf.dialog_title == "Save as"
+    assert pf.start_dir == "/tmp"
+    assert pf.file_filters == [("CSV", "*.csv")]
+    assert pf.default_extension == ".csv"
+    assert pf.default_filename == "out.csv"
+
+
+def test_dialog_props_are_live(app):
+    pf = bs.PathField(mode="open")
+    app._tk_root.update_idletasks()
+    assert pf.mode == "open"
+
+    pf.mode = "directory"
+    pf.start_dir = "/home/user"
+    pf.file_filters = [("Images", "*.png *.jpg")]
+    pf.dialog_title = "Choose a folder"
+    pf.default_extension = ".png"
+    pf.default_filename = "image.png"
+    app._tk_root.update_idletasks()
+
+    assert pf.mode == "directory"
+    assert pf.start_dir == "/home/user"
+    assert pf.file_filters == [("Images", "*.png *.jpg")]
+    assert pf.dialog_title == "Choose a folder"
+    assert pf.default_extension == ".png"
+    assert pf.default_filename == "image.png"
+
+
+def test_unset_dialog_props_default_to_none(app):
+    pf = bs.PathField()
+    app._tk_root.update_idletasks()
+    assert pf.dialog_title is None
+    assert pf.start_dir is None
+    assert pf.file_filters is None


### PR DESCRIPTION
Fixes #232 (a follow-up surfaced during the PathField widget review, #231).

## Change

The PathField dialog-configuration options were construction-only on the public wrapper, though the internal `PathEntry` already supports changing them at runtime via `@configure_delegate`. Exposes them as live get/set properties:

- `mode`
- `dialog_title`
- `start_dir`
- `file_filters`
- `default_extension`
- `default_filename`

So a field can switch the dialog it opens (`pf.mode = "save"`) or update its start directory based on a prior selection without being recreated. The properties read via the internal `cget` and write via `configure`, routing through the existing delegates — no new internal plumbing.

```python
pf = bs.PathField(mode="open")
pf.mode = "save"
pf.start_dir = last_used_folder
```

## Test / docs

- `tests/widgets/public/test_pathfield_live_props.py` (read construction values, live reassignment round-trips, unset → None).
- A note in the Dialog modes section of the PathField page.

## Verification

Tests pass (3); clean `-W` docs build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
