### PR TITLE
fix(scrollview): double-fire <Configure> bind + docs review

### DIFF
--- a/docs/_dev/widget-review-and-docs-standards.md
+++ b/docs/_dev/widget-review-and-docs-standards.md
@@ -104,10 +104,17 @@ resort.** A user should be able to build real things from the Guide alone.
 
 ### Lead with the mental model
 
-Open the page with the foundational concept — how to *think about* the widget —
-before any options or variations. Don't bury the mental model in a later section;
-a reader who gets the model up front can follow everything after it. State what
-the widget *is* and the one idea that makes it click, then build outward.
+Teach the foundational concept — how to *think about* the widget — before any
+options or variations. Don't bury the mental model in a later section; a reader
+who gets the model up front can follow everything after it.
+
+**Where it goes matters.** The page **intro** (the paragraph above the hero) is
+*definitional* — it states plainly *what the widget is* (and does), nothing more.
+The mental model / teaching — the one idea that makes it click, the key gotcha —
+leads the **first usage section**, not the intro. Don't put teaching prose in the
+intro paragraph; that is the usage body's job. (Maintainer feedback,
+2026-06-20: a "the one thing to get right…" lead in the ScrollView *intro* was
+moved down into its first usage section.)
 
 ### No kitchen-sink
 

--- a/docs/widgets/scrollview.rst
+++ b/docs/widgets/scrollview.rst
@@ -19,9 +19,10 @@ Usage
 Basic vertical scroll
 ~~~~~~~~~~~~~~~~~~~~~
 
-Children are packed top-to-bottom inside the scrollable area. Add
-``grow=True`` to let the ScrollView fill its parent and
-provide a height boundary for scrolling to begin.
+A ScrollView only scrolls once its size is **bounded** — otherwise it grows to
+fit its content and never has overflow to scroll. Give it ``grow=True`` to fill
+a sized parent, or a fixed ``height=``. Children are packed top-to-bottom inside
+the scrollable area.
 
 .. code-block:: python
 
@@ -173,9 +174,10 @@ descendants. To toggle it programmatically:
    sv.disable_scrolling()    # pause scrolling
    sv.enable_scrolling()     # resume
 
-After adding a large batch of widgets dynamically (outside the context
-block), call ``refresh_bindings()`` to ensure all new descendants are
-wired up:
+Descendants added later — including a second pass through the context block —
+are wired for wheel scrolling automatically as they lay out, so you normally
+do not need to do anything. ``refresh_bindings()`` is a safety net for the rare
+case where some new descendants miss scrolling after a large dynamic batch:
 
 .. code-block:: python
 
@@ -183,11 +185,12 @@ wired up:
    with sv:
        bs.Label("Static row")
 
-   # Later, add more rows dynamically
+   # Later, add more rows dynamically — wheel scrolling just works on them
    with sv:
        for i in range(100):
            bs.Label(f"Dynamic row {i}")
-   sv.refresh_bindings()
+
+   sv.refresh_bindings()   # only if some rows missed scrolling
 
 Widget sizing
 ~~~~~~~~~~~~~

--- a/src/bootstack/widgets/_impl/composites/scrollview.py
+++ b/src/bootstack/widgets/_impl/composites/scrollview.py
@@ -583,12 +583,11 @@ class ScrollView(Frame):
         self.vertical_scrollbar.lift()
         self.horizontal_scrollbar.lift()
 
-        # Bind configure event to update scroll region
+        # Bind configure event to update scroll region. (bind() auto-adds here,
+        # so this must run exactly once — a second identical bind double-fires
+        # _on_frame_configure on every resize, doubling the recursive subtree walk.)
         widget.bind('<Configure>', self._on_frame_configure)
         self._update_scrollbar_visibility()
-
-        # Bind configure event to update scroll region
-        widget.bind('<Configure>', self._on_frame_configure)
 
         # Enable scrolling based on mode
         if self._scrollbar_visibility in ('always', 'never', 'scroll'):

--- a/src/bootstack/widgets/scrollview.py
+++ b/src/bootstack/widgets/scrollview.py
@@ -1,6 +1,5 @@
 ﻿from __future__ import annotations
 
-import tkinter
 from typing import Any, Literal
 
 from bootstack.widgets._impl.composites.scrollview import ScrollView as _InternalScrollView

--- a/tests/widgets/public/test_scrollview_review.py
+++ b/tests/widgets/public/test_scrollview_review.py
@@ -1,0 +1,109 @@
+"""ScrollView review fixes (feat/scrollview-review).
+
+The audit surfaced one real defect and one cleanup:
+
+1. `add()` bound the content frame's `<Configure>` handler twice. The framework's
+   `bind()` auto-adds, so the duplicate made `_on_frame_configure` (a recursive
+   bindtag walk of the whole subtree + scrollregion/visibility recompute) run
+   **twice on every resize**. Removed the duplicate.
+2. A dead `import tkinter` in the public wrapper.
+
+These also lock down behaviors that an audit pass wrongly flagged as bugs but are
+in fact correct: a vertical wheel does nothing in `scroll_direction='horizontal'`,
+and the canvas background tracks a runtime theme toggle.
+"""
+import pytest
+
+import bootstack as bs
+from bootstack.widgets._impl.composites.scrollview import ScrollView as _ISV
+from bootstack.widgets._impl.primitives.frame import Frame as _Frame
+
+
+@pytest.fixture(scope="module")
+def app():
+    a = bs.App()
+    a.__enter__()
+    a._tk_root.deiconify()
+    a._tk_root.update_idletasks()
+    try:
+        yield a
+    finally:
+        try:
+            a.__exit__(None, None, None)
+        except Exception:
+            pass
+        try:
+            a._tk_root.destroy()
+        except Exception:
+            pass
+
+
+# ----- the double-fire fix -----
+
+def test_configure_handler_fires_once_per_resize(app):
+    # bind() auto-adds, so add() must bind <Configure> exactly once; a duplicate
+    # bind doubled the recursive subtree walk on every layout change.
+    sv = _ISV(app._tk_root, height=150)
+    sv.pack()
+    calls = []
+    sv._on_frame_configure = lambda e: calls.append(1)
+    content = _Frame(sv.canvas)
+    sv.add(content)
+    app._tk_root.update_idletasks()
+    calls.clear()
+    content.event_generate("<Configure>", when="now")
+    app._tk_root.update_idletasks()
+    assert len(calls) == 1
+
+
+# ----- construction across every mode / direction -----
+
+@pytest.mark.parametrize("direction", ["vertical", "horizontal", "both"])
+@pytest.mark.parametrize("visibility", ["always", "never", "hover", "scroll"])
+def test_constructs_for_every_mode_and_direction(app, direction, visibility):
+    sv = bs.ScrollView(
+        scroll_direction=direction,
+        scrollbar_visibility=visibility,
+        height=80,
+        width=120,
+    )
+    with sv:
+        bs.Label("x")
+    app._tk_root.update_idletasks()
+    assert sv._internal._direction == direction
+
+
+# ----- direction is honored on the wheel -----
+
+def test_horizontal_mode_ignores_vertical_wheel(app):
+    sv = bs.ScrollView(scroll_direction="horizontal", height=100, width=200)
+    with sv:
+        for i in range(30):
+            bs.Label(f"row {i}")
+    app._tk_root.update_idletasks()
+    canvas = sv._internal.canvas
+    before = canvas.yview()[0]
+
+    class _WheelEvent:
+        delta = -120
+        num = 0
+
+    sv._internal._on_mousewheel(_WheelEvent())
+    app._tk_root.update_idletasks()
+    assert canvas.yview()[0] == before  # vertical wheel is a no-op in horizontal mode
+
+
+# ----- canvas background tracks the theme -----
+
+def test_canvas_background_tracks_theme_toggle(app):
+    sv = bs.ScrollView(height=120)
+    with sv:
+        bs.Label("x")
+    app._tk_root.update_idletasks()
+    bs.set_theme("bootstrap-light")
+    app._tk_root.update_idletasks()
+    light_bg = sv._internal.canvas.cget("bg")
+    bs.set_theme("bootstrap-dark")
+    app._tk_root.update_idletasks()
+    dark_bg = sv._internal.canvas.cget("bg")
+    assert light_bg != dark_bg


### PR DESCRIPTION
ScrollView widget review (audit → fix → test → docs → file follow-ups), the
next widget in the interactive-widget review sweep after CodeEditor.

## Correctness fix

`add()` bound the content frame's `<Configure>` handler **twice**. The
framework's `bind()` auto-adds (verified: two identical binds → two
invocations), so the duplicate ran `_on_frame_configure` twice on every resize —
doubling the scrollregion recompute, the scrollbar-visibility check, **and a
recursive bindtag walk of the entire content subtree**. Now binds exactly once;
a regression test asserts a single fire per `<Configure>`.

## Cleanup

Removed a dead `import tkinter` from the public wrapper.

## Adversarial verification (two audit "bugs" disproved)

- "Mousewheel direction inversion" — **false**. A vertical wheel is a no-op in
  `scroll_direction='horizontal'` (guarded at the scroll-application site); the
  audit misread an early-exit optimization.
- "Canvas theming gap" — **false**. The canvas background tracks a runtime theme
  toggle (`#ffffff → #212529`).

## Docs

- Keep the **intro definitional**; move the "a ScrollView only scrolls when its
  size is **bounded**" mental model into the first usage section (per maintainer
  feedback on intro-vs-usage split, now codified in the standards doc).
- Correct the `refresh_bindings()` guidance: dynamically-added descendants are
  wired for wheel scrolling automatically as they lay out (verified) — it is a
  rare safety net, not a required call.

## Tests

`tests/widgets/public/test_scrollview_review.py` — single-fire regression, all
12 mode×direction combinations, horizontal-wheel guard, theme-toggle canvas bg.
All pass; `test_public_surface.py` green; clean `-W` docs build; example runs.

## Follow-ups filed

- #254 — `on_scroll` event + scroll-position getter (reactive scrolling)
- #255 — keyboard scrolling (PageUp/Down, Home/End, arrows) — a11y

🤖 Generated with [Claude Code](https://claude.com/claude-code)