### PR TITLE
fix: smoother carousel transitions on macOS

### DIFF
--- a/src/bootstack/widgets/_impl/composites/carousel.py
+++ b/src/bootstack/widgets/_impl/composites/carousel.py
@@ -351,8 +351,10 @@ class Carousel(Frame):
         self._stage.tag_lower(next_id)
         if cur_id is not None:
             self._stage.tag_lower(cur_id)
-        steps = 12
-        dx = -d * w / steps
+        steps = 8
+
+        def _ease(t: float) -> float:
+            return 2 * t * t if t < 0.5 else 1 - (-2 * t + 2) ** 2 / 2
 
         def step(i: int) -> None:
             if i >= steps:
@@ -366,9 +368,10 @@ class Carousel(Frame):
                 self._transitioning = False
                 self._after_change()
                 return
-            self._stage.move(next_id, dx, 0)
+            t = _ease(i / steps)
+            self._stage.coords(next_id, round(d * w * (1 - t)), 0)
             if cur_id is not None:
-                self._stage.move(cur_id, dx, 0)
+                self._stage.coords(cur_id, round(-d * w * t), 0)
             self._schedule.delay(_FRAME_MS, lambda: step(i + 1))
 
         step(1)
@@ -381,19 +384,21 @@ class Carousel(Frame):
             return
         self._transitioning = True
         steps = 10
+        # Pre-compute all frames up front so PhotoImage allocation doesn't happen
+        # inside the after() loop where it blocks the canvas refresh.
+        frames = [PhotoImage(PILImage.blend(cur, next_pil, i / steps)) for i in range(1, steps + 1)]
 
         def step(i: int) -> None:
-            if i > steps:
+            if i >= len(frames):
                 self._set_current(next_pil)
                 self._transitioning = False
                 self._after_change()
                 return
-            blended = PILImage.blend(cur, next_pil, i / steps)
-            self._fade_photo = PhotoImage(blended)
+            self._fade_photo = frames[i]
             self._stage.itemconfigure(self._img_id, image=self._fade_photo)
             self._schedule.delay(_FRAME_MS + 6, lambda: step(i + 1))
 
-        step(1)
+        step(0)
 
     def _after_change(self) -> None:
         bw, bh = self._box


### PR DESCRIPTION
## Summary

- **Slide transition**: replaced `canvas.move()` incremental steps with `canvas.coords()` absolute positions driven by a quadratic ease-in-out curve; reduced steps from 12 → 8. Fewer canvas repaints per transition, and easing makes the motion feel snappier than the original linear slide.
- **Fade transition**: pre-computes all `PhotoImage` frames before the `after()` loop starts. Per-frame PIL blend is fast; the `PhotoImage` allocation was the bottleneck (especially on macOS where the Tk/Quartz bridge adds overhead). The loop now just swaps already-allocated images.

Both changes are universal improvements but are most noticeable on macOS.

## Test plan

- [x] Trigger a slide transition (next/previous) and verify it feels smooth
- [x] Trigger a fade transition and verify it blends cleanly without stutter
- [x] Verify autoplay advances slides correctly
- [x] Verify transitions still work after a window resize

🤖 Generated with [Claude Code](https://claude.com/claude-code)