### PR TITLE
feat(menubutton): add live .text property for Button/Label parity (#275)

### DIFF
--- a/docs/widgets/menubutton.rst
+++ b/docs/widgets/menubutton.rst
@@ -21,7 +21,7 @@ and remember a value.
 Basic
 ~~~~~
 
-Pass a ``label=`` for button text and use ``add_item()`` to populate the menu.
+Pass the button ``text`` and use ``add_item()`` to populate the menu.
 Items can have an ``icon=`` and an ``on_click=`` callback.
 
 .. code-block:: python
@@ -113,8 +113,8 @@ Shortcuts are most useful when ``MenuButton`` is used in a menubar context:
 Icon button
 ~~~~~~~~~~~
 
-Omit ``label=`` to get an icon-only button — ``icon_only`` is inferred
-automatically when ``icon=`` is set and no label is provided. Set
+Omit the ``text`` to get an icon-only button — ``icon_only`` is inferred
+automatically when ``icon=`` is set and no text is provided. Set
 ``show_arrow=False`` to hide the chevron.
 
 .. code-block:: python
@@ -196,6 +196,29 @@ also be toggled after construction.
 .. image:: /_static/examples/menubutton-states-dark.png
    :class: bs-screenshot-dark
    :alt: MenuButton states — dark theme
+
+Reactive text
+~~~~~~~~~~~~~
+
+The button label is a live property. Read or set ``mb.text`` after
+construction to relabel the button — useful when the action it triggers
+changes (for example, an "Actions" button that becomes "Apply").
+
+.. code-block:: python
+
+   mb = bs.MenuButton("Actions")
+   mb.text = "Apply"
+
+Bind a ``Signal[str]`` to ``textsignal=`` to drive the label reactively. The
+``.text`` setter writes through a bound signal, so the two stay in sync.
+
+.. code-block:: python
+
+   label = bs.Signal("Actions")
+   mb = bs.MenuButton(textsignal=label)
+
+   label.set("Apply")   # updates the button
+   mb.text = "Reset"    # flows back into the signal
 
 Dynamic item management
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/bootstack/widgets/menubutton.py
+++ b/src/bootstack/widgets/menubutton.py
@@ -386,6 +386,29 @@ class MenuButton(IconProperty, PublicWidgetBase):
         return self._internal.context_menu
 
     @property
+    def text(self) -> str:
+        """The button's label text.
+
+        Reading reflects a bound `textsignal` (the option stays synced from
+        the variable). Setting writes through the bound variable when one
+        owns the text — keeping the signal in sync — and falls back to the
+        option otherwise. On an icon-only button the label stays hidden;
+        the setter still updates the underlying text.
+        """
+        return str(self._internal.cget("text"))
+
+    @text.setter
+    def text(self, value: str) -> None:
+        # When a textsignal/textvariable owns the text, ttk ignores the `text`
+        # option — write through the variable instead (which also keeps the
+        # bound signal in sync). Falls back to the option when unbound.
+        textvar = getattr(self._internal, "_textvariable", None)
+        if textvar is not None:
+            textvar.set(value)
+        else:
+            self._internal.configure(text=value)
+
+    @property
     def disabled(self) -> bool:
         """Whether the button is non-interactive."""
         return self._internal.instate(("disabled",))

--- a/tests/widgets/public/test_text_setter_textsignal.py
+++ b/tests/widgets/public/test_text_setter_textsignal.py
@@ -53,6 +53,38 @@ def test_badge_text_round_trip_with_textsignal(app):
     assert sig() == "9+"
 
 
+# ----- MenuButton gains .text get/set parity (#275) -----
+
+def test_menubutton_text_round_trip_unbound(app):
+    mb = bs.MenuButton("Actions")
+    assert mb.text == "Actions"
+    mb.text = "More"
+    assert mb.text == "More"
+
+
+def test_menubutton_text_round_trip_with_textsignal(app):
+    sig = bs.Signal("Initial")
+    mb = bs.MenuButton(textsignal=sig)
+    assert mb.text == "Initial"
+
+    # Setter writes through the bound variable and keeps the signal in sync.
+    mb.text = "Changed"
+    assert mb.text == "Changed"
+    assert sig() == "Changed"
+
+    # Signal writes flow back to .text.
+    sig.set("ViaSignal")
+    assert mb.text == "ViaSignal"
+
+
+def test_menubutton_text_settable_when_icon_only(app):
+    # icon_only hides the label, but setting .text still updates the underlying
+    # text (and reads back) — no error, parity with Button.
+    mb = bs.MenuButton(icon="gear", icon_only=True)
+    mb.text = "Settings"
+    assert mb.text == "Settings"
+
+
 # ----- display-vs-raw widgets stay live and read-only (must NOT break) -----
 
 def test_select_text_is_live_selected_label(app):


### PR DESCRIPTION
## Summary

`MenuButton` accepted `textsignal=` in its constructor — so its label could be *bound* — but exposed **no public `.text` property**, leaving the label unreadable and un-relabelable after construction. Every sibling action/display widget (`Button`, `Label`/`Badge`) already has a `.text` get/set. This closes the gap.

## Approach

Audited the internal first (as the issue asked): `MenuButton` → `DropdownButton` → the `_menubutton` primitive uses the **same `SignalMixin` as `Button`**, which stores `self._textvariable` when a `textsignal`/`textvariable` is bound. So the Button `.text` pattern transfers directly — no new machinery:

- **getter** reads `cget("text")` (reliably reflects a bound signal)
- **setter** writes through `_textvariable` when one owns the text (keeps the bound signal in sync), else falls back to `configure(text=)`

On an **icon-only** button (the issue's open question), the setter still updates the underlying text; the label stays hidden by the `icon_only` style — the least-surprising behavior, matching `Button` (which doesn't restrict either).

## Changes

- `widgets/menubutton.py` — live `.text` property mirroring `Button`.
- `tests/widgets/public/test_text_setter_textsignal.py` — 3 tests added to the existing round-trip guard: unbound round-trip, `textsignal=` two-way sync (set→signal, signal→`.text`), and the icon-only case.
- `docs/widgets/menubutton.rst` — new "Reactive text" section documenting `textsignal=` + the live `.text` property; also fixed two stale `label=` prose references on the page (the param is `text`; the examples already used it).

## Verification

- ✅ Full GUI suite passes — `python tests/run_gui.py` (no args), all legs.
- ✅ Clean `-W` docs build — zero warnings on the edited page. (The build's lone warning was a transient file-lock `PermissionError` copying an unrelated static PNG; confirmed transient on retry.)

Closes #275

🤖 Generated with [Claude Code](https://claude.com/claude-code)