### PR TITLE
fix(textarea): bind undo/redo to native <<Undo>>/<<Redo>> virtual events

### DIFF
--- a/docs/widgets/textarea.rst
+++ b/docs/widgets/textarea.rst
@@ -160,7 +160,8 @@ Undo and redo
 ~~~~~~~~~~~~~
 
 TextArea maintains a built-in undo/redo stack. Call ``undo()`` and ``redo()``
-programmatically, or let the user use Ctrl+Z / Ctrl+Y.
+programmatically, or let the user use the platform's standard undo/redo
+shortcuts (Ctrl+Z / Ctrl+Y on Windows and Linux, ⌘Z / ⌘⇧Z on macOS).
 
 .. code-block:: python
 
@@ -188,7 +189,8 @@ Keyboard
 - **Tab / Shift+Tab** — move focus to the next/previous widget. A TextArea is a
   form field, so Tab leaves it rather than inserting a tab character (use
   :doc:`codeeditor` when you want Tab to indent).
-- **Ctrl+Z / Ctrl+Y** — undo / redo the last edit.
+- **Undo / redo** — the platform's standard shortcuts (Ctrl+Z / Ctrl+Y on
+  Windows and Linux, ⌘Z / ⌘⇧Z on macOS).
 - Standard text editing and selection (arrows, Home/End, Shift+arrows) apply
   within the field.
 

--- a/src/bootstack/widgets/_impl/composites/textarea/core.py
+++ b/src/bootstack/widgets/_impl/composites/textarea/core.py
@@ -118,9 +118,14 @@ class _MultilineCore(tk.Frame):
         if read_only:
             self.text.configure(state=tk.DISABLED)
 
-        # Keyboard undo/redo (Ctrl+Z / Ctrl+Shift+Z)
-        self.text.bind("<Control-z>", lambda e: (self._undo_manager.undo(), "break")[1], add="+")
-        self.text.bind("<Control-Z>", lambda e: (self._undo_manager.redo(), "break")[1], add="+")
+        # Keyboard undo/redo: drive our UndoManager from Tk's platform-aware
+        # <<Undo>>/<<Redo>> virtual events rather than hardcoding keys, so the
+        # native per-OS shortcut applies (Ctrl+Z / Ctrl+Y on Windows & Linux,
+        # Cmd+Z / Cmd+Shift+Z on macOS). undo=False means Tk's own handlers for
+        # these events no-op; the widget-level binding runs first and "break"
+        # suppresses the (empty) class handler.
+        self.text.bind("<<Undo>>", lambda e: (self._undo_manager.undo(), "break")[1], add="+")
+        self.text.bind("<<Redo>>", lambda e: (self._undo_manager.redo(), "break")[1], add="+")
 
         # <<Modified>> still fires from Tk's edit_modified flag (independent
         # of the undo stack) — enrich with is_dirty payload.

--- a/tests/widgets/public/test_textarea_review.py
+++ b/tests/widgets/public/test_textarea_review.py
@@ -85,3 +85,17 @@ def test_tab_moves_focus_instead_of_inserting_tab(app):
     app._tk_root.update_idletasks()
     assert ta.value == "x"  # no tab character was inserted
     assert "\t" not in ta.value
+
+
+# ----- undo/redo bound to native virtual events -----
+
+def test_undo_redo_use_native_virtual_events(app):
+    # Drive the custom UndoManager from Tk's platform-aware <<Undo>>/<<Redo>>
+    # events so the OS-native shortcut applies (Ctrl+Z / Ctrl+Y on Windows),
+    # rather than hardcoding keys.
+    ta = bs.TextArea(value="x")
+    tw = ta._internal._core.text
+    assert tw.bind("<<Undo>>")  # bound
+    assert tw.bind("<<Redo>>")  # bound
+    # The old hardcoded redo key (Ctrl+Shift+Z) is no longer bound directly.
+    assert not tw.bind("<Control-Z>")


### PR DESCRIPTION
Follow-up to the TextArea review (#247).

## Problem

The textarea core hardcoded `<Control-z>`/`<Control-Z>` for undo/redo, which:
- forced **redo to Ctrl+Shift+Z on every platform**, and
- ignored Tk's platform-aware `<<Undo>>` / `<<Redo>>` virtual events, which already map to the OS-native keys (Ctrl+Z / **Ctrl+Y** on Windows & Linux, ⌘Z / ⌘⇧Z on macOS).

In other words it reinvented a binding Tk provides natively, and got the platform key wrong.

## Fix

Drive the custom `UndoManager` from the `<<Undo>>`/`<<Redo>>` virtual events instead of hardcoded keys. The OS decides the shortcut; no reinvention. `undo=False` keeps Tk's own handlers for these events no-op, and the widget-level binding runs first and `"break"`s to suppress the empty class handler. Programmatic `undo()`/`redo()` are unchanged.

**CodeEditor** shares this core, so it gets the same platform-correct undo/redo for free.

## Verification

- `<<Undo>>`/`<<Redo>>` bound; hardcoded `<Control-Z>` gone; programmatic undo/redo intact.
- `tests/widgets/public/test_textarea_review.py` (7) pass; clean `-W` docs build.
- Actual keypress behavior (Ctrl+Z / Ctrl+Y on Windows) is best confirmed in a real run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)