### PR TITLE
feat(signals): round-trip object values + expose only signal= on typed fields

### DIFF
--- a/docs/examples/datefield.py
+++ b/docs/examples/datefield.py
@@ -44,11 +44,12 @@ with bs.App(title="DateField Demo", padding=20, gap=16) as app:
         max_date=today + timedelta(days=30),
     )
 
-    # Reactive binding
+    # Reactive binding — the signal carries the date object
     bs.Label("Reactive Binding", font="heading-sm")
-    date_sig = bs.Signal("")
-    df = bs.DateField(label="Pick a date", textsignal=date_sig)
-    bs.Label(textsignal=date_sig, accent="secondary")
+    date_sig = bs.Signal(today)
+    bs.DateField(label="Pick a date", signal=date_sig)
+    date_text = date_sig.map(lambda d: d.strftime("%B %d, %Y") if d else "")
+    bs.Label(textsignal=date_text, accent="secondary")
 
     # States
     bs.Label("States", font="heading-sm")

--- a/docs/examples/timefield.py
+++ b/docs/examples/timefield.py
@@ -40,11 +40,12 @@ with bs.App(title="TimeField Demo", padding=20, gap=16) as app:
         interval=30,
     )
 
-    # Reactive binding
+    # Reactive binding — the signal carries the time object
     bs.Label("Reactive Binding", font="heading-sm")
-    time_sig = bs.Signal("")
-    bs.TimeField(label="Pick a time", textsignal=time_sig)
-    bs.Label(textsignal=time_sig, accent="secondary")
+    time_sig = bs.Signal(now)
+    bs.TimeField(label="Pick a time", signal=time_sig)
+    time_text = time_sig.map(lambda t: t.strftime("%I:%M %p") if t else "")
+    bs.Label(textsignal=time_text, accent="secondary")
 
     # States
     bs.Label("States", font="heading-sm")

--- a/docs/reference/signals.rst
+++ b/docs/reference/signals.rst
@@ -70,8 +70,12 @@ consistent.
 
    ``textsignal=`` is for widgets that carry text
    (:class:`~bootstack.TextField`, :class:`~bootstack.TextArea`). ``signal=`` is
-   for boolean and numeric widgets (:class:`~bootstack.Checkbox`,
-   :class:`~bootstack.Slider`, :class:`~bootstack.Switch`).
+   for widgets that carry a typed value — boolean, numeric, date, and time
+   (:class:`~bootstack.Checkbox`, :class:`~bootstack.Slider`,
+   :class:`~bootstack.NumberField`, :class:`~bootstack.DateField`,
+   :class:`~bootstack.TimeField`). A value-bound signal carries the typed value
+   itself: a :class:`~bootstack.DateField` ``signal=`` reads back a ``date``, not
+   a string.
 
 Reacting to changes
 -------------------

--- a/docs/widgets/datefield.rst
+++ b/docs/widgets/datefield.rst
@@ -106,14 +106,21 @@ the picker opens):
 Reactive binding
 ~~~~~~~~~~~~~~~~
 
-Pass a ``Signal[str]`` via ``textsignal=`` to keep the field text in sync with
-application state.
+Pass a ``Signal`` via ``signal=`` to two-way bind the field's ``date`` value to
+application state. The signal carries the ``date`` object itself — not its text —
+so reading it back gives you a ``date``. Seed it with a ``date`` to set the
+initial value.
 
 .. code-block:: python
 
-   date_sig = bs.Signal("")
-   bs.DateField(label="Pick a date", textsignal=date_sig)
-   bs.Label(textsignal=date_sig, accent="secondary")
+   from datetime import date
+
+   date_sig = bs.Signal(date.today())
+   bs.DateField(label="Pick a date", signal=date_sig)
+
+   # Derive a text signal for display
+   date_text = date_sig.map(lambda d: d.strftime("%B %d, %Y") if d else "")
+   bs.Label(textsignal=date_text, accent="secondary")
 
 Handling changes
 ~~~~~~~~~~~~~~~~

--- a/docs/widgets/numberfield.rst
+++ b/docs/widgets/numberfield.rst
@@ -149,7 +149,8 @@ float-typed ``Signal(0.0)`` when the field accepts decimals.
    qty.set(5)            # updates the field
    field.value          # 5  (a number, never a string)
 
-``textsignal=`` binds the raw display text instead — niche; prefer ``signal``.
+A number field binds its numeric value, so ``signal=`` is the only binding it
+takes — pass a number-typed ``Signal``, never a string.
 
 Validation
 ~~~~~~~~~~

--- a/docs/widgets/timefield.rst
+++ b/docs/widgets/timefield.rst
@@ -90,14 +90,21 @@ Use ``min_time=`` and ``max_time=`` to limit which times appear in the dropdown.
 Reactive binding
 ~~~~~~~~~~~~~~~~
 
-Pass a ``Signal[str]`` via ``textsignal=`` to keep the field text in sync with
-application state.
+Pass a ``Signal`` via ``signal=`` to two-way bind the field's ``time`` value to
+application state. The signal carries the ``time`` object itself — not its text —
+so reading it back gives you a ``time``. Seed it with a ``time`` to set the
+initial value.
 
 .. code-block:: python
 
-   time_sig = bs.Signal("")
-   bs.TimeField(label="Pick a time", textsignal=time_sig)
-   bs.Label(textsignal=time_sig, accent="secondary")
+   from datetime import time
+
+   time_sig = bs.Signal(time(9, 0))
+   bs.TimeField(label="Pick a time", signal=time_sig)
+
+   # Derive a text signal for display
+   time_text = time_sig.map(lambda t: t.strftime("%I:%M %p") if t else "")
+   bs.Label(textsignal=time_text, accent="secondary")
 
 Handling changes
 ~~~~~~~~~~~~~~~~

--- a/src/bootstack/signals/signal.py
+++ b/src/bootstack/signals/signal.py
@@ -90,6 +90,11 @@ class Signal(Generic[T]):
         self._name = name or f"SIG{next(self._cnt)}"
         self._type: Type[T] = type(value)
         self._master: tk.Misc | None = master
+        # An object-typed signal (e.g. a date/time, or any custom object) has no
+        # native Tk variable that round-trips it — a StringVar would hand back the
+        # string form. In that case the cached Python value is the source of truth
+        # and the backing variable serves only as the write-trace notification bus.
+        self._object_mode = not self._is_tk_native(value)
         self._var = self._create_variable(value)
         self._trace = _SignalTrace(self._var)
         # Map fid -> callback to allow multiple subscriptions of same function
@@ -98,6 +103,17 @@ class Signal(Generic[T]):
         self._callback_index: dict[Callable[[T], Any], set[str]] = {}
         # Cache last known value for robustness when Tcl variable is torn down
         self._last: T = value
+
+    @staticmethod
+    def _is_tk_native(value: Any) -> bool:
+        """Whether a value maps to a Tk variable that round-trips it losslessly.
+
+        Booleans, ints, floats, strings, and sets each have a backing Tk
+        variable that returns the same Python type on read. Any other value
+        (a `date`, `time`, or arbitrary object) does not, so it is held as a
+        Python object instead.
+        """
+        return isinstance(value, (bool, int, float, str, set))
 
     def _create_variable(self, value: T) -> tk.Variable:
         if isinstance(value, bool):
@@ -118,6 +134,10 @@ class Signal(Generic[T]):
         Returns:
             The current typed value.
         """
+        if self._object_mode:
+            # The Python object is authoritative; the backing var only holds a
+            # string rendering used to drive write traces.
+            return self._last
         try:
             value = self._var.get()
             self._last = value  # cache last good value
@@ -165,6 +185,9 @@ class Signal(Generic[T]):
         self = cls.__new__(cls)  # bypass __init__
         self._name = name or getattr(tk_var, "_name", str(tk_var))
         self._type = py_type  # type: ignore[assignment]
+        # Wrapping an existing Tk variable: it always round-trips its own native
+        # type, so object mode never applies here.
+        self._object_mode = False
         self._var = tk_var
         self._trace = _SignalTrace(self._var)
         self._subscribers = {}
@@ -210,6 +233,18 @@ class Signal(Generic[T]):
                 raise TypeError(
                     f"Expected {self._type.__name__}, got {type(value).__name__}"
                 )
+        if self._object_mode:
+            # Reduce redundant updates by comparing the Python objects, not the
+            # var's string form. Writing the string form fires write traces, so
+            # subscribers are notified with the real object via `__call__`.
+            if self._last == value:
+                return
+            self._last = value
+            try:
+                self._var.set(str(value))
+            except tk.TclError:
+                pass
+            return
         # Reduce redundant updates if value unchanged
         try:
             current = self._var.get()

--- a/src/bootstack/widgets/_core/field_mixin.py
+++ b/src/bootstack/widgets/_core/field_mixin.py
@@ -298,6 +298,24 @@ class ValueSignalMixin:
         self.on_change(_to_signal)
         self.on_destroy(lambda _e: self._release_value_signal())
 
+    def _sync_value_set(self, value: Any) -> None:
+        """Push a programmatic `field.value = …` to the bound signal.
+
+        The `on_change`-driven sync only fires on a user commit, so a
+        programmatic value set would otherwise leave the signal stale. Call this
+        from the wrapper's `value` setter. A no-op when no signal is bound, while
+        a signal↔field sync is in flight, or for an empty value.
+        """
+        if getattr(self, "_value_signal", None) is None:
+            return
+        if getattr(self, "_value_syncing", False) or value is None:
+            return
+        self._value_syncing = True
+        try:
+            self._push_to_signal(self.value)
+        finally:
+            self._value_syncing = False
+
     def _push_to_signal(self, value: Any) -> None:
         """Write `value` to the bound signal, reconciling numeric types.
 

--- a/src/bootstack/widgets/datefield.py
+++ b/src/bootstack/widgets/datefield.py
@@ -45,8 +45,6 @@ class DateField(ValueSignalMixin, FieldAddonMixin, PublicWidgetBase):
         signal: Reactive `Signal` two-way bound to the field's `date` value (not
             its text). When given, it seeds the initial value. This is the usual
             way to bind a date field.
-        textsignal: Reactive `Signal[str]` bound to the field's raw text rather
-            than its date value. Niche; prefer `signal`.
         show_picker_button: Show the calendar icon button. Default `True`.
         picker_title: Title of the picker dialog.
         picker_first_weekday: First day of week in the picker (0=Mon … 6=Sun).
@@ -80,7 +78,6 @@ class DateField(ValueSignalMixin, FieldAddonMixin, PublicWidgetBase):
         value_format: str = "longDate",
         label: str | None = None,
         message: str | None = None,
-        textsignal: "Signal[str] | None" = None,
         show_picker_button: bool = True,
         picker_title: str | None = None,
         picker_first_weekday: int = 6,
@@ -100,6 +97,12 @@ class DateField(ValueSignalMixin, FieldAddonMixin, PublicWidgetBase):
     ) -> None:
         self._parent = self._resolve_parent(parent)
         layout_kw = self._split_layout_kwargs(kwargs)
+        if "textsignal" in kwargs:
+            raise TypeError(
+                "DateField does not accept 'textsignal=' — a date field binds its "
+                "date value. Use signal= with a date-typed Signal "
+                "(e.g. Signal(date.today()))."
+            )
 
         tk_master = self._parent._child_master() if self._parent else None
 
@@ -115,8 +118,6 @@ class DateField(ValueSignalMixin, FieldAddonMixin, PublicWidgetBase):
             internal_kwargs["label"] = label
         if message is not None:
             internal_kwargs["message"] = message
-        if textsignal is not None:
-            internal_kwargs["textsignal"] = textsignal
         if picker_title is not None:
             internal_kwargs["picker_title"] = picker_title
         if range_start is not None:
@@ -199,6 +200,7 @@ class DateField(ValueSignalMixin, FieldAddonMixin, PublicWidgetBase):
     @value.setter
     def value(self, v: "date | str | None") -> None:
         self._internal.value = v
+        self._sync_value_set(self._internal.value)
 
     @property
     def disabled(self) -> bool:

--- a/src/bootstack/widgets/numberfield.py
+++ b/src/bootstack/widgets/numberfield.py
@@ -62,9 +62,6 @@ class NumberField(ValueSignalMixin, FieldAddonMixin, PublicWidgetBase):
             fractional values, so they bind cleanly; an `int`-typed `Signal(0)`
             holds whole numbers only. When given, it seeds the initial value.
             This is the usual way to bind a number field.
-        textsignal: Reactive `Signal[str]` bound to the field's raw text (rather
-            than its numeric value). Niche; prefer `signal`. The signal must be
-            typed as `str` — initialize with `Signal("0")`, not `Signal(0)`.
         label: Label displayed above the field.
         message: Hint or helper text displayed below the field.
         min_value: Minimum allowed value (inclusive). No lower bound if omitted.
@@ -104,7 +101,6 @@ class NumberField(ValueSignalMixin, FieldAddonMixin, PublicWidgetBase):
         value: int | float = 0,
         *,
         signal: "Signal | None" = None,
-        textsignal: "Signal | None" = None,
         value_format: str | None = None,
         label: str | None = None,
         message: str | None = None,
@@ -126,6 +122,12 @@ class NumberField(ValueSignalMixin, FieldAddonMixin, PublicWidgetBase):
     ) -> None:
         self._parent = self._resolve_parent(parent)
         layout_kw = self._split_layout_kwargs(kwargs)
+        if "textsignal" in kwargs:
+            raise TypeError(
+                "NumberField does not accept 'textsignal=' — a number field binds "
+                "its numeric value. Use signal= with a number-typed Signal "
+                "(e.g. Signal(0) or Signal(0.0))."
+            )
         tk_master = self._parent._child_master() if self._parent else None
 
         internal_kwargs: dict[str, Any] = {
@@ -135,8 +137,6 @@ class NumberField(ValueSignalMixin, FieldAddonMixin, PublicWidgetBase):
         }
         if wrap:
             internal_kwargs["wrap"] = True
-        if textsignal is not None:
-            internal_kwargs["textsignal"] = textsignal
         if value_format is not None:
             internal_kwargs["value_format"] = value_format
         if label is not None:
@@ -217,6 +217,7 @@ class NumberField(ValueSignalMixin, FieldAddonMixin, PublicWidgetBase):
     @value.setter
     def value(self, v: int | float) -> None:
         self._internal.value = v
+        self._sync_value_set(v)
 
     @property
     def read_only(self) -> bool:

--- a/src/bootstack/widgets/timefield.py
+++ b/src/bootstack/widgets/timefield.py
@@ -50,8 +50,6 @@ class TimeField(ValueSignalMixin, FieldAddonMixin, PublicWidgetBase):
         signal: Reactive `Signal` two-way bound to the field's `time` value (not
             its text). When given, it seeds the initial value. This is the usual
             way to bind a time field.
-        textsignal: Reactive `Signal[str]` bound to the field text. The
-            field value and signal stay in sync automatically.
         required: If `True`, field cannot be left empty.
         disabled: If `True`, field is non-interactive.
         read_only: If `True`, free-text entry is blocked; user must pick
@@ -78,7 +76,6 @@ class TimeField(ValueSignalMixin, FieldAddonMixin, PublicWidgetBase):
         max_time: datetime.time | str | None = None,
         label: str | None = None,
         message: str | None = None,
-        textsignal: "Signal[str] | None" = None,
         required: bool = False,
         disabled: bool = False,
         read_only: bool = False,
@@ -90,6 +87,12 @@ class TimeField(ValueSignalMixin, FieldAddonMixin, PublicWidgetBase):
     ) -> None:
         self._parent = self._resolve_parent(parent)
         layout_kw = self._split_layout_kwargs(kwargs)
+        if "textsignal" in kwargs:
+            raise TypeError(
+                "TimeField does not accept 'textsignal=' — a time field binds its "
+                "time value. Use signal= with a time-typed Signal "
+                "(e.g. Signal(time(9, 0)))."
+            )
         tk_master = self._parent._child_master() if self._parent else None
 
         internal_kwargs: dict[str, Any] = {
@@ -106,8 +109,6 @@ class TimeField(ValueSignalMixin, FieldAddonMixin, PublicWidgetBase):
             internal_kwargs["label"] = label
         if message is not None:
             internal_kwargs["message"] = message
-        if textsignal is not None:
-            internal_kwargs["textsignal"] = textsignal
         if required:
             internal_kwargs["required"] = True
         if disabled:
@@ -175,6 +176,7 @@ class TimeField(ValueSignalMixin, FieldAddonMixin, PublicWidgetBase):
     @value.setter
     def value(self, v: "datetime.time | str | None") -> None:
         self._internal.value = v
+        self._sync_value_set(self._internal.value)
 
     @property
     def disabled(self) -> bool:

--- a/tests/signals/test_signal.py
+++ b/tests/signals/test_signal.py
@@ -79,6 +79,39 @@ def test_set_widens_int_to_float(app):
 
 
 @pytest.mark.gui
+def test_object_signal_round_trips_date(app):
+    # #227: an object value (date/time/etc.) used to fall into a StringVar and
+    # read back its string form. It must round-trip the Python object.
+    import datetime
+
+    d = datetime.date(2025, 1, 15)
+    s = bs.Signal(d)
+    assert s() == d
+    assert type(s()) is datetime.date          # not str
+
+    seen = []
+    s.subscribe(seen.append)
+    d2 = datetime.date(2025, 2, 20)
+    s.set(d2)
+    assert s() == d2
+    assert type(s()) is datetime.date
+    assert seen == [d2]                          # subscriber got the object
+
+    # setting an equal object is a no-op (no re-notify)
+    s.set(datetime.date(2025, 2, 20))
+    assert seen == [d2]
+
+
+@pytest.mark.gui
+def test_object_signal_rejects_wrong_type(app):
+    import datetime
+
+    s = bs.Signal(datetime.date(2025, 1, 1))
+    with pytest.raises(TypeError):
+        s.set("2025-01-01")
+
+
+@pytest.mark.gui
 def test_subscribe_immediate_fires_with_current_value(app):
     s = bs.Signal(1)
     seen = []

--- a/tests/widgets/public/test_field_text_value.py
+++ b/tests/widgets/public/test_field_text_value.py
@@ -89,6 +89,53 @@ def test_typed_fields_signal_binds_value_not_text(app):
     assert isinstance(tf.value, datetime.time)
 
 
+def test_datetime_signal_reads_back_object_not_string(app):
+    # #227: a date/time signal used to land in a StringVar and read back its
+    # string form. It must round-trip the object — both directly and via a field.
+    import datetime
+
+    dsig = bs.Signal(datetime.date(2024, 1, 2))
+    assert dsig() == datetime.date(2024, 1, 2)
+    assert type(dsig()) is datetime.date          # not str
+
+    df = bs.DateField(signal=dsig)
+    app._tk_root.update_idletasks()
+
+    # field -> signal on a *programmatic* value set (was only firing on commit)
+    df.value = datetime.date(2030, 3, 4)
+    app._tk_root.update_idletasks()
+    assert dsig() == datetime.date(2030, 3, 4)
+    assert type(dsig()) is datetime.date
+
+    # a subscriber receives the object, not a string
+    seen = []
+    dsig.subscribe(lambda v: seen.append(v))
+    df.value = datetime.date(2031, 5, 6)
+    app._tk_root.update_idletasks()
+    assert seen == [datetime.date(2031, 5, 6)]
+
+    # TimeField, same contract
+    tsig = bs.Signal(datetime.time(9, 30))
+    tf = bs.TimeField(signal=tsig)
+    app._tk_root.update_idletasks()
+    tf.value = datetime.time(14, 45)
+    app._tk_root.update_idletasks()
+    assert tsig() == datetime.time(14, 45)
+    assert type(tsig()) is datetime.time
+
+
+@pytest.mark.parametrize("name, make", [
+    ("NumberField", lambda: bs.NumberField(textsignal=bs.Signal("0"))),
+    ("DateField", lambda: bs.DateField(textsignal=bs.Signal(""))),
+    ("TimeField", lambda: bs.TimeField(textsignal=bs.Signal(""))),
+])
+def test_typed_fields_reject_textsignal(app, name, make):
+    # A typed field binds its value via signal=; textsignal= is removed and must
+    # fail loudly (not be silently swallowed by **kwargs).
+    with pytest.raises(TypeError, match="textsignal"):
+        make()
+
+
 def test_value_signal_unsubscribes_on_destroy(app):
     # A Signal usually outlives the widgets bound to it; destroying a bound field
     # must release its subscription so the field is not pinned in memory.


### PR DESCRIPTION
## Summary

Makes `Signal` round-trip object values and exposes only `signal=` on the typed
fields, closing #227 and addressing the report in #237.

`Signal` previously chose its Tk variable from the initial value's type, so a
`date`/`time` (or any object) landed in a `StringVar` and read back its **string**
form. This blocked featuring `signal=` as a clean typed binding for date/time
fields.

## Changes

- **Object-mode `Signal`** — for non-Tk-native values (anything not
  `bool`/`int`/`float`/`str`/`set`), the cached Python object is the source of
  truth and the backing `StringVar` serves only as the write-trace notification
  bus. `__call__` returns the object; `set()` dedupes on the object and bumps the
  var to notify. **Native signals are completely unchanged** — the new branch only
  activates for object values.
- **Programmatic field→signal sync** — `ValueSignalMixin._sync_value_set()`, called
  from each field's `value` setter, pushes a programmatic `field.value = …` to the
  bound signal (was only firing on a user commit). Fixes #227 consequence 2.
- **Removed `textsignal=` from `NumberField`/`DateField`/`TimeField`** — these bind
  their typed value via `signal=`. A removed kwarg would be silently swallowed by
  `**kwargs`, so it's guarded with a clear `TypeError`. Text fields keep
  `textsignal=`.
- **Docs** — Date/Time/Number pages + `signals.rst` feature typed `signal=` (with a
  `.map()`-derived text signal for display); the two example files converted.

## Testing

- `tests/signals/test_signal.py` — object round-trip + wrong-type rejection.
- `tests/widgets/public/test_field_text_value.py` — signal reads back objects,
  programmatic-set push, `textsignal=` raises.
- Adversarially verified subscriptions, notification counts, two-way cycle guards,
  and `map()`/`immediate` are unaffected.
- Clean `-W` docs build; `test_public_surface.py` green.

Closes #227. Refs #237.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
