### PR TITLE
feat(button): activation-based on_click + disabled/text fixes (widget review)

### DIFF
--- a/docs/widgets/button.rst
+++ b/docs/widgets/button.rst
@@ -4,6 +4,11 @@ Button
 A clickable action trigger. Accepts the button text as the first positional
 argument.
 
+A button does one thing: it runs an action when activated. Wire that action with
+``on_click=`` and shape the rest with two independent knobs — ``accent=`` for
+*intent* (the semantic color) and ``variant=`` for *weight* (how much it stands
+out). Everything else on the page is a refinement of those three ideas.
+
 .. image:: /_static/examples/button-hero-light.png
    :class: bs-screenshot-light
    :alt: Button — light theme
@@ -204,35 +209,75 @@ automatically.
 Custom image
 ~~~~~~~~~~~~
 
-Besides Bootstrap Icon names, ``image=`` accepts an image handle for custom
-artwork (logos, embedded resources). The public image-handle API is being
-finalized for an upcoming release; until then, prefer icon names for button
-artwork.
-
-Handling clicks
-~~~~~~~~~~~~~~~
-
-Pass a callable to ``on_click=`` at construction, or call ``.on_click()``
-afterwards. The callback receives no arguments.
+For artwork beyond the Bootstrap Icons set — a logo, an embedded resource —
+pass an :class:`Image <bootstack.images.Image>` handle to ``image=``. Reach for
+``icon=`` for standard glyphs and ``image=`` for custom pictures.
 
 .. code-block:: python
 
-   # At construction
+   from bootstack.images import Image
+
+   bs.Button("Open", image=Image.open("logo.png"))
+
+The handle is also a live property — assigning ``button.image`` swaps the
+picture in place. See :doc:`/widgets/picture` and the
+:class:`Image <bootstack.images.Image>` reference for the full image API.
+
+Events
+~~~~~~
+
+A button fires on **activation** — a mouse release over it, ``Space``/``Return``
+while it has keyboard focus, or a programmatic :meth:`click`. A disabled button
+never fires on any of those paths. The simplest form is the ``on_click=``
+constructor callback, which takes **no arguments**:
+
+.. code-block:: python
+
    bs.Button("Save",   accent="primary", on_click=handle_save)
    bs.Button("Cancel", on_click=lambda: print("Cancelled"))
 
-   # As a subscription (cancellable)
+Use the ``on_click()`` method when you need a cancellable subscription or want to
+compose the event as a :class:`~bootstack.streams.Stream`. Its handler receives
+the activation :class:`~bootstack.events.Event`:
+
+.. code-block:: python
+
+   # Cancellable subscription
    btn = bs.Button("Save", accent="primary")
-   sub = btn.on_click(handle_save)
+   sub = btn.on_click(lambda event: handle_save())
    sub.cancel()  # unsubscribe
 
-   # As a Stream (composable)
-   btn.on_click().debounce(300).listen(lambda: handle_save())
+   # Composable Stream — e.g. ignore rapid double-clicks
+   btn.on_click().debounce(300).listen(lambda event: handle_save())
+
+.. note::
+
+   Because keyboard and programmatic activations carry no pointer, treat the
+   event's position and modifier fields as unset — use ``on_click=`` (or ignore
+   the argument) unless you specifically need a mouse-only gesture. See
+   :doc:`/tasks/handling-actions` for wiring actions across widgets and
+   :doc:`/reference/events` for the full event model.
+
+Keyboard
+~~~~~~~~
+
+- **Tab / Shift+Tab** — move focus to or from the button.
+- **Space / Return** — activate the focused button, firing the click exactly as a
+  mouse release does. A disabled button is skipped in the focus order.
 
 Widget sizing
 ~~~~~~~~~~~~~
 
 .. include:: ../shared/widget-sizing.rst
+
+See also
+--------
+
+* :doc:`menubutton` — a button that opens a menu of actions
+* :doc:`buttongroup` — a row of related buttons sharing one style
+* :doc:`togglebutton` — a button that holds an on/off state
+* :doc:`/tasks/handling-actions` — wiring actions and shortcuts across widgets
+* :doc:`/reference/events` — the event model behind ``on_click``
 
 API
 ---

--- a/src/bootstack/widgets/button.py
+++ b/src/bootstack/widgets/button.py
@@ -79,11 +79,16 @@ class Button(IconProperty, ImageProperty, PublicWidgetBase):
         if icon is not None and not text:
             icon_only = True
 
-        internal_kwargs: dict[str, Any] = {"text": text}
+        # The internal command is always our dispatcher so that a click —
+        # whether by mouse, keyboard (Space/Return), or click()/invoke() — runs
+        # the on_click= callback AND emits <<Click>> for on_click() subscribers,
+        # consistently and only when the button is enabled (ttk gates the
+        # command on state, unlike a raw <Button-1> binding).
+        self._on_click_cmd = on_click
+
+        internal_kwargs: dict[str, Any] = {"text": text, "command": self._dispatch_click}
         if not icon_only:
             internal_kwargs["compound"] = icon_position
-        if on_click is not None:
-            internal_kwargs["command"] = on_click
         if accent is not None:
             internal_kwargs["accent"] = accent
         if variant is not None:
@@ -123,16 +128,28 @@ class Button(IconProperty, ImageProperty, PublicWidgetBase):
     @property
     def text(self) -> str:
         """The button's text."""
+        # Read through the bound variable when present: with a textsignal/
+        # textvariable, ttk's `text` option no longer tracks the displayed text.
+        textvar = getattr(self._internal, "_textvariable", None)
+        if textvar is not None:
+            return str(textvar.get())
         return str(self._internal.cget("text"))
 
     @text.setter
     def text(self, value: str) -> None:
-        self._internal.configure(text=value)
+        # When a textsignal/textvariable owns the text, ttk ignores the `text`
+        # option — write through the variable instead (which also keeps the
+        # bound signal in sync). Falls back to the option when unbound.
+        textvar = getattr(self._internal, "_textvariable", None)
+        if textvar is not None:
+            textvar.set(value)
+        else:
+            self._internal.configure(text=value)
 
     @property
     def disabled(self) -> bool:
         """Whether the button is non-interactive."""
-        return str(self._internal.cget("state")) == "disabled"
+        return self._internal.instate(("disabled",))
 
     @disabled.setter
     def disabled(self, value: bool) -> None:
@@ -141,8 +158,26 @@ class Button(IconProperty, ImageProperty, PublicWidgetBase):
     # ----- Methods -----
 
     def click(self) -> None:
-        """Programmatically invoke the button's command."""
+        """Programmatically activate the button.
+
+        Runs the same path as a real click: the `on_click=` callback and any
+        `on_click()` handlers both fire. Does nothing while the button is
+        disabled.
+        """
         self._internal.invoke()
+
+    def _dispatch_click(self) -> None:
+        """ttk command target — runs on every activation, never while disabled.
+
+        Fires on mouse release over the button, keyboard Space/Return, and
+        `click()`/`invoke()`. Runs the constructor `on_click=` callback, then
+        emits `<<Click>>` so `on_click()` subscribers see the same activation.
+        """
+        if self._on_click_cmd is not None:
+            self._on_click_cmd()
+        # `when='now'` delivers to subscribers synchronously, so a click()/invoke()
+        # notifies handlers before it returns (matches the on_click= callback).
+        self._internal.event_generate("<<Click>>", when="now")
 
     # ----- Events -----
 
@@ -156,14 +191,17 @@ class Button(IconProperty, ImageProperty, PublicWidgetBase):
         Called with no handler, returns a composable `Stream`. Called with a
         handler, binds it immediately and returns a `Subscription`.
 
-        For a simple click action prefer the `on_click=` constructor argument,
-        which takes a no-argument callback. This method's handler receives the
-        curated `Event` (pointer position, modifier keys), consistent with every
-        other `on_*` shorthand.
+        Fires on activation — a mouse release over the button, a keyboard
+        Space/Return while focused, or :meth:`click`/`invoke` — and never while
+        the button is disabled, matching the `on_click=` constructor argument.
+        For a simple no-argument action prefer that constructor argument; use
+        this method (or its `Stream`) to compose the click event.
 
         Args:
-            handler: Called with the click :class:`~bootstack.events.Event`
-                (pointer position, modifier keys). Omit to get a composable
+            handler: Called with the click :class:`~bootstack.events.Event`.
+                The event marks the activation; because keyboard and
+                programmatic activations carry no pointer, treat position and
+                modifier fields as unset. Omit the handler to get a composable
                 :class:`~bootstack.streams.Stream`.
 
         Returns:
@@ -173,4 +211,7 @@ class Button(IconProperty, ImageProperty, PublicWidgetBase):
         return self.on("click", handler)
 
 
-register_widget_events(Button, {})
+# "click" resolves to the <<Click>> virtual event emitted by the command
+# dispatcher (see _dispatch_click) rather than the global <Button-1> mapping, so
+# both the handler and Stream forms fire on activation and honor disabled state.
+register_widget_events(Button, {"click": "<<Click>>"})

--- a/tests/widgets/public/test_button_review.py
+++ b/tests/widgets/public/test_button_review.py
@@ -1,0 +1,126 @@
+"""Button review fixes (feat/button-review).
+
+Three correctness fixes from the formal Button review:
+
+1. `disabled` getter reads the ttk state *flag* (`instate`), not a `cget('state')`
+   string compare — so a flag-set disabled state (e.g. via composite state
+   propagation) is reported correctly.
+2. `text` get/set route through the bound textvariable when a `textsignal` owns
+   the text (ttk's `text` option no longer tracks the display in that mode).
+3. `on_click()` resolves to the activation path (the `<<Click>>` event emitted by
+   the command dispatcher), so it fires on mouse/keyboard/`click()` activation,
+   honors disabled state, and is consistent with the `on_click=` callback. Both
+   the handler and Stream forms compose on the same event.
+"""
+import pytest
+
+import bootstack as bs
+
+
+@pytest.fixture(scope="module")
+def app():
+    a = bs.App()
+    a.__enter__()
+    a._tk_root.deiconify()
+    a._tk_root.update_idletasks()
+    try:
+        yield a
+    finally:
+        try:
+            a.__exit__(None, None, None)
+        except Exception:
+            pass
+        try:
+            a._tk_root.destroy()
+        except Exception:
+            pass
+
+
+# ----- disabled getter -----
+
+def test_disabled_setter_roundtrips(app):
+    b = bs.Button("x")
+    assert b.disabled is False
+    b.disabled = True
+    assert b.disabled is True
+    b.disabled = False
+    assert b.disabled is False
+
+
+def test_disabled_getter_reads_state_flag(app):
+    # A disabled flag set directly (as composite state propagation does) must be
+    # reported — the old cget('state') compare missed this.
+    b = bs.Button("x")
+    b._internal.state(("disabled",))
+    assert b.disabled is True
+
+
+# ----- text get/set with a bound signal -----
+
+def test_text_get_set_unbound(app):
+    b = bs.Button("Plain")
+    assert b.text == "Plain"
+    b.text = "New"
+    assert b.text == "New"
+
+
+def test_text_get_set_with_textsignal(app):
+    sig = bs.Signal("Initial")
+    b = bs.Button(textsignal=sig)
+    assert b.text == "Initial"
+
+    # Setting .text writes through the bound variable and keeps the signal in sync.
+    b.text = "Changed"
+    assert b.text == "Changed"
+    assert sig() == "Changed"
+
+    # Signal writes flow back to .text.
+    sig.set("ViaSignal")
+    assert b.text == "ViaSignal"
+
+
+# ----- on_click activation semantics -----
+
+def test_click_fires_both_callback_and_handler(app):
+    seen = {"cmd": 0, "handler": 0}
+    b = bs.Button("x", on_click=lambda: seen.__setitem__("cmd", seen["cmd"] + 1))
+    b.on_click(lambda e: seen.__setitem__("handler", seen["handler"] + 1))
+
+    b.click()
+    assert seen == {"cmd": 1, "handler": 1}
+
+
+def test_click_is_noop_when_disabled(app):
+    seen = {"cmd": 0, "handler": 0}
+    b = bs.Button("x", on_click=lambda: seen.__setitem__("cmd", seen["cmd"] + 1))
+    b.on_click(lambda e: seen.__setitem__("handler", seen["handler"] + 1))
+
+    b.disabled = True
+    b.click()
+    b._internal.invoke()
+    assert seen == {"cmd": 0, "handler": 0}
+
+
+def test_on_click_stream_form(app):
+    got = []
+    b = bs.Button("y")
+    sub = b.on_click().map(lambda e: "clicked").listen(lambda v: got.append(v))
+
+    b.click()
+    b.click()
+    assert got == ["clicked", "clicked"]
+
+    sub.cancel()
+    b.click()
+    assert got == ["clicked", "clicked"]
+
+
+def test_on_click_handler_receives_event(app):
+    received = []
+    b = bs.Button("z")
+    b.on_click(lambda e: received.append(e))
+    b.click()
+    assert len(received) == 1
+    # The activation event carries the widget; pointer/modifier fields are unset
+    # for programmatic/keyboard activation, so we only assert delivery here.
+    assert received[0] is not None


### PR DESCRIPTION
Formal **Button** widget review (audit → fix → test → docs → follow-up). Each audit claim was repro-verified before fixing.

## Correctness fixes

1. **`disabled` getter** — read the ttk state *flag* via `instate(("disabled",))` instead of a `cget("state")` string compare, which misreported a flag-set disabled state (reachable via composite state propagation: `cget('state')` returned `'normal'` while the button was disabled).
2. **`text` get/set** — route through the bound `textvariable` when a `textsignal`/`textvariable` owns the text. ttk's `text` option no longer tracks the display in that mode, so the setter silently no-op'd and the getter read stale; both are now symmetric and keep the signal in sync.
3. **`on_click` → activation-based** — `"click"` now resolves to a `<<Click>>` virtual event emitted by a command dispatcher rather than the global `<Button-1>` mapping. A click fires on mouse release over the button, keyboard `Space`/`Return`, or `click()`/`invoke()`, and **never while disabled** — and both the handler and `Stream` forms compose on the same event. Previously `on_click()` bound raw `<Button-1>`: it fired on disabled buttons, missed keyboard activation, and wasn't triggered by `click()`. The `on_click=` constructor callback was already correct and is unchanged. `ThemeToggle`/`SidebarToggle` (Button subclasses) verified — they pass `on_click=` and work unchanged.

## Docs

- Mental-model lead (action + intent/weight), proper **Events** section (activation semantics; `on_click=` vs `on_click()` vs `Stream`; `.. note::` on the unset-pointer caveat for keyboard/programmatic activation), **Keyboard** section, and **See also** cross-links.
- Corrected the stale *"image API being finalized — prefer icon names"* note: the `Image` handle is public (`bootstack.images`), with a working `image=` example + cross-links. Swept the rest of the docs/docstrings — no other stale image references.

## Tests / verification

- `tests/widgets/public/test_button_review.py` (8) — disabled flag-path + setter, text get/set with and without a bound signal, click fires both callback and handler, click no-op when disabled, Stream form, handler receives the event.
- `tests/test_public_surface.py` (161) green; example launches; clean `-W` docs build.

## Follow-up

- **#242** — the `.text`-setter-with-`textsignal` dead-write is a family-wide pattern (confirmed on `Label`); audit/fix the rest there rather than scope-creep this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)