### PR TITLE
fix(fields): scale field border padding for high DPI (#90)

### DIFF
--- a/src/bootstack/_runtime/utility.py
+++ b/src/bootstack/_runtime/utility.py
@@ -226,6 +226,27 @@ def get_image_name(image):
     return image._PhotoImage__photo.name
 
 
+def scale_padding_floor(base: int) -> int:
+    """Scale a padding value up for DPI, never dropping below `base`.
+
+    Used for the fixed gap between a nine-patch border (whose border slice grows
+    with DPI) and the widget packed inside it. If the gap does not grow with the
+    border, at high DPI the inner widget overpaints the now-thicker border slice
+    and the resting border disappears (#90).
+
+    Rounds rather than truncates so intermediate scales (e.g. 1.5x) do not lose a
+    pixel and clip the rounded corners, and floors at `base` so low DPI keeps its
+    tuned spacing.
+
+    Args:
+        base: The baseline padding in pixels at standard DPI.
+
+    Returns:
+        The DPI-scaled padding, at least `base`.
+    """
+    return max(base, round(base * _ScalingState.get_ui_scale()))
+
+
 def scale_size(widget=None, size=None):
     """Scale the size based on the scaling factor of tkinter.
     This is used most frequently to adjust the assets for

--- a/src/bootstack/widgets/_impl/composites/field.py
+++ b/src/bootstack/widgets/_impl/composites/field.py
@@ -16,6 +16,7 @@ from bootstack.widgets._impl.primitives.checkbutton import CheckButton
 from bootstack.widgets._impl.primitives.checktoggle import CheckToggle
 from bootstack.widgets._impl.mixins import configure_delegate
 from bootstack.widgets._impl.mixins.entry_mixin import EntryMixin
+from bootstack._runtime.utility import scale_padding_floor
 from bootstack.widgets._impl._parts.numberentry_part import NumberEntryPart
 from bootstack.widgets._impl._parts.textentry_part import TextEntryPart
 from bootstack.widgets._impl._parts.spinnerentry_part import SpinnerEntryPart
@@ -205,7 +206,10 @@ class Field(EntryMixin, Frame):
         )
         self._message_lbl = Label(self, localize=self._localize, text=message or '', font="caption", accent="secondary")
 
-        field_padding = 5
+        # The TField frame draws the visible border via a nine-patch whose border
+        # slice scales with DPI; this gap must grow with it, or at high DPI the
+        # entry overpaints the border slice and the resting border vanishes (#90).
+        field_padding = scale_padding_floor(5)
         self._field = Frame(self, accent=self._accent, padding=field_padding, ttk_class="TField", style_options={'density': self._density})
 
         if kind == "numeric":

--- a/src/bootstack/widgets/_impl/composites/textarea/textarea.py
+++ b/src/bootstack/widgets/_impl/composites/textarea/textarea.py
@@ -10,6 +10,7 @@ from bootstack.widgets._impl.primitives.gridframe import GridFrame
 from bootstack.widgets._impl.primitives.label import Label
 from bootstack.widgets._impl.composites.textarea.core import _MultilineCore, ScrollbarMode
 from bootstack.widgets.types import Master, AccentToken
+from bootstack._runtime.utility import scale_padding_floor
 
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
@@ -119,8 +120,10 @@ class TextArea(GridFrame):
 
         # ── core (row 1) ──────────────────────────────────────────────────
         if show_border:
+            # Padding must grow with the DPI-scaled TField border slice, else the
+            # text core overpaints the border at high DPI (#90, same as Field).
             self._field_frame = Frame(
-                self, accent=accent, padding=5, ttk_class="TField",
+                self, accent=accent, padding=scale_padding_floor(5), ttk_class="TField",
             )
             self._field_frame.grid(row=1, column=0, sticky="nsew")
             core_parent = self._field_frame

--- a/tests/widgets/public/test_field_hidpi_padding.py
+++ b/tests/widgets/public/test_field_hidpi_padding.py
@@ -1,0 +1,79 @@
+"""Regression for #90: the gap between a field's nine-patch border (whose slice
+scales with DPI) and the entry inside must scale with it, or at high DPI the entry
+overpaints the border slice and the resting border disappears.
+
+The fix is `scale_padding_floor`: round (not truncate) the DPI-scaled padding so
+intermediate scales like 1.5x don't lose a pixel and clip the rounded corners, and
+floor at the baseline so low DPI keeps its tuned spacing. A field's `TField` frame
+padding (and TextArea's) is computed from it at construction time.
+"""
+from __future__ import annotations
+
+import pytest
+
+import bootstack as bs
+from bootstack._runtime.utility import _ScalingState, scale_padding_floor
+
+
+@pytest.fixture(scope="module")
+def app():
+    a = bs.App()
+    a.__enter__()
+    a._tk_root.withdraw()
+    try:
+        yield a
+    finally:
+        _ScalingState.set_scale_factor(1.0)
+        try:
+            a.__exit__(None, None, None)
+        except Exception:
+            pass
+        try:
+            a._tk_root.destroy()
+        except Exception:
+            pass
+
+
+def test_scale_padding_floor_never_below_base():
+    # Below the baseline (low DPI) it must hold the tuned base, not shrink — a
+    # smaller gap clips the rounded corners.
+    _ScalingState.set_scale_factor(0.5)
+    assert scale_padding_floor(5) == 5
+
+
+def test_scale_padding_floor_rounds_not_truncates():
+    # ui_scale 1.125 -> 5 * 1.125 = 5.625; truncation gave 5 (clipped at 1.5x DPI),
+    # rounding gives 6.
+    _ScalingState.set_scale_factor(1.5)          # ui_scale ~1.125 on a 1.333 baseline
+    ui = _ScalingState.get_ui_scale()
+    assert scale_padding_floor(5) == max(5, round(5 * ui))
+    assert scale_padding_floor(5) >= 6
+
+
+def test_scale_padding_floor_scales_up_for_hidpi():
+    _ScalingState.set_scale_factor(2.667)        # ~200%
+    assert scale_padding_floor(5) > 5            # grows with the border slice
+
+
+@pytest.mark.gui
+def test_field_padding_tracks_dpi(app):
+    # The TextField's TField frame padding is built from scale_padding_floor.
+    _ScalingState.set_scale_factor(1.0)
+    low = bs.TextField(label="a")
+    low_pad = low._internal._field.cget("padding")[0]
+
+    _ScalingState.set_scale_factor(2.667)
+    high = bs.TextField(label="b")
+    high_pad = high._internal._field.cget("padding")[0]
+
+    assert int(high_pad) > int(low_pad)
+    assert int(low_pad) >= 5
+
+
+@pytest.mark.gui
+def test_textarea_padding_tracks_dpi(app):
+    # TextArea/CodeEditor share the same TField border pattern and fix.
+    _ScalingState.set_scale_factor(2.667)
+    ta = bs.TextArea(label="notes")
+    assert ta._internal._field_frame is not None
+    assert int(ta._internal._field_frame.cget("padding")[0]) > 5


### PR DESCRIPTION
## Summary

Fixes #90 — on high-DPI displays, the **resting (unfocused) border** of a `TextField`/`TextArea` (etc.) is invisible; clicking the field shows the focus border fine, and `hdpi=False` makes the resting border reappear.

## Root cause

The visible field border is drawn by the `TField` frame's nine-patch, whose **border slice scales with DPI**. The gap between that border and the widget packed inside it was a **hardcoded `padding=5`**. At high DPI the slice outgrows the fixed gap, so the inner widget's opaque fill **overpaints the border slice** and the resting border vanishes. The focus state survives because its border/ring is recolored to the high-contrast accent.

Verified by forcing the scale factor (the washout reproduces from the scale *number*, not physical 4K pixels — no special hardware needed). An earlier probe ruled out an image/LANCZOS-washout theory: `recolor_element_image` keeps full border contrast at every scale, so capping the image scale would not have helped.

## Fix

New `scale_padding_floor(base)` helper:
- **Rounds** (not truncates) the DPI-scaled padding, so intermediate scales like 1.5× don't lose a pixel and clip the rounded corners.
- **Floors at the baseline**, so low/normal DPI keeps its tuned 5px spacing.

Applied at both `ttk_class="TField"` sites:
- `Field` composite → all 7 field widgets (TextField, NumberField, PasswordField, DateField, TimeField, PathField, SpinnerField)
- `TextArea` → TextArea + CodeEditor

## Scope checked, not affected

Context menus, toasts, snackbars, tooltips, and the Select popup use the `show_border` relief border (a fixed ~1px ttk border, not a scaling nine-patch), so they don't have the overpaint bug.

## Testing

- New `tests/widgets/public/test_field_hidpi_padding.py` (5): floor-at-base, round-not-truncate, scale-up for hi-DPI, and field/TextArea padding tracks DPI at construction.
- Field suites + `test_public_surface.py` green.
- Visual confirmation across forced scales (1.0 / 1.333 / 1.5 / 2.667): resting borders visible at high DPI, rounded corners clean at all scales.

Closes #90.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
