### PR TITLE
feat: CodeEditor block indent/dedent (#252)

### DIFF
--- a/src/bootstack/widgets/_impl/composites/textarea/codeeditor.py
+++ b/src/bootstack/widgets/_impl/composites/textarea/codeeditor.py
@@ -107,6 +107,8 @@ class CodeEditor(Frame):
         self._light_theme = light_theme
         self._dark_theme = dark_theme
         self._show_line_numbers = show_line_numbers
+        self._tab_width = tab_width
+        self._insert_spaces = insert_spaces
         self._highlighter = None
         self._rules: list = []
         self._valid_signal: Signal = Signal(True)
@@ -399,6 +401,62 @@ class CodeEditor(Frame):
         """Hide the find/replace bar and clear search highlights."""
         self._search.hide()
 
+    # ── indent/dedent ─────────────────────────────────────────────────────
+
+    def indent(self) -> None:
+        """Indent selected lines by one tab stop, or insert at cursor."""
+        if self._smart_indent is not None:
+            self._smart_indent.indent()
+        else:
+            self._indent_or_dedent(indent=True)
+
+    def dedent(self) -> None:
+        """Dedent selected lines (or current line) by one tab stop."""
+        if self._smart_indent is not None:
+            self._smart_indent.dedent()
+        else:
+            self._indent_or_dedent(indent=False)
+
+    def _indent_or_dedent(self, indent: bool) -> None:
+        from bootstack.widgets._impl.composites.textarea.extensions.smart_indent import _sel_line_range
+        tw = self._core.text
+        ranges = tw.tag_ranges("sel")
+        if indent:
+            prefix = " " * self._tab_width if self._insert_spaces else "\t"
+            if not ranges:
+                col = int(tw.index("insert").split(".")[1])
+                spaces = self._tab_width - (col % self._tab_width)
+                tw.insert("insert", " " * spaces if self._insert_spaces else "\t")
+                return
+            start_line, end_line = _sel_line_range(ranges)
+            self._core.undo_block_start()
+            try:
+                for ln in range(start_line, end_line + 1):
+                    if tw.get(f"{ln}.0", f"{ln}.end"):
+                        tw.insert(f"{ln}.0", prefix)
+            finally:
+                self._core.undo_block_stop()
+            tw.tag_add("sel", f"{start_line}.0", f"{end_line}.end")
+        else:
+            if ranges:
+                start_line, end_line = _sel_line_range(ranges)
+            else:
+                start_line = end_line = int(tw.index("insert").split(".")[0])
+            self._core.undo_block_start()
+            try:
+                for ln in range(start_line, end_line + 1):
+                    line_text = tw.get(f"{ln}.0", f"{ln}.end")
+                    if self._insert_spaces:
+                        n = min(self._tab_width, len(line_text) - len(line_text.lstrip(" ")))
+                        if n:
+                            tw.delete(f"{ln}.0", f"{ln}.{n}")
+                    else:
+                        if line_text.startswith("\t"):
+                            tw.delete(f"{ln}.0", f"{ln}.1")
+            finally:
+                self._core.undo_block_stop()
+            if ranges:
+                tw.tag_add("sel", f"{start_line}.0", f"{end_line}.end")
 
     # ── validation ────────────────────────────────────────────────────────
 

--- a/src/bootstack/widgets/_impl/composites/textarea/extensions/smart_indent.py
+++ b/src/bootstack/widgets/_impl/composites/textarea/extensions/smart_indent.py
@@ -1,4 +1,4 @@
-﻿"""SmartIndent — auto-indent on Enter and Tab-to-spaces conversion.
+"""SmartIndent — auto-indent on Enter and Tab-to-spaces conversion.
 
 Filter-style extension: intercepts Return and Tab key events to provide
 editor-grade indentation. Does not intercept insert/delete in the chain
@@ -16,14 +16,20 @@ if TYPE_CHECKING:
 
 
 class SmartIndent(EditFilter):
-    """Provides auto-indent on Return and optional Tab-to-spaces conversion.
+    """Provides auto-indent on Return, Tab-to-spaces, and block indent/dedent.
 
     On `<Return>`:
         Inserts a newline followed by the same leading whitespace as the
         current line, so the cursor lands at the same indent level.
 
-    On `<Tab>` (when `insert_spaces=True`):
-        Inserts `tab_width` spaces instead of a literal tab character.
+    On `<Tab>` with a selection:
+        Indents every selected line by one tab stop.
+
+    On `<Tab>` with no selection (when `insert_spaces=True`):
+        Inserts spaces to the next tab stop instead of a literal tab character.
+
+    On `<Shift-Tab>`:
+        Dedents every selected line (or the current line) by one tab stop.
 
     Install via `core.add_filter(SmartIndent())`.
     """
@@ -37,8 +43,9 @@ class SmartIndent(EditFilter):
     def attach(self, core: _MultilineCore) -> None:
         self._core = core
         core.text.bind("<Return>", self._on_return, add="+")
-        if self._insert_spaces:
-            core.text.bind("<Tab>", self._on_tab, add="+")
+        core.text.bind("<Tab>", self._on_tab, add="+")
+        core.text.bind("<Shift-Tab>", self._on_shift_tab, add="+")
+        core.text.bind("<ISO_Left_Tab>", self._on_shift_tab, add="+")  # Linux/X11
 
     def detach(self, core: _MultilineCore) -> None:
         self._core = None
@@ -50,6 +57,27 @@ class SmartIndent(EditFilter):
 
     def delete(self, index1: str, index2: str | None = None) -> None:
         self.delegate.delete(index1, index2)
+
+    # ── public block operations ───────────────────────────────────────────
+
+    def indent(self) -> None:
+        """Indent selected lines by one tab stop, or insert at cursor."""
+        if self._core is None:
+            return
+        tw = self._core.text
+        ranges = tw.tag_ranges("sel")
+        if ranges:
+            self._indent_block(tw, ranges)
+        else:
+            col = int(tw.index("insert").split(".")[1])
+            spaces = self._tab_width - (col % self._tab_width)
+            tw.insert("insert", " " * spaces if self._insert_spaces else "\t")
+
+    def dedent(self) -> None:
+        """Dedent selected lines (or current line) by one tab stop."""
+        if self._core is None:
+            return
+        self._dedent_block(self._core.text, self._core.text.tag_ranges("sel"))
 
     # ── key handlers ─────────────────────────────────────────────────────
 
@@ -68,20 +96,82 @@ class SmartIndent(EditFilter):
         self._core.undo_block_stop()
         return "break"     # prevent default Return handling
 
-    def _on_tab(self, _event: tk.Event) -> str:
-        """Insert spaces instead of a literal tab."""
+    def _on_tab(self, _event: tk.Event) -> str | None:
+        """Indent selection, or insert spaces / fall through for a literal tab."""
         if self._core is None:
-            return ""
-        text = self._core.text
-        cursor = text.index("insert")
-        line_start = text.index(f"{cursor} linestart")
-        col = int(text.index(cursor).split(".")[1])
-        # Round up to the next tab stop
-        spaces = self._tab_width - (col % self._tab_width)
-        text.insert("insert", " " * spaces)
+            return None
+        tw = self._core.text
+        ranges = tw.tag_ranges("sel")
+        if ranges:
+            self._indent_block(tw, ranges)
+            return "break"
+        if self._insert_spaces:
+            col = int(tw.index("insert").split(".")[1])
+            spaces = self._tab_width - (col % self._tab_width)
+            tw.insert("insert", " " * spaces)
+            return "break"
+        # insert_spaces=False, no selection: let native Tab insert \t
+        return None
+
+    def _on_shift_tab(self, _event: tk.Event) -> str:
+        """Dedent selection or current line."""
+        if self._core is None:
+            return "break"
+        self._dedent_block(self._core.text, self._core.text.tag_ranges("sel"))
         return "break"
+
+    # ── helpers ───────────────────────────────────────────────────────────
+
+    def _indent_block(self, tw: tk.Text, ranges: tuple) -> None:
+        start_line, end_line = _sel_line_range(ranges)
+        indent = " " * self._tab_width if self._insert_spaces else "\t"
+        self._core.undo_block_start()
+        try:
+            for ln in range(start_line, end_line + 1):
+                if tw.get(f"{ln}.0", f"{ln}.end"):  # skip blank lines
+                    tw.insert(f"{ln}.0", indent)
+        finally:
+            self._core.undo_block_stop()
+        tw.tag_add("sel", f"{start_line}.0", f"{end_line}.end")
+
+    def _dedent_block(self, tw: tk.Text, ranges: tuple) -> None:
+        if ranges:
+            start_line, end_line = _sel_line_range(ranges)
+        else:
+            start_line = end_line = int(tw.index("insert").split(".")[0])
+        self._core.undo_block_start()
+        try:
+            for ln in range(start_line, end_line + 1):
+                line_text = tw.get(f"{ln}.0", f"{ln}.end")
+                if self._insert_spaces:
+                    n = min(self._tab_width, len(line_text) - len(line_text.lstrip(" ")))
+                    if n:
+                        tw.delete(f"{ln}.0", f"{ln}.{n}")
+                else:
+                    if line_text.startswith("\t"):
+                        tw.delete(f"{ln}.0", f"{ln}.1")
+        finally:
+            self._core.undo_block_stop()
+        if ranges:
+            tw.tag_add("sel", f"{start_line}.0", f"{end_line}.end")
 
 
 def _leading_whitespace(line: str) -> str:
     """Return the leading whitespace characters of *line*."""
     return line[: len(line) - len(line.lstrip())]
+
+
+def _sel_line_range(ranges: tuple) -> tuple[int, int]:
+    """Return (start_line, end_line) from a tag_ranges("sel") result.
+
+    If the selection ends exactly at column 0 of the last line (i.e. the user
+    selected to the very start of a line without including any content), that
+    trailing line is excluded so we don't indent/dedent a line the user didn't
+    intend to touch.
+    """
+    start_str, end_str = str(ranges[0]), str(ranges[1])
+    start_line = int(start_str.split(".")[0])
+    end_line = int(end_str.split(".")[0])
+    if end_str.split(".")[1] == "0" and end_line > start_line:
+        end_line -= 1
+    return start_line, end_line

--- a/src/bootstack/widgets/codeeditor.py
+++ b/src/bootstack/widgets/codeeditor.py
@@ -455,6 +455,27 @@ class CodeEditor(PublicWidgetBase):
         """Hide the find/replace bar."""
         self._internal.hide_search()
 
+    def indent(self) -> None:
+        """Indent selected lines by one tab stop, or insert a tab stop at the cursor.
+
+        With a selection, every selected line is indented by one tab stop (spaces
+        or a tab character, depending on the editor's `insert_spaces` setting).
+        The selection is preserved after the operation.
+
+        Without a selection, inserts spaces to the next tab stop at the cursor
+        (same as pressing Tab with no selection).
+        """
+        self._internal.indent()
+
+    def dedent(self) -> None:
+        """Dedent selected lines (or the current line) by one tab stop.
+
+        Removes up to one tab stop of leading whitespace from each line in the
+        selection. With no selection, dedents the line the cursor is on.
+        The selection is preserved after the operation.
+        """
+        self._internal.dedent()
+
     # ----- Event shorthands -----
 
     @overload


### PR DESCRIPTION
## Summary

- **Tab over a selection** indents every selected line by one tab stop (spaces or `\t` per `insert_spaces`). Selection is preserved afterward.
- **Shift+Tab** (and `<ISO_Left_Tab>` on Linux) dedents selected lines or the current line by one tab stop. Selection is preserved.
- **Tab with no selection** retains the existing tab-to-next-stop behaviour.
- All operations are a single undo step.
- **`editor.indent()` / `editor.dedent()`** — new public methods for programmatic use. Work regardless of `auto_indent=` setting.
- Stores `_tab_width` / `_insert_spaces` on the internal `CodeEditor` so `indent()`/`dedent()` work when `auto_indent=False` (no `SmartIndent` filter installed).

## Test plan

- [ ] `python -m pytest tests/test_public_surface.py tests/widgets/public/test_textarea_codeeditor_valid_error.py`
- [ ] Manual: open editor, type a few lines, select them, press Tab → all lines indented; Shift+Tab → all dedented; Ctrl+Z → both reversed in one undo
- [ ] Manual: Tab with no selection → inserts spaces to next tab stop (unchanged)
- [ ] Manual: `editor.indent()` / `editor.dedent()` in a script

🤖 Generated with [Claude Code](https://claude.com/claude-code)