### PR TITLE
feat(chart): data source ingestion (Phase 3)

### DIFF
--- a/docs/_dev/visualization-widget.md
+++ b/docs/_dev/visualization-widget.md
@@ -35,8 +35,19 @@ the figure host:
   - Returns a `ChartAnimation` handle (`stop`/`start`/`running`); auto-stops on
     destroy. What you draw with stays pure matplotlib.
 
-Remaining: **Phase 3** (`data_source=` ingestion) and **Phase 4** (seaborn extra
-+ themed nav toolbar + docs page).
+**Phase 3 — shipped (`data_source=` ingestion).** `Chart(render=fn,
+data_source=ds)` passes the source's records to `render(ax, rows)` and
+re-renders on any source change (via `on_change` + a re-read through
+`page_slice`, reusing the render coalescing). It reads the source's current
+**filtered/sorted view** (`where`/`order` propagate — `where()` emits a `filter`
+event), so filtering the source updates the chart. Requires `render`; mutually
+exclusive with `signal`. Demo: a Chart + DataTable on one source
+(`chart_data_source.py`). **Surfaced a DataTable design issue (#282):** the table
+writes its search/filter/sort to the *shared* source's `where`/`order` (search
+silenced), so a single source isn't safe across multiple interactive views — the
+demo disables the table's local search and filters the source directly.
+
+Remaining: **Phase 4** (seaborn extra + themed nav toolbar + docs page).
 
 ## Goal
 

--- a/docs/examples/chart_data_source.py
+++ b/docs/examples/chart_data_source.py
@@ -1,0 +1,74 @@
+"""Chart bound to a data source — live, and in sync with a DataTable.
+
+Run this directly. Requires the visualization extra: ``pip install bootstack[viz]``.
+A Chart and a DataTable share ONE data source:
+
+- **Add sale** inserts a record — both the chart and the table update.
+- **High sales only** filters the *source* (`sales.where(...)`) — both views
+  follow the filter, because the chart reads the source's filtered/sorted view.
+
+Note: the DataTable's own search box filters the *table's* local view only; it
+does not reshape the shared source, so it does not drive the chart. To filter
+what the chart shows, filter the source (as the toggle below does).
+
+With ``data_source=``, the chart's ``render`` receives the source's records (a
+list of dicts) and re-renders whenever the source changes — including when you
+filter or sort the source.
+"""
+
+import bootstack as bs
+from bootstack.data import MemoryDataSource, col
+
+MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug"]
+
+
+def render(ax, rows):
+    """Bar chart of sales by month — `rows` is the source's (filtered) records."""
+    ax.bar([r["month"] for r in rows], [r["sales"] for r in rows])
+    ax.set_title("Sales by month")
+    ax.set_ylabel("sales")
+
+
+with bs.App(title="Chart + DataTable", min_size=(720, 620), padding=16, gap=12) as app:
+    sales = MemoryDataSource()
+    sales.load([
+        {"month": "Jan", "sales": 120},
+        {"month": "Feb", "sales": 180},
+        {"month": "Mar", "sales": 150},
+    ])
+
+    bs.Label("One source, two views — filter or add and both follow", font="heading-md")
+    bs.Chart(render=render, data_source=sales, grow=True, horizontal="stretch")
+    # Search is disabled here on purpose: the table's search box filters its own
+    # local view, so it would not drive the chart. We filter the SOURCE below
+    # (the toggle) so both views stay in sync.
+    bs.DataTable(
+        data_source=sales, columns=["month", "sales"],
+        enable_search=False, grow=True, horizontal="stretch",
+    )
+
+    high_only = bs.Signal(False)
+
+    def apply_filter(checked: bool) -> None:
+        # Filter the SOURCE — the chart and the table both reflect it.
+        if checked:
+            sales.where(col("sales") >= 150)
+        else:
+            sales.where(None)
+
+    high_only.subscribe(apply_filter)
+
+    state = {"i": 3}
+
+    def add_sale():
+        i = state["i"]
+        state["i"] = i + 1
+        month = MONTHS[i % len(MONTHS)]
+        sales.insert({"month": f"{month}+{i}", "sales": 100 + (i * 37) % 140})
+
+    with bs.Row(gap=8):
+        bs.Switch("High sales only (>= 150)", signal=high_only)
+        bs.Spacer()
+        bs.Button("Add sale", accent="primary", on_click=add_sale)
+
+app.run()

--- a/src/bootstack/widgets/_impl/composites/chart.py
+++ b/src/bootstack/widgets/_impl/composites/chart.py
@@ -157,6 +157,7 @@ class Chart(Frame):
         figure: Any = None,
         render: Callable | None = None,
         signals: Sequence[Any] | None = None,
+        data_source: Any = None,
         debounce: int = 0,
         **kwargs: Any,
     ) -> None:
@@ -170,6 +171,9 @@ class Chart(Frame):
         self._render = render
         self._render_arity = _positional_arity(render) if render else 0
         self._signals = list(signals) if signals else []
+        self._data_source = data_source
+        self._rows: list[Any] = []
+        self._source_handle: Any = None
         self._debounce = max(0, int(debounce))
         self._debounce_job: Any = None
         self._render_pending = False
@@ -187,6 +191,14 @@ class Chart(Frame):
         self._widget = self._canvas.get_tk_widget()
         self._widget.configure(highlightthickness=0, bd=0)
         self._widget.pack(fill="both", expand=True)
+
+        # Bind a data source before the first render so its rows are available.
+        if self._data_source is not None:
+            self._rows = self._read_rows()
+            try:
+                self._source_handle = self._data_source.on_change(self._on_source_change)
+            except Exception:
+                self._source_handle = None
 
         if self._render is not None:
             self._render_managed()
@@ -242,13 +254,34 @@ class Chart(Frame):
         self._render_managed()
 
     def _current_data(self) -> Any:
-        """The data passed to a managed render — a signal value, a tuple of
-        values for multiple signals, or None when no signal is bound.
+        """The data passed to a managed render.
+
+        The bound data source's rows when one is set; otherwise a signal value
+        (or a tuple of values for multiple signals); or None.
         """
+        if self._data_source is not None:
+            return self._rows
         if not self._signals:
             return None
         values = [sig() for sig in self._signals]
         return values[0] if len(values) == 1 else tuple(values)
+
+    # ----- data source ------------------------------------------------------
+
+    def _read_rows(self) -> list[Any]:
+        """Read all current records from the source (respecting its filter/sort)."""
+        ds = self._data_source
+        if ds is None:
+            return []
+        try:
+            n = ds.count
+            return list(ds.page_slice(0, n)) if n else []
+        except Exception:
+            return []
+
+    def _on_source_change(self, _event: Any = None) -> None:
+        self._rows = self._read_rows()
+        self._request_render()
 
     # ----- managed render ---------------------------------------------------
 
@@ -529,6 +562,12 @@ class Chart(Frame):
             except Exception:
                 pass
         self._signal_handles = []
+        if self._source_handle is not None:
+            try:
+                self._source_handle.cancel()
+            except Exception:
+                pass
+            self._source_handle = None
         if self._debounce_job is not None:
             try:
                 self._debounce_job.cancel()

--- a/src/bootstack/widgets/chart.py
+++ b/src/bootstack/widgets/chart.py
@@ -46,17 +46,21 @@ class Chart(PublicWidgetBase):
     - **Figure host** — pass a ``figure`` you built. The chart embeds it and
       recolors its chrome to the theme. You own the figure; theming the data
       series is up to you.
-    - **Managed render** — pass a ``render`` callback and (optionally) one or
-      more ``signal`` objects. The chart owns the figure and redraws for you:
-      each redraw clears the axes, applies the theme as matplotlib settings —
-      including a semantic accent color cycle so multiple series are on-brand —
-      then calls your ``render``. It re-renders when the theme changes or a bound
-      signal updates::
+    - **Managed render** — pass a ``render`` callback and a reactive source: one
+      or more ``signal`` objects, or a ``data_source``. The chart owns the figure
+      and redraws for you: each redraw clears the axes, applies the theme as
+      matplotlib settings — including a semantic accent color cycle so multiple
+      series are on-brand — then calls your ``render``. It re-renders when the
+      theme changes or the bound signal / data source updates::
 
           count = bs.Signal(20)
           def render(ax, n):
               ax.plot(range(n), [i * i for i in range(n)])
           bs.Chart(render=render, signal=count)   # redraws when `count` changes
+
+      With ``data_source=``, ``render`` receives the source's records (a list of
+      dicts) and the chart re-renders whenever the source changes — so a chart
+      and a `DataTable` can share one source and stay in sync.
 
     Args:
         figure: The matplotlib `Figure` to display (figure-host mode). Omit to
@@ -66,7 +70,14 @@ class Chart(PublicWidgetBase):
             chart clears and re-themes the axes before each call, so just draw.
         signal: A `bootstack.Signal` (or a list of them) whose value is passed to
             ``render`` as `data`; the chart re-renders when it changes. Requires
-            ``render``.
+            ``render``. Mutually exclusive with ``data_source``.
+        data_source: A data source (any `bootstack.data` source) to plot. Its
+            records are passed to ``render`` as `data` (a list of dicts), and the
+            chart re-renders whenever the source changes — so a chart and a
+            `DataTable` can share one source and stay in sync. Reads all rows
+            matching the source's current ``where``/``order``, so filter or sort
+            the source to scope or shape what is plotted. Requires ``render``;
+            mutually exclusive with ``signal``.
         debounce: Milliseconds to coalesce rapid signal changes before
             re-rendering. ``0`` (default) re-renders on every change.
         parent: Explicit parent widget. If omitted, the current context-stack
@@ -84,6 +95,7 @@ class Chart(PublicWidgetBase):
         *,
         render: Callable | None = None,
         signal: Any = None,
+        data_source: Any = None,
         debounce: int = 0,
         parent: Any = None,
         **kwargs: Any,
@@ -98,6 +110,10 @@ class Chart(PublicWidgetBase):
             signals = [signal]
         if signals and render is None:
             raise BootstackError("Chart(signal=...) requires render= to draw the signal value.")
+        if data_source is not None and render is None:
+            raise BootstackError("Chart(data_source=...) requires render= to plot the rows.")
+        if data_source is not None and signals:
+            raise BootstackError("Chart accepts either data_source= or signal=, not both.")
 
         self._parent = self._resolve_parent(parent)
         layout_kw = self._split_layout_kwargs(kwargs)
@@ -107,6 +123,7 @@ class Chart(PublicWidgetBase):
             "figure": figure,
             "render": render,
             "signals": signals,
+            "data_source": data_source,
             "debounce": debounce,
         }
         internal_kwargs.update(kwargs)

--- a/tests/widgets/public/test_chart.py
+++ b/tests/widgets/public/test_chart.py
@@ -287,3 +287,109 @@ def test_theme_change_while_hidden_applies_on_return(shown_app):
     shown_app._tk_root.update()
 
     assert to_hex(chart.figure.get_facecolor()).lower() == get_theme_color("background").lower()
+
+
+# ----- data source ingestion --------------------------------------------------
+
+
+def _pump(root, n=5):
+    for _ in range(n):
+        root.update()
+
+
+def test_data_source_passes_rows_to_render(app):
+    from bootstack.data import MemoryDataSource
+
+    ds = MemoryDataSource()
+    ds.load([{"x": 1, "y": 10}, {"x": 2, "y": 20}, {"x": 3, "y": 30}])
+    seen = {"rows": None}
+
+    def render(ax, rows):
+        seen["rows"] = rows
+        ax.plot([r["x"] for r in rows], [r["y"] for r in rows])
+
+    bs.Chart(render=render, data_source=ds)
+    app._tk_root.update_idletasks()
+
+    assert seen["rows"] is not None
+    assert [r["x"] for r in seen["rows"]] == [1, 2, 3]
+
+
+def test_data_source_rerenders_on_change(app):
+    from bootstack.data import MemoryDataSource
+
+    ds = MemoryDataSource()
+    ds.load([{"x": 1, "y": 1}, {"x": 2, "y": 2}])
+    seen = {"n": 0}
+
+    def render(ax, rows):
+        seen["n"] = len(rows)
+        ax.plot([r["x"] for r in rows], [r["y"] for r in rows])
+
+    bs.Chart(render=render, data_source=ds)
+    app._tk_root.update_idletasks()
+    assert seen["n"] == 2
+
+    ds.insert({"x": 3, "y": 3})       # external mutation
+    _pump(app._tk_root)               # let on_change marshal + render coalesce
+    assert seen["n"] == 3
+
+
+def test_data_source_respects_source_filter(app):
+    from bootstack.data import MemoryDataSource, col
+
+    ds = MemoryDataSource()
+    ds.load([{"x": i, "y": i} for i in range(1, 6)])
+    ds.where(col("x") > 3)            # scope the source -> chart sees filtered rows
+    seen = {"xs": None}
+
+    def render(ax, rows):
+        seen["xs"] = [r["x"] for r in rows]
+        ax.plot(seen["xs"])
+
+    bs.Chart(render=render, data_source=ds)
+    app._tk_root.update_idletasks()
+    assert seen["xs"] == [4, 5]
+
+
+def test_data_source_rerenders_on_runtime_filter(app):
+    """Filtering the source at runtime (where()) re-renders the chart."""
+    from bootstack.data import MemoryDataSource, col
+
+    ds = MemoryDataSource()
+    ds.load([{"x": i} for i in range(1, 6)])
+    seen = {"xs": None}
+
+    def render(ax, rows):
+        seen["xs"] = [r["x"] for r in rows]
+        ax.plot(seen["xs"] or [0])
+
+    bs.Chart(render=render, data_source=ds)
+    app._tk_root.update_idletasks()
+    assert seen["xs"] == [1, 2, 3, 4, 5]
+
+    ds.where(col("x") > 3)            # runtime filter on the source
+    _pump(app._tk_root)
+    assert seen["xs"] == [4, 5]
+
+    ds.where(None)                     # clear -> back to all rows
+    _pump(app._tk_root)
+    assert seen["xs"] == [1, 2, 3, 4, 5]
+
+
+def test_data_source_without_render_raises(app):
+    from bootstack.data import MemoryDataSource
+
+    ds = MemoryDataSource()
+    ds.load([{"x": 1}])
+    with pytest.raises(BootstackError, match="render="):
+        bs.Chart(data_source=ds)
+
+
+def test_data_source_and_signal_conflict_raises(app):
+    from bootstack.data import MemoryDataSource
+
+    ds = MemoryDataSource()
+    ds.load([{"x": 1}])
+    with pytest.raises(BootstackError, match="not both"):
+        bs.Chart(render=lambda ax, d: None, data_source=ds, signal=bs.Signal(1))


### PR DESCRIPTION
Phase 3 of `bs.Chart` (tracks #277) — bind a chart to a data source. Builds on the merged managed-render + animation work.

## What this adds
```python
def render(ax, rows):                 # rows = the source's records (list of dicts)
    ax.bar([r["month"] for r in rows], [r["sales"] for r in rows])
bs.Chart(render=render, data_source=sales)   # re-renders whenever the source changes
```
- `render(ax, rows)` receives the source's records; the chart **re-renders on any source change** (insert/update/delete/reload/filter/sort), reusing the managed render loop's coalescing so high-churn feeds stay smooth.
- Reads the source's **current filtered/sorted view** (`page_slice`), so `ds.where(...)` / `ds.order(...)` propagate to the chart — filter the source to scope the plot. Uses the same `on_change` + re-read pattern as `DataTable` (thread-marshaled to the main thread). Subscription cancelled on destroy.
- `data_source` requires `render` and is mutually exclusive with `signal` (clear `BootstackError`).

## Demo
`docs/examples/chart_data_source.py` — a `Chart` and a `DataTable` on **one** `MemoryDataSource`: "Add sale" inserts a record (both update); a "High sales only" toggle filters the **source** (both follow).

## Surfaced a DataTable issue (#282)
The DataTable writes its interactive search/filter/sort to the **shared** source's `where`/`order` as view state (search silenced), so one source isn't safe across multiple interactive views. The demo disables the table's local search (`enable_search=False`) and filters the source directly. The chart itself is correct (reads the source's current view). Design decision tracked in #282 — out of scope here.

## Tests
`tests/widgets/public/test_chart.py` (**24**): rows passed to render, live re-render on insert, runtime `where()`/clear re-render, source-filter respected at construction, and the two `data_source` validation errors. Full `run_gui.py` suite green.

Remaining: **Phase 4** (seaborn extra + themed nav toolbar replacing raw-Tk `NavigationToolbar2Tk` + docs page) — planned for a fresh session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)