### PR TITLE
feat: per-view query isolation for DataTable (#282)

### DIFF
--- a/docs/examples/chart_filter_from_chart.py
+++ b/docs/examples/chart_filter_from_chart.py
@@ -1,0 +1,98 @@
+"""Filter the DataTable from a chart click, and vice-versa via broadcast search.
+
+The chart and the DataTable share ONE MemoryDataSource. Two integration points
+are shown:
+
+1. **Chart → table (click a bar)** — clicks call ``source.where(...)`` directly
+   on the shared source. The source broadcasts a DataChangeEvent and both views
+   update: the chart re-renders the filtered rows and the DataTable pages to
+   the matching record. This is always safe and works with any number of views.
+
+2. **Table → chart (type in the search box)** — the DataTable is created with
+   ``broadcast_search=True``, which un-silences the search filter so the same
+   DataChangeEvent propagates to the chart. The chart re-renders using only the
+   filtered rows.
+
+   .. WARNING::
+       ``broadcast_search=True`` should be set on **at most one** DataTable per
+       source. Two tables with this flag on the same source will overwrite each
+       other's filter on every keystroke, causing unpredictable results.
+
+Click the same bar again, or press **Clear filter**, to restore all rows.
+
+Requires: ``pip install bootstack[viz]``
+"""
+
+import bootstack as bs
+from bootstack.data import MemoryDataSource, col
+
+SALES = [
+    {"month": "Jan", "sales": 120},
+    {"month": "Feb", "sales": 180},
+    {"month": "Mar", "sales": 150},
+    {"month": "Apr", "sales": 90},
+    {"month": "May", "sales": 210},
+    {"month": "Jun", "sales": 160},
+]
+
+active_month = bs.Signal("")  # empty = show all
+_state = {"rows": []}           # rows last passed to render (for pick resolution)
+
+
+with bs.App(title="Filter from chart", min_size=(720, 580), padding=16, gap=12) as app:
+    sales = MemoryDataSource()
+    sales.load(SALES)
+
+    def render(ax, rows):
+        _state["rows"] = rows
+        months = [r["month"] for r in rows]
+        values = [r["sales"] for r in rows]
+        ax.bar(months, values)
+        ax.set_ylabel("Sales ($)")
+        month = active_month()
+        ax.set_title(f"Showing: {month if month else 'all months'} — click a bar to filter")
+
+    chart = bs.Chart(render=render, data_source=sales, grow=True, horizontal="stretch")
+
+    # broadcast_search=True: the search box filters the SHARED source, so
+    # the chart re-renders to match what you type. Safe only on ONE table
+    # per source — see the module docstring warning.
+    bs.DataTable(
+        data_source=sales,
+        columns=["month", "sales"],
+        broadcast_search=True,
+        grow=True,
+        horizontal="stretch",
+    )
+
+    def on_click(event):
+        if event.button != 1 or event.inaxes is None or event.xdata is None:
+            return
+        rows = _state["rows"]
+        axes = chart.figure.axes
+        if not axes or not rows:
+            return
+        # For a categorical bar chart, bar centers are at integer positions
+        # 0, 1, 2, ... Use round() to find the nearest bar to the click x.
+        idx = round(event.xdata)
+        if 0 <= idx < len(rows):
+            month = rows[idx]["month"]
+            if active_month() == month:
+                active_month.set("")
+                sales.where(None)
+            else:
+                active_month.set(month)
+                sales.where(col("month") == month)
+
+    chart.figure.canvas.mpl_connect("button_press_event", on_click)
+
+    def clear_filter():
+        active_month.set("")
+        sales.where(None)
+
+    with bs.Row(gap=8):
+        bs.Label("Click a bar to filter the table · click again to clear", font="caption")
+        bs.Spacer()
+        bs.Button("Clear filter", on_click=clear_filter)
+
+app.run()

--- a/docs/widgets/datatable.rst
+++ b/docs/widgets/datatable.rst
@@ -494,6 +494,42 @@ selection, and editing round-trip regardless of the backend. See
 :doc:`../reference/data-sources` for the source's filtering and sorting
 (``where()`` / ``order()``) and change broadcasting (``on_change`` / ``observe``).
 
+Multiple tables, one source
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Two ``DataTable`` widgets can share one source and stay independent. Search
+terms, column filters, and column sorting are **per-view state** — they do not
+mutate the shared source. Each table applies its own filter and sort transiently
+during reads, then restores the source for the next caller:
+
+.. code-block:: python
+
+   shared = MemoryDataSource()
+   shared.load(people)
+
+   table_active   = bs.DataTable(data_source=shared, columns=cols)
+   table_archived = bs.DataTable(data_source=shared, columns=cols)
+
+   # Searching in one has no effect on the other.
+   table_active.set_search("Smith")
+
+Applying ``where()`` or ``order()`` directly on the source still reaches every
+view — that is the correct way to drive a coordinated cross-view filter (for
+example, from a chart click). For that pattern, ``broadcast_search=True`` makes
+the table's own search box write to the source un-silenced, so a ``Chart`` or a
+second ``DataTable`` with no active search also re-renders:
+
+.. code-block:: python
+
+   # The table's search box now propagates to the chart bound to the same source.
+   table = bs.DataTable(data_source=shared, columns=cols, broadcast_search=True)
+
+.. warning::
+
+   Set ``broadcast_search=True`` on **at most one** ``DataTable`` per source.
+   Two tables with this flag on the same source will overwrite each other's
+   filter on every keystroke.
+
 Density and striping
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/bootstack/widgets/_impl/composites/tableview/tableview.py
+++ b/src/bootstack/widgets/_impl/composites/tableview/tableview.py
@@ -256,6 +256,7 @@ class TableView(Frame):
             enable_header_filtering: bool = True,
             enable_row_filtering: bool = True,
             enable_search: bool = True,
+            broadcast_search: bool = False,
             search_mode: Literal['standard', 'advanced'] = 'standard',
             search_trigger: Literal['enter', 'input'] = 'enter',
             # Paging & scrolling
@@ -399,6 +400,10 @@ class TableView(Frame):
         self._marker_icons: dict = {}
 
         self._search_mode_map: dict[str, str] = {}
+        self._broadcast_search: bool = broadcast_search
+        # Suppress the table's own _on_source_change re-load while a broadcast
+        # search is being applied (the load is done directly in _apply_where).
+        self._suppressing_search_broadcast: bool = False
         self._sorting = sorting_mode
         self._show_table_status = show_table_status
         self._show_column_chooser = show_column_chooser
@@ -500,8 +505,58 @@ class TableView(Frame):
             return silence()
         return contextlib.nullcontext()
 
+    @contextlib.contextmanager
+    def _apply_view_to_source(self):
+        """Temporarily apply this table's local filter/sort to the source (silenced).
+
+        Saves the source's current where/order state, applies the table's own
+        search + column-filter condition and sort order for the duration of the
+        block, then restores the source to its original state. This lets each
+        DataTable maintain independent view state over a shared source without
+        permanently mutating it.
+        """
+        ds = self._datasource
+        old_filter = getattr(ds, '_filter', None)
+        old_sort = list(getattr(ds, '_sort', []))
+        # Combine the source's own filter with this table's local search/column
+        # filters so source-level constraints (e.g. ds.where(...) called from
+        # app code) are respected alongside the table's per-view state.
+        # When broadcast_search is on the table already wrote its search condition
+        # to the source, so old_filter IS the combined condition — don't add local
+        # conditions again or they'd be applied twice.
+        if self._broadcast_search:
+            combined = old_filter
+        else:
+            combined = all_of(
+                old_filter,
+                self._build_search_condition(),
+                self._build_column_filter_condition(),
+            )
+        # Use the table's local sort when set; fall back to the source's sort
+        # so a source-level order() is respected when no column header is clicked.
+        sort_args = [k if asc else f"-{k}" for k, asc in self._sort_state.items()]
+        effective_sort = sort_args if sort_args else old_sort
+        with self._silence_source():
+            ds.where(combined)
+            ds.order(*effective_sort)
+        try:
+            yield
+        finally:
+            with self._silence_source():
+                try:
+                    ds.where(old_filter)
+                finally:
+                    ds.order(*old_sort)
+
     def _on_source_change(self, event=None) -> None:
         """Reload the current page after an external data-source change."""
+        if self._suppressing_search_broadcast:
+            # Consume the suppression — this is the hub flush that the broadcast
+            # write in _apply_where() triggered. The table already loaded page 0
+            # directly, so skip the redundant reload but allow future changes
+            # through by clearing the flag.
+            self._suppressing_search_broadcast = False
+            return
         try:
             self._clear_cache()
             self._load_page(self._current_page)
@@ -818,11 +873,6 @@ class TableView(Frame):
         return dict(self._sort_state)
 
     def set_sorting(self, key: str, ascending: bool = True) -> None:
-        try:
-            with self._silence_source():
-                self._datasource.order(key if ascending else f"-{key}")
-        except Exception:
-            return
         self._sort_state = {key: ascending}
         self._clear_cache()
         self._update_heading_icons()
@@ -843,11 +893,6 @@ class TableView(Frame):
             return
         self._group_by_key = key
         self._group_parents.clear()
-        try:
-            with self._silence_source():
-                self._datasource.order(key)
-        except Exception:
-            pass
         self._sort_state = {key: True}
         self._clear_cache()
         self._update_heading_icons()
@@ -1345,9 +1390,9 @@ class TableView(Frame):
 
     def _total_pages(self) -> int:
         try:
-            # Use cached count to avoid expensive COUNT(*) queries on every navigation
             if self._cached_total_count is None:
-                self._cached_total_count = self._datasource.count
+                with self._apply_view_to_source():
+                    self._cached_total_count = self._datasource.count
             total = self._cached_total_count
             size = getattr(self._datasource, "page_size", self._paging['page_size']) or 1
             return max(1, (total + size - 1) // size)
@@ -1359,10 +1404,13 @@ class TableView(Frame):
         if not append and page in self._page_cache:
             records = self._page_cache[page]
         else:
-            try:
-                records = self._datasource.page(page)
-            except Exception:
-                records = []
+            with self._apply_view_to_source():
+                try:
+                    records = self._datasource.page(page)
+                    if self._cached_total_count is None:
+                        self._cached_total_count = self._datasource.count
+                except Exception:
+                    records = []
             if not append:
                 self._remember_page(page, records)
         self._current_page = max(0, page)
@@ -1455,16 +1503,27 @@ class TableView(Frame):
         return any_of(*(make(c) for c in self._column_keys))
 
     def _apply_where(self) -> None:
-        """Compose the search term and column filters into a single where() clause."""
-        condition = all_of(
-            self._build_search_condition(),
-            self._build_column_filter_condition(),
-        )
-        try:
-            with self._silence_source():
+        """Recompute and apply the table's local filter state.
+
+        When `broadcast_search` is enabled, the combined condition is written to
+        the source un-silenced so that all other views (charts, etc.) re-render.
+        The table suppresses its own `_on_source_change` callback for this write
+        to avoid a double page-load.
+        """
+        if self._broadcast_search:
+            condition = all_of(
+                self._build_search_condition(),
+                self._build_column_filter_condition(),
+            )
+            try:
+                # Set the flag BEFORE the write; clear it in _on_source_change
+                # (not here in finally) so it is still True when the hub's
+                # after_idle flush fires, preventing a redundant second reload.
+                self._suppressing_search_broadcast = True
                 self._datasource.where(condition)
-        except Exception:
-            logger.exception("Failed to apply filters")
+            except Exception:
+                logger.exception("Failed to broadcast search filter")
+                self._suppressing_search_broadcast = False  # clear on error
         self._clear_cache()
         self._load_page(0)
         self._update_status_labels()
@@ -1487,11 +1546,6 @@ class TableView(Frame):
         asc = not self._sort_state.get(key, True)
         # Clear other sort states to keep single-column sort
         self._sort_state = {key: asc}
-        try:
-            with self._silence_source():
-                self._datasource.order(key if asc else f"-{key}")
-        except Exception:
-            pass
         self._clear_cache()
         self._update_heading_icons()
         self._load_page(0)
@@ -1559,9 +1613,11 @@ class TableView(Frame):
         # Sort
         sort_txt = ""
         try:
-            order = getattr(self._datasource, "_order_by", "")
-            if order:
-                sort_txt = MessageCatalog.translate("table.sort_status", order)
+            if self._sort_state and not self._group_by_key:
+                key, ascending = next(iter(self._sort_state.items()))
+                heading = self._column_heading(key)
+                direction = "↑" if ascending else "↓"
+                sort_txt = MessageCatalog.translate("table.sort_status", f"{heading} {direction}")
         except Exception:
             pass
         group_txt = ""
@@ -1846,11 +1902,6 @@ class TableView(Frame):
         col_idx = max(0, min(self._row_menu_col or 0, len(self._column_keys) - 1))
         key = self._column_keys[col_idx]
         self._sort_state = {key: ascending}
-        try:
-            with self._silence_source():
-                self._datasource.order(key if ascending else f"-{key}")
-        except Exception:
-            pass
         self._clear_cache()
         self._update_heading_icons()
         self._load_page(0)
@@ -2034,7 +2085,8 @@ class TableView(Frame):
             total_pages = self._total_pages()
             for page_idx in range(total_pages):
                 try:
-                    rows = self._datasource.page(page_idx)
+                    with self._apply_view_to_source():
+                        rows = self._datasource.page(page_idx)
                 except Exception:
                     break
                 if any(str(self._record_id(rec)) == rid for rec in rows):
@@ -2341,11 +2393,12 @@ class TableView(Frame):
         """Number of rows the given scope would export."""
         if scope == "selection":
             return len(self._tree.selection())
-        if scope == "page":
-            psize = self._ds_page_size()
-            start = self._current_page * psize
-            return len(self._datasource.page_slice(start, psize))
-        return self._datasource.count
+        with self._apply_view_to_source():
+            if scope == "page":
+                psize = self._ds_page_size()
+                start = self._current_page * psize
+                return len(self._datasource.page_slice(start, psize))
+            return self._datasource.count
 
     def _iter_raw_chunks(self, scope: str, chunk_size: int):
         """Yield lists of raw records for `scope`, paging through large 'all' scopes."""
@@ -2354,22 +2407,23 @@ class TableView(Frame):
             if rows:
                 yield rows
             return
-        if scope == "page":
-            psize = self._ds_page_size()
-            start = self._current_page * psize
-            rows = self._datasource.page_slice(start, psize)
-            if rows:
-                yield rows
-            return
-        # 'all' (the filtered/sorted set) — page through so memory stays flat.
-        total = self._datasource.count
-        offset = 0
-        while offset < total:
-            chunk = self._datasource.page_slice(offset, chunk_size)
-            if not chunk:
-                break
-            yield chunk
-            offset += len(chunk)
+        with self._apply_view_to_source():
+            if scope == "page":
+                psize = self._ds_page_size()
+                start = self._current_page * psize
+                rows = self._datasource.page_slice(start, psize)
+                if rows:
+                    yield rows
+                return
+            # 'all' (the filtered/sorted set) — page through so memory stays flat.
+            total = self._datasource.count
+            offset = 0
+            while offset < total:
+                chunk = self._datasource.page_slice(offset, chunk_size)
+                if not chunk:
+                    break
+                yield chunk
+                offset += len(chunk)
 
     def _to_delimited(self, rows: list, delimiter: str) -> str:
         """Serialize `rows` (raw records) as delimited text over the displayed columns."""
@@ -3125,16 +3179,9 @@ class TableView(Frame):
         key = self._column_keys[col]
         self._group_by_key = key
         self._group_parents.clear()
-        # Sort entire datasource by the grouping column so grouping reflects full dataset order
-        try:
-            with self._silence_source():
-                self._datasource.order(key)
-        except Exception:
-            pass
         self._sort_state = {key: True}
         self._clear_cache()
         self._update_heading_icons()
-        # Restart at first page to reflect new ordering
         self._load_page(0)
         self._update_status_labels()
 
@@ -3309,8 +3356,6 @@ class TableView(Frame):
 
     def _clear_sort(self) -> None:
         self._sort_state.clear()
-        with self._silence_source():
-            self._datasource.order()
         self._clear_cache()
         self._update_heading_icons()
         self._load_page(0)

--- a/src/bootstack/widgets/datatable.py
+++ b/src/bootstack/widgets/datatable.py
@@ -44,6 +44,18 @@ class DataTable(PublicWidgetBase):
         selection_mode: Row selection behavior. Default `'single'`.
         sorting_mode: Whether columns can be sorted. Default `'single'`.
         searchable: Show the search bar. Default `True`.
+        broadcast_search: When `True`, the search box and column filters write
+            their combined condition to the shared data source (un-silenced),
+            so all other views bound to the same source — including `Chart`
+            widgets — re-render to match. Defaults to `False` (per-view only).
+
+            .. warning::
+
+                Only enable this on **one** `DataTable` per source. Two tables
+                with ``broadcast_search=True`` on the same source will clobber
+                each other's filters on every keystroke, reproducing the
+                source-mutation coupling that per-view isolation was designed
+                to prevent.
         allow_filter: Enable column filtering. Default `True`.
         paging_mode: `'standard'` paginates the rows; `'virtual'` scrolls them
             in a single virtual view. Default `'standard'`.
@@ -99,6 +111,7 @@ class DataTable(PublicWidgetBase):
         selection_mode: SelectionMode = "single",
         sorting_mode: Literal["single", "none"] = "single",
         searchable: bool = True,
+        broadcast_search: bool = False,
         allow_filter: bool = True,
         paging_mode: Literal["standard", "virtual"] = "standard",
         page_size: int = 25,
@@ -129,6 +142,7 @@ class DataTable(PublicWidgetBase):
             "selection_mode": selection_mode,
             "sorting_mode": sorting_mode,
             "enable_search": searchable,
+            "broadcast_search": broadcast_search,
             "enable_filtering": allow_filter,
             "paging_mode": paging_mode,
             "page_size": page_size,

--- a/tests/widgets/public/test_datatable.py
+++ b/tests/widgets/public/test_datatable.py
@@ -221,3 +221,69 @@ def test_selection_multi_mode_is_a_list(shown_app):
     table.select_rows([10, 30])
     _pump(shown_app)
     assert sorted(r["id"] for r in table.selection) == [10, 30]
+
+
+# --------------------------------------------------------------------------- per-view isolation
+
+
+@pytest.mark.gui
+def test_two_tables_share_source_independent_search(shown_app):
+    """Two DataTables on one MemoryDataSource must filter independently.
+
+    Searching in table_a must not affect the rows visible in table_b, and
+    the source's own where/order state must be unchanged after both tables
+    have rendered.
+    """
+    src = MemoryDataSource()
+    src.load([dict(r) for r in ROWS])
+
+    table_a = bs.DataTable(
+        data_source=src, columns=["name", "role"],
+        enable_search=True, page_size=10,
+    )
+    table_b = bs.DataTable(
+        data_source=src, columns=["name", "role"],
+        enable_search=True, page_size=10,
+    )
+    _pump(shown_app)
+
+    # Both tables start with all rows.
+    assert len(table_a.to_rows("page")) == 3
+    assert len(table_b.to_rows("page")) == 3
+
+    # Apply a search to table_a only.
+    table_a._internal.set_search("Ada")
+    _pump(shown_app)
+
+    rows_a = table_a.to_rows("page")
+    rows_b = table_b.to_rows("page")
+
+    assert [r["name"] for r in rows_a] == ["Ada"], "table_a should be filtered"
+    assert len(rows_b) == 3, "table_b must not be affected by table_a's search"
+
+    # Source's own filter must be untouched.
+    assert src._filter is None, "source where() must not be mutated"
+
+
+@pytest.mark.gui
+def test_two_tables_share_source_independent_sort(shown_app):
+    """Sorting in one table must not change the sort order seen by the other."""
+    src = MemoryDataSource()
+    src.load([dict(r) for r in ROWS])
+
+    table_a = bs.DataTable(data_source=src, columns=["name", "role"], page_size=10)
+    table_b = bs.DataTable(data_source=src, columns=["name", "role"], page_size=10)
+    _pump(shown_app)
+
+    # Sort table_a descending by name.
+    table_a._internal.set_sorting("name", ascending=False)
+    _pump(shown_app)
+
+    names_a = [r["name"] for r in table_a.to_rows("page")]
+    names_b = [r["name"] for r in table_b.to_rows("page")]
+
+    assert names_a == sorted(names_a, reverse=True), "table_a should be sorted desc"
+    assert names_b == ["Ada", "Boole", "Church"], "table_b must keep insertion order"
+
+    # Source's own sort must be untouched.
+    assert src._sort == [], "source order() must not be mutated"


### PR DESCRIPTION
## Summary

- **Per-view isolation** — each `DataTable` on a shared source keeps its own search text, column filters, and sort state without mutating `DataSourceProtocol.where()`/`order()`. A new `_apply_view_to_source()` context manager applies the table's local conditions transiently during reads and restores the source to its original state, so a second table, chart, or any other subscriber sees the source unchanged.
- **`broadcast_search=True`** — opt-in flag that un-silences the table's search/filter writes to the shared source, driving charts and other subscribers to re-render in sync. Documented with a warning that only one table per source should set this flag.
- **Sort status label fixed** — `_update_status_labels()` was reading `_datasource._order_by`, an attribute that never existed on any DataSource; the sort status label was always blank. Fixed to read from the local `_sort_state`.
- **Demo** — `docs/examples/chart_filter_from_chart.py` shows both directions: chart-click calls `source.where()` directly (always safe), and `broadcast_search=True` makes the table's search bar propagate to the chart.

## Review findings fixed before merge

Three bugs caught in code review were corrected in the same commit:

1. `_find_record_page()` bypassed `_apply_view_to_source()` — after a form-dialog insert while a search was active, the post-insert auto-scroll scanned unfiltered pages and landed on the wrong one. Wrapped the inner `datasource.page()` call.
2. Double page load in `broadcast_search` mode — `_suppressing_search_broadcast` was cleared in `finally` before the hub's `after_idle` flush fired, causing `_on_source_change` to reload a second time. Flag is now consumed by `_on_source_change` directly (one-shot pattern).
3. Non-atomic restore in `_apply_view_to_source()` `finally` block — if `ds.where(old_filter)` raised, `ds.order(*old_sort)` was skipped. Added a nested `try/finally`.

## Test plan

- [ ] `pytest tests/widgets/public/test_datatable.py` — all 12 pass, including two new isolation tests (`test_two_tables_share_source_independent_search`, `test_two_tables_share_source_independent_sort`)
- [ ] Run `docs/examples/chart_filter_from_chart.py` — bar click filters both chart and table; table search filters chart when `broadcast_search=True`; Clear filter restores all rows
- [ ] Two tables on one source: search in one does not affect the other; source `_filter` stays `None` after both render

Closes #282

🤖 Generated with [Claude Code](https://claude.com/claude-code)