### PR TITLE
feat: ScrollView on_scroll event, scroll_position, keyboard scroll (#254/#255)

### DIFF
--- a/src/bootstack/events/__init__.py
+++ b/src/bootstack/events/__init__.py
@@ -32,6 +32,7 @@ from bootstack.events._payloads import (
     RangeSliderEvent,
     RowEvent,
     RowsEvent,
+    ScrollEvent,
     SelectionEvent,
     SliderCommitEvent,
     SliderEvent,
@@ -97,4 +98,6 @@ __all__ = [
     # Payloads — data source
     "DataChangeEvent",
     "ChangeKind",
+    # Payloads — scroll view
+    "ScrollEvent",
 ]

--- a/src/bootstack/events/_payloads.py
+++ b/src/bootstack/events/_payloads.py
@@ -487,3 +487,19 @@ class DataChangeEvent:
     record: Mapping[str, Any] | None = None
     """The affected record (or the applied updates) where cheaply available on
     `insert`/`update`; `None` otherwise."""
+
+
+# ---------------------------------------------------------------------------
+# ScrollView
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class ScrollEvent:
+    """Fires when a `ScrollView`'s viewport position changes."""
+
+    y: float = 0.0
+    """Vertical scroll position — 0.0 (top) to 1.0 (bottom)."""
+
+    x: float = 0.0
+    """Horizontal scroll position — 0.0 (left) to 1.0 (right)."""

--- a/src/bootstack/widgets/_impl/composites/scrollview.py
+++ b/src/bootstack/widgets/_impl/composites/scrollview.py
@@ -7,6 +7,7 @@ from bootstack.widgets._impl.primitives.frame import Frame
 from bootstack.widgets._impl.mixins.configure_mixin import configure_delegate
 from bootstack.widgets._impl.primitives.scrollbar import Scrollbar
 from bootstack.widgets.types import Master
+from bootstack.events import ScrollEvent
 
 
 class ScrollView(Frame):
@@ -88,6 +89,9 @@ class ScrollView(Frame):
             canvas_kw["width"] = canvas_width
         self.canvas = Canvas(self, **canvas_kw)
         self.canvas.bind("<Configure>", self._on_canvas_configure)
+        # Focus canvas on click so keyboard scrolling works.
+        self.canvas.bind("<Button-1>", lambda e: self.canvas.focus_set(), add="+")
+        self._setup_keyboard_bindings()
 
         # Create scrollbars. Thread our own surface through so the scrollbar track
         # matches the container (an auto-hiding bar then leaves no tinted gutter).
@@ -235,6 +239,20 @@ class ScrollView(Frame):
         else:
             self.bind_class(self._scroll_tag, "<MouseWheel>", self._on_mousewheel)
             self.bind_class(self._scroll_tag, "<Shift-MouseWheel>", self._on_shift_mousewheel)
+
+    def _setup_keyboard_bindings(self) -> None:
+        """Bind arrow / page / home / end keys to the canvas for keyboard scroll."""
+        c = self.canvas
+        # Vertical
+        c.bind("<Up>",    lambda e: self.canvas.yview_scroll(-1, "units") or "break", add="+")
+        c.bind("<Down>",  lambda e: self.canvas.yview_scroll( 1, "units") or "break", add="+")
+        c.bind("<Prior>", lambda e: self.canvas.yview_scroll(-1, "pages") or "break", add="+")
+        c.bind("<Next>",  lambda e: self.canvas.yview_scroll( 1, "pages") or "break", add="+")
+        c.bind("<Home>",  lambda e: self.canvas.yview_moveto(0.0) or "break", add="+")
+        c.bind("<End>",   lambda e: self.canvas.yview_moveto(1.0) or "break", add="+")
+        # Horizontal
+        c.bind("<Left>",  lambda e: self.canvas.xview_scroll(-1, "units") or "break", add="+")
+        c.bind("<Right>", lambda e: self.canvas.xview_scroll( 1, "units") or "break", add="+")
 
     def _layout_widgets(self):
         """Layout the canvas and scrollbars.
@@ -411,11 +429,23 @@ class ScrollView(Frame):
         """Update vertical scrollbar position."""
         self.vertical_scrollbar.set(first, last)
         self._update_scrollbar_visibility()
+        self._emit_scroll_event()
 
     def _on_canvas_scroll_x(self, first, last):
         """Update horizontal scrollbar position."""
         self.horizontal_scrollbar.set(first, last)
         self._update_scrollbar_visibility()
+        self._emit_scroll_event()
+
+    def _emit_scroll_event(self) -> None:
+        y = float(self.canvas.yview()[0])
+        x = float(self.canvas.xview()[0])
+        self.event_generate("<<BsScroll>>", data=ScrollEvent(y=y, x=x))
+
+    @property
+    def scroll_position(self) -> tuple[float, float]:
+        """Current scroll position as `(y, x)` fractions in `[0.0, 1.0]`."""
+        return float(self.canvas.yview()[0]), float(self.canvas.xview()[0])
 
     def _update_scrollbar_visibility(self):
         """Update scrollbar visibility based on current mode."""

--- a/src/bootstack/widgets/scrollview.py
+++ b/src/bootstack/widgets/scrollview.py
@@ -1,10 +1,13 @@
 ﻿from __future__ import annotations
 
-from typing import Any, Literal
+from typing import overload, Any, Callable, Literal
 
 from bootstack.widgets._impl.composites.scrollview import ScrollView as _InternalScrollView
 from bootstack.widgets._impl.primitives.flexframe import FlexFrame
+from bootstack.widgets._core.base import adapt_handler
 from bootstack.widgets._core.container import FlexContainer
+from bootstack.events import ScrollEvent, Subscription
+from bootstack.streams import Stream
 from bootstack.widgets.types import Padding, ScrollbarVariant
 
 
@@ -134,3 +137,45 @@ class ScrollView(FlexContainer):
             fraction: 0.0 (left) to 1.0 (right).
         """
         self._internal.xview_moveto(fraction)
+
+    @property
+    def scroll_position(self) -> tuple[float, float]:
+        """Current scroll position as `(y, x)` fractions in `[0.0, 1.0]`.
+
+        `(0.0, 0.0)` is the top-left corner; `(1.0, 1.0)` is the bottom-right.
+        Read this inside an `on_scroll` handler to get the new position:
+
+            sv.on_scroll(lambda e: print(e.y, e.x))
+        """
+        return self._internal.scroll_position
+
+    # ----- Events -----
+
+    @overload
+    def on_scroll(self) -> Stream: ...
+    @overload
+    def on_scroll(self, handler: Callable[[ScrollEvent], Any]) -> Subscription: ...
+    def on_scroll(self, handler: Callable[[ScrollEvent], Any] | None = None) -> Stream | Subscription:
+        """Register a callback fired whenever the viewport position changes.
+
+        Fires on mouse-wheel scrolls, programmatic `scroll_to_*` / `yview_moveto`
+        calls, and keyboard scrolling (arrow keys / Page Up / Page Down / Home /
+        End when the canvas has focus from a click).
+
+        Args:
+            handler: Called with a :class:`~bootstack.events.ScrollEvent` carrying
+                `y` (vertical fraction, 0.0–1.0) and `x` (horizontal fraction).
+                Omit to get a composable :class:`~bootstack.streams.Stream`.
+
+        Returns:
+            A cancellable :class:`~bootstack.events.Subscription` when a handler
+            is given, otherwise a :class:`~bootstack.streams.Stream`.
+        """
+        sequence = "<<BsScroll>>"
+        if handler is None:
+            def _source(h):
+                bid = self._internal.bind(sequence, adapt_handler(h), add="+")
+                return Subscription(self._internal, sequence, bid)
+            return Stream(self._internal, _source=_source)
+        bid = self._internal.bind(sequence, adapt_handler(handler), add="+")
+        return Subscription(self._internal, sequence, bid)


### PR DESCRIPTION
## Summary

**#254 — `on_scroll` + position getter**
- `scroll_position` property returns `(y, x)` fractions `[0.0, 1.0]`
- `on_scroll(handler)` fires a `ScrollEvent(y, x)` on every viewport position change — mouse wheel, programmatic `scroll_to_*` / `yview_moveto`, or keyboard
- New `ScrollEvent` dataclass added to `bootstack.events`

**#255 — keyboard scroll**
- Canvas gains focus on click (not via Tab traversal)
- Up/Down/Left/Right, Page Up/Down, Home/End scroll the viewport while the canvas has focus

## Test plan

- [ ] `python -m pytest tests/test_public_surface.py`
- [ ] `python docs/examples/dev_254_255_scrollview.py`
  - [ ] Mouse-wheel → status label updates with position
  - [ ] Click blank canvas area → arrow keys / Page / Home / End scroll
  - [ ] Top / Bottom buttons → position updates via `on_scroll`
  - [ ] "Read position" button → matches event values

🤖 Generated with [Claude Code](https://claude.com/claude-code)