### PR TITLE
fix(textarea): read-only state sync + Tab focus-trap (widget review)

### DIFF
--- a/docs/widgets/textarea.rst
+++ b/docs/widgets/textarea.rst
@@ -4,6 +4,12 @@ TextArea
 A multi-line text input with optional label, placeholder, scrollbars, and
 undo/redo support.
 
+The content is the ``value`` (read or set it directly, or bind a ``Signal`` with
+``textsignal=``). Listen as the user types with ``on_input``, or once they leave
+the field with ``on_change`` — that input-vs-commit choice is the main decision
+you make. Everything else (validation, undo/redo, dirty tracking) layers on top
+for richer editor-like fields.
+
 .. image:: /_static/examples/textarea-hero-light.png
    :class: bs-screenshot-light
    :alt: TextArea — light theme
@@ -127,6 +133,29 @@ commit-on-blur behaviour (fires when the user leaves the field).
    # As a debounced Stream
    ta.on_input().debounce(500).listen(lambda e: autosave(ta.value))
 
+.. note::
+
+   ``on_input`` fires on every edit (it runs often — keep the handler cheap or
+   ``debounce`` it); ``on_change`` fires once on blur. See
+   :doc:`/reference/events` for the full event model.
+
+Validation
+~~~~~~~~~~
+
+Mark the field ``required``, cap its length with ``max_length``, or attach rules
+with ``add_validation_rule()``; ``validate()`` runs them and the error shows
+below the field. Listen with ``on_valid`` / ``on_invalid``.
+
+.. code-block:: python
+
+   ta = bs.TextArea(label="Bio", required=True, max_length=200)
+   ta.add_validation_rule("stringLength", min=20, message="At least 20 characters.")
+
+   ta.on_invalid(lambda e: print("invalid:", e))
+   ta.validate()
+
+See :doc:`/reference/validation` for the full rule set and the typed-value model.
+
 Undo and redo
 ~~~~~~~~~~~~~
 
@@ -152,6 +181,16 @@ Use it to show unsaved-change indicators.
 
    # After saving
    ta.mark_saved()
+
+Keyboard
+~~~~~~~~
+
+- **Tab / Shift+Tab** — move focus to the next/previous widget. A TextArea is a
+  form field, so Tab leaves it rather than inserting a tab character (use
+  :doc:`codeeditor` when you want Tab to indent).
+- **Ctrl+Z / Ctrl+Y** — undo / redo the last edit.
+- Standard text editing and selection (arrows, Home/End, Shift+arrows) apply
+  within the field.
 
 Widget sizing
 ~~~~~~~~~~~~~

--- a/src/bootstack/widgets/_impl/composites/textarea/core.py
+++ b/src/bootstack/widgets/_impl/composites/textarea/core.py
@@ -246,6 +246,32 @@ class _MultilineCore(tk.Frame):
         if was_disabled:
             self.text.configure(state=tk.DISABLED)
 
+    @property
+    def read_only(self) -> bool:
+        """Whether the text is visible but not editable."""
+        return self._read_only
+
+    @read_only.setter
+    def read_only(self, value: bool) -> None:
+        # Keep the flag and the widget state in lockstep: the value/insert
+        # setters consult `_read_only` to know whether to lift the disabled
+        # state for a programmatic write.
+        self._read_only = bool(value)
+        self.text.configure(state=tk.DISABLED if self._read_only else tk.NORMAL)
+
+    def insert(self, index: str, text: str) -> None:
+        """Insert text at `index`, applying even when read-only.
+
+        Read-only blocks *user* edits, not programmatic ones, so this lifts the
+        disabled state for the write and restores it (matching the value setter).
+        """
+        was_disabled = self._read_only
+        if was_disabled:
+            self.text.configure(state=tk.NORMAL)
+        self.text.insert(index, text)
+        if was_disabled:
+            self.text.configure(state=tk.DISABLED)
+
     def bind_signal(self, signal) -> None:
         """Bind a Signal[str] — updates the text when the signal changes."""
         if self._signal is not None:

--- a/src/bootstack/widgets/_impl/composites/textarea/textarea.py
+++ b/src/bootstack/widgets/_impl/composites/textarea/textarea.py
@@ -160,6 +160,15 @@ class TextArea(GridFrame):
         else:
             self._core.grid(row=1, column=0, sticky="nsew")
 
+        # ── Tab moves focus (not a keyboard trap) ─────────────────────────
+        # A multi-line tk.Text inserts a literal tab on <Tab> and keeps focus,
+        # which traps keyboard users in a form field. Rebind Tab/Shift-Tab to
+        # move focus like every other field. (CodeEditor keeps Tab for indent —
+        # it is a separate composite and is unaffected.)
+        self._core.text.bind("<Tab>", self._focus_next, add="+")
+        self._core.text.bind("<Shift-Tab>", self._focus_prev, add="+")
+        self._core.text.bind("<ISO_Left_Tab>", self._focus_prev, add="+")
+
         # ── message label (row 2) ─────────────────────────────────────────
         self._message_lbl = Label(self, text=message or "", font="caption",
                                   accent="secondary")
@@ -222,18 +231,38 @@ class TextArea(GridFrame):
 
     def _show_placeholder(self) -> None:
         self._showing_placeholder = True
+        was_read_only = self._core._read_only
         self._core.text.configure(state=tk.NORMAL)
         self._core.text.insert("1.0", self._placeholder_text)
         self._core.text.configure(foreground="grey")
+        # Restore read-only state — showing a placeholder must not silently make
+        # a read-only field editable.
+        if was_read_only:
+            self._core.text.configure(state=tk.DISABLED)
 
     def _hide_placeholder(self) -> None:
         self._showing_placeholder = False
+        was_read_only = self._core._read_only
+        if was_read_only:
+            self._core.text.configure(state=tk.NORMAL)
         self._core.text.delete("1.0", tk.END)
         self._core.text.configure(foreground=self._default_fg)
+        if was_read_only:
+            self._core.text.configure(state=tk.DISABLED)
 
     def _on_focus_in_placeholder(self, _event: tk.Event) -> None:
         if self._showing_placeholder:
             self._hide_placeholder()
+
+    # ── focus traversal ───────────────────────────────────────────────────
+
+    def _focus_next(self, event: tk.Event) -> str:
+        event.widget.tk_focusNext().focus_set()
+        return "break"
+
+    def _focus_prev(self, event: tk.Event) -> str:
+        event.widget.tk_focusPrev().focus_set()
+        return "break"
 
     # ── message / error area ──────────────────────────────────────────────
 

--- a/src/bootstack/widgets/textarea.py
+++ b/src/bootstack/widgets/textarea.py
@@ -181,11 +181,13 @@ class TextArea(PublicWidgetBase):
     @property
     def read_only(self) -> bool:
         """Whether the text area is visible but not editable."""
-        return self._internal._core.text.cget("state") == "disabled"
+        return self._internal._core.read_only
 
     @read_only.setter
     def read_only(self, v: bool) -> None:
-        self._internal._core.text.configure(state="disabled" if v else "normal")
+        # Delegate to the core property so its `_read_only` flag stays in sync —
+        # the value/insert setters rely on it to apply programmatic writes.
+        self._internal._core.read_only = v
 
     @property
     def is_dirty(self) -> bool:
@@ -230,7 +232,7 @@ class TextArea(PublicWidgetBase):
             index: Target text position, e.g. `'end'` or `'1.0'`.
             text: Text to insert.
         """
-        self._internal._core.text.insert(index, text)
+        self._internal._core.insert(index, text)
 
     def select_all(self) -> None:
         """Select all text content."""

--- a/tests/widgets/public/test_textarea_review.py
+++ b/tests/widgets/public/test_textarea_review.py
@@ -1,0 +1,87 @@
+"""TextArea review fixes (feat/textarea-review).
+
+Read-only state management was broken: the public `read_only` setter and the
+placeholder code poked the tk.Text `state` directly without syncing the core's
+`_read_only` flag, so programmatic writes silently failed and the placeholder
+flipped a read-only field editable. And the multi-line text widget trapped Tab
+(inserting a tab char and keeping focus) — a keyboard trap for a form field.
+
+Fixes verified here:
+1. `read_only` set via the property keeps programmatic `value=`/`insert()` working
+   and reads back correctly (parity with constructor `read_only=True`).
+2. `insert()` applies even when read-only, leaving the field read-only.
+3. A placeholder shown on a read-only field does not make it editable.
+4. Tab moves focus instead of inserting a tab character.
+"""
+import pytest
+
+import bootstack as bs
+
+
+@pytest.fixture(scope="module")
+def app():
+    a = bs.App()
+    a.__enter__()
+    a._tk_root.deiconify()
+    a._tk_root.update_idletasks()
+    try:
+        yield a
+    finally:
+        try:
+            a.__exit__(None, None, None)
+        except Exception:
+            pass
+        try:
+            a._tk_root.destroy()
+        except Exception:
+            pass
+
+
+# ----- read-only state management -----
+
+def test_read_only_via_property_still_allows_programmatic_value(app):
+    ta = bs.TextArea(value="test")
+    ta.read_only = True
+    assert ta.read_only is True
+    ta.value = "new"
+    assert ta.value == "new"  # programmatic write applies despite read-only
+
+
+def test_read_only_via_constructor_allows_programmatic_value(app):
+    ta = bs.TextArea(value="test", read_only=True)
+    ta.value = "new"
+    assert ta.value == "new"
+
+
+def test_read_only_toggle_round_trip(app):
+    ta = bs.TextArea(value="a")
+    ta.read_only = True
+    ta.read_only = False
+    assert ta.read_only is False
+    ta.value = "editable"
+    assert ta.value == "editable"
+
+
+def test_insert_applies_when_read_only(app):
+    ta = bs.TextArea(value="abc", read_only=True)
+    ta.insert("end", "XYZ")
+    assert ta.value == "abcXYZ"
+    assert ta.read_only is True  # still read-only after the programmatic insert
+
+
+def test_placeholder_does_not_make_read_only_editable(app):
+    ta = bs.TextArea(placeholder="hint", read_only=True, value="")
+    app._tk_root.update_idletasks()
+    assert ta.read_only is True
+
+
+# ----- Tab is not a keyboard trap -----
+
+def test_tab_moves_focus_instead_of_inserting_tab(app):
+    ta = bs.TextArea(value="x")
+    tw = ta._internal._core.text
+    tw.focus_set()
+    tw.event_generate("<Tab>", when="now")
+    app._tk_root.update_idletasks()
+    assert ta.value == "x"  # no tab character was inserted
+    assert "\t" not in ta.value


### PR DESCRIPTION
Formal **TextArea** widget review (audit → fix → test → docs → follow-up). Four confirmed correctness bugs, each verified by a public-path repro before fixing.

## Correctness fixes

1. **`read_only` via the property left writes broken.** The property poked `text.configure(state=)` directly without syncing the core's `_read_only` flag, which the value/insert setters consult to lift the disabled state for a programmatic write. So after `ta.read_only = True`, `ta.value = "x"` silently failed (constructor `read_only=True` worked). Fix: a real `read_only` property on the core that keeps the flag and widget state in lockstep; the wrapper delegates to it.
2. **`insert()` ignored read-only** and silently failed on a disabled `tk.Text`. Now routes through a state-preserving `core.insert()` (lifts/restores the disabled state like the value setter), so programmatic inserts always apply.
3. **Placeholder broke read-only.** Showing/hiding the placeholder flipped the field to NORMAL and never restored it, leaving a "read-only" field editable. Now preserves the read-only state across placeholder render.
4. **Tab focus-trap.** A multi-line `tk.Text` inserts a literal tab on `<Tab>` and keeps focus — a keyboard trap in a form field. Rebound Tab/Shift-Tab to move focus. **CodeEditor is a separate composite and keeps Tab-for-indent** (verified unaffected).

## Docs

- Mental-model lead (value/textsignal; the input-vs-commit choice; validation/undo/dirty layer on top).
- New **Validation** section + `/reference/validation` cross-link (the gap the field reviews fixed).
- New **Keyboard** section (documents Tab-moves-focus and Ctrl+Z/Y).
- Events `.. note::` cross-linking `/reference/events`.

## Follow-up

- **#246** — add reactive `.valid`/`.error` Signal properties for field parity. **TextArea only** — CodeEditor is not a form field and is explicitly excluded from the form-validation surface.

## Verification

`tests/widgets/public/test_textarea_review.py` (6) pass; `tests/test_public_surface.py` (161) green; clean `-W` docs build; example launches; CodeEditor + normal editing/undo unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)