### PR TITLE
feat(textarea, codeeditor): reactive .valid / .error signals (#246)

### DIFF
--- a/docs/examples/dev_246_valid_error.py
+++ b/docs/examples/dev_246_valid_error.py
@@ -1,0 +1,48 @@
+"""Dev demo for #246 — TextArea and CodeEditor reactive .valid / .error signals.
+
+Demonstrates the new .valid (Signal[bool]) and .error (Signal[str]) properties
+added to TextArea and CodeEditor. Validation runs on blur or via validate().
+
+Run with:
+    python docs/examples/dev_246_valid_error.py
+"""
+import bootstack as bs
+
+with bs.App(title="#246 - .valid / .error signals", padding=20, gap=16) as app:
+
+    # TextArea ---------------------------------------------------------------
+    bs.Label("TextArea Validation", font="heading-sm")
+
+    ta = bs.TextArea(label="Notes", required=True, height=4, placeholder="Type at least 10 chars...")
+    ta.add_validation_rule("stringLength", min=10, message="Minimum 10 characters.")
+
+    ta_status = bs.Signal("valid: True")
+    ta.valid.subscribe(lambda ok: ta_status.set(f"valid: {ok}"))
+
+    bs.Label(textsignal=ta_status, accent="secondary")
+    bs.Label(textsignal=ta.error, accent="secondary")
+
+    with bs.Row(gap=8):
+        bs.Button("Validate", on_click=lambda: ta.validate())
+        bs.Button("Clear", accent="secondary", on_click=lambda: ta.clear())
+
+    bs.Divider()
+
+    # CodeEditor -------------------------------------------------------------
+    bs.Label("CodeEditor Validation", font="heading-sm")
+
+    ed = bs.CodeEditor(language="python", height=6)
+    ed.add_validation_rule("required", message="Editor cannot be empty.")
+    ed.add_validation_rule("stringLength", min=20, message="Minimum 20 characters.")
+
+    ed_status = bs.Signal("valid: True")
+    ed.valid.subscribe(lambda ok: ed_status.set(f"valid: {ok}"))
+
+    bs.Label(textsignal=ed_status, accent="secondary")
+    bs.Label(textsignal=ed.error, accent="secondary")
+
+    with bs.Row(gap=8):
+        bs.Button("Validate", on_click=lambda: ed.validate())
+        bs.Button("Seed content", accent="secondary", on_click=lambda: ed.insert("print('hello, world!')\n"))
+
+app.run()

--- a/docs/widgets/codeeditor.rst
+++ b/docs/widgets/codeeditor.rst
@@ -17,7 +17,7 @@ Usage
 
 Think of it as a standalone editing *surface*, not a form input: it ships the
 editor behaviors (a gutter, a search bar, undo grouping) built in, and it is
-**not** Field-wrapped — there is no label, validation, or ``disabled`` state.
+**not** Field-wrapped — there is no label or ``disabled`` state.
 Reach for :doc:`textarea` when you want a labeled multi-line field in a form.
 
 Basic usage
@@ -166,6 +166,30 @@ so map the stream — not the property — and read the position inside the map:
            .map(lambda e: "Ln {}, Col {}".format(*editor.cursor_position))
            .listen(status.set)
    )
+
+Validation
+~~~~~~~~~~
+
+Attach rules with ``add_validation_rule()``; ``validate()`` runs them
+immediately. Validation also runs automatically on blur. Listen for results with
+``on_valid`` / ``on_invalid``, or read the reactive ``valid`` and ``error``
+signals for binding.
+
+.. code-block:: python
+
+   editor = bs.CodeEditor(language="python")
+   editor.add_validation_rule("required", message="Content is required.")
+   editor.add_validation_rule("stringLength", min=10)
+
+   btn = bs.Button("Run", accent="primary")
+
+   def on_validity_change(ok):
+       btn.disabled = not ok
+
+   editor.valid.subscribe(on_validity_change)
+   editor.on_invalid(lambda e: print("invalid:", e.message))
+
+See :doc:`/reference/validation` for the full rule set.
 
 Undo and redo
 ~~~~~~~~~~~~~

--- a/docs/widgets/textarea.rst
+++ b/docs/widgets/textarea.rst
@@ -154,6 +154,25 @@ below the field. Listen with ``on_valid`` / ``on_invalid``.
    ta.on_invalid(lambda e: print("invalid:", e))
    ta.validate()
 
+For reactive binding — for example, disabling a submit button until the field is
+valid — read the ``valid`` and ``error`` Signals. They update automatically after
+every validation run (on blur or an explicit ``validate()`` call).
+
+.. code-block:: python
+
+   ta = bs.TextArea(required=True)
+   btn = bs.Button("Submit", accent="primary")
+   err_label = bs.Label("")
+
+   def on_validity_change(ok):
+       btn.disabled = not ok
+
+   def on_error_change(msg):
+       err_label.text = msg
+
+   ta.valid.subscribe(on_validity_change)
+   ta.error.subscribe(on_error_change)
+
 See :doc:`/reference/validation` for the full rule set and the typed-value model.
 
 Undo and redo

--- a/src/bootstack/widgets/_impl/composites/textarea/codeeditor.py
+++ b/src/bootstack/widgets/_impl/composites/textarea/codeeditor.py
@@ -14,9 +14,10 @@ from bootstack.widgets._impl.composites.textarea.extensions.indent_guides import
 from bootstack.widgets._impl.composites.textarea.search_overlay import SearchOverlay
 from bootstack.widgets.types import Master
 
+from bootstack.events import ValidationEvent
+from bootstack.signals import Signal
+
 from typing import TYPE_CHECKING
-if TYPE_CHECKING:
-    from bootstack.signals import Signal
 
 
 class CodeEditor(Frame):
@@ -107,6 +108,9 @@ class CodeEditor(Frame):
         self._dark_theme = dark_theme
         self._show_line_numbers = show_line_numbers
         self._highlighter = None
+        self._rules: list = []
+        self._valid_signal: Signal = Signal(True)
+        self._error_signal: Signal = Signal("")
 
         # ── core ──────────────────────────────────────────────────────────
         self._core = _MultilineCore(
@@ -188,6 +192,9 @@ class CodeEditor(Frame):
             self._core.text.bind("<<CursorMove>>", on_cursor_move, add="+")
             self._core.text.bind("<KeyRelease>", on_cursor_move, add="+")
             self._core.text.bind("<ButtonRelease-1>", on_cursor_move, add="+")
+
+        # ── validation: auto-run on blur ──────────────────────────────────
+        self._core.text.bind("<FocusOut>", self._on_focus_out_validate, add="+")
 
     # ── public API ────────────────────────────────────────────────────────
 
@@ -366,6 +373,58 @@ class CodeEditor(Frame):
         """Hide the find/replace bar and clear search highlights."""
         self._search.hide()
 
+
+    # ── validation ────────────────────────────────────────────────────────
+
+    def add_validation_rule(
+        self,
+        rule_type: str,
+        message: str | None = None,
+        **kwargs,
+    ) -> None:
+        """Add a validation rule to this editor.
+
+        Args:
+            rule_type: Rule name — `"required"`, `"pattern"`, `"stringLength"`, etc.
+            message: Custom error message. If None, the rule's default is used.
+            **kwargs: Rule-specific parameters (e.g. `minLength=`, `func=`).
+        """
+        from bootstack.validation.validation_rules import ValidationRule
+        self._rules.append(ValidationRule(rule_type, message=message, **kwargs))
+
+    def validate(self) -> bool:
+        """Run all validation rules immediately and return True if valid.
+
+        Triggers `<<Valid>>` / `<<Invalid>>` / `<<Validate>>` events and
+        updates the `_valid_signal` and `_error_signal`.
+        """
+        return self._run_validation(trigger="manual")
+
+    def _set_validity(self, is_valid: bool, message: str) -> None:
+        self._error_signal.set("" if is_valid else message)
+        self._valid_signal.set(is_valid)
+
+    def _run_validation(self, trigger: str = "blur") -> bool:
+        value = self.value
+        for rule in self._rules:
+            if trigger != "manual" and rule.trigger not in ("always", trigger):
+                continue
+            result = rule.validate(value)
+            if not result.is_valid:
+                self._set_validity(False, result.message)
+                data = ValidationEvent(value=value, is_valid=False, message=result.message)
+                self.event_generate("<<Invalid>>", data=data, when="tail")
+                self.event_generate("<<Validate>>", data=data, when="tail")
+                return False
+        self._set_validity(True, "")
+        data = ValidationEvent(value=value, is_valid=True, message="")
+        self.event_generate("<<Valid>>", data=data, when="tail")
+        self.event_generate("<<Validate>>", data=data, when="tail")
+        return True
+
+    def _on_focus_out_validate(self, _event: tk.Event) -> None:
+        if self._rules:
+            self._run_validation(trigger="blur")
 
     # ── internal ─────────────────────────────────────────────────────────
 

--- a/src/bootstack/widgets/_impl/composites/textarea/textarea.py
+++ b/src/bootstack/widgets/_impl/composites/textarea/textarea.py
@@ -12,9 +12,10 @@ from bootstack.widgets._impl.composites.textarea.core import _MultilineCore, Scr
 from bootstack.widgets.types import Master, AccentToken
 from bootstack._runtime.utility import scale_padding_floor
 
+from bootstack.signals import Signal
+
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
-    from bootstack.signals import Signal
     from bootstack.validation.validation_rules import ValidationRule
 
 
@@ -110,6 +111,8 @@ class TextArea(GridFrame):
         self._original_message = message or ""
         self._rules: list[ValidationRule] = []
         self._message_showing = False
+        self._valid_signal: Signal = Signal(True)
+        self._error_signal: Signal = Signal("")
 
         # ── label (row 0) ─────────────────────────────────────────────────
         if label:
@@ -307,13 +310,18 @@ class TextArea(GridFrame):
         """
         return self._run_validation(trigger="manual")
 
+    def _set_validity(self, is_valid: bool, message: str) -> None:
+        self._error_signal.set("" if is_valid else message)
+        self._valid_signal.set(is_valid)
+
     def _run_validation(self, trigger: str = "blur") -> bool:
         value = self.value
         for rule in self._rules:
-            if rule.trigger not in ("always", trigger):
+            if trigger != "manual" and rule.trigger not in ("always", trigger):
                 continue
             result = rule.validate(value)
             if not result.is_valid:
+                self._set_validity(False, result.message)
                 self._show_error(result.message)
                 data = ValidationEvent(
                     value=value, is_valid=False, message=result.message,
@@ -321,6 +329,7 @@ class TextArea(GridFrame):
                 self.event_generate("<<Invalid>>", data=data, when="tail")
                 self.event_generate("<<Validate>>", data=data, when="tail")
                 return False
+        self._set_validity(True, "")
         self._clear_error()
         data = ValidationEvent(value=value, is_valid=True, message="")
         self.event_generate("<<Valid>>", data=data, when="tail")

--- a/src/bootstack/widgets/codeeditor.py
+++ b/src/bootstack/widgets/codeeditor.py
@@ -8,8 +8,9 @@ from bootstack.widgets._impl.composites.textarea.codeeditor import CodeEditor as
 from bootstack.widgets._impl.composites.textarea.filter import EditFilter
 from bootstack.widgets._core.base import PublicWidgetBase, adapt_handler
 from bootstack.widgets._core.events import resolve_event, register_widget_events
-from bootstack.events import ChangeEvent, InputEvent, Subscription, TextModifiedEvent
+from bootstack.events import ChangeEvent, InputEvent, Subscription, TextModifiedEvent, ValidationEvent
 from bootstack.streams import Stream
+from bootstack.validation import RuleType
 from bootstack.widgets.types import AccentToken, Event
 
 if TYPE_CHECKING:
@@ -18,6 +19,9 @@ if TYPE_CHECKING:
 _CODEEDITOR_EVENTS: dict[str, str] = {
     "change":      "<<BsChange>>",
     "input":       "<<BsInput>>",
+    "valid":       "<<Valid>>",
+    "invalid":     "<<Invalid>>",
+    "validate":    "<<Validate>>",
     "modified":    "<<TextModified>>",
     "undo":        "<<TextUndo>>",
     "redo":        "<<TextRedo>>",
@@ -211,6 +215,24 @@ class CodeEditor(PublicWidgetBase):
         return getattr(self._internal._core, "signal", None)
 
     @property
+    def valid(self) -> "Signal[bool]":
+        """Reactive `Signal[bool]` — `True` when all validation rules pass.
+
+        Starts `True`. Updates after every validation run (blur or manual
+        `validate()` call). Subscribe to react immediately when validity changes:
+        `editor.valid.subscribe(lambda ok: btn.disabled = not ok)`.
+        """
+        return self._internal._valid_signal
+
+    @property
+    def error(self) -> "Signal[str]":
+        """Reactive `Signal[str]` — current validation error message.
+
+        Empty string when the editor is valid. Updates in lockstep with `valid`.
+        """
+        return self._internal._error_signal
+
+    @property
     def is_dirty(self) -> bool:
         """True if content has changed since the last `mark_saved()` call."""
         return self._internal.is_dirty
@@ -266,6 +288,24 @@ class CodeEditor(PublicWidgetBase):
         self._internal._core.read_only = v
 
     # ----- Methods -----
+
+    def validate(self) -> bool:
+        """Run validation rules against the current content.
+
+        Returns:
+            `True` if all rules pass, `False` otherwise.
+        """
+        return self._internal.validate()
+
+    def add_validation_rule(self, rule_type: RuleType, **kwargs: Any) -> None:
+        """Attach a validation rule to this editor.
+
+        Args:
+            rule_type: The kind of validation rule to apply.
+            **kwargs: Rule options such as `message=`, `min=`, `max=`,
+                `trigger=`.
+        """
+        self._internal.add_validation_rule(rule_type, **kwargs)
 
     def clear(self) -> None:
         """Clear all text content."""
@@ -426,6 +466,57 @@ class CodeEditor(PublicWidgetBase):
             is given, otherwise a :class:`~bootstack.streams.Stream`.
         """
         return self.on("input", handler)
+
+    @overload
+    def on_valid(self) -> Stream: ...
+    @overload
+    def on_valid(self, handler: Callable[[ValidationEvent], Any]) -> Subscription: ...
+    def on_valid(self, handler: Callable[[ValidationEvent], Any] | None = None) -> Stream | Subscription:
+        """Register a callback fired when validation passes.
+
+        Args:
+            handler: Called with a :class:`~bootstack.events.ValidationEvent`. Omit to
+                get a composable :class:`~bootstack.streams.Stream` instead.
+
+        Returns:
+            A cancellable :class:`~bootstack.events.Subscription` when a
+            handler is given, otherwise a :class:`~bootstack.streams.Stream`.
+        """
+        return self.on("valid", handler)
+
+    @overload
+    def on_invalid(self) -> Stream: ...
+    @overload
+    def on_invalid(self, handler: Callable[[ValidationEvent], Any]) -> Subscription: ...
+    def on_invalid(self, handler: Callable[[ValidationEvent], Any] | None = None) -> Stream | Subscription:
+        """Register a callback fired when validation fails.
+
+        Args:
+            handler: Called with a :class:`~bootstack.events.ValidationEvent`. Omit to
+                get a composable :class:`~bootstack.streams.Stream` instead.
+
+        Returns:
+            A cancellable :class:`~bootstack.events.Subscription` when a
+            handler is given, otherwise a :class:`~bootstack.streams.Stream`.
+        """
+        return self.on("invalid", handler)
+
+    @overload
+    def on_validate(self) -> Stream: ...
+    @overload
+    def on_validate(self, handler: Callable[[ValidationEvent], Any]) -> Subscription: ...
+    def on_validate(self, handler: Callable[[ValidationEvent], Any] | None = None) -> Stream | Subscription:
+        """Register a callback fired after any validation run.
+
+        Args:
+            handler: Called with a :class:`~bootstack.events.ValidationEvent`. Omit to
+                get a composable :class:`~bootstack.streams.Stream` instead.
+
+        Returns:
+            A cancellable :class:`~bootstack.events.Subscription` when a
+            handler is given, otherwise a :class:`~bootstack.streams.Stream`.
+        """
+        return self.on("validate", handler)
 
     @overload
     def on_modified(self) -> Stream: ...

--- a/src/bootstack/widgets/textarea.py
+++ b/src/bootstack/widgets/textarea.py
@@ -179,6 +179,24 @@ class TextArea(PublicWidgetBase):
         return getattr(self._internal, "signal", None)
 
     @property
+    def valid(self) -> "Signal[bool]":
+        """Reactive `Signal[bool]` — `True` when all validation rules pass.
+
+        Starts `True`. Updates after every validation run (blur or manual
+        `validate()` call). Subscribe to react immediately when validity changes:
+        `area.valid.subscribe(lambda ok: btn.disabled = not ok)`.
+        """
+        return self._internal._valid_signal
+
+    @property
+    def error(self) -> "Signal[str]":
+        """Reactive `Signal[str]` — current validation error message.
+
+        Empty string when the field is valid. Updates in lockstep with `valid`.
+        """
+        return self._internal._error_signal
+
+    @property
     def read_only(self) -> bool:
         """Whether the text area is visible but not editable."""
         return self._internal._core.read_only

--- a/tests/widgets/public/test_textarea_codeeditor_valid_error.py
+++ b/tests/widgets/public/test_textarea_codeeditor_valid_error.py
@@ -1,0 +1,180 @@
+"""#246 — TextArea and CodeEditor reactive .valid / .error signals.
+
+Both widgets should expose:
+  .valid  — Signal[bool], starts True, updates on each validation run
+  .error  — Signal[str], starts "", contains the error message on failure
+
+Validation runs:
+  - On blur (FocusOut on the inner text widget) when rules are present
+  - On manual validate() call
+
+These tests cover:
+  - Initial signal state (valid=True, error="")
+  - Signal updates after manual validate()
+  - Signal updates after blur-triggered validation
+  - Signal subscriber notification
+  - Both widgets share the same contract
+"""
+import pytest
+import bootstack as bs
+
+
+# ── TextArea ──────────────────────────────────────────────────────────────────
+
+def test_textarea_valid_signal_initial_state(app):
+    ta = bs.TextArea(required=True)
+    assert ta.valid() is True
+    assert ta.error() == ""
+
+
+def test_textarea_valid_signal_fails_on_empty_required(app):
+    ta = bs.TextArea(required=True, value="")
+    result = ta.validate()
+    assert result is False
+    assert ta.valid() is False
+    assert ta.error() != ""
+
+
+def test_textarea_valid_signal_passes_on_content(app):
+    ta = bs.TextArea(required=True, value="hello")
+    result = ta.validate()
+    assert result is True
+    assert ta.valid() is True
+    assert ta.error() == ""
+
+
+def test_textarea_valid_signal_resets_after_correction(app):
+    ta = bs.TextArea(required=True, value="")
+    ta.validate()
+    assert ta.valid() is False
+
+    ta.value = "fixed"
+    ta.validate()
+    assert ta.valid() is True
+    assert ta.error() == ""
+
+
+def test_textarea_valid_signal_notifies_subscriber(app):
+    ta = bs.TextArea(required=True, value="")
+    collected = []
+    ta.valid.subscribe(lambda v: collected.append(v))
+
+    ta.validate()   # fails → False
+    assert False in collected
+
+    ta.value = "ok"
+    ta.validate()   # passes → True
+    assert True in collected
+
+
+def test_textarea_error_signal_notifies_subscriber(app):
+    ta = bs.TextArea(required=True, value="")
+    errors = []
+    ta.error.subscribe(lambda msg: errors.append(msg))
+
+    ta.validate()
+    assert any(e != "" for e in errors)
+
+
+def test_textarea_blur_triggers_validation(app):
+    ta = bs.TextArea(required=True, value="")
+    # Simulate blur: call the internal handler directly (event_generate does not
+    # call Python bindings without a running event loop — the integration is
+    # covered by the manual validate() tests above; this checks the blur path).
+    ta._internal._on_focus_out(None)
+    assert ta.valid() is False
+
+
+def test_textarea_manual_validate_runs_blur_rules(app):
+    # stringLength defaults to trigger="blur"; manual validate() must still run it.
+    ta = bs.TextArea(value="hi")
+    ta.add_validation_rule("stringLength", min=10, message="Too short.")
+    result = ta.validate()
+    assert result is False
+    assert ta.valid() is False
+    assert ta.error() == "Too short."
+
+
+def test_textarea_no_rules_valid_stays_true(app):
+    ta = bs.TextArea(value="whatever")
+    ta.validate()
+    assert ta.valid() is True
+    assert ta.error() == ""
+
+
+# ── CodeEditor ────────────────────────────────────────────────────────────────
+
+def test_codeeditor_valid_signal_initial_state(app):
+    ed = bs.CodeEditor(value="")
+    assert ed.valid() is True
+    assert ed.error() == ""
+
+
+def test_codeeditor_valid_signal_fails_on_required_empty(app):
+    ed = bs.CodeEditor(value="")
+    ed.add_validation_rule("required")
+    result = ed.validate()
+    assert result is False
+    assert ed.valid() is False
+    assert ed.error() != ""
+
+
+def test_codeeditor_valid_signal_passes_on_content(app):
+    ed = bs.CodeEditor(value="print('hi')")
+    ed.add_validation_rule("required")
+    result = ed.validate()
+    assert result is True
+    assert ed.valid() is True
+    assert ed.error() == ""
+
+
+def test_codeeditor_valid_signal_resets_after_correction(app):
+    ed = bs.CodeEditor(value="")
+    ed.add_validation_rule("required")
+    ed.validate()
+    assert ed.valid() is False
+
+    ed.value = "x = 1"
+    ed.validate()
+    assert ed.valid() is True
+    assert ed.error() == ""
+
+
+def test_codeeditor_valid_signal_notifies_subscriber(app):
+    ed = bs.CodeEditor(value="")
+    ed.add_validation_rule("required")
+    collected = []
+    ed.valid.subscribe(lambda v: collected.append(v))
+
+    ed.validate()   # fails → False
+    assert False in collected
+
+    ed.value = "ok"
+    ed.validate()   # passes → True
+    assert True in collected
+
+
+def test_codeeditor_blur_triggers_validation(app):
+    ed = bs.CodeEditor(value="")
+    ed.add_validation_rule("required")
+    # Simulate blur via the internal handler (event_generate does not call
+    # Python bindings without a running event loop).
+    ed._internal._on_focus_out_validate(None)
+    assert ed.valid() is False
+
+
+def test_codeeditor_manual_validate_runs_blur_rules(app):
+    # stringLength defaults to trigger="blur"; manual validate() must still run it.
+    ed = bs.CodeEditor(value="hi")
+    ed.add_validation_rule("stringLength", min=10, message="Too short.")
+    result = ed.validate()
+    assert result is False
+    assert ed.valid() is False
+    assert ed.error() == "Too short."
+
+
+def test_codeeditor_no_rules_valid_stays_true(app):
+    ed = bs.CodeEditor(value="")
+    ed.validate()
+    assert ed.valid() is True
+    assert ed.error() == ""


### PR DESCRIPTION
## Summary

- Adds `.valid` (`Signal[bool]`) and `.error` (`Signal[str]`) properties to both `TextArea` and `CodeEditor`
- Signals update automatically on blur and on explicit `validate()` calls
- Adds `validate()` and `add_validation_rule()` to `CodeEditor` (previously had no validation)
- Adds `on_valid`, `on_invalid`, `on_validate` event shorthands to `CodeEditor`
- Fixes trigger filter: manual `validate()` now runs all rules regardless of their default trigger (matches `ValidationMixin` behavior — `trigger != "manual" and rule.trigger not in ("always", trigger)`)

## Test plan

- [ ] Run `python -m pytest tests/widgets/public/test_textarea_codeeditor_valid_error.py -v` — 17 tests, all green
- [ ] Run demo: `python docs/examples/dev_246_valid_error.py`
  - TextArea: leave blank and blur → invalid; type 10+ chars and blur → valid
  - CodeEditor: click Validate with empty editor → invalid; seed content and validate → valid
  - Status labels update reactively via Signal subscription

🤖 Generated with [Claude Code](https://claude.com/claude-code)