### PR TITLE
fix(label): .text setter writes through a bound textsignal (#242)

### DIFF
--- a/src/bootstack/widgets/label.py
+++ b/src/bootstack/widgets/label.py
@@ -162,7 +162,14 @@ class Label(IconProperty, ImageProperty, PublicWidgetBase):
 
     @text.setter
     def text(self, value: str) -> None:
-        self._internal.configure(text=value)
+        # When a textsignal/textvariable owns the text, ttk ignores the `text`
+        # option — write through the variable instead (which also keeps the
+        # bound signal in sync). Falls back to the option when unbound.
+        textvar = getattr(self._internal, "_textvariable", None)
+        if textvar is not None:
+            textvar.set(value)
+        else:
+            self._internal.configure(text=value)
 
     # ----- Events -----
 

--- a/tests/widgets/public/test_label_badge.py
+++ b/tests/widgets/public/test_label_badge.py
@@ -102,7 +102,13 @@ def test_label_text_signal(app_ctx):
     from bootstack.widgets import Label
     from bootstack.signals import Signal
     sig = Signal("initial")
-    lbl = Label(text_signal=sig)
+    lbl = Label(textsignal=sig)
     assert lbl.text == "initial"
     sig.set("updated")
     assert lbl.text == "updated"
+
+    # Setting .text writes through the bound variable and keeps the signal in
+    # sync (#242 — the setter no-op'd while a textsignal owned the text).
+    lbl.text = "Changed"
+    assert lbl.text == "Changed"
+    assert sig() == "Changed"

--- a/tests/widgets/public/test_text_setter_textsignal.py
+++ b/tests/widgets/public/test_text_setter_textsignal.py
@@ -1,0 +1,96 @@
+"""#242 — `.text` setter must write through a bound textsignal/textvariable.
+
+When a `textsignal=` (or a localized key) owns a widget's text, ttk ignores the
+`text` option, so a naive `.text` setter (`configure(text=...)`) silently no-ops.
+The fix routes the setter through the bound variable when present (the Button
+pattern), keeping the displayed text AND the bound signal in sync.
+
+Only widgets whose `.text` IS the displayed text get the writable fix: Button
+(reference) and Label/Badge. Widgets that SEPARATE a display string from a raw
+value — Select/SelectButton (selected-option label vs `.value`) and the typed
+fields (`'Jan 2, 2024'` vs a `date`) — keep `.text` read-only and derived; this
+file guards that those stay live and untouched by the fix.
+"""
+import datetime
+
+import pytest
+
+import bootstack as bs
+
+
+@pytest.fixture(scope="module")
+def app():
+    a = bs.App()
+    a.__enter__()
+    a._tk_root.deiconify()
+    a._tk_root.update_idletasks()
+    try:
+        yield a
+    finally:
+        try:
+            a.__exit__(None, None, None)
+        except Exception:
+            pass
+        try:
+            a._tk_root.destroy()
+        except Exception:
+            pass
+
+
+# ----- Label: the dead-setter bug (#242) -----
+
+def test_label_text_round_trip_unbound(app):
+    lbl = bs.Label("Plain")
+    assert lbl.text == "Plain"
+    lbl.text = "New"
+    assert lbl.text == "New"
+
+
+def test_label_text_round_trip_with_textsignal(app):
+    sig = bs.Signal("Initial")
+    lbl = bs.Label(textsignal=sig)
+    assert lbl.text == "Initial"
+
+    # Setter writes through the bound variable and keeps the signal in sync.
+    lbl.text = "Changed"
+    assert lbl.text == "Changed"
+    assert sig() == "Changed"
+
+    # Signal writes flow back to .text.
+    sig.set("ViaSignal")
+    assert lbl.text == "ViaSignal"
+
+
+# ----- Badge inherits the fix from Label -----
+
+def test_badge_text_round_trip_with_textsignal(app):
+    sig = bs.Signal("1")
+    badge = bs.Badge(textsignal=sig)
+    assert badge.text == "1"
+    badge.text = "9+"
+    assert badge.text == "9+"
+    assert sig() == "9+"
+
+
+# ----- display-vs-raw widgets stay live and read-only (must NOT break) -----
+
+def test_select_text_is_live_selected_label(app):
+    # .text is the display label of the selection; .value is the raw value.
+    sel = bs.Select(options=["Apple", "Banana", "Cherry"])
+    sel.value = "Banana"
+    assert sel.text == "Banana"
+    assert sel.value == "Banana"
+
+
+def test_selectbutton_text_is_live_selected_label(app):
+    sb = bs.SelectButton(options=["One", "Two", "Three"])
+    sb.value = "Three"
+    assert sb.text == "Three"
+
+
+def test_datefield_separates_display_text_from_raw_value(app):
+    # The display/raw split the fix must not conflate: .text is the formatted
+    # string, .value is the parsed date object.
+    df = bs.DateField(value=datetime.date(2024, 1, 2))
+    assert isinstance(df.value, datetime.date)
+    assert df.text and df.text != str(df.value)  # formatted display, not the repr


### PR DESCRIPTION
Closes #242.

When a `textsignal=` (or a localized key) owns a `Label`'s text, ttk ignores the `text` option — so the public `.text` **setter silently no-op'd**. The fix routes the setter through the bound `_textvariable` when present (the Button pattern), updating the display *and* keeping the bound signal in sync; it falls back to `configure(text=)` when unbound. `Badge` inherits the fix.

## Scope — one real bug, verified

An adversarial sweep of the text-bearing family (audit agent flagged 9 candidates) reduced to **a single live bug: `Label`**. The getter was already correct (`cget('text')` tracks a bound variable, verified). Everything else was either already live or not a text-binding target:

| Widget | `.text` | Verdict |
|--------|---------|---------|
| **Label / Badge** | get + **set** | ✅ fixed (setter only) |
| Select, SelectButton | get (read-only) | already live — selected-option display label vs `.value` — **untouched** |
| CodeEditor, TextArea | get (read-only) | mirrors `.value` — **untouched** |
| typed fields | get (read-only) | formatted display vs raw datum — **untouched** |
| RadioGroup, ToggleGroup, Tooltip | — | no text binding — no fix |

**Display-vs-raw safety:** every widget that separates a display string from a raw value keeps `.text` read-only and derived. Routing those through a `textvariable` would conflate the display with the raw value (Select even keeps a separate `_display_var`), so none of them were changed.

## Drive-by

Fixed a pre-existing broken test: `test_label_text_signal` passed `text_signal=` (silently swallowed) instead of `textsignal=`, so the signal never bound. The GUI one-App-per-process crash (#150) had masked the failure on full-file runs.

## Tests

`tests/widgets/public/test_text_setter_textsignal.py` (new, 6) — Label/Badge round-trip (setter → signal in sync; signal → `.text`) + read-only-and-live guards for Select/SelectButton/DateField. Plus the corrected assertion in `test_label_badge.py`.

- new file 6 ✓ · fixed label test ✓ · public-surface 161 ✓ · button-review 8 ✓

## Follow-up

Filed #275 — `MenuButton` accepts `textsignal=` but exposes no `.text` property at all (a missing-property feature gap, not a dead-setter bug); deliberately out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)