### PR TITLE
feat(chart): optional bs.Chart widget for matplotlib figures (Phase 1)

### DIFF
--- a/docs/_dev/visualization-widget.md
+++ b/docs/_dev/visualization-widget.md
@@ -1,0 +1,168 @@
+# Visualization widget (`bs.Chart`) — design brief
+
+Status: **design locked, Phase 1 building** on branch `worktree-chart-widget`
+(→ PR as `feat/chart-widget`). Optional dependency — core installs never import
+matplotlib. Supersedes the placeholder note in memory `project_seaborn_viz_plugin`.
+Tracked: GitHub #277.
+
+Decisions locked with the maintainer (2026-06-21): widget name is **`Chart`**;
+first cut is **Phase 1 MVP only** (figure host + theme bridge); seaborn is an
+additive extra, not a separate integration.
+
+## Goal
+
+Empower data visualization inside bootstack without making it a charting library.
+A user composes a chart the same way they compose any other widget, it matches the
+active theme (light/dark) automatically, and it can live-update from a `Signal` or
+a `DataSource`. matplotlib is the engine; seaborn rides on top of it for free.
+
+**Non-goal:** a bespoke plotting API. We do not wrap matplotlib's plotting calls.
+The user draws with matplotlib/seaborn; we own embedding, theming, and the redraw
+loop.
+
+## Why this shape
+
+Everything needed already exists in the framework — no core changes:
+
+- **Widget pattern** — `PublicWidgetBase` wrapper + internal `Frame` composite
+  hosting a canvas. Model file-for-file on `Picture` / `Avatar`
+  (`widgets/picture.py` + `widgets/_impl/composites/picture.py`). matplotlib's
+  `FigureCanvasTkAgg(fig, master=self).get_tk_widget().pack(fill="both",
+  expand=True)` drops straight into the internal `Frame`.
+- **Theme bridge** — `get_theme_color(token)`, `get_theme_provider().mode` /
+  `.typography`, and the canvas theme-repaint hook
+  (`Frame._enable_theme_repaint(self._redraw)`, fires on Publisher `Channel.STD`
+  after a rebuild, gated on `winfo_viewable()`).
+- **Reactivity** — `Signal.subscribe(cb) -> Handle` (cancel on `<Destroy>`),
+  `.map()` for derived; `DataSource.observe(cond, *order) -> Stream[list[Record]]`
+  and `.on_change()`, exactly as `ListView` / `DataTable` consume them today.
+- **Optional deps** — the `excel` / `parquet` / `hdf5` extras already establish the
+  pattern.
+
+## Dependency strategy
+
+```toml
+[project.optional-dependencies]
+viz = ["matplotlib>=3.8"]
+viz-seaborn = ["matplotlib>=3.8", "seaborn>=0.13"]
+```
+
+`chart.py` imports matplotlib **lazily inside `__init__`** and raises a friendly
+`BootstackError` ("install with `pip install bootstack[viz]`") if missing. Pillow
+(already core) covers any raster needs; no new core deps.
+
+Two embedding correctness rules:
+
+- **Use `matplotlib.figure.Figure` directly — never `pyplot`.** pyplot keeps
+  global figure-manager state and pops separate OS windows. Embedded figures must
+  be standalone `Figure()` objects.
+- **Set the figure DPI from the Tk scaling factor** (`ui_scale`) so charts stay
+  crisp on high-DPI — same family as issue #267.
+
+## Public API — two layers
+
+### Layer 0 — figure host (escape hatch, full control) — PHASE 1
+
+```python
+from matplotlib.figure import Figure
+fig = Figure()
+fig.add_subplot().plot([1, 2, 3])
+bs.Chart(fig)          # embeds it, applies best-effort theme recolor, redraws on theme change
+```
+
+### Layer 1 — managed render callback (reactive, recommended) — PHASE 2+
+
+```python
+def render(ax, data):
+    ax.plot(data["x"], data["y"])
+
+bs.Chart(render=render, signal=my_signal)     # re-renders when the signal changes
+bs.Chart(render=render, data_source=ds)       # re-renders when the source mutates
+```
+
+In the managed path the widget owns the whole lifecycle: clear axes → apply theme
+styling → call `render(ax, data)` → `canvas.draw()`.
+
+Conveniences: `chart.figure` / `chart.ax` accessors, `chart.draw()`, `debounce=`
+(ms) for high-frequency sources, and `toolbar=True` (see below).
+
+## Theme bridge (the differentiator)
+
+An internal helper translates the active theme into a matplotlib rcParams dict
+(figure/axes facecolors, text/tick/spine colors, grid, an accent `prop_cycle`, and
+fonts from `get_theme_provider().typography`). The managed render runs inside
+`with matplotlib.rc_context(rc):` so plotting calls inherit themed defaults *and* a
+semantic color cycle. On `<<BsThemeChanged>>` / Publisher `Channel.STD`, the widget
+re-renders under the new rc and redraws.
+
+**Honest tradeoff:** rc_context only governs the managed (`render=`) path. For the
+Layer-0 `figure=` escape hatch the figure is already built, so the widget can only
+do best-effort recolor of existing artists (facecolors, tick/spine/text). A fully
+bespoke figure owns its own styling — documented as such.
+
+## Navigation toolbar — replace the raw-Tk one (Phase 4)
+
+> ⚠ matplotlib's built-in `NavigationToolbar2Tk` (pan / zoom / home / back /
+> forward / save) is a raw `tk.Frame` of unstyled tk buttons. It clashes with the
+> themed app and violates the no-raw-Tk principle (memory
+> `feedback_no_raw_tk_use_framework_idioms`). **We must not pack it.**
+
+matplotlib separates navigation *logic* (`matplotlib.backend_bases.NavigationToolbar2`
+— history, pan, zoom-rectangle, mouse handlers) from the *Tk rendering*. Recommended
+(`toolbar=True`): instantiate `NavigationToolbar2Tk(canvas, master,
+pack_toolbar=False)` so its tk frame is created but **never mapped**, then build a
+bootstack `Toolbar` of themed icon buttons wired to `nav.home`/`back`/`forward`/
+`pan`/`zoom`/`save_figure`. This reuses matplotlib's pan/zoom math and the
+canvas-drawn rubber-band (painted on the canvas, not the toolbar frame) — zero
+reimplementation. Follow-ups: route `save_figure` through bootstack's file-dialog
+verb; feed `set_message` to a Label/StatusBar; reflect pan/zoom toggle state via
+button styling.
+
+## Signals — live update (Phase 2)
+
+`signal=` accepts one signal or a list, each `subscribe`d to `self._redraw` (cancel
+on `<Destroy>`). matplotlib `draw()` is not cheap → expose `debounce=<ms>` (route
+through `Stream.debounce`) and gate redraws on `winfo_viewable()`. `.map()`-derived
+signals work unchanged (keep a reference — weakref-held).
+
+## Data source — ingestion (Phase 3)
+
+`data_source=` accepts any `DataSourceProtocol`. Static: `ds.page_slice(0, big_n)`.
+Live: `ds.observe(condition, *order).listen(self._on_rows)` (re-emits the full
+matching set; initial emit immediate). For very large sources prefer `ds.on_change()`
++ a windowed read, as `ListView` / `DataTable` do. A chart and a `DataTable` on the
+**same source** stay in lockstep — the headline demo.
+
+## Seaborn (Phase 4)
+
+No separate integration. seaborn draws onto a matplotlib `Axes`, so
+`render(ax, data)` takes `sns.barplot(..., ax=ax)` directly. Seed seaborn's palette
+from accent colors inside the rc_context. Keep seaborn in `viz-seaborn`, out of the
+import path.
+
+## File layout
+
+| Purpose | Path |
+|---|---|
+| Public wrapper | `src/bootstack/widgets/chart.py` |
+| Internal composite | `src/bootstack/widgets/_impl/composites/chart.py` |
+| Register (lazy) | `widgets/__init__.py` → `_EXPORTS["Chart"] = "chart"` |
+| Register (top-level) | `bootstack/__init__.py` import + `__all__` |
+
+## Phasing
+
+1. **Phase 1 (MVP, this branch):** `bs.Chart(figure=...)` + theme bridge +
+   theme-change redraw + `viz` extra. Proves embedding + theming end-to-end.
+2. **Phase 2:** managed `render=` + `signal=` live updates + `debounce=`.
+3. **Phase 3:** `data_source=` ingestion (static + `observe`); Chart+DataTable demo.
+4. **Phase 4:** `viz-seaborn` extra + palette seeding; themed nav toolbar; docs page.
+
+## Risks / gotchas
+
+- **pyplot vs Figure** — the single biggest embedding bug if missed.
+- **Raw-Tk nav toolbar** — never pack `NavigationToolbar2Tk`; drive its methods
+  from a themed bootstack `Toolbar`.
+- **Redraw cost** — debounce reactive sources; gate on visibility.
+- **DPI** — set figure DPI from `ui_scale`.
+- **Don't advertise before it ships** — no docs/demo/promo mention of charts until
+  the widget is real (per `project_seaborn_viz_plugin`).

--- a/docs/examples/chart.py
+++ b/docs/examples/chart.py
@@ -1,0 +1,37 @@
+"""Chart — embed a matplotlib figure as a themed bootstack widget.
+
+Run this directly to see the widget. Requires the visualization extra:
+``pip install bootstack[viz]``. Click "Toggle theme" to watch the chart's
+background and text recolor with the rest of the app.
+
+Build figures with matplotlib's object API (``matplotlib.figure.Figure``), not
+``pyplot`` — an embedded figure must be a standalone object.
+"""
+
+import math
+
+from matplotlib.figure import Figure
+
+import bootstack as bs
+
+
+def build_figure() -> Figure:
+    """A small two-series line plot."""
+    fig = Figure(figsize=(5.5, 3.6))
+    ax = fig.add_subplot(111)
+    xs = [i / 12 for i in range(80)]
+    ax.plot(xs, [math.sin(x) for x in xs], label="sin")
+    ax.plot(xs, [math.cos(x) for x in xs], label="cos")
+    ax.set_title("Trigonometric curves")
+    ax.set_xlabel("x")
+    ax.set_ylabel("amplitude")
+    ax.legend(loc="upper right")
+    return fig
+
+
+with bs.App(title="Chart", size=(640, 480), padding=16, gap=12) as app:
+    bs.Label("A matplotlib figure, themed to match the app", font="heading-md")
+    bs.Chart(build_figure(), grow=True, horizontal="stretch")
+    bs.Button("Toggle theme", on_click=bs.toggle_theme)
+
+app.run()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,15 @@ hdf5 = [
     "pandas>=2",
     "tables>=3.8",
 ]
+# Visualization — embed matplotlib figures in a Chart widget.
+viz = [
+    "matplotlib>=3.8",
+]
+# Visualization with seaborn convenience layer on top of matplotlib.
+viz-seaborn = [
+    "matplotlib>=3.8",
+    "seaborn>=0.13",
+]
 docs = [
     "sphinx>=7.2",
     "pydata-sphinx-theme",

--- a/src/bootstack/__init__.py
+++ b/src/bootstack/__init__.py
@@ -81,6 +81,7 @@ from bootstack.widgets.pagestack import PageStack, StackPage
 from bootstack.widgets.pathfield import PathField
 from bootstack.widgets.avatar import Avatar
 from bootstack.widgets.carousel import Carousel
+from bootstack.widgets.chart import Chart
 from bootstack.widgets.gallery import Gallery
 from bootstack.widgets.passwordfield import PasswordField
 from bootstack.widgets.picture import Picture
@@ -143,7 +144,7 @@ __all__ = [
     # Data display
     "Label", "Badge", "ProgressBar", "Gauge", "ListView", "DataTable", "Tree", "TreeNode",
     # Media
-    "Picture", "Gallery", "Carousel", "Avatar",
+    "Picture", "Gallery", "Carousel", "Avatar", "Chart",
     # Navigation
     "PageStack", "StackPage", "Tabs", "TabPage",
     # Overlays

--- a/src/bootstack/widgets/__init__.py
+++ b/src/bootstack/widgets/__init__.py
@@ -39,6 +39,7 @@ _EXPORTS: dict[str, str] = {
     "Label": "label", "Badge": "label", "Picture": "picture", "Gallery": "gallery",
     "Carousel": "carousel", "Avatar": "avatar", "ProgressBar": "progressbar",
     "Gauge": "gauge", "ListView": "listview", "DataTable": "datatable", "Tree": "tree",
+    "Chart": "chart",
     # Navigation
     "PageStack": "pagestack", "StackPage": "pagestack",
     "Tabs": "tabs", "TabPage": "tabs",

--- a/src/bootstack/widgets/_impl/composites/chart.py
+++ b/src/bootstack/widgets/_impl/composites/chart.py
@@ -1,0 +1,126 @@
+"""Internal Chart composite — embeds a matplotlib figure in a themed frame.
+
+Hosts a matplotlib ``FigureCanvasTkAgg`` inside a bootstack `Frame` and keeps the
+figure's chrome colors (faces, spines, text) in sync with the active theme. The
+public `bootstack.Chart` wrapper drives this; nothing here is public.
+
+matplotlib is an optional dependency (the ``viz`` extra). It is imported lazily
+inside the methods so that importing bootstack never pulls it in — only
+constructing a `Chart` does.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from bootstack.widgets._impl.primitives.frame import Frame
+from bootstack.widgets.types import Master
+
+
+def _theme_palette() -> dict[str, str]:
+    """Resolve the chart's chrome colors from the active theme (best-effort)."""
+    from bootstack.style import get_theme_color
+
+    def color(token: str, fallback: str) -> str:
+        try:
+            return get_theme_color(token)
+        except Exception:
+            return fallback
+
+    fg = color("foreground", "#212529")
+    bg = color("background", "#ffffff")
+    return {
+        "figure_bg": bg,
+        "axes_bg": color("content", bg),
+        "fg": fg,
+        "grid": color("stroke_subtle", fg),
+    }
+
+
+class Chart(Frame):
+    """Frame hosting a matplotlib figure, recolored to match the theme."""
+
+    def __init__(self, master: Master = None, *, figure: Any = None, **kwargs: Any) -> None:
+        super().__init__(master, **kwargs)
+
+        from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
+        from matplotlib.figure import Figure
+
+        self._figure = figure if figure is not None else Figure()
+        self._canvas = FigureCanvasTkAgg(self._figure, master=self)
+        self._widget = self._canvas.get_tk_widget()
+        self._widget.configure(highlightthickness=0, bd=0)
+        self._widget.pack(fill="both", expand=True)
+
+        self._style_figure()
+        self._canvas.draw_idle()
+        self._enable_theme_repaint(self._on_theme_changed)
+
+    # ----- theme ------------------------------------------------------------
+
+    def _style_figure(self) -> None:
+        """Recolor the figure's chrome (faces, spines, text) to the theme.
+
+        Best-effort pass over the *existing* artists — it does not impose a grid
+        or restyle data series, which the figure's author owns. Never raises: a
+        bespoke figure's quirks must not break the embed.
+        """
+        pal = _theme_palette()
+        fig = self._figure
+        try:
+            fig.set_facecolor(pal["figure_bg"])
+            for ax in fig.axes:
+                ax.set_facecolor(pal["axes_bg"])
+                for spine in ax.spines.values():
+                    spine.set_color(pal["fg"])
+                ax.tick_params(colors=pal["fg"], which="both")
+                ax.xaxis.label.set_color(pal["fg"])
+                ax.yaxis.label.set_color(pal["fg"])
+                ax.title.set_color(pal["fg"])
+                for label in (*ax.get_xticklabels(), *ax.get_yticklabels()):
+                    label.set_color(pal["fg"])
+                for line in (*ax.get_xgridlines(), *ax.get_ygridlines()):
+                    line.set_color(pal["grid"])
+                legend = ax.get_legend()
+                if legend is not None:
+                    frame = legend.get_frame()
+                    frame.set_facecolor(pal["axes_bg"])
+                    frame.set_edgecolor(pal["fg"])
+                    for text in legend.get_texts():
+                        text.set_color(pal["fg"])
+        except Exception:
+            pass
+
+    def _on_theme_changed(self) -> None:
+        """Re-resolve theme colors and redraw (called after a theme rebuild)."""
+        self._style_figure()
+        try:
+            self._canvas.draw_idle()
+        except Exception:
+            pass
+
+    # ----- figure -----------------------------------------------------------
+
+    def set_figure(self, figure: Any) -> None:
+        """Replace the embedded figure, tearing down the old canvas widget."""
+        from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
+        from matplotlib.figure import Figure
+
+        if figure is None:
+            figure = Figure()
+        if self._widget is not None:
+            self._widget.destroy()
+        self._figure = figure
+        self._canvas = FigureCanvasTkAgg(self._figure, master=self)
+        self._widget = self._canvas.get_tk_widget()
+        self._widget.configure(highlightthickness=0, bd=0)
+        self._widget.pack(fill="both", expand=True)
+        self._style_figure()
+        self._canvas.draw_idle()
+
+    def draw(self) -> None:
+        """Force a redraw of the current figure."""
+        try:
+            self._canvas.draw_idle()
+        except Exception:
+            pass

--- a/src/bootstack/widgets/chart.py
+++ b/src/bootstack/widgets/chart.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from typing import Any
+
+from bootstack.errors import BootstackError
+from bootstack.widgets._core.base import PublicWidgetBase
+from bootstack.widgets._impl.composites.chart import Chart as _InternalChart
+
+
+def _require_matplotlib() -> None:
+    """Raise a friendly error if the optional matplotlib dependency is missing."""
+    try:
+        import matplotlib  # noqa: F401
+    except ImportError as exc:
+        raise BootstackError(
+            "Chart requires matplotlib, which is not installed. Install the "
+            "optional visualization extra with:\n\n    pip install bootstack[viz]"
+        ) from exc
+
+
+class Chart(PublicWidgetBase):
+    """Embed a matplotlib figure in a bootstack app, themed to match.
+
+    `Chart` is the bridge between bootstack and the scientific Python plotting
+    stack. You build a plot with matplotlib (or seaborn, which draws onto the
+    same axes) and hand the figure to a `Chart`; it embeds the figure as a
+    first-class widget that fills its space and recolors its chrome — figure and
+    axes backgrounds, spines, ticks, and text — to match the active theme,
+    flipping with light/dark like everything else in the app.
+
+    `Chart` is deliberately not a plotting API: it does not wrap matplotlib's
+    drawing calls. You keep the full expressive power of matplotlib/seaborn and
+    bootstack owns only the embedding, theming, and redraw.
+
+    matplotlib is an optional dependency. Install it with the visualization
+    extra: ``pip install bootstack[viz]`` (or ``bootstack[viz-seaborn]`` to add
+    seaborn). Constructing a `Chart` without matplotlib installed raises a
+    `bootstack.errors.BootstackError` explaining how to install it.
+
+    Build the figure with matplotlib's object API (``matplotlib.figure.Figure``)
+    rather than ``pyplot`` — an embedded figure must be a standalone object, and
+    ``pyplot`` would also open a separate window.
+
+    Args:
+        figure: The matplotlib `Figure` to display. Omit to start with an empty
+            figure you populate later via the `ax` accessor or the `figure`
+            property.
+        parent: Explicit parent widget. If omitted, the current context-stack
+            container is used.
+        **kwargs: Layout placement options applied by the parent container
+            (e.g. `grow`, `horizontal`, `row`, `column`), plus container styling
+            such as `surface` and `padding`. See :doc:`/tasks/layout`.
+    """
+
+    _internal_class = _InternalChart
+
+    def __init__(self, figure: Any = None, *, parent: Any = None, **kwargs: Any) -> None:
+        _require_matplotlib()
+        self._parent = self._resolve_parent(parent)
+        layout_kw = self._split_layout_kwargs(kwargs)
+        tk_master = self._parent._child_master() if self._parent else None
+
+        internal_kwargs: dict[str, Any] = {"figure": figure}
+        internal_kwargs.update(kwargs)
+        self._internal = self._internal_class(tk_master, **internal_kwargs)
+        self._attach_to_parent(layout_kw)
+
+    # ----- Properties -----
+
+    @property
+    def figure(self) -> Any:
+        """The embedded matplotlib `Figure`.
+
+        Assign a new `Figure` to swap what is displayed; the old canvas is torn
+        down and the new figure is themed and drawn.
+        """
+        return self._internal._figure
+
+    @figure.setter
+    def figure(self, value: Any) -> None:
+        self._internal.set_figure(value)
+
+    @property
+    def ax(self) -> Any:
+        """The figure's primary `Axes`, creating one if the figure is empty.
+
+        A convenience for the common single-plot case::
+
+            chart = bs.Chart()
+            chart.ax.plot([1, 2, 3])
+            chart.draw()
+        """
+        fig = self._internal._figure
+        return fig.axes[0] if fig.axes else fig.add_subplot(111)
+
+    # ----- Methods -----
+
+    def draw(self) -> None:
+        """Redraw the figure after mutating it in place.
+
+        Call this after drawing onto `ax` (or the figure) so the change appears.
+        Theme changes redraw automatically — this is for your own updates.
+        """
+        self._internal.draw()

--- a/tests/test_public_surface.py
+++ b/tests/test_public_surface.py
@@ -48,7 +48,7 @@ EXPECTED_TOPLEVEL = {
     "Label", "Badge", "ProgressBar", "Gauge", "ListView", "DataTable",
     "Tree", "TreeNode",
     # media
-    "Picture", "Gallery", "Carousel", "Avatar",
+    "Picture", "Gallery", "Carousel", "Avatar", "Chart",
     # navigation
     "PageStack", "StackPage", "Tabs", "TabPage",
     # overlays

--- a/tests/widgets/public/test_chart.py
+++ b/tests/widgets/public/test_chart.py
@@ -1,0 +1,83 @@
+"""Chart (Phase 1) — embeds a matplotlib figure as a themed widget.
+
+matplotlib is an optional dependency (the ``viz`` extra); the whole module skips
+when it is not installed.
+"""
+import pytest
+
+pytest.importorskip("matplotlib")
+
+from matplotlib.colors import to_hex  # noqa: E402
+from matplotlib.figure import Figure  # noqa: E402
+
+import bootstack as bs  # noqa: E402
+from bootstack.errors import BootstackError  # noqa: E402
+from bootstack.style import get_theme_color  # noqa: E402
+
+
+def test_chart_is_public():
+    assert hasattr(bs, "Chart")
+    assert "Chart" in bs.__all__
+
+
+def test_chart_embeds_figure(app):
+    fig = Figure()
+    fig.add_subplot(111).plot([1, 2, 3], [4, 5, 6])
+    chart = bs.Chart(fig)
+    app._tk_root.update_idletasks()
+
+    assert chart.figure is fig
+    # The matplotlib canvas tk widget is realized inside the chart frame.
+    assert chart._internal._widget.winfo_exists()
+
+
+def test_chart_empty_then_ax(app):
+    chart = bs.Chart()
+    chart.ax.plot([0, 1], [1, 0])  # `ax` creates an axes on the empty figure
+    chart.draw()
+    app._tk_root.update_idletasks()
+
+    assert chart.figure.axes  # an axes now exists
+
+
+def test_chart_figure_setter_swaps(app):
+    chart = bs.Chart()
+    original = chart.figure
+    replacement = Figure()
+
+    chart.figure = replacement
+    app._tk_root.update_idletasks()
+
+    assert chart.figure is replacement
+    assert chart.figure is not original
+
+
+def test_chart_recolors_figure_to_theme(shown_app):
+    fig = Figure()
+    fig.add_subplot(111).plot([1, 2, 3])
+    chart = bs.Chart(fig)
+    shown_app._tk_root.update_idletasks()
+
+    # The figure face is themed on construction.
+    assert to_hex(chart.figure.get_facecolor()).lower() == get_theme_color("background").lower()
+
+    # Toggling the theme recolors it (publisher repaint runs while visible).
+    bs.toggle_theme()
+    shown_app._tk_root.update_idletasks()
+    assert to_hex(chart.figure.get_facecolor()).lower() == get_theme_color("background").lower()
+
+
+def test_chart_without_matplotlib_raises(monkeypatch, app):
+    """Constructing a Chart without matplotlib gives a friendly install error."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "matplotlib" or name.startswith("matplotlib."):
+            raise ModuleNotFoundError("No module named 'matplotlib'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    with pytest.raises(BootstackError, match="bootstack\\[viz\\]"):
+        bs.Chart()


### PR DESCRIPTION
First of four phases bringing data visualization to bootstack (tracks #277), all targeted before the 0.1.0 stable cut. Phase 1 is the **figure-host** layer.

## What this adds
- **`bs.Chart`** — embed a matplotlib `Figure` as a first-class, theme-aware widget. It fills its space and recolors its chrome (figure/axes faces, spines, ticks, text, legend) to the active theme, flipping with light/dark via the canvas theme-repaint hook.
- **Optional dependency** — new `viz` / `viz-seaborn` extras. matplotlib is imported **lazily**, so core installs never pull it in; constructing a `Chart` without it raises a friendly `BootstackError` pointing at `pip install bootstack[viz]`.
- Not a plotting API — you draw with matplotlib/seaborn; bootstack owns embedding, theming, and redraw. Build figures with `matplotlib.figure.Figure` (never `pyplot`).

## API (Phase 1)
```python
from matplotlib.figure import Figure
import bootstack as bs

fig = Figure()
fig.add_subplot(111).plot([1, 2, 3])
with bs.App() as app:
    bs.Chart(fig, grow=True, horizontal="stretch")
app.run()
```
Plus `chart.figure` (get/set, swaps the embed), `chart.ax` (primary axes, created on demand), `chart.draw()`.

## Tradeoff (documented)
Theme recolor on the `figure=` path is best-effort over existing artists; it does not restyle data series or impose a grid (the figure's author owns those). The semantic color cycle arrives with the managed `render=` path in Phase 2.

## Tests
- `tests/widgets/public/test_chart.py` — 6 tests (skip cleanly without matplotlib): embedding, figure setter swap, empty-then-`ax`, theme recolor on `toggle_theme`, and the missing-matplotlib guard.
- Surface guard updated. **167 tests + full `run_gui.py` suite green.**

## Follow-up phases (separate PRs, before 0.1.0)
2. Managed `render=` callback, `signal=` live updates, semantic color cycle, `debounce=`.
3. `data_source=` ingestion (static + live `observe`); Chart+DataTable shared-source demo.
4. `viz-seaborn` palette seeding; themed navigation toolbar (replacing raw-Tk `NavigationToolbar2Tk`); docs page + screenshots.

Design brief: `docs/_dev/visualization-widget.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)