### PR TITLE
feat(spinnerfield): increment()/decrement() parity with NumberField (#234)

### DIFF
--- a/docs/widgets/spinnerfield.rst
+++ b/docs/widgets/spinnerfield.rst
@@ -189,6 +189,22 @@ to surface it:
    The full rule taxonomy and aggregating a whole form's validity live in the
    :doc:`Validation </reference/validation>` guide.
 
+Programmatic stepping
+~~~~~~~~~~~~~~~~~~~~~
+
+Call ``increment()`` and ``decrement()`` to step the value in code — the same
+as pressing the spin buttons. They work in both modes and honor the field's
+bounds and ``wrap`` setting.
+
+.. code-block:: python
+
+   field = bs.SpinnerField(value=10, min_value=0, max_value=100, step=5)
+   field.increment()    # → 15
+   field.decrement(2)   # → 5
+
+   picker = bs.SpinnerField(value="Low", options=["Low", "Medium", "High"])
+   picker.increment()   # → "Medium"
+
 Keyboard
 ~~~~~~~~
 

--- a/src/bootstack/widgets/_impl/_parts/spinnerentry_part.py
+++ b/src/bootstack/widgets/_impl/_parts/spinnerentry_part.py
@@ -170,6 +170,55 @@ class SpinnerEntryPart(ValidationMixin, Spinbox):
             self.event_generate('<<Change>>', data=data)
             self._prev_changed_value = self._value
 
+    def step(self, n: int = 1) -> None:
+        """Step the value by `n` positions (negative steps down).
+
+        A thin abstraction over the native spinbox: fires its own
+        `<<Increment>>` / `<<Decrement>>` virtual events `n` times (the same
+        events its arrow buttons and Up/Down keys generate), so the spinbox
+        handles bounds, wrapping, and the text-vs-numeric mode itself. The
+        stepped text is then committed so the parsed value and a `<<Change>>`
+        event reflect the step. No-op when disabled or read-only.
+
+        Args:
+            n: Number of steps. Positive steps up, negative steps down.
+        """
+        states = self.state()
+        if 'disabled' in states or 'readonly' in states:
+            return
+
+        prev_value = self._value
+        event = '<<Increment>>' if n >= 0 else '<<Decrement>>'
+
+        # A programmatic step is a value change, not typed input — silence the
+        # per-keystroke <<Input>> while the native spinbox rewrites the display
+        # text, then re-subscribe (mirrors NumberEntryPart's silenced stepping).
+        fid = getattr(self, '_on_input_fid', None)
+        if fid:
+            try:
+                fid.cancel()
+            except TclError:
+                pass
+            self._on_input_fid = None
+        try:
+            for _ in range(abs(n)):
+                # `when='now'` delivers synchronously so commit() below sees
+                # the stepped text immediately.
+                self.event_generate(event, when='now')
+            self.commit()
+        finally:
+            self._prev_change_text = self.textsignal()
+            if fid:
+                self._on_input_fid = self.textsignal.subscribe(self._handle_change)
+
+        if self._value != prev_value:
+            self._prev_changed_value = self._value
+            self.event_generate('<<Change>>', data=ChangeEvent(
+                value=self._value,
+                prev_value=prev_value,
+                text=self.textsignal(),
+            ))
+
     def _parse_or_none(self, s: str):
         """Parse string using value_format, returning None on empty/invalid input."""
         # If a non-string is passed (e.g., datetime/date), assume it's already parsed

--- a/src/bootstack/widgets/_impl/composites/spinnerentry.py
+++ b/src/bootstack/widgets/_impl/composites/spinnerentry.py
@@ -101,6 +101,14 @@ class SpinnerEntry(Field):
         self._increment = increment
         self._wrap = wrap
 
+    def step(self, n: int = 1) -> None:
+        """Step the value by `n` increments (positive) or decrements (negative).
+
+        Args:
+            n: Number of steps. Positive steps up, negative steps down.
+        """
+        self.entry_widget.step(n)
+
     @property
     def values(self) -> list[str]:
         """Get the list of valid values (text mode only)."""

--- a/src/bootstack/widgets/spinnerfield.py
+++ b/src/bootstack/widgets/spinnerfield.py
@@ -217,6 +217,30 @@ class SpinnerField(FieldAddonMixin, PublicWidgetBase):
 
     # ----- Methods -----
 
+    def increment(self, steps: int = 1) -> None:
+        """Step the value up by `steps` positions.
+
+        In numeric mode this adds `steps` × the step size; in text mode it
+        advances `steps` positions through `options`. Honors the field's
+        bounds and `wrap` setting.
+
+        Args:
+            steps: Number of steps to increment. Defaults to `1`.
+        """
+        self._internal.step(steps)
+
+    def decrement(self, steps: int = 1) -> None:
+        """Step the value down by `steps` positions.
+
+        In numeric mode this subtracts `steps` × the step size; in text mode it
+        moves back `steps` positions through `options`. Honors the field's
+        bounds and `wrap` setting.
+
+        Args:
+            steps: Number of steps to decrement. Defaults to `1`.
+        """
+        self._internal.step(-steps)
+
     def focus(self) -> None:
         """Give keyboard focus to this field."""
         self._entry_widget().focus_set()

--- a/tests/widgets/public/test_spinnerfield_step.py
+++ b/tests/widgets/public/test_spinnerfield_step.py
@@ -1,0 +1,104 @@
+"""SpinnerField increment()/decrement() parity with NumberField (#234).
+
+SpinnerField gains the programmatic stepping methods NumberField already
+exposes. They are a thin abstraction over the native spinbox's own stepping
+(its `<<Increment>>` / `<<Decrement>>` virtual events), so bounds, wrapping,
+and the text-vs-numeric mode are all handled natively. A step commits the
+value and fires `<<Change>>`, and is a no-op when disabled or read-only.
+"""
+import pytest
+
+import bootstack as bs
+
+
+@pytest.fixture(scope="module")
+def app():
+    a = bs.App()
+    a.__enter__()
+    a._tk_root.deiconify()
+    a._tk_root.update_idletasks()
+    try:
+        yield a
+    finally:
+        try:
+            a.__exit__(None, None, None)
+        except Exception:
+            pass
+        try:
+            a._tk_root.destroy()
+        except Exception:
+            pass
+
+
+def test_increment_decrement_numeric(app):
+    sf = bs.SpinnerField(value=5, min_value=0, max_value=10, step=2)
+    app._tk_root.update_idletasks()
+
+    sf.increment()
+    assert sf.value == "7"
+    sf.increment(2)  # 7 -> 9 -> 10 (clamped)
+    assert sf.value == "10"
+    sf.decrement()
+    assert sf.value == "8"
+
+
+def test_numeric_clamps_at_bounds(app):
+    sf = bs.SpinnerField(value=8, min_value=0, max_value=10, step=5)
+    app._tk_root.update_idletasks()
+
+    sf.increment()  # 13 -> clamped to 10
+    assert sf.value == "10"
+    sf.increment()  # stays at the max
+    assert sf.value == "10"
+
+
+def test_numeric_wraps_when_enabled(app):
+    sf = bs.SpinnerField(value=9, min_value=0, max_value=10, step=2, wrap=True)
+    app._tk_root.update_idletasks()
+
+    sf.increment()  # 11 -> wraps
+    assert sf.value == "0"
+    sf.decrement()  # wraps back to the top
+    assert sf.value == "10"
+
+
+def test_increment_decrement_text_mode(app):
+    sf = bs.SpinnerField(value="Low", options=["Low", "Medium", "High"], wrap=True)
+    app._tk_root.update_idletasks()
+
+    sf.increment()
+    assert sf.value == "Medium"
+    sf.increment()
+    assert sf.value == "High"
+    sf.decrement(2)
+    assert sf.value == "Low"
+
+
+def test_step_fires_change_event(app):
+    sf = bs.SpinnerField(value=5, min_value=0, max_value=10, step=1)
+    app._tk_root.update_idletasks()
+
+    seen = []
+    sf.on_change(lambda e: seen.append((e.prev_value, e.value)))
+
+    sf.increment()
+    sf.decrement()
+    app._tk_root.update_idletasks()
+
+    assert seen == [("5", "6"), ("6", "5")]
+
+
+def test_step_noop_when_disabled(app):
+    sf = bs.SpinnerField(value=5, min_value=0, max_value=10, step=1, disabled=True)
+    app._tk_root.update_idletasks()
+
+    sf.increment()
+    assert sf.value == "5"
+
+
+def test_step_noop_when_read_only(app):
+    sf = bs.SpinnerField(value=5, min_value=0, max_value=10, step=1, read_only=True)
+    app._tk_root.update_idletasks()
+
+    sf.increment()
+    assert sf.value == "5"


### PR DESCRIPTION
Closes #234.

## Summary

`SpinnerField` gains the programmatic stepping methods `NumberField` already exposes:

- `increment(steps=1)` / `decrement(steps=1)` — identical signature to `NumberField`.

Per the maintainer's scope call, **only the methods** are mirrored. `NumberField`'s public surface has no live `min_value`/`max_value`/`step` properties and no `on_increment`/`on_decrement` shorthands, so those are intentionally left off SpinnerField too.

## Implementation

A thin abstraction over the native `ttk.Spinbox` — no reimplemented stepping arithmetic:

- `SpinnerEntryPart.step(n)` fires the spinbox's own `<<Increment>>`/`<<Decrement>>` virtual events `n` times (`when='now'`, synchronous), then `commit()` syncs the parsed value and emits `<<Change>>`. Bounds, wrapping, and the text-vs-numeric mode are all handled by ttk natively.
- `SpinnerEntry` composite delegates `step(n)` → the part (mirrors `NumericEntry`).
- The wrapper's `increment()`/`decrement()` call `self._internal.step(±steps)`.

## Event / leak audit

- **No memory leak** — textsignal subscribers steady at 1, `<<Change>>`/`<<Increment>>` bindings flat across 50 steps.
- **No double-fired `<<Change>>`** — exactly N events for N steps, no recursion.
- **Fixed a spurious `<<Input>>`** the native text rewrite would otherwise trip per step. A programmatic step is a value change, not typed input, so the input subscriber is silenced around the native rewrite (matching `NumberEntryPart`'s silenced stepping). Verified a genuine text change still fires `<<Input>>` afterward (subscriber correctly re-attached).

## Tests / docs

- `tests/widgets/public/test_spinnerfield_step.py` (7) — numeric step, clamp, wrap, text mode, change-event, disabled/read-only no-ops.
- "Programmatic stepping" section added to `docs/widgets/spinnerfield.rst` (snippet API-verified); example file launches clean.
- Field suite + `test_public_surface` green (one file per process, #150).

🤖 Generated with [Claude Code](https://claude.com/claude-code)