### PR TITLE
feat(splitview): key-relative pane placement + clean sash IndexError

### DIFF
--- a/docs/widgets/splitview.rst
+++ b/docs/widgets/splitview.rst
@@ -15,10 +15,15 @@ can be moved at runtime to redistribute space.
 Usage
 -----
 
+A SplitView arranges its panes along one axis with a draggable sash between each
+pair. ``weight`` sets how panes share space; drag a sash (or call
+``sash_position``) to override. Panes are addressed by key — give each one a name
+to look it up, reorder it, or remove it at runtime.
+
 Basic split
 ~~~~~~~~~~~
 
-Call `.add()` once per pane. Use the returned value as a context manager
+Call ``add()`` once per pane. Use the returned value as a context manager
 to place children inside that pane.
 
 .. code-block:: python
@@ -73,7 +78,7 @@ one with ``weight=1``.
 Three or more panes
 ~~~~~~~~~~~~~~~~~~~
 
-Call `.add()` for each pane. Each pair of adjacent panes gets its own
+Call ``add()`` for each pane. Each pair of adjacent panes gets its own
 independently draggable sash.
 
 .. code-block:: python
@@ -89,23 +94,29 @@ independently draggable sash.
 Managing panes
 ~~~~~~~~~~~~~~
 
-`add()` returns a :class:`SplitPane <bootstack.widgets.splitview.SplitPane>`
-handle. Give it a ``key=`` to address the pane later — look one up with
-``item()``, enumerate them all with ``panes``, and drop one with ``remove()``.
-The pane's ``weight`` is a live property, so you can re-balance the split at
-runtime; for an exact sash position in pixels use ``sash_position()``.
+``add()`` returns a :class:`SplitPane <bootstack.widgets.splitview.SplitPane>`
+handle. Pass the pane's key as the first argument to address it later — look one
+up with ``item()``, enumerate them all with ``panes``, place a new pane next to
+another with ``before=`` / ``after=``, reorder an existing one with ``move()``,
+and drop one with ``remove()``. The pane's ``weight`` is a live property, so you
+can re-balance the split at runtime; for an exact sash position in pixels use
+``sash_position()``.
 
 .. code-block:: python
 
    sv = bs.SplitView(grow=True)
-   with sv.add(key="sidebar", weight=1):
+   with sv.add("sidebar", weight=1):
        bs.Label("Sidebar")
-   with sv.add(key="main", weight=3):
+   with sv.add("main", weight=3):
        bs.Label("Main")
 
-   sv.item("sidebar").weight = 2     # re-balance live
-   sv.sash_position(0, 200)          # or place the sash exactly
-   sv.remove("sidebar")              # drop a pane (and its content)
+   with sv.add("preview", after="main"):   # place by key, never an index
+       bs.Label("Preview")
+
+   sv.move("preview", before="sidebar")    # reorder by key
+   sv.item("sidebar").weight = 2           # re-balance live
+   sv.sash_position(0, 200)                # place the first sash exactly
+   sv.remove("preview")                    # drop a pane (and its content)
 
 Pane layout
 ~~~~~~~~~~~

--- a/src/bootstack/widgets/splitview.py
+++ b/src/bootstack/widgets/splitview.py
@@ -117,7 +117,8 @@ class SplitPane:
     @property
     def weight(self) -> int:
         """Relative resize weight — panes with a higher weight take proportionally
-        more space when the container grows. Assigning a new value resizes live.
+        more space when the container grows. A pane with `weight=0` keeps its size
+        and does not grow (a fixed pane). Assigning a new value resizes live.
         """
         return int(self._paned.pane(self._frame, "weight"))
 
@@ -143,8 +144,9 @@ class SplitView(PublicWidgetBase):
     Add panes with `.add()` and place children inside each pane using the
     returned `SplitPane` handle. Sashes between panes can be dragged at runtime
     to resize them. Panes are addressable by key — enumerate them with `panes`,
-    look one up with `item()`, insert one at a position with `insert()`, reorder
-    with `move()`, and drop one with `remove()`.
+    look one up with `item()`, place a new one next to another with
+    `add(before=)` / `add(after=)`, reorder with `move()`, and drop one with
+    `remove()`.
 
     Args:
         orient: Pane arrangement — `'horizontal'` (side-by-side) or
@@ -207,8 +209,10 @@ class SplitView(PublicWidgetBase):
 
     def add(
         self,
-        *,
         key: str | None = None,
+        *,
+        before: str | None = None,
+        after: str | None = None,
         weight: int = 1,
         layout: LayoutKind = "column",
         padding: Padding | None = None,
@@ -222,9 +226,15 @@ class SplitView(PublicWidgetBase):
     ) -> SplitPane:
         """Add a pane and return a handle for placing its children and controlling it.
 
+        Panes are appended in order by default. Pass `before=` or `after=` (the
+        key of an existing pane) to place the new pane next to another one.
+
         Args:
-            key: Unique identifier used with `item()` and `remove()`.
-                Auto-generated if omitted.
+            key: Unique identifier for the pane, used with `item()`, `move()`,
+                and `remove()`. Auto-generated when omitted.
+            before: Place the new pane immediately before the pane with this key.
+            after: Place the new pane immediately after the pane with this key.
+                Mutually exclusive with `before`; omit both to append at the end.
             weight: Relative size weight when the container is resized. Panes
                 with a higher weight take proportionally more space. Settable
                 afterward via the pane's `weight` property. Defaults to `1`.
@@ -250,59 +260,12 @@ class SplitView(PublicWidgetBase):
         Returns:
             `SplitPane` — use as a context manager to place children, and as a
             handle to read/set `weight` or `remove()` the pane.
+
+        Raises:
+            KeyError: If `before`/`after` names a pane that does not exist.
+            ValueError: If both `before` and `after` are given.
         """
-        return self._create_pane(
-            index=None, key=key, weight=weight,
-            layout=layout, padding=padding, gap=gap,
-            horizontal_items=horizontal_items, vertical_items=vertical_items,
-            grow_items=grow_items,
-            columns=columns, rows=rows, auto_flow=auto_flow,
-        )
-
-    def insert(
-        self,
-        index: int,
-        *,
-        key: str | None = None,
-        weight: int = 1,
-        layout: LayoutKind = "column",
-        padding: Padding | None = None,
-        gap: int = 0,
-        horizontal_items: str | None = None,
-        vertical_items: str | None = None,
-        grow_items: bool = False,
-        columns: int | list[int | str] | None = None,
-        rows: int | list[int | str] | None = None,
-        auto_flow: AutoFlow = "row",
-    ) -> SplitPane:
-        """Add a pane at a specific position. Accepts the same options as `add()`.
-
-        Args:
-            index: Zero-based position to insert the new pane at. Existing panes
-                at or after this position shift toward the end.
-            key: Unique identifier used with `item()` and `remove()`.
-                Auto-generated if omitted.
-            weight: Relative size weight. Defaults to `1`.
-            layout: Internal pane layout. Defaults to `'column'`.
-            padding: Space in pixels inside the pane border. Defaults to `None`.
-            gap: Space in pixels between children. Defaults to `0`.
-            horizontal_items: How children sit on the horizontal axis — edge
-                values `'left'`/`'center'`/`'right'`/`'stretch'`, plus `'space-*'`
-                when horizontal is the stacking axis. Defaults to `'stretch'` in grid mode,
-                `'center'` in a column and `'left'` in a row.
-            vertical_items: How children sit on the vertical axis — edge values
-                `'top'`/`'center'`/`'bottom'`/`'stretch'`, plus `'space-*'` when
-                vertical is the stacking axis. Defaults to `'stretch'` in grid mode,
-                `'center'` in a row and `'top'` in a column.
-            grow_items: For `'column'`/`'row'`, when `True` every child grows
-                equally to share the main axis. Defaults to `False`.
-            columns: Column definitions for `'grid'` layout.
-            rows: Row definitions for `'grid'` layout.
-            auto_flow: Grid auto-flow direction. Defaults to `'row'`.
-
-        Returns:
-            `SplitPane` — same handle returned by `add()`.
-        """
+        index = self._resolve_placement(before, after)
         return self._create_pane(
             index=index, key=key, weight=weight,
             layout=layout, padding=padding, gap=gap,
@@ -311,16 +274,55 @@ class SplitView(PublicWidgetBase):
             columns=columns, rows=rows, auto_flow=auto_flow,
         )
 
-    def move(self, key: str, index: int) -> None:
-        """Move an existing pane to a new position.
+    def move(self, key: str, *, before: str | None = None, after: str | None = None) -> None:
+        """Move an existing pane next to another pane.
 
         Args:
             key: The key of the pane to move.
-            index: Zero-based target position.
+            before: Move it immediately before the pane with this key.
+            after: Move it immediately after the pane with this key. Pass
+                exactly one of `before` or `after`.
+
+        Raises:
+            KeyError: If `key`, `before`, or `after` names a pane that does
+                not exist.
+            ValueError: If not exactly one of `before`/`after` is given, or if
+                the anchor is the pane being moved.
         """
-        pane = self._panes[key]
-        self._internal.insert(index, pane._frame)
+        if key not in self._panes:
+            raise KeyError(f"no pane with key {key!r}")
+        if (before is None) == (after is None):
+            raise ValueError("pass exactly one of before= or after=")
+        anchor = before if before is not None else after
+        if anchor == key:
+            raise ValueError(f"cannot move pane {key!r} relative to itself")
+        # The target index is computed against the order with the moved pane
+        # removed, which is how ttk's insert(pos, existing) re-seats it.
+        order = [k for k in self._panes if k != key]
+        if anchor not in order:
+            raise KeyError(f"no pane with key {anchor!r}")
+        pos = order.index(anchor)
+        index = pos if before is not None else pos + 1
+        self._internal.insert(index, self._panes[key]._frame)
         self._resync_order()
+
+    def _resolve_placement(self, before: str | None, after: str | None) -> int | None:
+        """Translate a `before=`/`after=` key into an insertion index for a new pane.
+
+        Returns `None` to append (the default, and the case where the anchor is
+        the last pane — ttk cannot target the slot past the final pane).
+        """
+        if before is not None and after is not None:
+            raise ValueError("pass only one of before= or after=, not both")
+        if before is None and after is None:
+            return None
+        anchor = before if before is not None else after
+        order = list(self._panes)
+        if anchor not in order:
+            raise KeyError(f"no pane with key {anchor!r}")
+        pos = order.index(anchor)
+        index = pos if before is not None else pos + 1
+        return index if index < len(order) else None
 
     def _create_pane(self, *, index: int | None, key: str | None, weight: int, **layout_kw: Any) -> SplitPane:
         if key is None:
@@ -394,13 +396,28 @@ class SplitView(PublicWidgetBase):
         """Get or set the position of a sash.
 
         Args:
-            index: Zero-based sash index.
+            index: Zero-based sash index. A split view with `n` panes has
+                `n - 1` sashes.
             position: New position in pixels. If `None`, returns the
                 current position.
 
         Returns:
             Current sash position in pixels when `position` is `None`.
+
+        Raises:
+            IndexError: If `index` does not refer to an existing sash.
         """
+        n_sashes = max(0, len(self._internal.panes()) - 1)
+        if not 0 <= index < n_sashes:
+            if n_sashes == 0:
+                raise IndexError(
+                    f"sash index {index} out of range: this split view has no "
+                    f"sashes yet (add at least two panes)"
+                )
+            raise IndexError(
+                f"sash index {index} out of range: valid sash indices are "
+                f"0..{n_sashes - 1}"
+            )
         if position is None:
             return self._internal.sashpos(index)
         self._internal.sashpos(index, position)

--- a/tests/widgets/public/test_splitview_review.py
+++ b/tests/widgets/public/test_splitview_review.py
@@ -1,0 +1,166 @@
+"""SplitView review fixes (feat/splitview-review).
+
+The review reshaped pane placement to be key-based (matching the rest of the
+widget's identity model) and closed a Tk-leak:
+
+1. `add()` takes the pane `key` positionally and places by key with
+   `before=`/`after=`; the integer-index `insert()` is gone (folded into `add`).
+2. `move()` repositions by key with `before=`/`after=` instead of an integer.
+3. `sash_position()` raises a clean `IndexError` for an out-of-range sash index
+   instead of leaking a raw `_tkinter.TclError`.
+
+Pane bookkeeping (order after placement/move/remove) is verified to stay in sync
+with the live ttk order.
+"""
+import tkinter
+
+import pytest
+
+import bootstack as bs
+
+
+@pytest.fixture(scope="module")
+def app():
+    a = bs.App()
+    a.__enter__()
+    a._tk_root.deiconify()
+    a._tk_root.update_idletasks()
+    try:
+        yield a
+    finally:
+        try:
+            a.__exit__(None, None, None)
+        except Exception:
+            pass
+        try:
+            a._tk_root.destroy()
+        except Exception:
+            pass
+
+
+def _sv(app, *keys):
+    sv = bs.SplitView(width=600, height=300)
+    for k in keys:
+        with sv.add(k):
+            bs.Label(k)
+    app._tk_root.update_idletasks()
+    return sv
+
+
+# ----- positional key + key-relative placement -----
+
+def test_add_takes_key_positionally(app):
+    sv = bs.SplitView(width=400, height=200)
+    pane = sv.add("main")
+    assert pane.key == "main"
+    assert sv.keys() == ("main",)
+
+
+def test_add_auto_generates_key_when_omitted(app):
+    sv = bs.SplitView(width=400, height=200)
+    assert sv.add().key  # non-empty auto key
+
+
+def test_add_before(app):
+    sv = _sv(app, "a", "c")
+    sv.add("b", before="c")
+    assert sv.keys() == ("a", "b", "c")
+
+
+def test_add_after(app):
+    sv = _sv(app, "a", "b")
+    sv.add("mid", after="a")
+    assert sv.keys() == ("a", "mid", "b")
+
+
+def test_add_after_last_appends(app):
+    sv = _sv(app, "a", "b")
+    sv.add("end", after="b")
+    assert sv.keys() == ("a", "b", "end")
+
+
+def test_add_before_missing_key_raises_keyerror(app):
+    sv = _sv(app, "a")
+    with pytest.raises(KeyError):
+        sv.add("x", before="nope")
+
+
+def test_add_before_and_after_together_raises(app):
+    sv = _sv(app, "a", "b")
+    with pytest.raises(ValueError):
+        sv.add("x", before="a", after="b")
+
+
+# ----- move by key -----
+
+def test_move_before(app):
+    sv = _sv(app, "a", "b", "c")
+    sv.move("c", before="a")
+    assert sv.keys() == ("c", "a", "b")
+
+
+def test_move_after(app):
+    sv = _sv(app, "a", "b", "c")
+    sv.move("a", after="b")
+    assert sv.keys() == ("b", "a", "c")
+
+
+def test_move_requires_exactly_one_anchor(app):
+    sv = _sv(app, "a", "b")
+    with pytest.raises(ValueError):
+        sv.move("a")
+    with pytest.raises(ValueError):
+        sv.move("a", before="b", after="b")
+
+
+def test_move_relative_to_self_raises(app):
+    sv = _sv(app, "a", "b")
+    with pytest.raises(ValueError):
+        sv.move("a", after="a")
+
+
+def test_move_missing_anchor_raises_keyerror(app):
+    sv = _sv(app, "a", "b")
+    with pytest.raises(KeyError):
+        sv.move("a", after="nope")
+
+
+# ----- insert is gone -----
+
+def test_insert_method_removed(app):
+    assert not hasattr(bs.SplitView, "insert")
+
+
+# ----- sash_position out-of-range is a clean IndexError, not a Tk leak -----
+
+def test_sash_position_out_of_range_raises_indexerror(app):
+    sv = _sv(app, "a", "b")  # 2 panes -> 1 sash (index 0 valid)
+    assert isinstance(sv.sash_position(0), int)
+    for bad in (1, -1, 99):
+        with pytest.raises(IndexError):
+            sv.sash_position(bad)
+
+
+def test_sash_position_no_sashes_raises_indexerror(app):
+    sv = _sv(app, "only")  # 1 pane -> 0 sashes
+    with pytest.raises(IndexError):
+        sv.sash_position(0)
+
+
+def test_sash_position_does_not_leak_tclerror(app):
+    sv = _sv(app, "a", "b")
+    try:
+        sv.sash_position(5)
+    except tkinter.TclError:  # pragma: no cover
+        pytest.fail("sash_position leaked a raw TclError")
+    except IndexError:
+        pass
+
+
+# ----- remove keeps order/bookkeeping consistent -----
+
+def test_remove_middle_pane_keeps_order(app):
+    sv = _sv(app, "a", "b", "c")
+    sv.remove("b")
+    assert sv.keys() == ("a", "c")
+    assert len(sv.sash_positions) == 1  # 2 panes -> 1 sash


### PR DESCRIPTION
SplitView widget review (audit → fix → test → docs → file follow-ups), continuing
the interactive-widget sweep.

## API reshape — key-relative placement

SplitView's identity model is key-based everywhere (`add(key=)`, `item(key)`,
`remove(key)`), but placement used integer indices — fragile (a remembered index
goes stale across add/remove) and inconsistent. Reshaped to address position by
key, the way the rest of the widget works:

- **`add(key=None, *, before=, after=, …)`** — the pane key is now the
  **positional** first argument (`sv.add("sidebar")`); place a new pane next to
  another with `before=` / `after=` (omit to append).
- **`move(key, *, before=, after=)`** — reposition an existing pane by key.
- **`insert()` removed** — fully covered by `add(after=…)`. Pre-release clean
  break, no shim.
- **`sash_position` stays integer** — a sash is a keyless divider between panes;
  integer index is its only natural handle (and the 2-pane case is just
  `sash_position(0)`).

```python
sv.add("preview", after="editor")     # place by key, never an index
sv.move("sidebar", before="main")     # reorder by key
```

## Correctness fix — Tk leak

`sash_position(index)` out of range (e.g. `sash_position(0)` before adding two
panes) leaked a raw `_tkinter.TclError` — a toolkit leak on the public surface.
Now a clean `IndexError`. With integer indices gone from `add`/`move`, their
TclError leaks are eliminated too: a bad `before=`/`after=` key raises `KeyError`,
contradictory args raise `ValueError`.

Also documented `weight=0` (a fixed, non-growing pane).

## Audit verification

The audit's "fragile string-match in `_resync_order`" suspicion was empirically
disproven — `str(frame) == panes()[i]`, and add/insert/move/remove all keep
order in sync. `remove()` and `weight` get/set verified correct.

## Tests

`tests/widgets/public/test_splitview_review.py` (17) — positional key, before/after
placement, append-on-`after=last`, move by key, every clean error path, `insert`
removed, sash `IndexError` guard, remove-keeps-order. All pass; surface guard
green; clean `-W` docs build; example runs.

## Follow-up filed

- #258 — `on_sash_moved` event (no events today; ttk emits no native sash event)

🤖 Generated with [Claude Code](https://claude.com/claude-code)