### PR TITLE
docs(buttongroup): review pass — Events/Keyboard sections + regression tests

### DIFF
--- a/docs/widgets/buttongroup.rst
+++ b/docs/widgets/buttongroup.rst
@@ -4,6 +4,13 @@ ButtonGroup
 A row (or column) of visually-connected buttons sharing a common accent and
 variant. Buttons are added one at a time via ``add()``.
 
+Think of a ButtonGroup as a set of related *actions* with one shared style and
+one shared click handler: each button carries a ``key``, and ``on_click()`` on
+the group reports which key was pressed — so you handle the whole cluster in one
+place instead of wiring each button separately. Reach for :doc:`togglegroup`
+instead when the buttons represent a *selection* to remember rather than actions
+to fire.
+
 .. image:: /_static/examples/buttongroup-hero-light.png
    :class: bs-screenshot-light
    :alt: ButtonGroup — light theme
@@ -191,32 +198,43 @@ once. Toggle the ``disabled`` property at runtime to re-enable.
    :class: bs-screenshot-dark
    :alt: ButtonGroup disabled — dark theme
 
-Handling clicks
-~~~~~~~~~~~~~~~
+Events
+~~~~~~
 
-Use ``on_click()`` on the group to handle any button press in one place.
-The handler receives a :class:`ButtonGroupClickEvent
-<bootstack.events.ButtonGroupClickEvent>` with ``key``, ``text``, and ``icon``
-for the clicked button.
+Use ``on_click()`` on the group to handle any button press in one place — the
+handler receives a :class:`ButtonGroupClickEvent
+<bootstack.events.ButtonGroupClickEvent>` with the ``key``, ``text``, and
+``icon`` of the button that fired. A disabled button never fires.
 
 .. code-block:: python
 
    bg = bs.ButtonGroup(accent="primary")
    bg.add("Save",   icon="save",  key="save")
-   bg.add("Cancel", icon="x-lg", key="cancel")
+   bg.add("Cancel", icon="x-lg",  key="cancel")
    bg.add("Delete", icon="trash", key="delete")
 
    def handle_click(e):
        print(e.key, e.text, e.icon)
 
-   bg.on_click(handle_click)
-
-   # As a subscription (cancellable)
+   # Subscription (cancellable)
    sub = bg.on_click(handle_click)
    sub.cancel()
 
-   # As a Stream (composable)
-   bg.on_click().listen(handle_click)
+   # Stream (composable) — e.g. only the "delete" key
+   bg.on_click().filter(lambda e: e.key == "delete").listen(handle_click)
+
+.. note::
+
+   See :doc:`/tasks/handling-actions` for routing actions across a screen and
+   :doc:`/reference/events` for the event model behind ``on_click``.
+
+Keyboard
+~~~~~~~~
+
+- **Tab / Shift+Tab** — move focus between the buttons in the group (disabled
+  buttons are skipped).
+- **Space / Return** — activate the focused button, firing ``on_click`` exactly
+  as a mouse click does.
 
 Managing items
 ~~~~~~~~~~~~~~

--- a/src/bootstack/widgets/_impl/composites/buttongroup.py
+++ b/src/bootstack/widgets/_impl/composites/buttongroup.py
@@ -366,6 +366,6 @@ class ButtonGroup(Frame):
         for widget in self._widgets.values():
             try:
                 widget.configure(state=value)
-            except:
+            except Exception:
                 # Widget doesn't support state configuration
                 pass

--- a/tests/widgets/public/test_buttongroup_review.py
+++ b/tests/widgets/public/test_buttongroup_review.py
@@ -1,0 +1,127 @@
+"""ButtonGroup review — regression coverage for the group contract.
+
+The review found no correctness bugs; these lock the behaviors that matter for a
+group: disabled state propagates to every member (on construction, via the live
+property, and to buttons added while disabled), `on_click` reports the clicked
+button's key/text/icon and honors disabled, and item management stays consistent
+across add/remove.
+"""
+import pytest
+
+import bootstack as bs
+
+
+@pytest.fixture(scope="module")
+def app():
+    a = bs.App()
+    a.__enter__()
+    a._tk_root.deiconify()
+    a._tk_root.update_idletasks()
+    try:
+        yield a
+    finally:
+        try:
+            a.__exit__(None, None, None)
+        except Exception:
+            pass
+        try:
+            a._tk_root.destroy()
+        except Exception:
+            pass
+
+
+def _member_states(bg):
+    return [str(bg.item(k).cget("state")) for k in bg.keys]
+
+
+# ----- disabled propagation -----
+
+def test_disabled_propagates_from_constructor(app):
+    bg = bs.ButtonGroup(disabled=True)
+    bg.add("A", key="a")
+    bg.add("B", key="b")
+    assert bg.disabled is True
+    assert _member_states(bg) == ["disabled", "disabled"]
+
+
+def test_disabled_property_toggles_all_members(app):
+    bg = bs.ButtonGroup()
+    bg.add("A", key="a")
+    bg.add("B", key="b")
+    assert _member_states(bg) == ["normal", "normal"]
+
+    bg.disabled = True
+    assert _member_states(bg) == ["disabled", "disabled"]
+
+    bg.disabled = False
+    assert _member_states(bg) == ["normal", "normal"]
+
+
+def test_button_added_while_disabled_inherits_state(app):
+    bg = bs.ButtonGroup()
+    bg.add("A", key="a")
+    bg.disabled = True
+    bg.add("B", key="b")  # added after the group was disabled
+    assert _member_states(bg) == ["disabled", "disabled"]
+
+
+# ----- on_click -----
+
+def test_on_click_reports_clicked_button(app):
+    bg = bs.ButtonGroup()
+    bg.add("Save", icon="save", key="save")
+    bg.add("Delete", key="del")
+    seen = []
+    bg.on_click(lambda e: seen.append((e.key, e.text, e.icon)))
+
+    bg.item("save").invoke()
+    assert seen == [("save", "Save", "save")]
+
+
+def test_disabled_member_does_not_fire(app):
+    bg = bs.ButtonGroup()
+    bg.add("Save", key="save")
+    seen = []
+    bg.on_click(lambda e: seen.append(e.key))
+
+    bg.disabled = True
+    bg.item("save").invoke()
+    assert seen == []
+
+
+def test_on_click_stream_form(app):
+    bg = bs.ButtonGroup()
+    bg.add("A", key="a")
+    bg.add("B", key="b")
+    keys = []
+    bg.on_click().map(lambda e: e.key).listen(keys.append)
+
+    bg.item("a").invoke()
+    bg.item("b").invoke()
+    assert keys == ["a", "b"]
+
+
+# ----- item management -----
+
+def test_keys_len_contains(app):
+    bg = bs.ButtonGroup()
+    bg.add("A", key="a")
+    bg.add_all([dict(label="B", key="b"), "C"])  # "C" gets an auto key
+    assert bg.keys[:2] == ("a", "b")
+    assert len(bg) == 3
+    assert "a" in bg
+    assert "missing" not in bg
+
+
+def test_remove_and_query(app):
+    bg = bs.ButtonGroup()
+    bg.add("Save", key="save")
+    bg.add("Cancel", key="cancel")
+    assert bg.query_item("save", "text") == "Save"
+
+    bg.update_item("save", text="Saving…")
+    assert bg.query_item("save", "text") == "Saving…"
+
+    bg.remove("cancel")
+    assert "cancel" not in bg
+    assert len(bg) == 1


### PR DESCRIPTION
Formal **ButtonGroup** widget review (audit → verify → docs → tests).

## Audit result: no correctness bugs

Verified via public-path repros:
- **Disabled propagation** is fully correct — `ButtonGroup(disabled=True)`, live `group.disabled = ...`, re-disabling after enabling, and buttons `add()`ed while the group is disabled all end up consistent.
- **`on_click`** reports the clicked button's `key`/`text`/`icon` via `ButtonGroupClickEvent`, never fires for a disabled button, and composes as a `Stream`.

(The audit ran adversarially and public-path-only — no findings depended on poking internals.)

## No live-property additions

`accent`/`variant`/`density`/`orient` have working internal delegates but are intentionally **construction-only** — a group's styling and orientation are design-time decisions, not legitimate runtime needs. Left as-is by design (runtime scoping was already decided across the widget set).

## Changes

- **Docs** — mental-model lead (group = keyed actions + one shared handler; reach for `ToggleGroup` for selection); retitled *Handling clicks* → **Events** with `/reference/events` + `/tasks/handling-actions` cross-links and a corrected example (it previously registered `on_click` twice — now shows distinct subscription + Stream forms); new **Keyboard** section (Tab between members, Space/Return activates).
- **Hygiene** — bare `except:` → `except Exception:` in the internal `_delegate_state` (the one real code-quality item; not a public bug).
- **Tests** — `tests/widgets/public/test_buttongroup_review.py` (8) locking disabled propagation, `on_click` (handler/stream/disabled), and item management.

## Verification

8 tests pass; `tests/test_public_surface.py` (161) green; clean `-W` docs build; example launches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)