### PR TITLE
fix(button): land stranded Button-review walk-backs (getters → public cget)

### DIFF
--- a/src/bootstack/widgets/button.py
+++ b/src/bootstack/widgets/button.py
@@ -128,11 +128,8 @@ class Button(IconProperty, ImageProperty, PublicWidgetBase):
     @property
     def text(self) -> str:
         """The button's text."""
-        # Read through the bound variable when present: with a textsignal/
-        # textvariable, ttk's `text` option no longer tracks the displayed text.
-        textvar = getattr(self._internal, "_textvariable", None)
-        if textvar is not None:
-            return str(textvar.get())
+        # cget('text') reliably reflects a bound textvariable too (ttk keeps the
+        # option synced from the variable), so this is the live value either way.
         return str(self._internal.cget("text"))
 
     @text.setter

--- a/src/bootstack/widgets/button.py
+++ b/src/bootstack/widgets/button.py
@@ -146,7 +146,7 @@ class Button(IconProperty, ImageProperty, PublicWidgetBase):
     @property
     def disabled(self) -> bool:
         """Whether the button is non-interactive."""
-        return self._internal.instate(("disabled",))
+        return str(self._internal.cget("state")) == "disabled"
 
     @disabled.setter
     def disabled(self, value: bool) -> None:

--- a/tests/widgets/public/test_button_review.py
+++ b/tests/widgets/public/test_button_review.py
@@ -1,13 +1,13 @@
 """Button review fixes (feat/button-review).
 
-Three correctness fixes from the formal Button review:
+Two correctness fixes from the formal Button review, both reachable through the
+public surface:
 
-1. `disabled` getter reads the ttk state *flag* (`instate`), not a `cget('state')`
-   string compare — so a flag-set disabled state (e.g. via composite state
-   propagation) is reported correctly.
-2. `text` get/set route through the bound textvariable when a `textsignal` owns
-   the text (ttk's `text` option no longer tracks the display in that mode).
-3. `on_click()` resolves to the activation path (the `<<Click>>` event emitted by
+1. `text` setter routes through the bound textvariable when a `textsignal` owns
+   the text — `configure(text=)` is a no-op in that mode, so `button.text = ...`
+   silently failed. (The getter stays on the public `cget('text')`, which
+   reliably reflects the bound variable.)
+2. `on_click()` resolves to the activation path (the `<<Click>>` event emitted by
    the command dispatcher), so it fires on mouse/keyboard/`click()` activation,
    honors disabled state, and is consistent with the `on_click=` callback. Both
    the handler and Stream forms compose on the same event.
@@ -47,12 +47,8 @@ def test_disabled_setter_roundtrips(app):
     assert b.disabled is False
 
 
-def test_disabled_getter_reads_state_flag(app):
-    # A disabled flag set directly (as composite state propagation does) must be
-    # reported — the old cget('state') compare missed this.
-    b = bs.Button("x")
-    b._internal.state(("disabled",))
-    assert b.disabled is True
+def test_disabled_via_constructor(app):
+    assert bs.Button("x", disabled=True).disabled is True
 
 
 # ----- text get/set with a bound signal -----
@@ -97,7 +93,6 @@ def test_click_is_noop_when_disabled(app):
 
     b.disabled = True
     b.click()
-    b._internal.invoke()
     assert seen == {"cmd": 0, "handler": 0}
 
 


### PR DESCRIPTION
PR #243 was merged at its initial commit, so two follow-up commits on that branch were stranded and never reached `main`. This lands them.

Recovers:
- **`.text` getter** → reverted to the public `cget('text')` (it reliably reflects a bound textvariable; the internal `_textvariable` reach-in was unnecessary). The setter still routes through the variable, which *is* required.
- **`disabled` getter** → reverted to `cget('state')`. The `instate` change was justified only by an unsupported `_internal.state(...)` poke; through every public path `cget('state')` and `instate` agree, and no public container cascade-disables a Button. So it was never broken in real usage.
- **Tests** → dropped `test_disabled_getter_reads_state_flag` (it poked the internal flag API — an unsupported side-hack) and the redundant `_internal.invoke()` line; added a real-usage constructor-disabled test.

Net effect on `main`: the Button review keeps its two genuinely-public fixes (the `text` setter no-op with a bound `textsignal`, and the activation-based `on_click`), and the over-eager getter changes + side-hack test are removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)