### PR TITLE
fix(codeeditor): read-only insert no-op + cursor_position + docs review

### DIFF
--- a/docs/widgets/codeeditor.rst
+++ b/docs/widgets/codeeditor.rst
@@ -4,6 +4,11 @@ CodeEditor
 A full-featured code editor with syntax highlighting, line numbers, bracket
 matching, smart indent, and built-in search/replace.
 
+Think of it as a standalone editing *surface*, not a form input: it ships the
+editor behaviors (a gutter, a search bar, undo grouping) built in, and it is
+**not** Field-wrapped — there is no label, validation, or ``disabled`` state.
+Reach for :doc:`textarea` when you want a labeled multi-line field in a form.
+
 .. image:: /_static/examples/codeeditor-hero-light.png
    :class: bs-screenshot-light
    :alt: CodeEditor — light theme
@@ -66,6 +71,10 @@ Read-only state
    bs.CodeEditor(value=code, language="python")                   # editable
    bs.CodeEditor(value=code, language="python", read_only=True)   # read-only
 
+Read-only blocks *typing*, not programmatic edits: ``editor.value = ...``,
+``editor.insert(...)``, and ``editor.clear()`` all still apply, leaving the
+editor read-only afterward.
+
 .. image:: /_static/examples/codeeditor-states-light.png
    :class: bs-screenshot-light
    :alt: CodeEditor states — light theme
@@ -92,8 +101,10 @@ Editor options
 Handling changes
 ~~~~~~~~~~~~~~~~
 
-``on_change()`` fires on every edit. Use ``on_input()`` for keystroke-level
-feedback.
+``on_change()`` fires on every edit, delivering a
+:class:`~bootstack.events.ChangeEvent` whose ``value`` is the editor text. Use
+``on_input()`` for keystroke-level feedback before the change is committed. See
+:doc:`/reference/events` for the full event model.
 
 .. code-block:: python
 
@@ -108,18 +119,43 @@ Cursor position
 ~~~~~~~~~~~~~~~
 
 ``on_cursor_move()`` fires after any key press or mouse click that moves the
-insertion cursor.
+insertion cursor. Read ``cursor_position`` — a 1-indexed ``(line, column)``
+tuple — to drive a status-bar readout.
 
 .. code-block:: python
 
    editor = bs.CodeEditor(language="python")
 
    def show_pos(e):
-       idx = editor._internal._core.text.index("insert")
-       line, col = idx.split(".")
-       status.text = f"Ln {line}, Col {int(col) + 1}"
+       line, col = editor.cursor_position
+       status.text = f"Ln {line}, Col {col}"
 
    editor.on_cursor_move(show_pos)
+
+Text positions
+~~~~~~~~~~~~~~
+
+Methods that take a position — ``insert()`` and ``goto_line()`` — address it
+two ways:
+
+* ``"end"`` — just past the last character.
+* ``"line.column"`` — a line and column, for example ``"1.0"`` for the very
+  start or ``"3.4"`` for line 3 just after its fourth character. **Lines are
+  1-indexed; columns are 0-indexed**, so column ``0`` is the start of a line.
+
+.. code-block:: python
+
+   editor.insert("end", "\n# appended")   # add a trailing line
+   editor.insert("1.0", "#!/usr/bin/env python\n")  # prepend a shebang
+   editor.goto_line(42)                   # jump to line 42 (1-indexed)
+
+.. note::
+
+   ``cursor_position`` reports a **1-indexed** ``(line, column)`` tuple — column
+   ``1`` is the start of a line — because it is meant for a status-bar readout
+   (``Ln 1, Col 1``). That display convention differs from the **0-indexed**
+   column in a ``"line.column"`` address: the cursor at the very start reads
+   ``(1, 1)`` but is inserted at by ``"1.0"``.
 
 Undo and redo
 ~~~~~~~~~~~~~
@@ -159,6 +195,31 @@ Search and replace
    editor.show_search()   # open find bar
    editor.show_replace()  # open find/replace bar
    editor.hide_search()   # close the bar
+
+Keyboard
+~~~~~~~~
+
+The editor uses editor-grade key bindings rather than form-field traversal.
+Undo and redo bind to the platform's native shortcuts (``Ctrl+Z`` / ``Ctrl+Y``
+on Windows and Linux, ``Cmd+Z`` / ``Cmd+Shift+Z`` on macOS).
+
+============================  ============================================================
+Key                           Action
+============================  ============================================================
+``Tab``                       Insert indentation to the next tab stop
+``Return``                    New line, matching the current indent (``auto_indent``)
+Undo / redo                   Native per-platform shortcut (see above)
+``Ctrl+F`` / ``Cmd+F``        Open the find bar
+``Ctrl+H`` / ``Cmd+H``        Open the find/replace bar
+``Escape``                    Close the find/replace bar
+============================  ============================================================
+
+.. note::
+
+   ``Tab`` inserts indentation, so it does not move focus out of the editor —
+   that is deliberate for a code surface, matching desktop editors. Move focus
+   away by clicking another control. When you instead want a labeled multi-line
+   field where ``Tab`` advances focus, use :doc:`textarea`.
 
 Widget sizing
 ~~~~~~~~~~~~~

--- a/src/bootstack/widgets/codeeditor.py
+++ b/src/bootstack/widgets/codeeditor.py
@@ -216,6 +216,18 @@ class CodeEditor(PublicWidgetBase):
         return self._internal.is_dirty
 
     @property
+    def cursor_position(self) -> tuple[int, int]:
+        """The insertion cursor position as a 1-indexed `(line, column)` tuple.
+
+        Line 1, column 1 is the start of the content. Read it in an
+        `on_cursor_move` handler to drive a status-bar readout. Read-only —
+        use `goto_line()` to move the cursor.
+        """
+        idx = self._internal._core.text.index("insert")
+        line, col = idx.split(".")
+        return int(line), int(col) + 1
+
+    @property
     def language(self) -> str | None:
         """Active syntax highlighting language, or `None` if disabled."""
         return self._internal._language
@@ -248,10 +260,10 @@ class CodeEditor(PublicWidgetBase):
 
     @read_only.setter
     def read_only(self, v: bool) -> None:
-        self._internal._core._read_only = v
-        self._internal._core.text.configure(
-            state=tkinter.DISABLED if v else tkinter.NORMAL
-        )
+        # Route through the core property so the `_read_only` flag and the Tk
+        # widget state stay in lockstep (the value/insert setters consult the
+        # flag to lift the disabled state for programmatic writes).
+        self._internal._core.read_only = v
 
     # ----- Methods -----
 
@@ -265,11 +277,14 @@ class CodeEditor(PublicWidgetBase):
         `index` is a text position: `'end'` for the end of the content, or a
         `'line.column'` string such as `'1.0'` (line 1, column 0).
 
+        Read-only blocks *user* edits, not programmatic ones: this applies even
+        when `read_only=True`, leaving the editor read-only afterward.
+
         Args:
             index: Target text position, e.g. `'end'` or `'1.0'`.
             text: Text to insert.
         """
-        self._internal._core.text.insert(index, text)
+        self._internal._core.insert(index, text)
 
     def select_all(self) -> None:
         """Select all text content."""

--- a/tests/widgets/public/test_codeeditor_review.py
+++ b/tests/widgets/public/test_codeeditor_review.py
@@ -1,0 +1,131 @@
+"""CodeEditor review fixes (feat/codeeditor-review).
+
+The public `insert()` bypassed the core's read-only-aware `insert()` and poked
+the Tk text widget directly, so a programmatic `insert()` silently no-op'd when
+`read_only=True` (a disabled Tk text drops insert/delete) — the same read-only
+desync class fixed in TextArea. And the public `read_only` setter duplicated the
+core's flag/state sync by hand instead of routing through the core property.
+
+Fixes verified here:
+1. `insert()` applies even when read-only, leaving the editor read-only.
+2. `read_only` set via the property keeps programmatic `value=`/`insert()` working
+   and reads back correctly (parity with constructor `read_only=True`).
+3. Undo/redo stay bound to the native `<<Undo>>`/`<<Redo>>` virtual events.
+4. Tab inserts indentation (kept intentionally — CodeEditor is not a form field,
+   so it does NOT adopt TextArea's Tab-moves-focus behavior).
+"""
+import pytest
+
+import bootstack as bs
+
+
+@pytest.fixture(scope="module")
+def app():
+    a = bs.App()
+    a.__enter__()
+    a._tk_root.deiconify()
+    a._tk_root.update_idletasks()
+    try:
+        yield a
+    finally:
+        try:
+            a.__exit__(None, None, None)
+        except Exception:
+            pass
+        try:
+            a._tk_root.destroy()
+        except Exception:
+            pass
+
+
+# ----- read-only state management -----
+
+def test_insert_applies_when_read_only_via_constructor(app):
+    ed = bs.CodeEditor(value="abc", read_only=True)
+    ed.insert("end", "XYZ")
+    assert ed.value == "abcXYZ"
+    assert ed.read_only is True  # still read-only after the programmatic insert
+
+
+def test_insert_applies_when_read_only_via_property(app):
+    ed = bs.CodeEditor(value="abc")
+    ed.read_only = True
+    ed.insert("end", "XYZ")
+    assert ed.value == "abcXYZ"
+    assert ed.read_only is True
+
+
+def test_read_only_via_property_still_allows_programmatic_value(app):
+    ed = bs.CodeEditor(value="test")
+    ed.read_only = True
+    assert ed.read_only is True
+    ed.value = "new"
+    assert ed.value == "new"  # programmatic write applies despite read-only
+
+
+def test_read_only_via_constructor_allows_programmatic_value(app):
+    ed = bs.CodeEditor(value="test", read_only=True)
+    ed.value = "new"
+    assert ed.value == "new"
+
+
+def test_read_only_toggle_round_trip(app):
+    ed = bs.CodeEditor(value="a")
+    ed.read_only = True
+    ed.read_only = False
+    assert ed.read_only is False
+    ed.value = "editable"
+    assert ed.value == "editable"
+
+
+# ----- cursor position (1-indexed line/col) -----
+
+def test_cursor_position_start(app):
+    ed = bs.CodeEditor(value="line1\nline2\nthird")
+    ed._internal._core.text.mark_set("insert", "1.0")
+    assert ed.cursor_position == (1, 1)
+
+
+def test_cursor_position_mid(app):
+    ed = bs.CodeEditor(value="line1\nline2\nthird")
+    ed._internal._core.text.mark_set("insert", "3.5")
+    assert ed.cursor_position == (3, 6)  # column is 1-indexed for display
+
+
+def test_cursor_position_tracks_goto_line(app):
+    ed = bs.CodeEditor(value="a\nb\nc")
+    ed.goto_line(2)
+    assert ed.cursor_position == (2, 1)
+
+
+# ----- undo/redo bound to native virtual events -----
+
+def test_undo_redo_use_native_virtual_events(app):
+    # Drive the custom UndoManager from Tk's platform-aware <<Undo>>/<<Redo>>
+    # events so the OS-native shortcut applies (Ctrl+Z / Ctrl+Y on Windows),
+    # rather than hardcoding keys.
+    ed = bs.CodeEditor(value="x")
+    tw = ed._internal._core.text
+    assert tw.bind("<<Undo>>")  # bound
+    assert tw.bind("<<Redo>>")  # bound
+
+
+# ----- Tab is kept as indent (not focus traversal) -----
+
+def test_tab_inserts_indent(app):
+    # CodeEditor keeps Tab-as-indent (unlike TextArea, which moves focus): the
+    # SmartIndent handler inserts spaces to the next tab stop.
+    ed = bs.CodeEditor(value="code")
+    tw = ed._internal._core.text
+    tw.mark_set("insert", "1.0")
+    ed._internal._smart_indent._on_tab(None)
+    assert ed.value == "    code"  # four spaces to the first tab stop
+
+
+def test_return_replicates_indentation(app):
+    ed = bs.CodeEditor(value="    indented")
+    tw = ed._internal._core.text
+    tw.mark_set("insert", "end-1c")
+    ed._internal._smart_indent._on_return(None)
+    tw.insert("insert", "X")
+    assert ed.value == "    indented\n    X"


### PR DESCRIPTION
CodeEditor widget review (audit → fix → test → docs → file follow-ups), the
next widget in the interactive-widget review sweep after TextArea.

## Audit

Explore agent vs the internal composite, then adversarial verification. The
agent's "no bugs" verdict on `read_only` was **wrong** — empirically disproved
(see fix). Everything else verified correct: undo/redo already bind the native
`<<Undo>>`/`<<Redo>>` virtual events, Tab-as-indent (intentional — not a form
field), find/replace (wrap-around, read-only-guarded replace), smart-indent, no
event double-emit, and **no form-validation surface** (correct — CodeEditor is
not Field-wrapped).

## Correctness fix

`insert()` was a **silent no-op when `read_only=True`**: it called the Tk text
widget's `insert()` directly, and a disabled Tk text drops insert/delete. This is
the same read-only desync class fixed in TextArea (#247). It now routes through
the core's read-only-aware `insert()`, which lifts the disabled state for the
programmatic write and restores it. The `read_only` setter likewise now routes
through the core property instead of hand-syncing the flag and widget state.

Verified: `insert()` / `value=` / `clear()` all apply under read-only and leave
the editor read-only.

## New API

Read-only `cursor_position -> (line, column)` property (1-indexed, for status-bar
display), replacing a docs example that reached into
`editor._internal._core.text.index(...)`.

## Docs

Mental-model lead; **Keyboard** section; **Text positions** section (documents the
`'end'` / `'line.column'` addressing model); read-only-applies-to-programmatic
note; events `:class:`/`:doc:` cross-links; internals leak removed.

## Tests

`tests/widgets/public/test_codeeditor_review.py` (11) — read-only insert/value,
`cursor_position`, native undo/redo bindings, Tab-as-indent kept. All pass;
`test_public_surface.py` green; clean `-W` docs build; example runs.

## Follow-ups filed

- #250 — Pythonic `(row, column)` position model to replace `"line.column"`
  strings (CodeEditor + TextArea; full design captured in the issue)
- #251 — public selection API (parked on #250)
- #252 — block indent/dedent (Tab/Shift-Tab on a selection) + keyboard
  focus-escape a11y note

🤖 Generated with [Claude Code](https://claude.com/claude-code)