### PR TITLE
docs: align widget intros (definitional) vs Usage lead-ins (teaching)

### DIFF
--- a/docs/_dev/widget-review-and-docs-standards.md
+++ b/docs/_dev/widget-review-and-docs-standards.md
@@ -111,10 +111,28 @@ who gets the model up front can follow everything after it.
 **Where it goes matters.** The page **intro** (the paragraph above the hero) is
 *definitional* — it states plainly *what the widget is* (and does), nothing more.
 The mental model / teaching — the one idea that makes it click, the key gotcha —
-leads the **first usage section**, not the intro. Don't put teaching prose in the
-intro paragraph; that is the usage body's job. (Maintainer feedback,
-2026-06-20: a "the one thing to get right…" lead in the ScrollView *intro* was
-moved down into its first usage section.)
+leads the **Usage** section: a short paragraph between the `Usage` heading and the
+first `~~~` subsection. Don't put teaching prose in the intro paragraph; that is
+the usage body's job.
+
+Both sides of this matter:
+
+- **Don't teach in the intro.** Move "think of it as…", "the one thing to get
+  right…", "reach for X when…" framing out of the intro and into the Usage lead-in.
+- **Don't leave Usage bare.** A page should not jump from the `Usage` heading
+  straight into a `~~~` subsection with no prose. *Every* reviewed widget — even a
+  simple one like Slider — opens Usage with a brief mental-model lead-in (for Slider,
+  the change-vs-commit decision; for a field, the value/text model).
+- **A relocated lead-in is not automatically a good lead-in.** After moving prose
+  from the intro into Usage, re-read it in place: a paragraph written as an intro
+  often *re-introduces* the widget ("A password field is a single-line text input
+  that masks…"), which is redundant with the definitional intro just above. Trim the
+  restatement and lead with the model.
+
+(Maintainer feedback, 2026-06-20: the ScrollView intro's "the one thing to get
+right…" lead was moved into Usage; then a full pass relocated teaching out of 11
+reviewed widgets' intros and added Usage lead-ins to Slider/RangeSlider, which had
+none.)
 
 ### No kitchen-sink
 

--- a/docs/widgets/button.rst
+++ b/docs/widgets/button.rst
@@ -4,11 +4,6 @@ Button
 A clickable action trigger. Accepts the button text as the first positional
 argument.
 
-A button does one thing: it runs an action when activated. Wire that action with
-``on_click=`` and shape the rest with two independent knobs — ``accent=`` for
-*intent* (the semantic color) and ``variant=`` for *weight* (how much it stands
-out). Everything else on the page is a refinement of those three ideas.
-
 .. image:: /_static/examples/button-hero-light.png
    :class: bs-screenshot-light
    :alt: Button — light theme
@@ -19,6 +14,11 @@ out). Everything else on the page is a refinement of those three ideas.
 
 Usage
 -----
+
+A button does one thing: it runs an action when activated. Wire that action with
+``on_click=`` and shape the rest with two independent knobs — ``accent=`` for
+*intent* (the semantic color) and ``variant=`` for *weight* (how much it stands
+out). Everything else here is a refinement of those three ideas.
 
 Accent colors
 ~~~~~~~~~~~~~

--- a/docs/widgets/buttongroup.rst
+++ b/docs/widgets/buttongroup.rst
@@ -4,13 +4,6 @@ ButtonGroup
 A row (or column) of visually-connected buttons sharing a common accent and
 variant. Buttons are added one at a time via ``add()``.
 
-Think of a ButtonGroup as a set of related *actions* with one shared style and
-one shared click handler: each button carries a ``key``, and ``on_click()`` on
-the group reports which key was pressed — so you handle the whole cluster in one
-place instead of wiring each button separately. Reach for :doc:`togglegroup`
-instead when the buttons represent a *selection* to remember rather than actions
-to fire.
-
 .. image:: /_static/examples/buttongroup-hero-light.png
    :class: bs-screenshot-light
    :alt: ButtonGroup — light theme
@@ -21,6 +14,13 @@ to fire.
 
 Usage
 -----
+
+Think of a ButtonGroup as a set of related *actions* with one shared style and
+one shared click handler: each button carries a ``key``, and ``on_click()`` on
+the group reports which key was pressed — so you handle the whole cluster in one
+place instead of wiring each button separately. Reach for :doc:`togglegroup`
+instead when the buttons represent a *selection* to remember rather than actions
+to fire.
 
 Basic usage
 ~~~~~~~~~~~

--- a/docs/widgets/codeeditor.rst
+++ b/docs/widgets/codeeditor.rst
@@ -4,11 +4,6 @@ CodeEditor
 A full-featured code editor with syntax highlighting, line numbers, bracket
 matching, smart indent, and built-in search/replace.
 
-Think of it as a standalone editing *surface*, not a form input: it ships the
-editor behaviors (a gutter, a search bar, undo grouping) built in, and it is
-**not** Field-wrapped — there is no label, validation, or ``disabled`` state.
-Reach for :doc:`textarea` when you want a labeled multi-line field in a form.
-
 .. image:: /_static/examples/codeeditor-hero-light.png
    :class: bs-screenshot-light
    :alt: CodeEditor — light theme
@@ -19,6 +14,11 @@ Reach for :doc:`textarea` when you want a labeled multi-line field in a form.
 
 Usage
 -----
+
+Think of it as a standalone editing *surface*, not a form input: it ships the
+editor behaviors (a gutter, a search bar, undo grouping) built in, and it is
+**not** Field-wrapped — there is no label, validation, or ``disabled`` state.
+Reach for :doc:`textarea` when you want a labeled multi-line field in a form.
 
 Basic usage
 ~~~~~~~~~~~

--- a/docs/widgets/datefield.rst
+++ b/docs/widgets/datefield.rst
@@ -12,15 +12,15 @@ calendar picker button. Supports single-date and date-range selection modes.
    :class: bs-screenshot-dark
    :alt: DateField — dark theme
 
+Usage
+-----
+
 A date field reads and writes a real ``date`` through
 ``field.value`` — ``None`` when empty, or a ``(start, end)`` tuple in range mode —
 never a string. Users type a date or pick one from the calendar button;
 ``value_format`` controls only how it is displayed. Restrict what the picker
 offers with ``min_date`` / ``max_date`` / ``disabled_dates``, and validate the
 chosen date with rules.
-
-Usage
------
 
 Basic usage
 ~~~~~~~~~~~

--- a/docs/widgets/numberfield.rst
+++ b/docs/widgets/numberfield.rst
@@ -12,15 +12,15 @@ mouse-wheel stepping.
    :class: bs-screenshot-dark
    :alt: NumberField demo — dark theme
 
+Usage
+-----
+
 A number field reads and writes a real ``int`` or ``float`` through
 ``field.value`` — or ``None`` when empty — never a string. Bind a
 :doc:`Signal </reference/signals>` with ``signal=`` to keep a typed variable in
 lockstep. Type into it, press the ±steppers, or step with the arrow keys and
 mouse wheel; ``min_value``/``max_value`` clamp the result, while ``value_format``
 changes only how the number is displayed.
-
-Usage
------
 
 Basic
 ~~~~~

--- a/docs/widgets/passwordfield.rst
+++ b/docs/widgets/passwordfield.rst
@@ -11,15 +11,14 @@ Masked text input for password entry with an optional visibility toggle.
    :class: bs-screenshot-dark
    :alt: PasswordField demo — dark theme
 
-A password field is a single-line text input that masks what the user types.
+Usage
+-----
+
 Read or set the secret through ``field.value`` — always the unmasked string — or
 bind it with ``textsignal=``. Users can briefly reveal the input by holding the
 eye toggle, and you can drive masking from code with ``reveal()`` / ``hide()``.
 Validation runs against the typed value, exactly like a plain
 :doc:`text field <textfield>`.
-
-Usage
------
 
 Basic
 ~~~~~

--- a/docs/widgets/pathfield.rst
+++ b/docs/widgets/pathfield.rst
@@ -13,14 +13,14 @@ updated and a ``change`` event fires.
    :class: bs-screenshot-dark
    :alt: PathField — dark theme
 
-A path field is a text input with a browse button. ``field.value`` is the
-selected path as a string — the user types it or picks it from a native dialog,
-and ``mode`` chooses which dialog opens (open a file, open many, save, or pick a
-directory). ``on_change`` fires after a pick or a manual edit; in
-``'open_multiple'`` mode the raw tuple of paths is on ``field.dialog_result``.
-
 Usage
 -----
+
+``field.value`` is the selected path as a string — the user types it or picks it
+from a native dialog, and ``mode`` chooses which dialog opens (open a file, open
+many, save, or pick a directory). ``on_change`` fires after a pick or a manual
+edit; in ``'open_multiple'`` mode the raw tuple of paths is on
+``field.dialog_result``.
 
 Basic usage
 ~~~~~~~~~~~

--- a/docs/widgets/rangeslider.rst
+++ b/docs/widgets/rangeslider.rst
@@ -14,6 +14,12 @@ A two-handle track for selecting a low/high value range.
 Usage
 -----
 
+A range slider selects a low and a high value within a
+``min_value``/``max_value`` range, both clamped to the bounds. As with the
+single-handle :doc:`Slider <slider>`, ``on_change`` fires continuously as a
+handle moves and ``on_commit`` fires once on release — reach for ``on_commit``
+when the per-update work is expensive.
+
 Basic
 ~~~~~
 

--- a/docs/widgets/scrollview.rst
+++ b/docs/widgets/scrollview.rst
@@ -16,13 +16,14 @@ Mouse-wheel scrolling is automatically enabled for all descendants.
 Usage
 -----
 
+A ScrollView only scrolls once its size is **bounded** — otherwise it grows to
+fit its content and never has overflow to scroll. Give it ``grow=True`` to fill
+a sized parent, or a fixed ``height=``.
+
 Basic vertical scroll
 ~~~~~~~~~~~~~~~~~~~~~
 
-A ScrollView only scrolls once its size is **bounded** — otherwise it grows to
-fit its content and never has overflow to scroll. Give it ``grow=True`` to fill
-a sized parent, or a fixed ``height=``. Children are packed top-to-bottom inside
-the scrollable area.
+Children are packed top-to-bottom inside the scrollable area.
 
 .. code-block:: python
 

--- a/docs/widgets/slider.rst
+++ b/docs/widgets/slider.rst
@@ -14,6 +14,11 @@ A single-handle track for selecting a numeric value within a range.
 Usage
 -----
 
+A slider holds a numeric ``value`` within a ``min_value``/``max_value`` range,
+always clamped to the bounds. The decision you make is *when* to react:
+``on_change`` fires continuously as the handle moves, while ``on_commit`` fires
+once on release — reach for ``on_commit`` when the work per update is expensive.
+
 Basic
 ~~~~~
 

--- a/docs/widgets/spinnerfield.rst
+++ b/docs/widgets/spinnerfield.rst
@@ -12,16 +12,15 @@ of values or a numeric range.
    :class: bs-screenshot-dark
    :alt: SpinnerField — dark theme
 
-A spinner steps through a fixed set of values with up/down buttons (or the arrow
-keys), in one of two modes: pass ``options=`` to cycle a list of strings, or
-``min_value`` / ``max_value`` / ``step`` for a numeric range — not both.
-``field.value`` is the current string (text mode) or number (numeric mode), and
-``textsignal=`` binds the displayed text. For free numeric entry without a fixed
-step reach for :doc:`NumberField <numberfield>`; for a long list,
-:doc:`Select <select>`.
-
 Usage
 -----
+
+A spinner steps with the up/down buttons or the arrow keys, in one of two modes:
+pass ``options=`` to cycle a list of strings, or ``min_value`` / ``max_value`` /
+``step`` for a numeric range — not both. ``field.value`` is the current string
+(text mode) or number (numeric mode), and ``textsignal=`` binds the displayed
+text. For free numeric entry without a fixed step reach for
+:doc:`NumberField <numberfield>`; for a long list, :doc:`Select <select>`.
 
 Text mode
 ~~~~~~~~~

--- a/docs/widgets/textarea.rst
+++ b/docs/widgets/textarea.rst
@@ -4,12 +4,6 @@ TextArea
 A multi-line text input with optional label, placeholder, scrollbars, and
 undo/redo support.
 
-The content is the ``value`` (read or set it directly, or bind a ``Signal`` with
-``textsignal=``). Listen as the user types with ``on_input``, or once they leave
-the field with ``on_change`` — that input-vs-commit choice is the main decision
-you make. Everything else (validation, undo/redo, dirty tracking) layers on top
-for richer editor-like fields.
-
 .. image:: /_static/examples/textarea-hero-light.png
    :class: bs-screenshot-light
    :alt: TextArea — light theme
@@ -20,6 +14,12 @@ for richer editor-like fields.
 
 Usage
 -----
+
+The content is the ``value`` (read or set it directly, or bind a ``Signal`` with
+``textsignal=``). Listen as the user types with ``on_input``, or once they leave
+the field with ``on_change`` — that input-vs-commit choice is the main decision
+you make. Everything else (validation, undo/redo, dirty tracking) layers on top
+for richer editor-like fields.
 
 Basic usage
 ~~~~~~~~~~~

--- a/docs/widgets/textfield.rst
+++ b/docs/widgets/textfield.rst
@@ -12,6 +12,9 @@ validation, and reactive signal binding.
    :class: bs-screenshot-dark
    :alt: TextField demo — dark theme
 
+Usage
+-----
+
 A field keeps three things distinct: the ``label`` beside it, the ``value`` you
 read and write in code, and the display ``text`` the user sees. Read the current
 input with ``field.value``, or bind a :doc:`Signal </reference/signals>` with
@@ -19,9 +22,6 @@ input with ``field.value``, or bind a :doc:`Signal </reference/signals>` with
 two beats — ``on_input`` on every keystroke, ``on_change`` once the value is
 committed (on blur or Enter) — so you choose live feedback or settled value per
 handler.
-
-Usage
------
 
 Basic
 ~~~~~

--- a/docs/widgets/timefield.rst
+++ b/docs/widgets/timefield.rst
@@ -12,14 +12,14 @@ can type a custom time or select from the dropdown.
    :class: bs-screenshot-dark
    :alt: TimeField — dark theme
 
+Usage
+-----
+
 A time field reads and writes a real ``time`` through ``field.value`` — or
 ``None`` when empty. The user types a time (``'14:30'`` or ``'2:30 PM'``) or picks
 one from the dropdown; ``value_format`` controls only how it is displayed, and
 ``min_time`` / ``max_time`` limit which times the dropdown offers. The field
 starts empty — pass ``value=`` to seed a starting time.
-
-Usage
------
 
 Basic usage
 ~~~~~~~~~~~


### PR DESCRIPTION
A consistency pass across all already-reviewed widget pages: separate the page
**intro** (what the widget *is*) from the **teaching** (how to think about it).

## The rule

Every reviewed widget page now follows one shape:

> definitional intro → hero → **Usage lead-in (the mental model)** → subsections

The intro above the hero states only what the widget is and does. The mental
model / key gotcha leads the Usage section (a short paragraph between the `Usage`
heading and the first subsection).

## Changes

- **Teaching moved out of 11 intros** into a Usage lead-in: `button`,
  `buttongroup`, `textarea`, `codeeditor`, and the 7 field pages.
- **Trimmed re-introductions** in the relocated lead where it restated the
  definitional intro (`passwordfield`, `pathfield`, `spinnerfield`) — they now lead
  with the model instead of re-defining the widget. (Moving a paragraph doesn't
  make it read right in its new home — each was re-read in place.)
- **Added Usage lead-ins** to `slider` and `rangeslider`, which had none — a page
  jumping from `Usage` straight into a subsection reads bare next to the others.
  Both now open with the change-vs-commit decision.
- **Harmonized** `scrollview`: its bounded-size teaching moved from the first
  subsection up to a Usage-level lead.

## Standard

Codified both sides of the rule in `docs/_dev/widget-review-and-docs-standards.md`:
no teaching in the intro, no bare Usage section, and a relocated lead-in must not
re-introduce the widget.

Clean `-W` build. Docs-only; 15 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)