### PR TITLE
feat(chart): managed reactive render + blitting animation (Phase 2)

### DIFF
--- a/docs/_dev/visualization-widget.md
+++ b/docs/_dev/visualization-widget.md
@@ -1,13 +1,42 @@
 # Visualization widget (`bs.Chart`) — design brief
 
-Status: **design locked, Phase 1 building** on branch `worktree-chart-widget`
-(→ PR as `feat/chart-widget`). Optional dependency — core installs never import
-matplotlib. Supersedes the placeholder note in memory `project_seaborn_viz_plugin`.
-Tracked: GitHub #277.
+Status: **Phase 1 shipped** (PR #279, `feat/chart-widget`). **Phase 2 +
+animation** built on `feat/chart-reactive` (combined PR). Optional dependency —
+core installs never import matplotlib. Supersedes the placeholder note in memory
+`project_seaborn_viz_plugin`. Tracked: GitHub #277.
 
 Decisions locked with the maintainer (2026-06-21): widget name is **`Chart`**;
-first cut is **Phase 1 MVP only** (figure host + theme bridge); seaborn is an
-additive extra, not a separate integration.
+seaborn is an additive extra, not a separate integration.
+
+**Phase 2 — shipped (reactive + animation).** Two update paths landed on top of
+the figure host:
+
+- **Managed render** (`render=` + `signal=`) — the chart owns the figure and
+  redraw loop, applying the theme as rcParams (incl. a semantic accent
+  `prop_cycle`) before each `render(ax, data)`. Re-renders on theme change and
+  on signal change; rapid changes **coalesce to one render per idle frame** so a
+  fast source can't starve the loop.
+- **Blitting animation** (`chart.animate(setup, update, interval=)`) — the fast
+  path for continuous animation. A full `clear()`+rebuild is ~31 ms/frame
+  (~32 fps ceiling); blitting (update artists in place + redraw only them over a
+  cached background) is ~0.2 ms/frame. Decisions made during build:
+  - **Time-based motion** — the callback receives elapsed *seconds* (not a frame
+    index) for the default continuous animation, so apparent velocity stays
+    constant under Tk timer jitter. Explicit `frames=` still steps fixed data.
+  - **Visibility gating** — runs only when *actually visible*: paused on
+    `<Map>`/`<Unmap>` (tabs/pages/minimize — reliable cross-platform) and on
+    `<Visibility>` full-cover (best-effort, mainly X11). Off-screen charts on a
+    dashboard cost nothing. A theme change that arrives while hidden is applied
+    on the next `<Map>` (deferred via the `Frame` theme-repaint hook).
+  - **Theme on blit** — clearing FuncAnimation's `_blit_cache` on theme change
+    forces a background re-grab (the cache otherwise only refreshes on a view
+    change). Animated *series* keep their `setup` colors; chart *chrome* tracks
+    the theme.
+  - Returns a `ChartAnimation` handle (`stop`/`start`/`running`); auto-stops on
+    destroy. What you draw with stays pure matplotlib.
+
+Remaining: **Phase 3** (`data_source=` ingestion) and **Phase 4** (seaborn extra
++ themed nav toolbar + docs page).
 
 ## Goal
 

--- a/docs/examples/chart_animation.py
+++ b/docs/examples/chart_animation.py
@@ -1,0 +1,45 @@
+"""Chart animation — a smooth, high-FPS plot via blitting.
+
+Run this directly. Requires the visualization extra: ``pip install bootstack[viz]``.
+The wave scrolls smoothly because ``chart.animate`` updates the line's data in
+place and blits only that line over a cached background (instead of rebuilding
+the whole figure each frame), and because the motion is driven by *elapsed time*
+rather than the frame count — so it keeps a constant speed even if frame timing
+jitters. Pause/Play control it; toggle the theme and it keeps running, recolored.
+
+Use this for continuous animation. For event-driven updates that change the
+plotted data occasionally (e.g. a control), use the ``render=`` path instead —
+see chart_reactive.py.
+"""
+
+import numpy as np
+
+import bootstack as bs
+
+xs = np.linspace(0, 12, 240)  # fixed x grid
+
+
+def setup(ax):
+    """Create the artists once and fix the axes (blitting needs stable axes)."""
+    (line,) = ax.plot(xs, np.zeros_like(xs), linewidth=2)
+    ax.set_xlim(xs[0], xs[-1])
+    ax.set_ylim(-1.2, 1.2)
+    ax.set_title("Live animation (blitting)")
+    return line
+
+
+def frame(t, line):
+    """Per frame: `t` is elapsed seconds — motion at a constant 2 rad/s."""
+    line.set_ydata(np.sin(xs + t * 2.0))
+
+
+with bs.App(title="Chart animation", min_size=(680, 480), padding=16, gap=12) as app:
+    chart = bs.Chart(grow=True, horizontal="stretch")
+    anim = chart.animate(setup, frame, interval=16)  # ~60 fps target
+
+    with bs.Row(gap=8):
+        bs.Button("Pause", on_click=anim.stop)
+        bs.Button("Play", on_click=anim.start)
+        bs.Button("Toggle theme", on_click=bs.toggle_theme)
+
+app.run()

--- a/docs/examples/chart_reactive.py
+++ b/docs/examples/chart_reactive.py
@@ -1,0 +1,40 @@
+"""Chart (reactive) — a managed render that redraws when bound data changes.
+
+Run this directly. Requires the visualization extra: ``pip install bootstack[viz]``.
+The ``render=`` path rebuilds the figure whenever a bound `Signal` changes —
+ideal for event-driven updates like a control changing a parameter. Drag the
+slider to change the wave's frequency; the chart re-renders with the theme's
+accent color cycle. Click "Toggle theme" to recolor.
+
+For smooth, high-FPS animation (a continuously moving plot), use
+``chart.animate(...)`` instead — see chart_animation.py.
+"""
+
+import math
+
+import bootstack as bs
+
+
+def render(ax, frequency: float) -> None:
+    """Plot sine and cosine at the bound frequency. `ax` arrives themed."""
+    xs = [i * 0.1 for i in range(120)]
+    ax.plot(xs, [math.sin(frequency * x) for x in xs], label="sin")
+    ax.plot(xs, [math.cos(frequency * x) for x in xs], label="cos")
+    ax.set_ylim(-1.2, 1.2)
+    ax.set_title(f"frequency = {frequency:.1f}")
+    ax.legend(loc="upper right")
+
+
+with bs.App(title="Reactive Chart", min_size=(640, 480), padding=16, gap=12) as app:
+    # A Signal must be created inside the running app (the event loop must exist).
+    freq = bs.Signal(1.0)
+
+    bs.Label("Drag the slider — the chart re-renders", font="heading-md")
+    bs.Chart(render=render, signal=freq, grow=True, horizontal="stretch")
+
+    with bs.Row(gap=8, horizontal="stretch"):
+        bs.Label("Frequency")
+        bs.Slider(min_value=0.2, max_value=4.0, signal=freq, grow=True)
+    bs.Button("Toggle theme", on_click=bs.toggle_theme)
+
+app.run()

--- a/src/bootstack/widgets/_impl/composites/chart.py
+++ b/src/bootstack/widgets/_impl/composites/chart.py
@@ -1,50 +1,186 @@
 """Internal Chart composite — embeds a matplotlib figure in a themed frame.
 
-Hosts a matplotlib ``FigureCanvasTkAgg`` inside a bootstack `Frame` and keeps the
-figure's chrome colors (faces, spines, text) in sync with the active theme. The
-public `bootstack.Chart` wrapper drives this; nothing here is public.
+Two modes, both hosting a matplotlib ``FigureCanvasTkAgg`` inside a bootstack
+`Frame`:
 
-matplotlib is an optional dependency (the ``viz`` extra). It is imported lazily
-inside the methods so that importing bootstack never pulls it in — only
-constructing a `Chart` does.
+- **Figure host** (``figure=``): the caller owns a `Figure`; the composite embeds
+  it and recolors its chrome (faces, spines, text) to the active theme — a
+  best-effort pass over the existing artists.
+- **Managed render** (``render=``): the composite owns the figure and redraw
+  loop. Each redraw clears the axes, applies the theme as matplotlib rcParams
+  (including a semantic accent color cycle), calls the caller's ``render(ax,
+  data)``, and draws. It re-renders on theme change and whenever a bound
+  `Signal` changes (optionally debounced).
+
+The public `bootstack.Chart` wrapper drives this; nothing here is public.
+matplotlib is an optional dependency (the ``viz`` extra), imported lazily inside
+the methods so importing bootstack never pulls it in.
 """
 
 from __future__ import annotations
 
-from typing import Any
+import inspect
+from typing import Any, Callable, Sequence
 
 from bootstack.widgets._impl.primitives.frame import Frame
 from bootstack.widgets.types import Master
 
+# Accent roles used, in order, for the categorical series color cycle.
+_CYCLE_ROLES = ("primary", "success", "info", "warning", "danger", "secondary")
 
-def _theme_palette() -> dict[str, str]:
-    """Resolve the chart's chrome colors from the active theme (best-effort)."""
+# family name -> resolved family (or None if matplotlib can't find it). Cached so
+# the theme-rc build does not probe the font manager on every redraw.
+_FONT_CACHE: dict[str, str | None] = {}
+
+
+def _color(token: str, fallback: str) -> str:
+    """Resolve a theme color token to a hex string, falling back on failure."""
     from bootstack.style import get_theme_color
 
-    def color(token: str, fallback: str) -> str:
-        try:
-            return get_theme_color(token)
-        except Exception:
-            return fallback
+    try:
+        return get_theme_color(token)
+    except Exception:
+        return fallback
 
-    fg = color("foreground", "#212529")
-    bg = color("background", "#ffffff")
+
+def _resolve_font_family(name: str) -> str | None:
+    """Return `name` if matplotlib can resolve that font family, else None."""
+    if name in _FONT_CACHE:
+        return _FONT_CACHE[name]
+    resolved: str | None = None
+    try:
+        from matplotlib.font_manager import FontProperties, fontManager
+
+        if fontManager.findfont(FontProperties(family=name), fallback_to_default=False):
+            resolved = name
+    except Exception:
+        resolved = None
+    _FONT_CACHE[name] = resolved
+    return resolved
+
+
+def _theme_palette() -> dict[str, str]:
+    """The chart's chrome colors from the active theme (best-effort)."""
+    fg = _color("foreground", "#212529")
+    bg = _color("background", "#ffffff")
     return {
         "figure_bg": bg,
-        "axes_bg": color("content", bg),
+        "axes_bg": _color("content", bg),
         "fg": fg,
-        "grid": color("stroke_subtle", fg),
+        "grid": _color("stroke_subtle", fg),
     }
 
 
-class Chart(Frame):
-    """Frame hosting a matplotlib figure, recolored to match the theme."""
+def _theme_rc() -> dict[str, Any]:
+    """Translate the active theme into a matplotlib rcParams dict.
 
-    def __init__(self, master: Master = None, *, figure: Any = None, **kwargs: Any) -> None:
+    Governs artists created within a ``matplotlib.rc_context(rc)`` block: figure
+    and axes faces, spine/tick/label/title colors, grid color, a semantic accent
+    ``prop_cycle`` for series, and the theme body font.
+    """
+    pal = _theme_palette()
+    fg = pal["fg"]
+    rc: dict[str, Any] = {
+        "figure.facecolor": pal["figure_bg"],
+        "savefig.facecolor": pal["figure_bg"],
+        "axes.facecolor": pal["axes_bg"],
+        "axes.edgecolor": fg,
+        "axes.labelcolor": fg,
+        "axes.titlecolor": fg,
+        "text.color": fg,
+        "xtick.color": fg,
+        "ytick.color": fg,
+        "xtick.labelcolor": fg,
+        "ytick.labelcolor": fg,
+        "grid.color": pal["grid"],
+        "legend.facecolor": pal["axes_bg"],
+        "legend.edgecolor": fg,
+    }
+
+    cycle: list[str] = []
+    for role in _CYCLE_ROLES:
+        hexval = _color(f"{role}[500]", "") or _color(role, "")
+        if hexval:
+            cycle.append(hexval)
+    if cycle:
+        try:
+            from cycler import cycler
+
+            rc["axes.prop_cycle"] = cycler(color=cycle)
+        except Exception:
+            pass
+
+    try:
+        from bootstack.style.style import get_theme_provider
+
+        spec = get_theme_provider().typography.body
+        rc["font.size"] = spec.size
+        family = _resolve_font_family(spec.font)
+        if family:
+            rc["font.family"] = family
+    except Exception:
+        pass
+
+    return rc
+
+
+def _positional_arity(fn: Callable) -> int:
+    """Count the positional parameters of `fn` (``*args`` counts as 2)."""
+    try:
+        sig = inspect.signature(fn)
+    except (TypeError, ValueError):
+        return 2
+    params = sig.parameters.values()
+    if any(p.kind == p.VAR_POSITIONAL for p in params):
+        return 2
+    return sum(
+        1 for p in params if p.kind in (p.POSITIONAL_ONLY, p.POSITIONAL_OR_KEYWORD)
+    )
+
+
+def _as_artist_list(result: Any) -> list[Any]:
+    """Normalize a setup() return (one artist or several) to a list."""
+    if result is None:
+        return []
+    if isinstance(result, (list, tuple)):
+        return list(result)
+    return [result]
+
+
+class Chart(Frame):
+    """Frame hosting a matplotlib figure — themed, optionally managed/reactive."""
+
+    def __init__(
+        self,
+        master: Master = None,
+        *,
+        figure: Any = None,
+        render: Callable | None = None,
+        signals: Sequence[Any] | None = None,
+        debounce: int = 0,
+        **kwargs: Any,
+    ) -> None:
         super().__init__(master, **kwargs)
 
         from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
         from matplotlib.figure import Figure
+
+        from bootstack.scheduling import Schedule
+
+        self._render = render
+        self._render_arity = _positional_arity(render) if render else 0
+        self._signals = list(signals) if signals else []
+        self._debounce = max(0, int(debounce))
+        self._debounce_job: Any = None
+        self._render_pending = False
+        self._signal_handles: list[Any] = []
+        self._schedule = Schedule(self)
+        self._anim: Any = None  # matplotlib FuncAnimation when animate() is used
+        self._anim_artists: list[Any] = []
+        self._anim_wanted = False        # user intent: should it be playing
+        self._anim_running_now = False   # actual timer state we last applied
+        self._anim_obscured = False      # fully covered by another window
+        self._anim_first_draw_cid: Any = None
 
         self._figure = figure if figure is not None else Figure()
         self._canvas = FigureCanvasTkAgg(self._figure, master=self)
@@ -52,54 +188,161 @@ class Chart(Frame):
         self._widget.configure(highlightthickness=0, bd=0)
         self._widget.pack(fill="both", expand=True)
 
-        self._style_figure()
-        self._canvas.draw_idle()
-        self._enable_theme_repaint(self._on_theme_changed)
+        if self._render is not None:
+            self._render_managed()
+        else:
+            self._style_figure()
+            self._canvas.draw_idle()
 
-    # ----- theme ------------------------------------------------------------
+        self._enable_theme_repaint(self._on_theme_changed)
+        self._bind_signals()
+        # Visibility gating for animations: pause when the chart is hidden
+        # (Map/Unmap — tabs, pages, minimized; reliable cross-platform) or fully
+        # covered by another window (Visibility — best-effort, mainly X11).
+        self.bind("<Map>", self._on_anim_visibility, add="+")
+        self.bind("<Unmap>", self._on_anim_visibility, add="+")
+        self.bind("<Visibility>", self._on_anim_obscured, add="+")
+        self.bind("<Destroy>", self._on_destroy, add="+")
+
+    # ----- reactive wiring --------------------------------------------------
+
+    def _bind_signals(self) -> None:
+        for sig in self._signals:
+            try:
+                self._signal_handles.append(sig.subscribe(self._on_signal_change))
+            except Exception:
+                pass
+
+    def _on_signal_change(self, *_: Any) -> None:
+        if self._debounce > 0:
+            if self._debounce_job is not None:
+                try:
+                    self._debounce_job.cancel()
+                except Exception:
+                    pass
+            self._debounce_job = self._schedule.delay(self._debounce, self._request_render)
+        else:
+            self._request_render()
+
+    def _request_render(self) -> None:
+        """Coalesce a burst of changes into one render at the next idle frame.
+
+        A timer or stream that updates a bound signal faster than matplotlib can
+        draw would otherwise queue an unbounded backlog of synchronous rebuilds
+        and starve the event loop. Collapsing to one render per idle keeps the UI
+        responsive and the redraw rate bounded by what the figure can sustain.
+        """
+        if self._render_pending or not self.winfo_exists():
+            return
+        self._render_pending = True
+        self._schedule.idle(self._flush_render)
+
+    def _flush_render(self) -> None:
+        self._render_pending = False
+        self._render_managed()
+
+    def _current_data(self) -> Any:
+        """The data passed to a managed render — a signal value, a tuple of
+        values for multiple signals, or None when no signal is bound.
+        """
+        if not self._signals:
+            return None
+        values = [sig() for sig in self._signals]
+        return values[0] if len(values) == 1 else tuple(values)
+
+    # ----- managed render ---------------------------------------------------
+
+    def _render_managed(self) -> None:
+        """Clear, apply the theme rc, call the caller's render, and draw."""
+        if self._render is None or not self.winfo_exists():
+            return
+        import matplotlib
+
+        rc = _theme_rc()
+        fig = self._figure
+        fig.clear()
+        fig.set_facecolor(rc["figure.facecolor"])
+        data = self._current_data()
+        with matplotlib.rc_context(rc):
+            ax = fig.add_subplot(111)
+            if self._render_arity >= 2:
+                self._render(ax, data)
+            else:
+                self._render(ax)
+        self._canvas.draw_idle()
+
+    # ----- figure-host theming ----------------------------------------------
 
     def _style_figure(self) -> None:
-        """Recolor the figure's chrome (faces, spines, text) to the theme.
+        """Recolor an externally-built figure's chrome to the theme.
 
         Best-effort pass over the *existing* artists — it does not impose a grid
-        or restyle data series, which the figure's author owns. Never raises: a
-        bespoke figure's quirks must not break the embed.
+        or restyle data series, which the figure's author owns. Never raises.
         """
         pal = _theme_palette()
         fig = self._figure
         try:
             fig.set_facecolor(pal["figure_bg"])
             for ax in fig.axes:
-                ax.set_facecolor(pal["axes_bg"])
-                for spine in ax.spines.values():
-                    spine.set_color(pal["fg"])
-                ax.tick_params(colors=pal["fg"], which="both")
-                ax.xaxis.label.set_color(pal["fg"])
-                ax.yaxis.label.set_color(pal["fg"])
-                ax.title.set_color(pal["fg"])
-                for label in (*ax.get_xticklabels(), *ax.get_yticklabels()):
-                    label.set_color(pal["fg"])
-                for line in (*ax.get_xgridlines(), *ax.get_ygridlines()):
-                    line.set_color(pal["grid"])
-                legend = ax.get_legend()
-                if legend is not None:
-                    frame = legend.get_frame()
-                    frame.set_facecolor(pal["axes_bg"])
-                    frame.set_edgecolor(pal["fg"])
-                    for text in legend.get_texts():
-                        text.set_color(pal["fg"])
+                self._recolor_axes(ax, pal)
         except Exception:
             pass
+
+    @staticmethod
+    def _recolor_axes(ax: Any, pal: dict[str, str]) -> None:
+        """Recolor one axes' chrome (faces, spines, ticks, labels) to the theme."""
+        ax.set_facecolor(pal["axes_bg"])
+        for spine in ax.spines.values():
+            spine.set_color(pal["fg"])
+        ax.tick_params(colors=pal["fg"], which="both")
+        ax.xaxis.label.set_color(pal["fg"])
+        ax.yaxis.label.set_color(pal["fg"])
+        ax.title.set_color(pal["fg"])
+        for label in (*ax.get_xticklabels(), *ax.get_yticklabels()):
+            label.set_color(pal["fg"])
+        for line in (*ax.get_xgridlines(), *ax.get_ygridlines()):
+            line.set_color(pal["grid"])
+        legend = ax.get_legend()
+        if legend is not None:
+            frame = legend.get_frame()
+            frame.set_facecolor(pal["axes_bg"])
+            frame.set_edgecolor(pal["fg"])
+            for text in legend.get_texts():
+                text.set_color(pal["fg"])
 
     def _on_theme_changed(self) -> None:
         """Re-resolve theme colors and redraw (called after a theme rebuild)."""
-        self._style_figure()
-        try:
-            self._canvas.draw_idle()
-        except Exception:
-            pass
+        if self._anim is not None:
+            # Recolor the axes chrome, then force the animation to recapture its
+            # blit background in the new theme. The blit cache only re-grabs when
+            # the axes *view* changes, so a recolor alone would keep restoring the
+            # stale background over the new colors — clearing the cache forces a
+            # fresh grab on the next frame. Animated artists keep their setup
+            # colors. (Falls back to a plain draw if matplotlib internals shift.)
+            pal = _theme_palette()
+            try:
+                self._figure.set_facecolor(pal["figure_bg"])
+                for ax in self._figure.axes:
+                    self._recolor_axes(ax, pal)
+                self._canvas.draw()  # render the new-colored background to the buffer
+                cache = getattr(self._anim, "_blit_cache", None)
+                if cache is not None:
+                    cache.clear()  # next frame re-grabs the background
+            except Exception:
+                try:
+                    self._canvas.draw()
+                except Exception:
+                    pass
+        elif self._render is not None:
+            self._render_managed()  # full re-render picks up the new rc + cycle
+        else:
+            self._style_figure()
+            try:
+                self._canvas.draw_idle()
+            except Exception:
+                pass
 
-    # ----- figure -----------------------------------------------------------
+    # ----- figure / lifecycle -----------------------------------------------
 
     def set_figure(self, figure: Any) -> None:
         """Replace the embedded figure, tearing down the old canvas widget."""
@@ -115,12 +358,180 @@ class Chart(Frame):
         self._widget = self._canvas.get_tk_widget()
         self._widget.configure(highlightthickness=0, bd=0)
         self._widget.pack(fill="both", expand=True)
-        self._style_figure()
-        self._canvas.draw_idle()
+        if self._render is not None:
+            self._render_managed()
+        else:
+            self._style_figure()
+            self._canvas.draw_idle()
 
     def draw(self) -> None:
-        """Force a redraw of the current figure."""
+        """Redraw — re-run the managed render, or refresh the hosted figure."""
+        if self._render is not None:
+            self._render_managed()
+        else:
+            try:
+                self._canvas.draw_idle()
+            except Exception:
+                pass
+
+    # ----- animation (blitting) ---------------------------------------------
+
+    def animate(
+        self,
+        setup: Callable,
+        update: Callable,
+        *,
+        interval: int = 30,
+        frames: Any = None,
+    ) -> Any:
+        """Drive a blitting animation, returning the matplotlib animation object.
+
+        Owns the figure: clears it, builds a themed axes, calls ``setup(ax)``
+        once to create the artists, then each frame calls ``update(value,
+        artists)`` and redraws only those artists over a cached background.
+        `value` is elapsed seconds for a continuous animation (so motion is
+        time-based and jitter-free), or the frame value when `frames` is given.
+        """
+        import itertools
+        import time
+
+        import matplotlib
+        from matplotlib.animation import FuncAnimation
+
+        self._stop_anim()
+        update_arity = _positional_arity(update)
+        # Continuous animation (no explicit `frames`) is driven by elapsed
+        # wall-clock time, not the frame index — so uneven timer delivery does
+        # not change the apparent velocity (no speed-up / slow-down jitter).
+        timed = frames is None
+        start = {"t": None}
+
+        rc = _theme_rc()
+        fig = self._figure
+        fig.clear()
+        fig.set_facecolor(rc["figure.facecolor"])
+        with matplotlib.rc_context(rc):
+            ax = fig.add_subplot(111)
+            # Create the artists ONCE. FuncAnimation re-invokes init_func on every
+            # full redraw (resize/theme), so init must only RETURN the artists —
+            # re-running setup there would accumulate a new artist each redraw.
+            self._anim_artists = _as_artist_list(setup(ax))
+
+        def init() -> list[Any]:
+            return self._anim_artists
+
+        def func(frame: Any) -> list[Any]:
+            artists = self._anim_artists
+            arg = artists[0] if len(artists) == 1 else artists
+            if timed:
+                if start["t"] is None:
+                    start["t"] = time.perf_counter()
+                value: Any = time.perf_counter() - start["t"]
+            else:
+                value = frame
+            if update_arity >= 2:
+                update(value, arg)
+            else:
+                update(value)
+            return self._anim_artists
+
+        self._anim = FuncAnimation(
+            fig,
+            func,
+            init_func=init,
+            frames=frames if frames is not None else itertools.count(),
+            interval=max(1, int(interval)),
+            blit=True,
+            cache_frame_data=False,
+        )
+        self._anim_wanted = True
+        self._anim_obscured = False
+        # FuncAnimation auto-starts on the first draw_event; assume running, then
+        # reconcile against actual visibility once that first draw has happened
+        # (covers a chart created on a hidden tab).
+        self._anim_running_now = True
+
+        def _after_first_draw(_event: Any) -> None:
+            if self._anim_first_draw_cid is not None:
+                try:
+                    self._canvas.mpl_disconnect(self._anim_first_draw_cid)
+                except Exception:
+                    pass
+                self._anim_first_draw_cid = None
+            self._apply_anim_state()
+
+        self._anim_first_draw_cid = self._canvas.mpl_connect("draw_event", _after_first_draw)
+        self._canvas.draw_idle()
+        return self._anim
+
+    def _anim_visible(self) -> bool:
+        """Whether the chart is actually visible — mapped and not fully covered."""
         try:
-            self._canvas.draw_idle()
+            return bool(self.winfo_viewable()) and not self._anim_obscured
         except Exception:
-            pass
+            return not self._anim_obscured
+
+    def _apply_anim_state(self) -> None:
+        """Run the animation only when wanted AND actually visible."""
+        anim = self._anim
+        if anim is None:
+            return
+        should = self._anim_wanted and self._anim_visible()
+        if should == self._anim_running_now:
+            return
+        try:
+            anim.resume() if should else anim.pause()
+        except Exception:
+            return
+        self._anim_running_now = should
+
+    def _set_anim_wanted(self, wanted: bool) -> None:
+        self._anim_wanted = bool(wanted)
+        self._apply_anim_state()
+
+    def _on_anim_visibility(self, event: Any = None) -> None:
+        if event is not None and getattr(event, "widget", None) is not self:
+            return
+        if self._anim is not None:
+            self._apply_anim_state()
+
+    def _on_anim_obscured(self, event: Any = None) -> None:
+        # `<Visibility>` is best-effort (mainly X11); only a FULL cover pauses.
+        state = getattr(event, "state", "") if event is not None else ""
+        self._anim_obscured = state == "VisibilityFullyObscured"
+        if self._anim is not None:
+            self._apply_anim_state()
+
+    def _stop_anim(self) -> None:
+        anim = self._anim
+        self._anim = None
+        self._anim_wanted = False
+        self._anim_running_now = False
+        if self._anim_first_draw_cid is not None:
+            try:
+                self._canvas.mpl_disconnect(self._anim_first_draw_cid)
+            except Exception:
+                pass
+            self._anim_first_draw_cid = None
+        if anim is not None:
+            try:
+                anim.event_source.stop()
+            except Exception:
+                pass
+
+    def _on_destroy(self, event: Any = None) -> None:
+        if event is not None and getattr(event, "widget", None) is not self:
+            return
+        self._stop_anim()
+        for handle in self._signal_handles:
+            try:
+                handle.cancel()
+            except Exception:
+                pass
+        self._signal_handles = []
+        if self._debounce_job is not None:
+            try:
+                self._debounce_job.cancel()
+            except Exception:
+                pass
+            self._debounce_job = None

--- a/src/bootstack/widgets/chart.py
+++ b/src/bootstack/widgets/chart.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Callable
 
 from bootstack.errors import BootstackError
 from bootstack.widgets._core.base import PublicWidgetBase
@@ -41,10 +41,34 @@ class Chart(PublicWidgetBase):
     rather than ``pyplot`` — an embedded figure must be a standalone object, and
     ``pyplot`` would also open a separate window.
 
+    There are two ways to use it:
+
+    - **Figure host** — pass a ``figure`` you built. The chart embeds it and
+      recolors its chrome to the theme. You own the figure; theming the data
+      series is up to you.
+    - **Managed render** — pass a ``render`` callback and (optionally) one or
+      more ``signal`` objects. The chart owns the figure and redraws for you:
+      each redraw clears the axes, applies the theme as matplotlib settings —
+      including a semantic accent color cycle so multiple series are on-brand —
+      then calls your ``render``. It re-renders when the theme changes or a bound
+      signal updates::
+
+          count = bs.Signal(20)
+          def render(ax, n):
+              ax.plot(range(n), [i * i for i in range(n)])
+          bs.Chart(render=render, signal=count)   # redraws when `count` changes
+
     Args:
-        figure: The matplotlib `Figure` to display. Omit to start with an empty
-            figure you populate later via the `ax` accessor or the `figure`
-            property.
+        figure: The matplotlib `Figure` to display (figure-host mode). Omit to
+            start empty, or when using ``render``.
+        render: A drawing callback for managed mode, called as ``render(ax)`` or
+            ``render(ax, data)`` where `data` is the bound signal value(s). The
+            chart clears and re-themes the axes before each call, so just draw.
+        signal: A `bootstack.Signal` (or a list of them) whose value is passed to
+            ``render`` as `data`; the chart re-renders when it changes. Requires
+            ``render``.
+        debounce: Milliseconds to coalesce rapid signal changes before
+            re-rendering. ``0`` (default) re-renders on every change.
         parent: Explicit parent widget. If omitted, the current context-stack
             container is used.
         **kwargs: Layout placement options applied by the parent container
@@ -54,13 +78,37 @@ class Chart(PublicWidgetBase):
 
     _internal_class = _InternalChart
 
-    def __init__(self, figure: Any = None, *, parent: Any = None, **kwargs: Any) -> None:
+    def __init__(
+        self,
+        figure: Any = None,
+        *,
+        render: Callable | None = None,
+        signal: Any = None,
+        debounce: int = 0,
+        parent: Any = None,
+        **kwargs: Any,
+    ) -> None:
         _require_matplotlib()
+
+        if signal is None:
+            signals: list[Any] = []
+        elif isinstance(signal, (list, tuple)):
+            signals = list(signal)
+        else:
+            signals = [signal]
+        if signals and render is None:
+            raise BootstackError("Chart(signal=...) requires render= to draw the signal value.")
+
         self._parent = self._resolve_parent(parent)
         layout_kw = self._split_layout_kwargs(kwargs)
         tk_master = self._parent._child_master() if self._parent else None
 
-        internal_kwargs: dict[str, Any] = {"figure": figure}
+        internal_kwargs: dict[str, Any] = {
+            "figure": figure,
+            "render": render,
+            "signals": signals,
+            "debounce": debounce,
+        }
         internal_kwargs.update(kwargs)
         self._internal = self._internal_class(tk_master, **internal_kwargs)
         self._attach_to_parent(layout_kw)
@@ -102,3 +150,72 @@ class Chart(PublicWidgetBase):
         Theme changes redraw automatically — this is for your own updates.
         """
         self._internal.draw()
+
+    def animate(
+        self,
+        setup: Callable,
+        update: Callable,
+        *,
+        interval: int = 30,
+        frames: Any = None,
+    ) -> "ChartAnimation":
+        """Drive a smooth, high-performance animation via blitting.
+
+        Unlike the managed ``render=`` path (which rebuilds the whole figure on
+        each update — right for occasional data changes, but limited to ~30 fps),
+        animation updates artists in place and redraws only them over a cached
+        background, sustaining high frame rates.
+
+        Args:
+            setup: Called once with the themed `Axes`. Create your artists with
+                initial or empty data and set FIXED axis limits — blitting needs
+                stable axes — then return the artist, or a list of artists, to
+                animate.
+            update: Called every frame as ``update(value, artist)`` (or
+                ``update(value)``), where `artist` is whatever `setup` returned.
+                For a continuous animation (the default) `value` is the elapsed
+                time in **seconds** since the animation started — drive motion by
+                this and the apparent speed stays constant even when frame timing
+                jitters. If you pass `frames`, `value` is the current frame value
+                instead. Mutate the artist's data in place; do not create new
+                artists or rescale the axes.
+            interval: Target milliseconds between frames. Default 30 (~33 fps).
+            frames: An iterable of frame values to step through fixed data, or
+                None (default) for a continuous, time-driven animation.
+
+        Returns:
+            A `ChartAnimation` handle — call `stop()` / `start()` to control it.
+            The animation stops automatically when the widget is destroyed.
+        """
+        self._internal.animate(setup, update, interval=interval, frames=frames)
+        return ChartAnimation(self._internal)
+
+
+class ChartAnimation:
+    """Handle for a running `Chart` animation.
+
+    Returned by `Chart.animate`. Use it to pause and resume the animation or
+    query whether it is playing.
+
+    The animation is also gated on visibility: it pauses automatically when the
+    chart is hidden (a switched-away tab, a scrolled-off region, a minimized
+    window) or fully covered by another window, and resumes when shown — so an
+    off-screen chart on a dashboard costs nothing. `stop` / `start` set your
+    intent on top of that gate.
+    """
+
+    def __init__(self, chart: Any) -> None:
+        self._chart = chart
+
+    def stop(self) -> None:
+        """Pause the animation; the last drawn frame stays on screen."""
+        self._chart._set_anim_wanted(False)
+
+    def start(self) -> None:
+        """Resume the animation (subject to the chart being visible)."""
+        self._chart._set_anim_wanted(True)
+
+    @property
+    def running(self) -> bool:
+        """Whether the animation is currently playing (wanted and visible)."""
+        return bool(self._chart._anim_wanted and self._chart._anim_visible())

--- a/tests/widgets/public/test_chart.py
+++ b/tests/widgets/public/test_chart.py
@@ -1,4 +1,5 @@
-"""Chart (Phase 1) — embeds a matplotlib figure as a themed widget.
+"""Chart — embeds a matplotlib figure as a themed widget, with a managed
+reactive render path (``render=`` + ``signal=``).
 
 matplotlib is an optional dependency (the ``viz`` extra); the whole module skips
 when it is not installed.
@@ -81,3 +82,208 @@ def test_chart_without_matplotlib_raises(monkeypatch, app):
     monkeypatch.setattr(builtins, "__import__", fake_import)
     with pytest.raises(BootstackError, match="bootstack\\[viz\\]"):
         bs.Chart()
+
+
+# ----- Phase 2: managed render + reactive signals -----------------------------
+
+
+def test_managed_render_draws(app):
+    def render(ax):
+        ax.plot([0, 1, 2], [2, 1, 2])
+
+    chart = bs.Chart(render=render)
+    app._tk_root.update_idletasks()
+
+    axes = chart.figure.axes
+    assert len(axes) == 1
+    assert len(axes[0].lines) == 1
+
+
+def test_render_receives_signal_value_and_rerenders(app):
+    n = bs.Signal(3)
+
+    def render(ax, count):
+        ax.plot(range(count), range(count))
+
+    chart = bs.Chart(render=render, signal=n)
+    app._tk_root.update_idletasks()
+    assert chart.figure.axes[0].lines[0].get_xdata().tolist() == [0, 1, 2]
+
+    n.set(6)  # debounce=0 -> re-renders synchronously
+    app._tk_root.update_idletasks()
+    assert chart.figure.axes[0].lines[0].get_xdata().tolist() == [0, 1, 2, 3, 4, 5]
+
+
+def test_render_arity_one_ignores_data(app):
+    n = bs.Signal(5)
+
+    def render(ax):  # no data param — bound signal still drives re-render
+        ax.plot([0, 1], [1, 0])
+
+    chart = bs.Chart(render=render, signal=n)
+    app._tk_root.update_idletasks()
+    assert len(chart.figure.axes[0].lines) == 1
+
+    n.set(9)
+    app._tk_root.update_idletasks()
+    assert len(chart.figure.axes[0].lines) == 1  # one axes, one line, no crash
+
+
+def test_managed_render_uses_semantic_color_cycle(app):
+    def render(ax):
+        ax.plot([0, 1], [0, 1])  # series 1 -> primary
+        ax.plot([0, 1], [1, 0])  # series 2 -> success
+
+    chart = bs.Chart(render=render)
+    app._tk_root.update_idletasks()
+
+    lines = chart.figure.axes[0].lines
+    assert to_hex(lines[0].get_color()).lower() == get_theme_color("primary[500]").lower()
+    assert to_hex(lines[1].get_color()).lower() == get_theme_color("success[500]").lower()
+
+
+def test_signal_without_render_raises(app):
+    with pytest.raises(BootstackError, match="render="):
+        bs.Chart(signal=bs.Signal(1))
+
+
+def test_managed_rerenders_on_theme_change(shown_app):
+    def render(ax):
+        ax.plot([1, 2, 3])
+
+    chart = bs.Chart(render=render)
+    shown_app._tk_root.update_idletasks()
+    assert to_hex(chart.figure.get_facecolor()).lower() == get_theme_color("background").lower()
+
+    bs.toggle_theme()
+    shown_app._tk_root.update_idletasks()
+    assert to_hex(chart.figure.get_facecolor()).lower() == get_theme_color("background").lower()
+
+
+def test_rapid_signal_changes_coalesce_to_one_render(app):
+    """A burst of signal changes renders once (per idle), not once per change."""
+    calls = {"n": 0}
+    value = bs.Signal(0)
+
+    def render(ax, v):
+        calls["n"] += 1
+        ax.plot(range(max(1, v)))
+
+    bs.Chart(render=render, signal=value)
+    app._tk_root.update_idletasks()
+    base = calls["n"]  # the synchronous render at construction
+
+    for v in range(1, 6):  # five rapid changes, no idle pump between
+        value.set(v)
+    app._tk_root.update_idletasks()  # single coalesced flush
+
+    assert calls["n"] == base + 1
+
+
+# ----- animation (blitting) ---------------------------------------------------
+
+
+def test_animate_sets_up_artists_and_returns_handle(shown_app):
+    created = {"n": 0}
+
+    def setup(ax):
+        created["n"] += 1
+        (line,) = ax.plot([], [])
+        ax.set_xlim(0, 10)
+        ax.set_ylim(-1, 1)
+        return line
+
+    def update(frame, line):
+        line.set_data([0, frame], [0, 1])
+
+    chart = bs.Chart()
+    anim = chart.animate(setup, update, interval=20)
+    shown_app._tk_root.update()  # let the first draw start the animation
+
+    assert created["n"] == 1               # setup ran exactly once
+    assert len(chart.figure.axes) == 1
+    assert len(chart._internal._anim_artists) == 1
+    assert anim.running is True
+
+
+def test_animation_handle_stop_start(shown_app):
+    def setup(ax):
+        (line,) = ax.plot([], [])
+        ax.set_xlim(0, 1)
+        ax.set_ylim(0, 1)
+        return line
+
+    chart = bs.Chart()
+    anim = chart.animate(setup, lambda frame, line: None, interval=20)
+    shown_app._tk_root.update()
+
+    anim.stop()
+    assert anim.running is False
+    anim.start()
+    assert anim.running is True
+
+
+def test_animation_recolors_on_theme_change(shown_app):
+    def setup(ax):
+        (line,) = ax.plot([], [])
+        ax.set_xlim(0, 1)
+        ax.set_ylim(0, 1)
+        return line
+
+    chart = bs.Chart()
+    chart.animate(setup, lambda frame, line: None, interval=20)
+    shown_app._tk_root.update()
+    before = to_hex(chart.figure.get_facecolor()).lower()
+
+    bs.toggle_theme()
+    shown_app._tk_root.update()
+    after = to_hex(chart.figure.get_facecolor()).lower()
+
+    assert after == get_theme_color("background").lower()
+    assert after != before
+
+
+def test_animation_pauses_when_hidden_resumes_when_shown(shown_app):
+    def setup(ax):
+        (line,) = ax.plot([], [])
+        ax.set_xlim(0, 1)
+        ax.set_ylim(0, 1)
+        return line
+
+    chart = bs.Chart()
+    anim = chart.animate(setup, lambda frame, line: None, interval=20)
+    shown_app._tk_root.update()
+    assert anim.running is True                       # visible -> playing
+    assert chart._internal._anim_running_now is True
+
+    chart.detach()                                    # hide it (<Unmap>)
+    shown_app._tk_root.update()
+    assert anim.running is False                      # hidden -> paused
+    assert chart._internal._anim_running_now is False
+
+    chart.attach()                                    # show it again (<Map>)
+    shown_app._tk_root.update()
+    assert anim.running is True                       # shown -> resumed
+    assert chart._internal._anim_running_now is True
+
+
+def test_theme_change_while_hidden_applies_on_return(shown_app):
+    """A theme changed while the chart is hidden is applied when it reappears."""
+    def setup(ax):
+        (line,) = ax.plot([], [])
+        ax.set_xlim(0, 1)
+        ax.set_ylim(0, 1)
+        return line
+
+    chart = bs.Chart()
+    chart.animate(setup, lambda frame, line: None, interval=20)
+    shown_app._tk_root.update()
+
+    chart.detach()                                    # hide on "another page"
+    shown_app._tk_root.update()
+    bs.toggle_theme()                                 # theme changes while hidden
+    shown_app._tk_root.update()
+    chart.attach()                                    # navigate back
+    shown_app._tk_root.update()
+
+    assert to_hex(chart.figure.get_facecolor()).lower() == get_theme_color("background").lower()


### PR DESCRIPTION
Phase 2 of `bs.Chart` (tracks #277) — **stacked on #279** (base `feat/chart-widget`; GitHub will retarget to `main` once #279 merges). Adds two update paths on top of the Phase 1 figure host. What you draw with stays **pure matplotlib** — bootstack owns only embedding, theming, the redraw loop, and lifecycle.

## Managed reactive render
```python
count = bs.Signal(20)
def render(ax, n):
    ax.plot(range(n), [i*i for i in range(n)])
bs.Chart(render=render, signal=count)   # re-renders when count changes
```
- The chart owns the figure/redraw loop: clears, applies the theme as matplotlib rcParams (incl. a **semantic accent `prop_cycle`** so multi-series plots are on-brand), calls `render(ax, data)`, draws.
- Re-renders on theme change and on bound-`Signal` change; `debounce=` available.
- **Coalescing:** rapid signal changes collapse to one render per idle frame, so a fast source can't starve the event loop (a full rebuild is ~31 ms/frame).

## Blitting animation
```python
def setup(ax):                 # once: create artists, fix limits
    (line,) = ax.plot(xs, np.zeros_like(xs)); ax.set_ylim(-1.2, 1.2); return line
def frame(t, line):            # per frame: t = elapsed seconds
    line.set_ydata(np.sin(xs + t*2))
anim = chart.animate(setup, frame, interval=16)   # ~60fps, ~0.2 ms/frame
```
- **Blitting** updates artists in place and redraws only them over a cached background — ~150× faster than a full rebuild.
- **Time-based motion:** the callback gets elapsed *seconds*, so apparent speed stays constant under Tk timer jitter (no speed-up/slow-down). `frames=` still steps fixed data.
- **Visibility-gated:** pauses when the chart is hidden (`<Map>`/`<Unmap>` — tabs, pages, minimize; reliable cross-platform) or fully covered (`<Visibility>` — best-effort, mainly X11), resumes on return. **Off-screen charts cost nothing** → dashboards scale. A theme change while hidden is applied on the next show.
- Returns a `ChartAnimation` handle (`stop`/`start`/`running`); auto-stops on destroy.

## Tests & examples
- `tests/widgets/public/test_chart.py` — **18 tests**: managed render, signal re-render + coalescing, render arity, semantic color cycle, animation setup-once contract, stop/start, theme recolor (render + anim), visibility pause/resume via `detach()`/`attach()`, and theme-change-while-hidden applied on return.
- Examples: `chart_reactive.py` (event-driven `render=`), `chart_animation.py` (blitting). Design brief updated.

Full `run_gui.py` suite green.

Remaining: Phase 3 (`data_source=` ingestion), Phase 4 (seaborn extra + themed nav toolbar + docs page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)