### PR TITLE
feat(textarea,codeeditor): Pythonic position model, drop Tk index strings (#250)

### DIFF
--- a/docs/widgets/codeeditor.rst
+++ b/docs/widgets/codeeditor.rst
@@ -135,27 +135,37 @@ tuple — to drive a status-bar readout.
 Text positions
 ~~~~~~~~~~~~~~
 
-Methods that take a position — ``insert()`` and ``goto_line()`` — address it
-two ways:
-
-* ``"end"`` — just past the last character.
-* ``"line.column"`` — a line and column, for example ``"1.0"`` for the very
-  start or ``"3.4"`` for line 3 just after its fourth character. **Lines are
-  1-indexed; columns are 0-indexed**, so column ``0`` is the start of a line.
+Positions are **1-indexed** ``line`` and ``col`` numbers — ``(1, 1)`` is the
+start of the content. The same coordinates flow through every position method:
+``insert()`` accepts them, ``cursor_position`` reports them, and ``goto()`` moves
+to them. Omit ``col`` to mean the start of the line. Most edits need no position
+at all — ``insert()`` defaults to the cursor, and ``append()`` adds to the end.
 
 .. code-block:: python
 
-   editor.insert("end", "\n# appended")   # add a trailing line
-   editor.insert("1.0", "#!/usr/bin/env python\n")  # prepend a shebang
-   editor.goto_line(42)                   # jump to line 42 (1-indexed)
+   editor.insert("snippet")               # at the cursor (the common case)
+   editor.append("\n# appended")          # add a trailing line
+   editor.insert("#!/usr/bin/env python\n", 1, 1)  # prepend at the start
+   editor.insert(">>> ", 3)               # at the start of line 3
+   editor.goto(42)                        # jump to the start of line 42
+   editor.goto(42, 8)                      # jump to line 42, column 8
 
-.. note::
+   line, col = editor.cursor_position     # e.g. (42, 8) for a status bar
 
-   ``cursor_position`` reports a **1-indexed** ``(line, column)`` tuple — column
-   ``1`` is the start of a line — because it is meant for a status-bar readout
-   (``Ln 1, Col 1``). That display convention differs from the **0-indexed**
-   column in a ``"line.column"`` address: the cursor at the very start reads
-   ``(1, 1)`` but is inserted at by ``"1.0"``.
+For a live readout, drive a :class:`~bootstack.Signal` from the
+``on_cursor_move`` event stream. ``cursor_position`` is a point-in-time tuple,
+so map the stream — not the property — and read the position inside the map:
+
+.. code-block:: python
+
+   status = bs.Signal("Ln 1, Col 1")
+   bs.Label(textsignal=status)
+
+   (
+       editor.on_cursor_move()
+           .map(lambda e: "Ln {}, Col {}".format(*editor.cursor_position))
+           .listen(status.set)
+   )
 
 Undo and redo
 ~~~~~~~~~~~~~
@@ -171,7 +181,7 @@ group multiple programmatic edits into a single undo step.
 
    # Group edits into one undo step
    with editor.undo_block():
-       editor.insert("1.0", "# Auto-generated\\n")
+       editor.insert("# Auto-generated\\n", 1, 1)
        editor.value = reformatted
 
 Dirty tracking

--- a/src/bootstack/widgets/_impl/composites/textarea/codeeditor.py
+++ b/src/bootstack/widgets/_impl/composites/textarea/codeeditor.py
@@ -225,13 +225,14 @@ class CodeEditor(Frame):
         """End a compound undo block."""
         self._core.undo_block_stop()
 
-    def goto_line(self, n: int) -> None:
-        """Move the cursor to the start of line *n* and scroll it into view.
+    def goto(self, line: int, col: int = 1) -> None:
+        """Move the cursor to a 1-indexed *(line, col)* and scroll it into view.
 
         Args:
-            n: 1-indexed line number.
+            line: 1-indexed line number.
+            col: 1-indexed column. Defaults to 1 (the start of the line).
         """
-        idx = f"{n}.0"
+        idx = f"{line}.{col - 1}"
         try:
             self._core.text.mark_set("insert", idx)
             self._core.text.see(idx)

--- a/src/bootstack/widgets/codeeditor.py
+++ b/src/bootstack/widgets/codeeditor.py
@@ -217,11 +217,11 @@ class CodeEditor(PublicWidgetBase):
 
     @property
     def cursor_position(self) -> tuple[int, int]:
-        """The insertion cursor position as a 1-indexed `(line, column)` tuple.
+        """The insertion cursor as a 1-indexed `(line, col)` tuple.
 
-        Line 1, column 1 is the start of the content. Read it in an
-        `on_cursor_move` handler to drive a status-bar readout. Read-only —
-        use `goto_line()` to move the cursor.
+        `(1, 1)` is the start of the content — the same coordinates `insert()`
+        and `goto()` accept. Read it in an `on_cursor_move` handler to drive a
+        status-bar readout. Read-only — use `goto()` to move the cursor.
         """
         idx = self._internal._core.text.index("insert")
         line, col = idx.split(".")
@@ -271,20 +271,41 @@ class CodeEditor(PublicWidgetBase):
         """Clear all text content."""
         self._internal.value = ""
 
-    def insert(self, index: str, text: str) -> None:
-        """Insert `text` at `index`.
+    def insert(self, text: str, line: int | None = None, col: int | None = None) -> None:
+        """Insert `text` at a position, defaulting to the cursor.
 
-        `index` is a text position: `'end'` for the end of the content, or a
-        `'line.column'` string such as `'1.0'` (line 1, column 0).
+        With no `line`/`col`, inserts at the current cursor. Pass `line` to
+        insert at the start of that line, or `line` and `col` together for an
+        exact position. Both are 1-indexed — `(1, 1)` is the start of the
+        content, the same coordinates `cursor_position` reports and `goto()`
+        accepts.
 
         Read-only blocks *user* edits, not programmatic ones: this applies even
         when `read_only=True`, leaving the editor read-only afterward.
 
         Args:
-            index: Target text position, e.g. `'end'` or `'1.0'`.
             text: Text to insert.
+            line: 1-indexed line, or `None` to use the cursor's line. Defaults
+                to `None`.
+            col: 1-indexed column, or `None` for the start of the line.
+                Defaults to `None`.
         """
+        if line is None:
+            index = "insert"
+        else:
+            index = f"{line}.{(col or 1) - 1}"
         self._internal._core.insert(index, text)
+
+    def append(self, text: str) -> None:
+        """Append `text` to the end of the content.
+
+        Applies even when `read_only=True`, leaving the editor read-only
+        afterward.
+
+        Args:
+            text: Text to add at the end of the content.
+        """
+        self._internal._core.insert("end-1c", text)
 
     def select_all(self) -> None:
         """Select all text content."""
@@ -297,14 +318,20 @@ class CodeEditor(PublicWidgetBase):
         """Move keyboard focus to the editor."""
         self._internal.focus_set()
 
-    def goto_line(self, n: int) -> None:
-        """Move the cursor to the start of line `n` and scroll it into view.
+    def goto(self, line: int, col: int = 1) -> None:
+        """Move the cursor to a position and scroll it into view.
+
+        Both are 1-indexed — `(1, 1)` is the start of the content, the same
+        coordinates `cursor_position` reports and `insert()` accepts. Omit
+        `col` to land at the start of the line.
 
         Args:
-            n: 1-indexed line number.
+            line: 1-indexed line number.
+            col: 1-indexed column, or omit for the start of the line. Defaults
+                to 1.
         """
         self._internal.focus_set()
-        self._internal.goto_line(n)
+        self._internal.goto(line, col)
 
     def undo(self) -> None:
         """Undo the last edit."""
@@ -321,7 +348,7 @@ class CodeEditor(PublicWidgetBase):
         Usage::
 
             with editor.undo_block():
-                editor.insert("1.0", "# header\\n")
+                editor.insert("# header\\n", 1, 1)
                 editor.value = new_content
         """
         self._internal.undo_block_start()

--- a/src/bootstack/widgets/textarea.py
+++ b/src/bootstack/widgets/textarea.py
@@ -222,17 +222,27 @@ class TextArea(PublicWidgetBase):
         """
         self._internal.add_validation_rule(rule_type, **kwargs)
 
-    def insert(self, index: str, text: str) -> None:
-        """Insert `text` at `index`.
+    def insert(self, text: str) -> None:
+        """Insert `text` at the cursor.
 
-        `index` is a text position: `'end'` for the end of the content, or a
-        `'line.column'` string such as `'1.0'` (line 1, column 0).
+        Read-only blocks *user* edits, not programmatic ones: this applies
+        even when `read_only=True`, leaving the area read-only afterward.
 
         Args:
-            index: Target text position, e.g. `'end'` or `'1.0'`.
-            text: Text to insert.
+            text: Text to insert at the current cursor position.
         """
-        self._internal._core.insert(index, text)
+        self._internal._core.insert("insert", text)
+
+    def append(self, text: str) -> None:
+        """Append `text` to the end of the content.
+
+        Applies even when `read_only=True`, leaving the area read-only
+        afterward.
+
+        Args:
+            text: Text to add at the end of the content.
+        """
+        self._internal._core.insert("end-1c", text)
 
     def select_all(self) -> None:
         """Select all text content."""

--- a/tests/features/code_editor_public.py
+++ b/tests/features/code_editor_public.py
@@ -75,7 +75,7 @@ with App(title="CodeEditor — public layer", minsize=(780, 640), padding=16, ga
         Button("Mark saved", variant="outline",
                on_click=lambda: (py_editor.mark_saved(), _refresh_dirty()))
         Button("Goto line 5", variant="outline",
-               on_click=lambda: py_editor.goto_line(5))
+               on_click=lambda: py_editor.goto(5))
         Button("Select all", variant="outline",
                on_click=lambda: py_editor.select_all())
         Button("Clear", variant="outline",

--- a/tests/widgets/public/test_codeeditor_review.py
+++ b/tests/widgets/public/test_codeeditor_review.py
@@ -42,7 +42,7 @@ def app():
 
 def test_insert_applies_when_read_only_via_constructor(app):
     ed = bs.CodeEditor(value="abc", read_only=True)
-    ed.insert("end", "XYZ")
+    ed.append("XYZ")
     assert ed.value == "abcXYZ"
     assert ed.read_only is True  # still read-only after the programmatic insert
 
@@ -50,7 +50,7 @@ def test_insert_applies_when_read_only_via_constructor(app):
 def test_insert_applies_when_read_only_via_property(app):
     ed = bs.CodeEditor(value="abc")
     ed.read_only = True
-    ed.insert("end", "XYZ")
+    ed.append("XYZ")
     assert ed.value == "abcXYZ"
     assert ed.read_only is True
 
@@ -92,10 +92,16 @@ def test_cursor_position_mid(app):
     assert ed.cursor_position == (3, 6)  # column is 1-indexed for display
 
 
-def test_cursor_position_tracks_goto_line(app):
+def test_cursor_position_tracks_goto(app):
     ed = bs.CodeEditor(value="a\nb\nc")
-    ed.goto_line(2)
-    assert ed.cursor_position == (2, 1)
+    ed.goto(2)
+    assert ed.cursor_position == (2, 1)  # col defaults to the start of the line
+
+
+def test_goto_with_column(app):
+    ed = bs.CodeEditor(value="one\ntwo\nthree")
+    ed.goto(3, 4)  # line 3, col 4 (1-indexed)
+    assert ed.cursor_position == (3, 4)
 
 
 # ----- undo/redo bound to native virtual events -----
@@ -129,3 +135,44 @@ def test_return_replicates_indentation(app):
     ed._internal._smart_indent._on_return(None)
     tw.insert("insert", "X")
     assert ed.value == "    indented\n    X"
+
+
+# ----- position model: insert(text, line, col) + append (1-indexed, #250) -----
+
+def test_insert_at_cursor(app):
+    ed = bs.CodeEditor(value="abc")
+    ed._internal._core.text.mark_set("insert", "1.1")  # between a and b
+    ed.insert("Z")
+    assert ed.value == "aZbc"
+
+
+def test_insert_at_line_start(app):
+    ed = bs.CodeEditor(value="one\ntwo\nthree")
+    ed.insert(">>", 2)  # start of line 2
+    assert ed.value == "one\n>>two\nthree"
+
+
+def test_insert_at_line_and_col(app):
+    ed = bs.CodeEditor(value="one\ntwo\nthree")
+    ed.insert("X", 2, 2)  # line 2, col 2 (1-indexed) -> before 'w'
+    assert ed.value == "one\ntXwo\nthree"
+
+
+def test_insert_at_origin(app):
+    ed = bs.CodeEditor(value="abc")
+    ed.insert("# ", 1, 1)  # (1, 1) is the content start
+    assert ed.value == "# abc"
+
+
+def test_append(app):
+    ed = bs.CodeEditor(value="abc")
+    ed.append("\nmore")
+    assert ed.value == "abc\nmore"
+
+
+def test_append_round_trips_with_cursor_position(app):
+    # The coordinates insert/append produce read back through cursor_position.
+    ed = bs.CodeEditor(value="one\ntwo")
+    ed.insert("X", 1, 1)
+    ed._internal._core.text.mark_set("insert", "1.1")
+    assert ed.cursor_position == (1, 2)

--- a/tests/widgets/public/test_textarea_review.py
+++ b/tests/widgets/public/test_textarea_review.py
@@ -64,9 +64,23 @@ def test_read_only_toggle_round_trip(app):
 
 def test_insert_applies_when_read_only(app):
     ta = bs.TextArea(value="abc", read_only=True)
-    ta.insert("end", "XYZ")
+    ta.append("XYZ")
     assert ta.value == "abcXYZ"
     assert ta.read_only is True  # still read-only after the programmatic insert
+
+
+def test_insert_at_cursor(app):
+    # TextArea is a form field: insert is positionless (at the cursor only).
+    ta = bs.TextArea(value="abc")
+    ta._internal._core.text.mark_set("insert", "1.1")  # between a and b
+    ta.insert("Z")
+    assert ta.value == "aZbc"
+
+
+def test_append(app):
+    ta = bs.TextArea(value="abc")
+    ta.append("\nmore")
+    assert ta.value == "abc\nmore"
 
 
 def test_placeholder_does_not_make_read_only_editable(app):


### PR DESCRIPTION
Closes #250.

Removes the last Tkinter indexing leak in the public API — the `"line.column"` / `"end"` index strings on the multi-line text widgets — replacing it with a clean surface tailored to each widget's role.

## Design: shared spine, divergent reach

The two widgets share a core but are different products, so the API meets each where the user's head is:

- **`TextArea` is a form field** → positionless. `insert(text)` (at cursor) + `append(text)` (at end). No line/col, ever.
- **`CodeEditor` is an editor** → a unified **1-indexed `(line, col)`** vocabulary, because only its users think in lines.

The everyday calls (`value`, `insert` at cursor, `append`, `clear`) are byte-for-byte identical on both; only `CodeEditor` grows coordinates.

## CodeEditor: one rule, three ways

```python
ed.insert(text, line, col)      # write at a position (line alone = start of line)
ed.goto(line, col)              # move the cursor to a position
line, col = ed.cursor_position  # read the position
```

All 1-indexed, `(1, 1)` is the content start, `col` optional → start of line. No negative indices, no `'end'` sentinel — `append()` names the end case.

`goto_line(n)` → **`goto(line, col=1)`** (clean break, pre-freeze): mirrors `cursor_position` and lets you place the cursor at an exact diagnostic location (`line:col` from a linter). `goto(42)` is the old `goto_line(42)`.

## API changes (breaking — pre-release, no shims)

| Widget | Before | After |
|--------|--------|-------|
| `TextArea` | `insert(index, text)` | `insert(text)` + `append(text)` |
| `CodeEditor` | `insert(index, text)` | `insert(text, line=None, col=None)` + `append(text)` |
| `CodeEditor` | `goto_line(n)` | `goto(line, col=1)` |
| `CodeEditor` | `cursor_position` | unchanged shape; docstring de-stopgapped |

## Docs

- `codeeditor.rst` "Text positions" rewritten for the unified model.
- Added a **reactive status-bar** pattern — `on_cursor_move().map(...).listen(status.set)` driving a `Signal` (the `.map()` lives on the event *stream*, not the snapshot property).
- Dropped the obsolete line/col inconsistency note. The `.tk` escape hatch stays documented at the property level, not advertised in the guide (per the no-toolkit-internals-in-docs rule).

## Verification

- `test_codeeditor_review.py` 18 ✓ · `test_textarea_review.py` 9 ✓ · `test_public_surface.py` 161 ✓ (one App per process, #150)
- Clean `-W` Sphinx build
- API + reactive snippet smoke-tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)