### PR TITLE
Trust audit of the 2026-06-22 session: fixes + missing tests/docs

### DIFF
--- a/docs/_dev/review-2026-06-22-trust-audit.md
+++ b/docs/_dev/review-2026-06-22-trust-audit.md
@@ -1,0 +1,113 @@
+# Trust audit — 2026-06-22 session (14 PRs + `0.1.0a14`)
+
+Adversarial review of all work merged to `main` in the ~6 hours ending
+`5def69b6` (PRs #289, #291–#299 + the `0.1.0a14` release), prompted by the
+maintainer finding repeated errors/hallucinations from the session's agent.
+Method: five parallel reviewers (one per PR cluster), a clean `-W` docs build,
+and the full GUI suite (`tests/run_gui.py`). Result: **605 passed, 1 failed**;
+docs build clean.
+
+Severity legend: 🔴 broken on `main` · 🟠 real logic bug · 🟡 hallucination /
+mislabel / doc-test gap · 🟢 verified clean.
+
+## 🔴 Must fix — broken on `main`
+
+1. **PR #299 toolbar regression — merged with a failing test.**
+   `src/bootstack/widgets/toolbar.py:240-256` `_apply_bar_defaults` uses
+   "widget has `**kwargs`" (`has_var_kw`) as a proxy for "accepts
+   `density`/`surface`". Wrong here — `**kwargs` is the layout passthrough, not a
+   config passthrough.
+   - Crash: `toolbar.add_widget(bs.Checkbox/Switch/ToggleButton/Radio, ...)` →
+     `TypeError: got unexpected keyword argument(s): density, surface` (those
+     widgets' `**kwargs` reject unknowns).
+   - No-op: for `TextField`/`Select`/`ProgressBar`/`Badge` the injected `surface`
+     is swallowed by `_split_layout_kwargs` and dropped — #263's goal unmet.
+   - Proof: `tests/widgets/public/test_add_toolbar.py::test_add_widget_class_inherits_bar_density_skips_unsupported_surface`
+     **fails on `main`** — the agent's own test asserts `surface` is skipped for
+     `TextField`, the code injects it. Test and impl contradict; merged anyway.
+   - Fix direction: drop `has_var_kw`; inject only when the param is explicitly in
+     the signature (matches the test's intent).
+
+## 🟠 Real logic bugs
+
+2. **DataTable `iter_rows` clobbers the shared source.**
+   `tableview/tableview.py` `_iter_raw_chunks` (~:2410, PR #293) `yield`s inside
+   `with self._apply_view_to_source()`. As a generator, a caller that `break`s out
+   of `iter_rows("all")` leaves this view's filter/sort applied to the **shared**
+   source until GC — defeating the per-view isolation the PR adds. `to_rows`/
+   `to_csv` drain fully (safe); `iter_rows` (lazy/partial by design) is not. Fix:
+   materialize rows under the CM, then yield outside it.
+
+3. **Doc examples that are a Python `SyntaxError`.**
+   `widgets/codeeditor.py:223` and `widgets/textarea.py` docstrings show
+   `...subscribe(lambda ok: btn.disabled = not ok)` — assignment in a `lambda`.
+   Copy-paste crash. (The `.rst` versions correctly use a named `def`.)
+
+## 🟡 Hallucinations, mislabels, doc/test gaps
+
+- **Hallucinated test kwarg (#293):** `tests/widgets/public/test_datatable.py`
+  (~:233/238/256/261) pass `enable_search=True` to `bs.DataTable`; the public
+  kwarg is `searchable`. `enable_search` is dropped via `**kwargs`; the test only
+  passes because the default is already `True` — configures nothing.
+- **Mislabeled "fix" (#296):** "fix read_only setter" (`codeeditor.py:314`) just
+  renames `_internal._core` → `_internal.core` (same object). No read-only bug on
+  that path; commit overstates.
+- **Stale doc now false (#292):** `src/bootstack/signals/README.md:110-112` still
+  says "create `Signal` after the App / pass `master=`" — the gotcha this PR
+  overturned. (README also documents nonexistent `get()`/`unsubscribe()`.)
+- **Undocumented new API (#296/#297):** `CodeEditor.selection`, `selected_text`,
+  `indent()`, `dedent()`, Tab/Shift+Tab keyboard behavior absent from
+  `docs/widgets/codeeditor.rst`.
+- **Missing tests:** #296/#297 (selection coords, block indent/dedent edge cases)
+  and #298 (`on_scroll`/`scroll_position`/keyboard scroll) ship with zero tests.
+- **Tests via internals (#293):** `test_datatable.py:248,259` drive
+  `_internal.set_search`/`set_sorting` instead of public `set_search`/`sort_by`.
+- **Inaccurate claims:** #297 "selection preserved" actually expands partial
+  selections to whole lines; #297 keyboard indent only works when
+  `auto_indent=True`; ScrollView `scroll_position` docstring claims `(1.0,1.0)` is
+  reachable (it's the top-left fraction, never 1.0).
+- **Internal leak (#299):** `add_button`/`add_label` return internal `_impl`
+  primitives (annotated `-> Any`); `add_divider`/`add_spacer` still return `None`
+  (half-done #262).
+
+## 🟢 Verified clean
+
+- **Signal rewrite (#292)** — correct. Object-mode survived; all three `set()`
+  branches dedupe/notify once; re-realization across App lifecycles works; escape
+  hatches fine. 22/22 signal tests pass.
+- **Internal-access scrub (#295)** — every private→public swap resolves to a real
+  symbol. No hallucinated APIs.
+- **Carousel (#289), PyInstaller metadata (#291), new
+  `docs/examples/chart_filter_from_chart.py`** — verified against real API.
+- **`dev_246` removal** — clean, no dangling refs.
+- **Full suite** — 605 passed, 1 failed (only the #299 toolbar test), 0 other
+  regressions.
+
+> ⚠ Correction: an earlier pass reported "docs `-W` build exit 0." That reading
+> was wrong — the build command was piped to `tail`, so the captured exit code
+> was `tail`'s, not sphinx's (the same pipe-masks-exit-code trap that hid the
+> failing test leg). The docs build is in fact **broken on `main`** — see the
+> pre-existing section. When checking exit codes, never pipe the command whose
+> status you care about.
+
+## Pre-existing (not from this session)
+
+- **Docs `-W` build is broken on `main`.** `docs/shared/widget-sizing.rst:5,35,65`
+  → `ERROR: Inconsistent title style: skip from level 3 to 5` (3 errors, build
+  exits 1). The `'''`-underlined Column/Row/Grid sub-headings in this *included*
+  fragment land at heading level 5 while the including page's context is level 3.
+  Introduced by the Row/Column split (`3c2067d1`, PR #266) — **outside** the 6-hour
+  window, but real and contradicts the repo's "keep the build warning-free" rule.
+  Fix direction: the include fragment should not carry section titles that skip a
+  level — use `.. rubric::` (or a heading char one level below the include site)
+  for Column/Row/Grid. Not yet fixed (out of the 1–3 scope).
+- `_impl/composites/toolbar.py` reads `self._surface` in ~6 places (incl.
+  window-controls build) but never assigns it in `__init__`; the new public
+  `surface` property guards one read with `getattr(..., "chrome")`, but a
+  window-controls toolbar would still `AttributeError`. Separate item.
+
+## Fix plan
+
+Branch `feat/*` off `main`. Address in order: (1) #299 `has_var_kw`, (2)
+`iter_rows` leak, (3) the two `lambda` docstrings. Then sweep the 🟡 items.
+Commits held for per-commit maintainer approval.

--- a/docs/_dev/review-2026-06-22-trust-audit.md
+++ b/docs/_dev/review-2026-06-22-trust-audit.md
@@ -66,9 +66,17 @@ mislabel / doc-test gap · 🟢 verified clean.
   selections to whole lines; #297 keyboard indent only works when
   `auto_indent=True`; ScrollView `scroll_position` docstring claims `(1.0,1.0)` is
   reachable (it's the top-left fraction, never 1.0).
-- **Internal leak (#299):** `add_button`/`add_label` return internal `_impl`
-  primitives (annotated `-> Any`); `add_divider`/`add_spacer` still return `None`
-  (half-done #262).
+- **Internal leak (#299): FIXED for button/label.** `add_button`/`add_label` now
+  build and return the public :class:`bootstack.Button` / :class:`bootstack.Label`
+  (live properties; no `_impl` leak), carrying the bar's `density`/`surface`. Added
+  `surface=` to `bs.Button` so a ghost toolbar button still blends into the chrome
+  bar; preserved window-drag bindings on draggable-titlebar labels via an internal
+  `_attach_drag` helper. Item spacing is now a uniform `padx=2` for all added items
+  (was 0 for buttons / 4 for labels) — a small, intentional consistency change.
+  **`add_divider`/`add_spacer` still return `None` (deferred):** returning a public
+  `Divider`/`Spacer` is entangled with the pack-based internal toolbar (a `Spacer`
+  needs `expand=True` packing the generic container protocol doesn't apply), tracked
+  with the unified-toolbars work; the handle's only use is detach/attach.
 
 ## 🟢 Verified clean
 

--- a/docs/_dev/review-2026-06-22-trust-audit.md
+++ b/docs/_dev/review-2026-06-22-trust-audit.md
@@ -101,10 +101,13 @@ mislabel / doc-test gap · 🟢 verified clean.
   Fix direction: the include fragment should not carry section titles that skip a
   level — use `.. rubric::` (or a heading char one level below the include site)
   for Column/Row/Grid. Not yet fixed (out of the 1–3 scope).
-- `_impl/composites/toolbar.py` reads `self._surface` in ~6 places (incl.
-  window-controls build) but never assigns it in `__init__`; the new public
-  `surface` property guards one read with `getattr(..., "chrome")`, but a
-  window-controls toolbar would still `AttributeError`. Separate item.
+- ~~`_impl/composites/toolbar.py` reads `self._surface` but never assigns it in
+  `__init__`, so a window-controls toolbar would `AttributeError`.~~ **Investigated
+  → NOT a bug.** The `Frame`/`TTKWrapperBase` base class always sets `_surface`
+  (defaults to `'content'`), so `Toolbar(show_window_controls=True)` constructs
+  fine even with no `surface` kwarg. Verified empirically. The reviewer
+  over-flagged this one; the `getattr(..., "chrome")` in the `surface` property is
+  merely defensive, not load-bearing. No fix needed.
 
 ## Fix plan
 

--- a/docs/shared/widget-sizing.rst
+++ b/docs/shared/widget-sizing.rst
@@ -2,8 +2,7 @@ All widgets accept self-placement kwargs via ``**kwargs``. The parent
 container determines which options apply — ``Column`` / ``Row`` parents use
 the layout kwargs below, grid-based parents use grid kwargs.
 
-Column (vertical layout)
-''''''''''''''''''''''''
+.. rubric:: Column (vertical layout)
 
 Used inside a ``Column``, ``App``, or any other container with a column layout.
 Children are arranged top-to-bottom, so ``horizontal`` aligns each child across
@@ -32,8 +31,7 @@ the order of the children sets their top-to-bottom position.)
        or a 2-tuple ``(top, bottom)`` for asymmetric spacing. Overrides
        the vertical component of ``margin=``.
 
-Row (horizontal layout)
-'''''''''''''''''''''''
+.. rubric:: Row (horizontal layout)
 
 Used inside a ``Row`` or any other container with a row layout. Children are
 arranged left-to-right, so ``vertical`` aligns each child across the height and
@@ -62,8 +60,7 @@ of the children sets their left-to-right position.)
        or a 2-tuple ``(top, bottom)`` for asymmetric spacing. Overrides
        the vertical component of ``margin=``.
 
-Grid
-''''
+.. rubric:: Grid
 
 Used inside a ``Grid`` container.
 

--- a/docs/widgets/codeeditor.rst
+++ b/docs/widgets/codeeditor.rst
@@ -167,6 +167,35 @@ so map the stream — not the property — and read the position inside the map:
            .listen(status.set)
    )
 
+Selection and block indent
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``selection`` reads and writes the selected range as a pair of 1-indexed
+``(line, col)`` tuples — the same coordinates the position methods use — or
+``None`` when nothing is selected. ``selected_text`` returns the selected string.
+
+.. code-block:: python
+
+   editor = bs.CodeEditor(value="line one\nline two\nline three")
+
+   sel = editor.selection          # e.g. ((1, 1), (2, 5)), or None
+   text = editor.selected_text     # the selected text, or ""
+
+   editor.selection = ((2, 1), (3, 1))  # select line 2
+   editor.selection = None              # clear the selection
+
+``indent()`` and ``dedent()`` shift whole lines by one tab stop. With a
+selection they act on every selected line and leave those lines selected;
+with no selection ``indent()`` inserts a tab stop at the cursor and
+``dedent()`` outdents the current line. They are the programmatic form of
+pressing ``Tab`` / ``Shift+Tab`` (see Keyboard).
+
+.. code-block:: python
+
+   editor.selection = ((2, 1), (3, 1))
+   editor.indent()    # indent lines 2–3 by one tab stop
+   editor.dedent()    # and back out again
+
 Validation
 ~~~~~~~~~~
 
@@ -240,7 +269,8 @@ on Windows and Linux, ``Cmd+Z`` / ``Cmd+Shift+Z`` on macOS).
 ============================  ============================================================
 Key                           Action
 ============================  ============================================================
-``Tab``                       Insert indentation to the next tab stop
+``Tab``                       Indent the selected lines, or insert a tab stop at the cursor
+``Shift+Tab``                 Dedent the selected lines, or the current line
 ``Return``                    New line, matching the current indent (``auto_indent``)
 Undo / redo                   Native per-platform shortcut (see above)
 ``Ctrl+F`` / ``Cmd+F``        Open the find bar
@@ -250,10 +280,17 @@ Undo / redo                   Native per-platform shortcut (see above)
 
 .. note::
 
-   ``Tab`` inserts indentation, so it does not move focus out of the editor —
-   that is deliberate for a code surface, matching desktop editors. Move focus
-   away by clicking another control. When you instead want a labeled multi-line
-   field where ``Tab`` advances focus, use :doc:`textarea`.
+   ``Tab`` indents, so it does not move focus out of the editor — that is
+   deliberate for a code surface, matching desktop editors. Move focus away by
+   clicking another control. When you instead want a labeled multi-line field
+   where ``Tab`` advances focus, use :doc:`textarea`.
+
+.. note::
+
+   The ``Tab`` / ``Shift+Tab`` block indent/dedent keys are active when
+   ``auto_indent=True`` (the default). The :meth:`~bootstack.CodeEditor.indent`
+   and :meth:`~bootstack.CodeEditor.dedent` methods work regardless of the
+   setting — see `Selection and block indent`_.
 
 Widget sizing
 ~~~~~~~~~~~~~

--- a/docs/widgets/scrollview.rst
+++ b/docs/widgets/scrollview.rst
@@ -193,6 +193,49 @@ case where some new descendants miss scrolling after a large dynamic batch:
 
    sv.refresh_bindings()   # only if some rows missed scrolling
 
+Scroll events and position
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``on_scroll()`` fires whenever the viewport moves — mouse-wheel, keyboard, or a
+programmatic ``scroll_to_*`` / ``yview_moveto`` call. The handler receives a
+:class:`~bootstack.events.ScrollEvent` with ``y`` and ``x`` fractions. Read
+``scroll_position`` at any time for the same ``(y, x)`` pair.
+
+.. code-block:: python
+
+   sv = bs.ScrollView(grow=True)
+
+   sv.on_scroll(lambda e: print(f"at {e.y:.0%} down, {e.x:.0%} across"))
+
+   y, x = sv.scroll_position   # current position, e.g. (0.0, 0.0) at the top
+
+Each fraction is the proportion of content scrolled past the viewport's top-left
+edge: ``0.0`` at the start, climbing toward ``1.0`` as you near the end (it stops
+short of ``1.0`` while content still fills the viewport). ``on_scroll()`` with no
+handler returns a composable :class:`~bootstack.streams.Stream`, so you can
+debounce a position readout. See :doc:`/reference/events` for the event model.
+
+Keyboard scrolling
+~~~~~~~~~~~~~~~~~~~
+
+Once the canvas has keyboard focus (click inside it), arrow keys and the paging
+keys scroll the viewport.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 60
+
+   * - Key
+     - Action
+   * - ``Up`` / ``Down``
+     - Scroll one line vertically
+   * - ``Left`` / ``Right``
+     - Scroll one unit horizontally
+   * - ``Page Up`` / ``Page Down``
+     - Scroll one page vertically
+   * - ``Home`` / ``End``
+     - Jump to the top / bottom
+
 Widget sizing
 ~~~~~~~~~~~~~
 

--- a/docs/widgets/toolbar.rst
+++ b/docs/widgets/toolbar.rst
@@ -95,6 +95,25 @@ for the application name or section titles.
    tb.add_divider()
    tb.add_button("New", icon="file-earmark-plus")
 
+Controlling items after creation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``add_button()`` returns the :class:`~bootstack.Button` and ``add_label()``
+returns the :class:`~bootstack.Label`, so you can keep a reference and drive it
+later with the widget's live properties — no need to rebuild the bar.
+
+.. code-block:: python
+
+   save = tb.add_button("Save", icon="floppy", on_click=save_doc)
+   status = tb.add_label("Ready")
+
+   save.disabled = True              # disable until there are changes
+   save.text = "Saving…"             # update the label text
+   status.text = "All changes saved"
+
+The bar applies its own ``density`` and ``surface`` to the items it builds, so a
+returned button or label already matches the rest of the toolbar.
+
 Adding menus
 ~~~~~~~~~~~~
 

--- a/src/bootstack/signals/README.md
+++ b/src/bootstack/signals/README.md
@@ -1,36 +1,45 @@
 Signals for bootstack
 =====================
 
-Lightweight reactive state built on top of tkinter's ``Variable`` API.
-Signals wrap a ``tk.Variable`` and provide a small, typed interface for
-reading, writing, deriving, and subscribing to changes.
+Lightweight reactive state. A ``Signal[T]`` holds a value, notifies subscribers
+when it changes, and can be bound two-way to widgets. It is backed by a Tk
+variable, but that variable is created lazily, so the Tk surface never leaks
+into the public API.
+
+> The user-facing guide is ``docs/reference/signals.rst`` (teaching) and the
+> API Reference page for ``bootstack.signals`` (lookup). This README covers the
+> package internals; keep it in sync with ``signal.py``.
 
 Architecture
-- ``Signal[T]``: Generic wrapper around a ``tk.Variable`` with ``get()``,
-  ``set()``, ``subscribe()``, and ``map()``.
-- ``_SignalTrace`` (internal): Manages Tcl traces for a variable
+- ``Signal[T]`` (public): the reactive cell — ``signal()`` to read, ``set()`` to
+  write, ``subscribe()`` to observe, ``map()`` to derive.
+- Lazy Tk-var realization: ``Signal(...)`` creates **no** Tk variable at
+  construction, so a signal can be created at module level (before any ``App``).
+  The backing variable is realized on first bind/escape-hatch access against the
+  running interpreter, and re-realized cleanly across ``App`` lifecycles.
+- Object mode: values that are not Tk-native (anything other than
+  ``bool``/``int``/``float``/``str``/``set`` — e.g. a ``date`` or a dataclass)
+  are held as the authoritative Python object; the Tk variable is used only as a
+  change-notification bus. Native values are stored in the Tk variable directly.
+- ``_SignalTrace`` (internal): manages the Tcl variable trace
   (``trace_add``/``trace_remove``).
-- ``TraceOperation``: Literal type alias for trace operations
-  ("array", "read", "write", "unset").
 
 Key behaviors
-- Value access: ``signal()`` returns the current value; ``signal.set(v)``
-  updates it. Signals can be passed directly to widget options like
-  ``textsignal``; bootstack uses the underlying Tcl variable name.
-- Subscriptions: ``subscribe(cb, immediate=False)`` registers a callback and
-  returns a trace id. Multiple subscriptions of the same callback are supported.
-  Use ``unsubscribe(cb)`` to remove all subscriptions for that callback or
-  ``unsubscribe_all()`` to clear all.
-- Derived signals: ``map(transform)`` creates a new signal that follows this
-  one using a transform function. A weak reference prevents the parent from
-  keeping derived signals alive unnecessarily.
-- Robustness: The last known value is cached and returned if the underlying
-  Tcl variable is destroyed. Redundant updates are skipped when the new value
-  equals the current one. ``set()`` enforces the signal's type, except that an
-  ``int`` is widened to a ``float``-typed signal.
+- Read / write: ``signal()`` returns the current value; ``signal.set(v)`` updates
+  it. A ``set()`` to an equal value is a no-op (no notification).
+- Subscriptions: ``subscribe(callback, *, immediate=False)`` returns a
+  ``streams.Handle``; call ``handle.cancel()`` to unsubscribe. ``immediate=True``
+  fires the callback once with the current value at subscribe time.
+- Derived signals: ``map(transform)`` returns a new signal that follows this one.
+  A weak reference keeps the parent from holding the derived signal alive.
+- Robustness: the last value is cached and returned even if the backing variable
+  has been dropped (e.g. between ``App`` lifecycles).
+- Escape hatch: ``Signal.from_variable(tk_var)`` wraps an existing Tk variable,
+  and ``signal.var`` exposes the backing variable. These are the only Tk-aware
+  paths; everything else stays Tk-free.
 
 Usage
-1) Quick start
+1) Quick start (works at module level — no ``App`` required)
 ```python
 from bootstack.signals import Signal
 
@@ -40,73 +49,50 @@ count.set(1)
 print(count())        # -> 1
 ```
 
-2) With widgets
+2) Two-way binding to a widget
 ```python
 import bootstack as bs
 
-app = bs.App()
-name = bs.Signal("")
-
-entry = bs.Entry(app, textvariable=name)
-entry.pack()
-
-label = bs.Label(app)
-label.pack()
-
-name.subscribe(lambda v: label.configure(text=f"Hello, {v}!"), immediate=True)
-
-app.mainloop()
+with bs.App() as app:
+    name = bs.Signal("")
+    bs.TextField(textsignal=name)          # edits flow into the signal
+    bs.Label(textsignal=name.map(lambda v: f"Hello, {v}!"))  # derived display
+app.run()
 ```
 
-3) Derived signals with ``map``
+3) Subscribing and unsubscribing
 ```python
-from bootstack.signals import Signal
+import bootstack as bs
 
-price = Signal(10.0)
-with_tax = price.map(lambda p: round(p * 1.07, 2))
+with bs.App() as app:
+    flag = bs.Signal(False)
 
-with_tax.subscribe(lambda v: print("price with tax:", v), immediate=True)
-price.set(12.0)
+    def on_flag(value):
+        print("flag:", value)
+
+    handle = flag.subscribe(on_flag, immediate=True)  # prints: flag: False
+    flag.set(True)                                     # prints: flag: True
+    handle.cancel()                                    # stop observing
+app.run()
 ```
 
-4) Wrap existing tkinter variables
+4) Typed (object-mode) values
 ```python
-import tkinter as tk
-from bootstack.signals import Signal
+from datetime import date
+import bootstack as bs
 
-root = tk.Tk()
-tk_var = tk.IntVar(value=5)
-sig = Signal.from_variable(tk_var)
-
-sig.subscribe(print, immediate=True)  # -> 5
-tk_var.set(6)  # prints 6
-sig.set(7)     # keeps both in sync
-```
-
-5) Multiple subscriptions and immediate firing
-```python
-from bootstack.signals import Signal
-
-flag = Signal(False)
-
-fid1 = flag.subscribe(lambda v: print("A:", v), immediate=True)
-fid2 = flag.subscribe(lambda v: print("B:", v))
-
-flag.set(True)  # triggers both
-
-flag.unsubscribe(lambda v: print("B:", v))  # remove all B callbacks
+with bs.App():
+    due = bs.Signal(date.today())
+    bs.DateField(signal=due)        # binds the typed value
+    print(type(due()))              # -> <class 'datetime.date'> (not str)
 ```
 
 Import path
-- Public API is available at the top-level namespace:
-  - ``import bootstack as bs; bs.Signal``
-  - ``from bootstack.signals import Signal, TraceOperation``
+- ``import bootstack as bs; bs.Signal``
+- ``from bootstack.signals import Signal``
 
 Notes
-- Tkinter is not thread-safe. Perform cross-thread updates using ``after``
-  on a Tk widget.
-- Callbacks should be fast; long-running work should be scheduled off the UI
+- The UI toolkit is not thread-safe. Marshal cross-thread updates onto the UI
+  via the framework's scheduling, not by touching the signal from a worker
   thread.
-- Create ``Signal`` after you create the App so the underlying ``tk.Variable``
-  is attached to the same interpreter, or pass ``master=...`` when constructing
-  ``Signal``.
+- Keep subscriber callbacks fast; offload long-running work.

--- a/src/bootstack/widgets/_impl/composites/tableview/tableview.py
+++ b/src/bootstack/widgets/_impl/composites/tableview/tableview.py
@@ -2407,23 +2407,30 @@ class TableView(Frame):
             if rows:
                 yield rows
             return
-        with self._apply_view_to_source():
-            if scope == "page":
+        # The view (this table's filter/sort) is applied to the SHARED source only
+        # for the duration of each read, never across a `yield` — otherwise a
+        # caller that stops iterating early (e.g. `break`s out of `iter_rows`)
+        # would suspend the generator inside the context manager and leave the
+        # shared source clobbered until GC, defeating per-view isolation.
+        if scope == "page":
+            with self._apply_view_to_source():
                 psize = self._ds_page_size()
                 start = self._current_page * psize
                 rows = self._datasource.page_slice(start, psize)
-                if rows:
-                    yield rows
-                return
-            # 'all' (the filtered/sorted set) — page through so memory stays flat.
+            if rows:
+                yield rows
+            return
+        # 'all' (the filtered/sorted set) — page through so memory stays flat.
+        with self._apply_view_to_source():
             total = self._datasource.count
-            offset = 0
-            while offset < total:
+        offset = 0
+        while offset < total:
+            with self._apply_view_to_source():
                 chunk = self._datasource.page_slice(offset, chunk_size)
-                if not chunk:
-                    break
-                yield chunk
-                offset += len(chunk)
+            if not chunk:
+                break
+            yield chunk
+            offset += len(chunk)
 
     def _to_delimited(self, rows: list, delimiter: str) -> str:
         """Serialize `rows` (raw records) as delimited text over the displayed columns."""

--- a/src/bootstack/widgets/_impl/composites/toolbar.py
+++ b/src/bootstack/widgets/_impl/composites/toolbar.py
@@ -479,14 +479,18 @@ class Toolbar(Frame):
             **kwargs
         )
         lbl.pack(side='left', padx=4)
-
-        # Make label draggable too if toolbar is draggable
-        if self._draggable:
-            lbl.bind('<Button-1>', self._on_drag_start, add='+')
-            lbl.bind('<B1-Motion>', self._on_drag_motion, add='+')
-            lbl.bind('<Double-Button-1>', self._on_drag_double, add='+')
-
+        self._attach_drag(lbl)
         return lbl
+
+    def _attach_drag(self, widget) -> None:
+        """Wire window-drag bindings onto a child widget so the bar can be
+        grabbed there (used for a draggable titlebar). No-op when the bar is not
+        draggable. Buttons are intentionally excluded — they are click targets."""
+        if not self._draggable:
+            return
+        widget.bind('<Button-1>', self._on_drag_start, add='+')
+        widget.bind('<B1-Motion>', self._on_drag_motion, add='+')
+        widget.bind('<Double-Button-1>', self._on_drag_double, add='+')
 
     def add_separator(self, length: int = 16, **kwargs) -> Separator:
         """Add a vertical separator to the toolbar.
@@ -520,13 +524,7 @@ class Toolbar(Frame):
         """
         spacer = Frame(self._content_frame)
         spacer.pack(side='left', fill='both', expand=True)
-
-        # Make spacer draggable too
-        if self._draggable:
-            spacer.bind('<Button-1>', self._on_drag_start, add='+')
-            spacer.bind('<B1-Motion>', self._on_drag_motion, add='+')
-            spacer.bind('<Double-Button-1>', self._on_drag_double, add='+')
-
+        self._attach_drag(spacer)
         return spacer
 
     def add_widget(self, widget: Widget, **pack_kwargs) -> Widget:

--- a/src/bootstack/widgets/button.py
+++ b/src/bootstack/widgets/button.py
@@ -8,7 +8,7 @@ from bootstack.widgets._core.events import register_widget_events
 from bootstack.widgets._core.icon_image_props import IconProperty, ImageProperty
 from bootstack.events import Event, Subscription
 from bootstack.streams import Stream
-from bootstack.widgets.types import AccentToken, WidgetDensity, IconPosition, ButtonVariant, IconSpec, LocalizeMode
+from bootstack.widgets.types import AccentToken, WidgetDensity, IconPosition, ButtonVariant, IconSpec, LocalizeMode, SurfaceToken
 
 if TYPE_CHECKING:
     from bootstack.signals import Signal
@@ -41,6 +41,10 @@ class Button(IconProperty, ImageProperty, PublicWidgetBase):
             buttons uniform width (e.g. `width=10`).
         textsignal: Reactive `Signal[str]` bound to the button text. Updates
             automatically when the signal changes.
+        surface: The background surface the button sits on — `'content'`,
+            `'card'`, `'card_raised'`, `'chrome'`, or `'overlay'`. Affects how a
+            `ghost`/`outline` button blends with its container (e.g. a toolbar
+            sets `'chrome'`). Defaults to the theme's content surface.
         density: Padding density.
         disabled: If `True`, the button is non-interactive and visually dimmed.
         localize: Whether the text is translated through the catalog — `True`,
@@ -66,6 +70,7 @@ class Button(IconProperty, ImageProperty, PublicWidgetBase):
         image: Any = None,
         width: int | None = None,
         textsignal: "Signal[str] | None" = None,
+        surface: SurfaceToken | str | None = None,
         density: WidgetDensity | None = None,
         disabled: bool = False,
         localize: LocalizeMode | None = None,
@@ -109,6 +114,8 @@ class Button(IconProperty, ImageProperty, PublicWidgetBase):
             internal_kwargs["width"] = width
         if textsignal is not None:
             internal_kwargs["textsignal"] = textsignal
+        if surface is not None:
+            internal_kwargs["surface"] = surface
         if density is not None:
             internal_kwargs["density"] = density
         if disabled:

--- a/src/bootstack/widgets/codeeditor.py
+++ b/src/bootstack/widgets/codeeditor.py
@@ -462,7 +462,8 @@ class CodeEditor(PublicWidgetBase):
 
         With a selection, every selected line is indented by one tab stop (spaces
         or a tab character, depending on the editor's `insert_spaces` setting).
-        The selection is preserved after the operation.
+        The affected lines stay selected afterward (a partial-line selection is
+        re-selected to span the whole lines).
 
         Without a selection, inserts spaces to the next tab stop at the cursor
         (same as pressing Tab with no selection).
@@ -473,8 +474,9 @@ class CodeEditor(PublicWidgetBase):
         """Dedent selected lines (or the current line) by one tab stop.
 
         Removes up to one tab stop of leading whitespace from each line in the
-        selection. With no selection, dedents the line the cursor is on.
-        The selection is preserved after the operation.
+        selection. With no selection, dedents the line the cursor is on. The
+        affected lines stay selected afterward (a partial-line selection is
+        re-selected to span the whole lines).
         """
         self._internal.dedent()
 

--- a/src/bootstack/widgets/codeeditor.py
+++ b/src/bootstack/widgets/codeeditor.py
@@ -219,8 +219,10 @@ class CodeEditor(PublicWidgetBase):
         """Reactive `Signal[bool]` — `True` when all validation rules pass.
 
         Starts `True`. Updates after every validation run (blur or manual
-        `validate()` call). Subscribe to react immediately when validity changes:
-        `editor.valid.subscribe(lambda ok: btn.disabled = not ok)`.
+        `validate()` call). Subscribe a named handler to react immediately when
+        validity changes (a `lambda` cannot assign, so define a function):
+        `def on_valid(ok): btn.disabled = not ok` then
+        `editor.valid.subscribe(on_valid)`.
         """
         return self._internal._valid_signal
 

--- a/src/bootstack/widgets/scrollview.py
+++ b/src/bootstack/widgets/scrollview.py
@@ -140,10 +140,15 @@ class ScrollView(FlexContainer):
 
     @property
     def scroll_position(self) -> tuple[float, float]:
-        """Current scroll position as `(y, x)` fractions in `[0.0, 1.0]`.
+        """Current scroll position as `(y, x)` fractions.
 
-        `(0.0, 0.0)` is the top-left corner; `(1.0, 1.0)` is the bottom-right.
-        Read this inside an `on_scroll` handler to get the new position:
+        Each value is the fraction of the content that lies above (`y`) or to the
+        left (`x`) of the viewport's top-left corner. `(0.0, 0.0)` means scrolled
+        fully to the top-left. As you scroll toward the end the value grows toward
+        `1.0` but does not reach it while content fills the viewport (it tops out
+        at roughly `1.0` minus the visible fraction) — only an axis whose content
+        is shorter than the viewport reads `0.0`. Read this inside an `on_scroll`
+        handler to get the new position:
 
             sv.on_scroll(lambda e: print(e.y, e.x))
         """

--- a/src/bootstack/widgets/textarea.py
+++ b/src/bootstack/widgets/textarea.py
@@ -183,8 +183,10 @@ class TextArea(PublicWidgetBase):
         """Reactive `Signal[bool]` — `True` when all validation rules pass.
 
         Starts `True`. Updates after every validation run (blur or manual
-        `validate()` call). Subscribe to react immediately when validity changes:
-        `area.valid.subscribe(lambda ok: btn.disabled = not ok)`.
+        `validate()` call). Subscribe a named handler to react immediately when
+        validity changes (a `lambda` cannot assign, so define a function):
+        `def on_valid(ok): btn.disabled = not ok` then
+        `area.valid.subscribe(on_valid)`.
         """
         return self._internal._valid_signal
 

--- a/src/bootstack/widgets/toolbar.py
+++ b/src/bootstack/widgets/toolbar.py
@@ -240,19 +240,23 @@ class Toolbar(PublicWidgetBase):
     def _apply_bar_defaults(self, widget_cls: type, kwargs: dict[str, Any]) -> None:
         """Default `density`/`surface` from the bar onto a class being built, but
         only for parameters the widget actually accepts (and not if the caller
-        already passed them)."""
+        already passed them).
+
+        A widget is treated as accepting `density`/`surface` only when it declares
+        that parameter by name. A bare `**kwargs` catch-all does NOT count: in the
+        public layer `**kwargs` is the layout-placement passthrough, and several
+        widgets use it to *reject* unknown keys — injecting into those raises a
+        `TypeError`, and injecting into ones that ignore it is a silent no-op.
+        """
         import inspect
 
         try:
             params = inspect.signature(widget_cls).parameters
         except (TypeError, ValueError):
             return
-        has_var_kw = any(
-            p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values()
-        )
-        if "density" in params or has_var_kw:
+        if "density" in params:
             kwargs.setdefault("density", self._internal.density)
-        if "surface" in params or has_var_kw:
+        if "surface" in params:
             kwargs.setdefault("surface", self._internal.surface)
 
     # ----- Container protocol (so `parent=toolbar` works) -----

--- a/src/bootstack/widgets/toolbar.py
+++ b/src/bootstack/widgets/toolbar.py
@@ -9,6 +9,8 @@ from bootstack.widgets.types import AccentToken, WidgetDensity, SurfaceToken, Bu
 
 if TYPE_CHECKING:
     from bootstack.widgets._impl.composites.menu.model import MenuGroup
+    from bootstack.widgets.button import Button
+    from bootstack.widgets.label import Label
 
 
 class Toolbar(PublicWidgetBase):
@@ -113,8 +115,8 @@ class Toolbar(PublicWidgetBase):
         accent: AccentToken | str | None = None,
         variant: ButtonVariant | None = None,
         **kwargs: Any,
-    ) -> Any:
-        """Add a button to the toolbar and return a handle for later control.
+    ) -> "Button":
+        """Add a button to the toolbar and return it for later control.
 
         When both `label` and `icon` are given, the button shows text and icon
         side by side. When only `icon` is given, the button is icon-only.
@@ -128,22 +130,25 @@ class Toolbar(PublicWidgetBase):
                 `button_variant` (default `'ghost'`).
 
         Returns:
-            An internal button handle. Use it to reconfigure or disable the
-            button after creation: ``btn.configure(state='disabled')``.
+            The :class:`~bootstack.Button` — use its live properties to control
+            it later, e.g. ``btn.disabled = True`` or ``btn.text = 'Saving…'``.
         """
-        kw: dict[str, Any] = {}
-        if label is not None:
-            kw["text"] = label
+        from bootstack.widgets.button import Button
+
+        kw: dict[str, Any] = {
+            "text": label or "",
+            "variant": variant or self.button_variant,
+            "density": self.density,
+            "surface": self._internal.surface,
+        }
         if icon is not None:
             kw["icon"] = icon
         if on_click is not None:
-            kw["command"] = on_click
+            kw["on_click"] = on_click
         if accent is not None:
             kw["accent"] = accent
-        if variant is not None:
-            kw["variant"] = variant
-        kw.update(kwargs)
-        return self._internal.add_button(**kw)
+        kw.update(kwargs)  # explicit kwargs (incl. text=) win over the defaults
+        return Button(parent=self, **kw)
 
     def add_menu(self, text: str, *, key: str | None = None) -> "MenuGroup":
         """Add a dropdown menu (File / Edit / …) as a toolbar item.
@@ -177,8 +182,8 @@ class Toolbar(PublicWidgetBase):
         icon: str | None = None,
         font: str | None = None,
         **kwargs: Any,
-    ) -> Any:
-        """Add a non-interactive label to the toolbar and return a handle.
+    ) -> "Label":
+        """Add a non-interactive label to the toolbar and return it.
 
         Args:
             text: Label text.
@@ -186,18 +191,21 @@ class Toolbar(PublicWidgetBase):
             font: Font token, e.g. `'heading-md'` or `'caption'`.
 
         Returns:
-            An internal label handle. Use it to update or hide the label after
-            creation: ``lbl.configure(text='Updated')``.
+            The :class:`~bootstack.Label` — use its live properties to update it
+            later, e.g. ``lbl.text = 'Updated'``.
         """
-        kw: dict[str, Any] = {}
-        if text is not None:
-            kw["text"] = text
+        from bootstack.widgets.label import Label
+
+        kw: dict[str, Any] = {"text": text or "", "surface": self._internal.surface}
         if icon is not None:
             kw["icon"] = icon
         if font is not None:
             kw["font"] = font
         kw.update(kwargs)
-        return self._internal.add_label(**kw)
+        lbl = Label(parent=self, **kw)
+        # On a draggable bar (e.g. a titlebar) the label doubles as a drag handle.
+        self._internal._attach_drag(lbl._internal)
+        return lbl
 
     def add_divider(self, length: int = 16) -> None:
         """Add a vertical divider.

--- a/tests/widgets/public/test_add_toolbar.py
+++ b/tests/widgets/public/test_add_toolbar.py
@@ -52,6 +52,52 @@ def test_add_toolbar_context_manager_scopes_and_returns_handle(app):
     assert len(tb._internal.content.winfo_children()) == 1
 
 
+def test_add_button_returns_public_button_with_live_props(app):
+    import bootstack as bs
+
+    tb = app.add_toolbar()
+    btn = tb.add_button("Save", icon="floppy", on_click=lambda: None)
+    assert isinstance(btn, bs.Button)  # public widget, not an _impl primitive
+    btn.disabled = True
+    assert btn.disabled is True
+    btn.text = "Saving"
+    assert btn.text == "Saving"
+
+
+def test_add_label_returns_public_label_with_live_props(app):
+    import bootstack as bs
+
+    tb = app.add_toolbar()
+    lbl = tb.add_label("Ready")
+    assert isinstance(lbl, bs.Label)
+    lbl.text = "Done"
+    assert lbl.text == "Done"
+
+
+def test_add_button_inherits_bar_density_variant(app):
+    tb = app.add_toolbar(density="compact", button_variant="ghost")
+    btn = tb.add_button("X")
+    # Built on the bar's content frame, carrying the bar's defaults.
+    assert btn._internal.winfo_parent() == str(tb._internal.content)
+
+
+def test_add_button_text_kwarg_still_supported(app):
+    # Backwards-compatible: text= (legacy) works alongside the label positional.
+    tb = app.add_toolbar()
+    btn = tb.add_button(text="Explicit")
+    assert btn.text == "Explicit"
+
+
+def test_titlebar_label_is_draggable_button_is_not(app):
+    # A draggable bar (window controls) makes labels double as drag handles;
+    # buttons stay click targets.
+    tb = app.add_toolbar(show_window_controls=True)
+    lbl = tb.add_label("Title")
+    btn = tb.add_button(icon="x")
+    assert lbl._internal.bind("<B1-Motion>")       # label drags the window
+    assert not btn._internal.bind("<B1-Motion>")   # button does not
+
+
 def test_add_widget_class_inherits_bar_density_skips_unsupported_surface(app):
     import bootstack as bs
 

--- a/tests/widgets/public/test_codeeditor_selection_indent.py
+++ b/tests/widgets/public/test_codeeditor_selection_indent.py
@@ -1,0 +1,104 @@
+"""CodeEditor selection API (#296) and block indent/dedent (#297).
+
+These two PRs added public surface that shipped without tests. Coordinates are
+1-indexed ``(line, col)`` throughout, matching ``cursor_position`` / ``goto()``.
+"""
+import pytest
+
+import bootstack as bs
+
+pytestmark = pytest.mark.gui
+
+
+# ----- selection API (#296) -----
+
+def test_selection_none_when_empty(app):
+    ed = bs.CodeEditor(value="abc")
+    assert ed.selection is None
+    assert ed.selected_text == ""
+
+
+def test_selection_set_read_and_text(app):
+    ed = bs.CodeEditor(value="line one\nline two\nline three")
+    ed.selection = ((1, 1), (2, 5))
+    assert ed.selection == ((1, 1), (2, 5))
+    assert ed.selected_text == "line one\nline"
+
+
+def test_selection_round_trips_coordinates(app):
+    ed = bs.CodeEditor(value="hello\nworld")
+    ed.selection = ((1, 2), (2, 4))
+    assert ed.selection == ((1, 2), (2, 4))
+
+
+def test_selection_clear(app):
+    ed = bs.CodeEditor(value="abc def")
+    ed.selection = ((1, 1), (1, 4))
+    assert ed.selected_text == "abc"
+    ed.selection = None
+    assert ed.selection is None
+    assert ed.selected_text == ""
+
+
+# ----- block indent / dedent (#297) -----
+
+def test_indent_no_selection_inserts_tab_stop(app):
+    ed = bs.CodeEditor(value="code")
+    ed.goto(1, 1)
+    ed.indent()
+    assert ed.value == "    code"
+
+
+def test_indent_selected_lines(app):
+    ed = bs.CodeEditor(value="a\nb\nc")
+    ed.selection = ((1, 1), (3, 2))  # spans lines 1-3
+    ed.indent()
+    assert ed.value == "    a\n    b\n    c"
+
+
+def test_indent_keeps_affected_lines_selected(app):
+    ed = bs.CodeEditor(value="a\nb")
+    ed.selection = ((1, 1), (2, 2))
+    ed.indent()
+    sel = ed.selection
+    assert sel is not None
+    assert sel[0][0] == 1 and sel[1][0] == 2  # lines 1-2 still selected
+
+
+def test_dedent_selected_lines(app):
+    ed = bs.CodeEditor(value="    a\n    b\n    c")
+    ed.selection = ((1, 1), (3, 6))
+    ed.dedent()
+    assert ed.value == "a\nb\nc"
+
+
+def test_dedent_partial_indent_removes_only_what_exists(app):
+    # 2 leading spaces, tab_width 4 -> loses just the 2 it has (no underflow).
+    ed = bs.CodeEditor(value="  a")
+    ed.goto(1, 1)
+    ed.dedent()
+    assert ed.value == "a"
+
+
+def test_dedent_no_leading_whitespace_is_noop(app):
+    ed = bs.CodeEditor(value="abc")
+    ed.goto(1, 1)
+    ed.dedent()
+    assert ed.value == "abc"
+
+
+def test_indent_dedent_round_trip(app):
+    ed = bs.CodeEditor(value="a\nb\nc")
+    ed.selection = ((1, 1), (3, 2))
+    ed.indent()
+    ed.dedent()
+    assert ed.value == "a\nb\nc"
+
+
+def test_indent_works_when_auto_indent_disabled(app):
+    # The indent()/dedent() methods are independent of the auto_indent setting
+    # (only the Tab/Shift+Tab key bindings depend on it).
+    ed = bs.CodeEditor(value="a\nb", auto_indent=False)
+    ed.selection = ((1, 1), (2, 2))
+    ed.indent()
+    assert ed.value == "    a\n    b"

--- a/tests/widgets/public/test_datatable.py
+++ b/tests/widgets/public/test_datatable.py
@@ -239,11 +239,11 @@ def test_two_tables_share_source_independent_search(shown_app):
 
     table_a = bs.DataTable(
         data_source=src, columns=["name", "role"],
-        enable_search=True, page_size=10,
+        searchable=True, page_size=10,
     )
     table_b = bs.DataTable(
         data_source=src, columns=["name", "role"],
-        enable_search=True, page_size=10,
+        searchable=True, page_size=10,
     )
     _pump(shown_app)
 
@@ -252,7 +252,7 @@ def test_two_tables_share_source_independent_search(shown_app):
     assert len(table_b.to_rows("page")) == 3
 
     # Apply a search to table_a only.
-    table_a._internal.set_search("Ada")
+    table_a.set_search("Ada")
     _pump(shown_app)
 
     rows_a = table_a.to_rows("page")
@@ -276,7 +276,7 @@ def test_two_tables_share_source_independent_sort(shown_app):
     _pump(shown_app)
 
     # Sort table_a descending by name.
-    table_a._internal.set_sorting("name", ascending=False)
+    table_a.sort_by("name", ascending=False)
     _pump(shown_app)
 
     names_a = [r["name"] for r in table_a.to_rows("page")]

--- a/tests/widgets/public/test_datatable.py
+++ b/tests/widgets/public/test_datatable.py
@@ -287,3 +287,37 @@ def test_two_tables_share_source_independent_sort(shown_app):
 
     # Source's own sort must be untouched.
     assert src._sort == [], "source order() must not be mutated"
+
+
+@pytest.mark.gui
+def test_iter_rows_suspended_does_not_clobber_shared_source(shown_app):
+    """A suspended iter_rows() generator must not hold this view's filter/sort
+    on the shared source.
+
+    The view (the table's search/sort) is applied to the shared source only
+    around each read, never across a ``yield`` — otherwise pausing or abandoning
+    iteration mid-stream leaves the source filtered for every other view until
+    the generator is garbage-collected.
+    """
+    src = MemoryDataSource()
+    src.load([dict(r) for r in ROWS])
+
+    table = bs.DataTable(
+        data_source=src, columns=["name", "role"],
+        searchable=True, page_size=10,
+    )
+    _pump(shown_app)
+
+    table.set_search("math")  # matches Boole + Church
+    _pump(shown_app)
+
+    it = table.iter_rows("all")
+    first = next(it)  # advance once; the generator is now suspended
+    assert first["role"] == "math"
+
+    # While the generator is still alive (not closed), the shared source must
+    # already be restored — the view CM must not span the yield.
+    assert src._filter is None, "iter_rows left the source filtered while suspended"
+    assert src._sort == [], "iter_rows left the source sorted while suspended"
+
+    it.close()

--- a/tests/widgets/public/test_scrollview_events.py
+++ b/tests/widgets/public/test_scrollview_events.py
@@ -1,0 +1,88 @@
+"""ScrollView scroll events, position, and keyboard scrolling (#298).
+
+This surface shipped without tests. `on_scroll` and `scroll_position` work
+headless; keyboard scrolling needs a mapped, focused canvas (`shown_app`), so
+the wiring is asserted deterministically and the behavior is checked when focus
+can be taken.
+"""
+import pytest
+
+import bootstack as bs
+from bootstack.events import ScrollEvent
+from bootstack.streams import Stream
+
+pytestmark = pytest.mark.gui
+
+
+def _tall(parent_app, **kw):
+    sv = bs.ScrollView(height=100, width=200, **kw)
+    with sv:
+        for i in range(60):
+            bs.Label(f"row {i}")
+    parent_app._tk_root.update_idletasks()
+    return sv
+
+
+# ----- scroll_position -----
+
+def test_scroll_position_starts_at_top(app):
+    sv = _tall(app)
+    assert sv.scroll_position == (0.0, 0.0)
+
+
+def test_scroll_position_reflects_programmatic_scroll(app):
+    sv = _tall(app)
+    sv.yview_moveto(0.5)
+    app._tk_root.update_idletasks()
+    assert sv.scroll_position[0] == pytest.approx(0.5, abs=0.05)
+
+
+def test_scroll_position_stays_below_one_while_filled(app):
+    # The position is the fraction above the viewport top, so it tops out below
+    # 1.0 while content still fills the viewport (the docstring's contract).
+    sv = _tall(app)
+    sv.scroll_to_bottom()
+    app._tk_root.update_idletasks()
+    assert 0.0 < sv.scroll_position[0] < 1.0
+
+
+# ----- on_scroll -----
+
+def test_on_scroll_fires_with_scroll_event(app):
+    sv = _tall(app)
+    events = []
+    sv.on_scroll(lambda e: events.append(e))
+    sv.yview_moveto(0.5)
+    app._tk_root.update_idletasks()
+    assert events, "on_scroll did not fire"
+    assert isinstance(events[-1], ScrollEvent)
+    assert 0.0 <= events[-1].y <= 1.0
+
+
+def test_on_scroll_without_handler_returns_stream(app):
+    sv = _tall(app)
+    assert isinstance(sv.on_scroll(), Stream)
+
+
+# ----- keyboard scrolling -----
+
+def test_keyboard_bindings_registered(app):
+    sv = _tall(app)
+    canvas = sv._internal.canvas
+    for key in ("<Up>", "<Down>", "<Prior>", "<Next>",
+                "<Home>", "<End>", "<Left>", "<Right>"):
+        assert canvas.bind(key), f"{key} is not bound"
+
+
+def test_keyboard_end_jumps_to_bottom(shown_app):
+    sv = _tall(shown_app)
+    canvas = sv._internal.canvas
+    canvas.focus_force()
+    shown_app._tk_root.update()
+    if shown_app._tk_root.focus_get() is not canvas:
+        pytest.skip("canvas could not take keyboard focus in this environment")
+    canvas.yview_moveto(0.0)
+    shown_app._tk_root.update()
+    canvas.event_generate("<End>", when="now")
+    shown_app._tk_root.update()
+    assert canvas.yview()[0] > 0.0  # End jumped toward the bottom


### PR DESCRIPTION
Adversarial review of all work merged to `main` in the ~6 hours ending `5def69b6` (PRs #289, #291–#299 + the `0.1.0a14` release), prompted by repeated errors/hallucinations from that session's agent. Full findings: `docs/_dev/review-2026-06-22-trust-audit.md`.

Verdict: the session was mostly sound, but **not trustworthy as-is** — one PR was merged with its own test failing, plus real bugs and a scatter of doc/test-quality gaps. All fixed and verified here.

## Must-fix (broken on `main`)
- **#299 toolbar regression** — `_apply_bar_defaults` used "has `**kwargs`" as a proxy for "accepts `density`/`surface`", so `toolbar.add_widget(Checkbox/Switch/ToggleButton/Radio)` raised `TypeError` and was a silent no-op for `TextField`/`Select`/etc. **Its own test `test_add_widget_class_inherits_bar_density_skips_unsupported_surface` was failing on `main`.** Now injects only explicitly-declared params; test passes.

## Real bugs
- **DataTable `iter_rows` clobbered the shared source** — the view-mutation context manager spanned a `yield`, so stopping iteration early left this view's filter/sort on the shared source until GC. CM now wraps each read only. Regression test added (proven to fail pre-fix).
- **Two `lambda ok: btn.disabled = not ok` docstrings** (assignment in a lambda = `SyntaxError`) → named-handler examples.

## Doc/test-quality sweep
- **`-W` docs build was broken** (since PR #266) — `widget-sizing.rst` section titles inside an include skipped a heading level. Switched to `.. rubric::`; build clean again.
- **DataTable tests** used a hallucinated `enable_search=` kwarg (silently dropped; real one is `searchable=`) and `_internal` pokes → routed through the public surface.
- **`signals/README.md`** was pervasively stale (`get()`/`unsubscribe()`, `bs.Entry`, `app.mainloop()`, raw `tk.Tk()`, and the `master=` gotcha #292 overturned) → rewritten.
- **CodeEditor #296/#297** (selection API, block indent/dedent) and **ScrollView #298** (`on_scroll`/`scroll_position`/keyboard) shipped undocumented and untested → docs sections + 20 new tests; corrected the `scroll_position` and indent/dedent docstrings.

## Feature follow-up (#262)
- `Toolbar.add_button`/`add_label` returned internal `_impl` primitives → now return the public `bs.Button`/`bs.Label` with live properties. Added `surface=` to `bs.Button` so a ghost toolbar button blends into a chrome bar; preserved draggable-titlebar label drag. Item spacing is now a uniform `padx=2` (the pack-based bar has no `gap`; a real gap migration is tracked with the unified-toolbars rework). `add_divider`/`add_spacer` deferred (Spacer needs `expand=` packing the pack-based bar can't express).

## Verified clean (no change needed)
The riskiest change — the **Signal lazy-realization rewrite (#292)** — is correct (verified live). The **internal-access scrub (#295)**, carousel, pyinstaller, and the new chart example all check out. Two flagged "bugs" were disproved over-flags (the #296 `read_only` "fix" was a no-op rename; `Toolbar._surface` is always defaulted by the base class).

## Verification
- Full GUI suite: **all legs passed** (was 605 passed / 1 failed → green).
- Docs `-W` build: **exit 0, 0 warnings** (was broken).
- iter_rows regression test confirmed to fail on pre-fix code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)