### PR TITLE
docs(button): document surface= (build-time) in the narrative page

### DIFF
--- a/docs/widgets/button.rst
+++ b/docs/widgets/button.rst
@@ -64,6 +64,14 @@ actions from secondary ones.
    :class: bs-screenshot-dark
    :alt: Button style variants — dark theme
 
+.. note::
+
+   A ``ghost`` or ``outline`` button looks right only when it matches the
+   surface it sits on. On a non-default container (a :doc:`card`, a darker
+   chrome strip, an overlay) pass ``surface=`` at construction (``'card'``,
+   ``'chrome'``, ``'overlay'``, …) to match. It is a build-time setting, not a
+   runtime property; a :doc:`toolbar` sets it for you on the buttons it builds.
+
 Icons
 ~~~~~
 

--- a/src/bootstack/widgets/button.py
+++ b/src/bootstack/widgets/button.py
@@ -41,10 +41,12 @@ class Button(IconProperty, ImageProperty, PublicWidgetBase):
             buttons uniform width (e.g. `width=10`).
         textsignal: Reactive `Signal[str]` bound to the button text. Updates
             automatically when the signal changes.
-        surface: The background surface the button sits on — `'content'`,
-            `'card'`, `'card_raised'`, `'chrome'`, or `'overlay'`. Affects how a
-            `ghost`/`outline` button blends with its container (e.g. a toolbar
-            sets `'chrome'`). Defaults to the theme's content surface.
+        surface: The background the button is placed on — `'content'`, `'card'`,
+            `'card_raised'`, `'chrome'`, or `'overlay'`. Set it so a
+            `ghost`/`outline` button looks right on a non-default container (e.g.
+            a toolbar sets `'chrome'` on the buttons it builds). A build-time
+            setting, not a live property. Defaults to the theme's content
+            surface.
         density: Padding density.
         disabled: If `True`, the button is non-interactive and visually dimmed.
         localize: Whether the text is translated through the catalog — `True`,


### PR DESCRIPTION
Follow-up to the trust audit (PR #301). Reviewing the last merged item — the toolbar return-handle change (#262), which added `surface=` to `bs.Button` — surfaced one documentation gap: the new param was only in the autodoc, not the narrative Button widget page.

This adds a short usage note in `docs/widgets/button.rst` and tightens the constructor docstring. Wording is usage-only (no implementation detail, per the "no toolkit internals in docs" convention): `surface=` matches the background a `ghost`/`outline` button sits on so it looks right on a non-default container (card / chrome / overlay); a toolbar sets it for you on the buttons it builds. Explicitly noted as a **build-time** setting, not a live property.

No code change. Clean `-W` docs build (0 warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)