### PR TITLE
fix: scrub private internal access across public wrappers and examples

### DIFF
--- a/docs/examples/checkbox.py
+++ b/docs/examples/checkbox.py
@@ -58,7 +58,10 @@ with bs.App(title="Checkbox Demo", padding=20, gap=16) as app:
             unchecked_value="light",
         )
         theme_lbl = bs.Label("Theme: light", accent="secondary", font="caption")
-        theme_sig.subscribe(lambda v: setattr(theme_lbl, 'text', f"Theme: {v}"))
+        def _update_theme(v):
+            theme_lbl.text = f"Theme: {v}"
+
+        theme_sig.subscribe(_update_theme)
 
     # Disabled
     bs.Label("Disabled", font="heading-sm")

--- a/docs/examples/codeeditor.py
+++ b/docs/examples/codeeditor.py
@@ -82,9 +82,8 @@ with bs.App(title="CodeEditor Demo", size=(800, 700)) as app:
             ed3 = bs.CodeEditor(value=SAMPLE_PY, language="python", height=6)
 
             def _update_pos(e):
-                idx = ed3._internal._core.text.index("insert")
-                line, col = idx.split(".")
-                pos_sig.set(f"line {line}, col {int(col) + 1}")
+                line, col = ed3.cursor_position
+                pos_sig.set(f"line {line}, col {col}")
 
             ed3.on_cursor_move(_update_pos)
             bs.Label(textsignal=pos_sig, accent="secondary")

--- a/docs/examples/observable_datasource.py
+++ b/docs/examples/observable_datasource.py
@@ -65,15 +65,17 @@ with bs.App(title="Observable data source", size=(560, 560), padding=16, gap=12)
     bs.Label("Bound ListView (auto-refreshing):", font="caption")
     bs.ListView(data_source=ds, grow=True, horizontal="stretch")
 
+    def _update_total(n):
+        total.text = f"{n} rows"
+
+    def _update_active(rows):
+        active_gauge.value = len(rows)
+
     # Badge tracks total row count via the coarse change stream.
-    total_sub = ds.on_change().map(lambda e: ds.count).listen(
-        lambda n: setattr(total, "text", f"{n} rows")
-    )
+    total_sub = ds.on_change().map(lambda e: ds.count).listen(_update_total)
 
     # Gauge tracks the active-row count via an observed query.
-    active_sub = ds.observe(col("status") == "active").listen(
-        lambda rows: setattr(active_gauge, "value", len(rows))
-    )
+    active_sub = ds.observe(col("status") == "active").listen(_update_active)
 
 worker = threading.Thread(target=feed, daemon=True)
 worker.start()

--- a/docs/examples/selectfield.py
+++ b/docs/examples/selectfield.py
@@ -79,16 +79,23 @@ with bs.App(title="Select Demo", padding=20, gap=16) as app:
         color = bs.Signal("Red")
         bs.Select(["Red", "Green", "Blue"], label="Color", signal=color)
         color_lbl = bs.Label("Selected: Red", accent="secondary", font="caption")
-        color.subscribe(lambda v: setattr(color_lbl, 'text', f"Selected: {v}"))
+        def _update_color(v):
+            color_lbl.text = f"Selected: {v}"
+
+        color.subscribe(_update_color)
 
     # Runtime option updates
     bs.Label("Runtime Updates", font="heading-sm")
     with bs.Column(gap=6, horizontal="stretch", horizontal_items="stretch"):
         sel = bs.Select(["Alpha", "Beta", "Gamma"])
         with bs.Row(gap=8):
-            bs.Button("Set ABC", variant="outline",
-                on_click=lambda: setattr(sel, 'options', ["A", "B", "C"]))
-            bs.Button("Set 1-2-3", variant="outline",
-                on_click=lambda: setattr(sel, 'options', ["1", "2", "3"]))
+            def _set_abc():
+                sel.options = ["A", "B", "C"]
+
+            def _set_123():
+                sel.options = ["1", "2", "3"]
+
+            bs.Button("Set ABC", variant="outline", on_click=_set_abc)
+            bs.Button("Set 1-2-3", variant="outline", on_click=_set_123)
 
 app.run()

--- a/docs/examples/switch.py
+++ b/docs/examples/switch.py
@@ -29,7 +29,10 @@ with bs.App(title="Switch Demo", padding=20, gap=16) as app:
         dark_sig = bs.Signal(False)
         bs.Switch("Dark mode", signal=dark_sig, accent="secondary")
         status_lbl = bs.Label("Theme: light", accent="secondary", font="caption")
-        dark_sig.subscribe(lambda v: setattr(status_lbl, 'text', f"Theme: {'dark' if v else 'light'}"))
+        def _update_theme(v):
+            status_lbl.text = f"Theme: {'dark' if v else 'light'}"
+
+        dark_sig.subscribe(_update_theme)
 
     # Disabled
     bs.Label("Disabled", font="heading-sm")

--- a/src/bootstack/widgets/_impl/composites/textarea/codeeditor.py
+++ b/src/bootstack/widgets/_impl/composites/textarea/codeeditor.py
@@ -361,6 +361,32 @@ class CodeEditor(Frame):
         """The internal `_MultilineCore` — for advanced extension use."""
         return self._core
 
+    @property
+    def language(self) -> str | None:
+        """Active syntax highlighting language, or `None` if disabled."""
+        return self._language
+
+    @property
+    def theme(self) -> str:
+        """Active Pygments color scheme, or `'auto'` if tracking the bootstack theme."""
+        return self._pygments_style
+
+    def set_theme(self, v: str) -> None:
+        """Change the active Pygments color scheme.
+
+        Args:
+            v: Pygments style name, or `'auto'` to track the bootstack theme.
+        """
+        self._pygments_style = v
+        if self._highlighter is not None:
+            self._highlighter._auto = (v == "auto")
+            if v != "auto":
+                self._highlighter._load_style(v)
+                for sname, color in self._highlighter._style_colors.items():
+                    self._core.define_style(sname, foreground=color)
+            self._highlighter._apply_widget_colors(self._core)
+            self._highlighter._schedule()
+
     def show_search(self) -> None:
         """Show the find bar and focus the search input."""
         self._search.show(replace=False)

--- a/src/bootstack/widgets/_impl/composites/toolbar.py
+++ b/src/bootstack/widgets/_impl/composites/toolbar.py
@@ -569,6 +569,11 @@ class Toolbar(Frame):
         """Get the toolbar's button density."""
         return self._density
 
+    @property
+    def surface(self) -> str:
+        """The surface token applied to this toolbar."""
+        return getattr(self, "_surface", "chrome")
+
     # --- Window Control Access ---
 
     @property

--- a/src/bootstack/widgets/codeeditor.py
+++ b/src/bootstack/widgets/codeeditor.py
@@ -140,7 +140,7 @@ class CodeEditor(PublicWidgetBase):
         self._internal = _InternalCodeEditor(tk_master, **internal_kwargs)
 
         # Generate <<CursorMove>> so on_cursor_move() subscribers always work.
-        t = self._internal._core.text
+        t = self._internal.core.text
         t.bind("<KeyRelease>",      lambda e: t.event_generate("<<CursorMove>>"), add="+")
         t.bind("<ButtonRelease-1>", lambda e: t.event_generate("<<CursorMove>>"), add="+")
 
@@ -158,7 +158,7 @@ class CodeEditor(PublicWidgetBase):
     # ----- Event routing -----
 
     def _text_widget(self) -> tkinter.Misc:
-        return self._internal._core.text
+        return self._internal.core.text
 
     @overload
     def on(self, event: str) -> Stream: ...
@@ -212,7 +212,7 @@ class CodeEditor(PublicWidgetBase):
     @property
     def signal(self) -> "Signal[str] | None":
         """The reactive `Signal` bound to this editor, or `None`."""
-        return getattr(self._internal._core, "signal", None)
+        return getattr(self._internal.core, "signal", None)
 
     @property
     def valid(self) -> "Signal[bool]":
@@ -245,14 +245,14 @@ class CodeEditor(PublicWidgetBase):
         and `goto()` accept. Read it in an `on_cursor_move` handler to drive a
         status-bar readout. Read-only — use `goto()` to move the cursor.
         """
-        idx = self._internal._core.text.index("insert")
+        idx = self._internal.core.text.index("insert")
         line, col = idx.split(".")
         return int(line), int(col) + 1
 
     @property
     def language(self) -> str | None:
         """Active syntax highlighting language, or `None` if disabled."""
-        return self._internal._language
+        return self._internal.language
 
     @language.setter
     def language(self, v: str | None) -> None:
@@ -261,24 +261,16 @@ class CodeEditor(PublicWidgetBase):
     @property
     def theme(self) -> str:
         """Active Pygments color scheme, or `'auto'` if tracking the bootstack theme."""
-        return self._internal._pygments_style
+        return self._internal.theme
 
     @theme.setter
     def theme(self, v: str) -> None:
-        self._internal._pygments_style = v
-        if self._internal._highlighter is not None:
-            self._internal._highlighter._auto = (v == "auto")
-            if v != "auto":
-                self._internal._highlighter._load_style(v)
-                for sname, color in self._internal._highlighter._style_colors.items():
-                    self._internal._core.define_style(sname, foreground=color)
-            self._internal._highlighter._apply_widget_colors(self._internal._core)
-            self._internal._highlighter._schedule()
+        self._internal.set_theme(v)
 
     @property
     def read_only(self) -> bool:
         """Whether the editor content is visible but not editable."""
-        return self._internal._core._read_only
+        return self._internal.core.read_only
 
     @read_only.setter
     def read_only(self, v: bool) -> None:
@@ -334,7 +326,7 @@ class CodeEditor(PublicWidgetBase):
             index = "insert"
         else:
             index = f"{line}.{(col or 1) - 1}"
-        self._internal._core.insert(index, text)
+        self._internal.core.insert(index, text)
 
     def append(self, text: str) -> None:
         """Append `text` to the end of the content.
@@ -345,11 +337,11 @@ class CodeEditor(PublicWidgetBase):
         Args:
             text: Text to add at the end of the content.
         """
-        self._internal._core.insert("end-1c", text)
+        self._internal.core.insert("end-1c", text)
 
     def select_all(self) -> None:
         """Select all text content."""
-        tw = self._internal._core.text
+        tw = self._internal.core.text
         tw.focus_set()
         tw.tag_add("sel", "1.0", "end-1c")
         tw.mark_set("insert", "end-1c")

--- a/src/bootstack/widgets/spinnerfield.py
+++ b/src/bootstack/widgets/spinnerfield.py
@@ -200,7 +200,7 @@ class SpinnerField(FieldAddonMixin, PublicWidgetBase):
     @property
     def disabled(self) -> bool:
         """Whether the field is fully non-interactive."""
-        return str(self._internal._entry.cget("state")) == "disabled"
+        return self._internal._entry.instate(("disabled",))
 
     @disabled.setter
     def disabled(self, v: bool) -> None:

--- a/src/bootstack/widgets/splitview.py
+++ b/src/bootstack/widgets/splitview.py
@@ -381,7 +381,7 @@ class SplitView(PublicWidgetBase):
         pane = self._panes.pop(key)
         # `WidgetCapabilitiesMixin.forget()` shadows `ttk.Panedwindow.forget(pane)`
         # with a zero-arg method, so invoke the underlying Tk command directly.
-        self._internal.tk.call(self._internal._w, "forget", pane._frame)
+        self._internal.tk.call(str(self._internal), "forget", pane._frame)
         pane._frame.destroy()
 
     # ----- Sash control -----

--- a/src/bootstack/widgets/timefield.py
+++ b/src/bootstack/widgets/timefield.py
@@ -181,7 +181,7 @@ class TimeField(ValueSignalMixin, FieldAddonMixin, PublicWidgetBase):
     @property
     def disabled(self) -> bool:
         """Whether the field is disabled (non-interactive and greyed out)."""
-        return str(self._internal._entry.cget("state")) == "disabled"
+        return self._internal._entry.instate(("disabled",))
 
     @disabled.setter
     def disabled(self, v: bool) -> None:
@@ -190,7 +190,7 @@ class TimeField(ValueSignalMixin, FieldAddonMixin, PublicWidgetBase):
     @property
     def read_only(self) -> bool:
         """Whether the field is read-only (selectable but not editable)."""
-        return str(self._internal._entry.cget("state")) == "readonly"
+        return self._internal._entry.instate(("readonly",))
 
     @read_only.setter
     def read_only(self, v: bool) -> None:

--- a/src/bootstack/widgets/toolbar.py
+++ b/src/bootstack/widgets/toolbar.py
@@ -242,7 +242,7 @@ class Toolbar(PublicWidgetBase):
         if "density" in params:
             kwargs.setdefault("density", self._internal.density)
         if "surface" in params:
-            kwargs.setdefault("surface", self._internal._surface)
+            kwargs.setdefault("surface", self._internal.surface)
 
     # ----- Container protocol (so `parent=toolbar` works) -----
 


### PR DESCRIPTION
## Summary

Audit-driven cleanup of private internal access patterns found across public wrappers and example files.

- **`codeeditor.py` (public)** — all `_internal._core.*` replaced with `_internal.core.*` (the existing public `core` property); `language`/`theme` getters now delegate to new internal properties; `theme` setter consolidates into `_internal.set_theme()` so highlighter internals stay encapsulated in the internal class
- **`codeeditor.py` (internal)** — added `language`, `theme` properties and `set_theme()` method
- **`timefield.py`, `spinnerfield.py`** — `str(cget("state")) == "disabled"` string compare → `instate(("disabled",))` per CLAUDE.md gotchas
- **`splitview.py`** — `._w` raw Tcl path → `str(self._internal)`
- **`toolbar.py` (internal)** — added `surface` property; public wrapper reads `_internal.surface` instead of `_internal._surface`
- **4 example files** — `setattr(widget, ...)` lambda hacks replaced with named functions
- **`docs/examples/codeeditor.py`** — `._internal._core.text.index(...)` replaced with `cursor_position`

## Test plan

- [ ] `python -m pytest tests/test_public_surface.py -q` — 162 passed
- [ ] Run `python docs/examples/codeeditor.py` — verify cursor position readout still works
- [ ] Run `python docs/examples/checkbox.py`, `switch.py`, `selectfield.py`, `observable_datasource.py` — verify reactive labels update correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)