### PR TITLE
fix(icons): DPI-scale the public icon handle + MenuButton chevron (#267)

### DIFF
--- a/src/bootstack/_runtime/utility.py
+++ b/src/bootstack/_runtime/utility.py
@@ -247,6 +247,27 @@ def scale_padding_floor(base: int) -> int:
     return max(base, round(base * _ScalingState.get_ui_scale()))
 
 
+def scale_icon_size(base: int) -> int:
+    """Scale a logical icon size to physical pixels for the current DPI.
+
+    Icons are authored at logical (96-DPI) sizes. On a higher-DPI display the
+    surrounding fonts and layout scale up via Tk scaling, so an icon rendered at
+    its literal logical size lands too small for its container and gets resampled
+    by the display, reading as soft (#267). Rendering at the physical size makes
+    the glyph land 1:1 in the scaled layout, so it stays crisp.
+
+    Floors at `base` (mirrors `scale_padding_floor`) so an uninitialized scale
+    state or a sub-baseline display never renders an icon smaller than requested.
+
+    Args:
+        base: The logical icon size in pixels at standard (96-DPI) scaling.
+
+    Returns:
+        The DPI-scaled size, at least `base`.
+    """
+    return max(base, round(base * _ScalingState.get_ui_scale()))
+
+
 def scale_size(widget=None, size=None):
     """Scale the size based on the scaling factor of tkinter.
     This is used most frequently to adjust the assets for

--- a/src/bootstack/images.py
+++ b/src/bootstack/images.py
@@ -37,6 +37,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from bootstack._core.images import _ImageService
+from bootstack._runtime.utility import scale_icon_size
 
 if TYPE_CHECKING:
     from PIL.Image import Image as _PILImage
@@ -248,7 +249,7 @@ class Image:
             # every scroll doesn't re-render the glyph each time; dropped by
             # _invalidate() on a theme change so token colors re-render.
             if self._icon_pil is None:
-                size = self._icon.size
+                size = scale_icon_size(self._icon.size)
                 size = size if size % 2 == 0 else size + 1
                 self._icon_pil = _ImageService._render_icon(
                     self._icon.name, size, self._resolve_icon_color()
@@ -285,7 +286,7 @@ class Image:
             return self._photo
         if self._icon is not None:
             color = self._resolve_icon_color()
-            photo = _ImageService.get_icon(self._icon.name, self._icon.size, color)
+            photo = _ImageService.get_icon(self._icon.name, scale_icon_size(self._icon.size), color)
         elif self._path is not None:
             photo = _ImageService.open(self._path)
         elif self._data is not None:

--- a/src/bootstack/style/builders/menubutton.py
+++ b/src/bootstack/style/builders/menubutton.py
@@ -65,7 +65,9 @@ def _create_chevron_images(
         icon_name: Name of the icon to use (default: 'caret-down-fill')
         density: Button density ('default' or 'compact')
     """
-    size = _chevron_size(density)
+    # Scale to physical pixels for DPI (#267); matches the combobox/spinbox
+    # chevrons (which scale via entry_icon_size) so all chevrons render crisp.
+    size = b.scale(_chevron_size(density))
     normal_chevron = _ImageService.get_icon(icon_name, size, foreground)
     disabled_chevron = _ImageService.get_icon(icon_name, size, disabled)
 

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -56,6 +56,33 @@ def test_hex_color_is_static():
     assert get_icon("house", color="#ff8800")._is_theme_following is False
 
 
+def test_get_icon_logical_size_unchanged_at_baseline():
+    # The reported (logical) size is the user's request, regardless of DPI; the
+    # physical render size is a separate, internal concern.
+    assert get_icon("house", size=24).width == 24
+
+
+def test_handle_renders_at_physical_size_for_dpi(monkeypatch):
+    # #267: the public icon handle renders the glyph at the DPI-scaled physical
+    # size so it lands 1:1 in a scaled layout (crisp), while the handle's
+    # reported size stays logical.
+    from bootstack._runtime.utility import _ScalingState
+
+    monkeypatch.setattr(_ScalingState, "get_ui_scale", classmethod(lambda cls: 1.5))
+    icon = get_icon("house", size=24, color="#112233")  # hex → no app needed
+    assert icon.width == 24  # logical, unchanged
+    assert icon._load_pil().size == (36, 36)  # physical: round(24 * 1.5)
+
+
+def test_handle_never_renders_smaller_than_requested(monkeypatch):
+    # A sub-baseline / uninitialized scale must never shrink an icon below its
+    # logical size (the scale_icon_size floor).
+    from bootstack._runtime.utility import _ScalingState
+
+    monkeypatch.setattr(_ScalingState, "get_ui_scale", classmethod(lambda cls: 0.75))
+    assert get_icon("house", size=24, color="#112233")._load_pil().size == (24, 24)
+
+
 @pytest.mark.parametrize("ext", [".ico", ".png", ".icns"])
 def test_appicon_save_exports_each_format(tmp_path, ext):
     out = tmp_path / f"app{ext}"


### PR DESCRIPTION
Closes #267.

## Problem

Icons on the **public `get_icon()` / `image=` handle** and the **MenuButton
chevron** rendered at their literal *logical* size and never accounted for DPI.
On a fractional/high-DPI display the surrounding fonts and layout scale up via
Tk scaling, so a logical-sized glyph lands too small for its container and gets
resampled by the display — reading as **soft**.

## What this does

- Adds **`scale_icon_size(base)`** (`_runtime/utility.py`) — logical→physical DPI
  scaling, floored at the requested size (mirrors the existing
  `scale_padding_floor`, so it can never shrink an icon below the request).
- Applies it in **both** `Image` render paths (`_load_pil` for the PIL
  consumers, `_materialize` for the `image=`/PhotoImage path). The public icon
  handle is now the single DPI-correct path. The handle's reported `width`/
  `height` stay **logical** — the public contract is unchanged.
- Routes the **MenuButton chevron** through `b.scale()` so it matches the
  combobox/spinbox chevrons (which already scale via `entry_icon_size`).

## Diagnosis correction

The issue's headline ("most visible on the Workbench rail") was a misdiagnosis.
Empirical probing shows the rail already scales correctly (28→41px via
`normalize_icon_spec`); its softness in that screenshot was the capture/downscale
path the issue half-suspected, not icon sizing. The two genuinely soft paths
were the public handle and the MenuButton chevron — both fixed here.

## Verification

Probe (ui_scale 1.0 → 1.5):

| Path | before | after |
|------|-------:|------:|
| public `get_icon` | 24 → 24 | 24 → **36** |
| MenuButton chevron | 16 → 16 | 16 → **23** |

Baseline (100% DPI) render sizes are unchanged.

- New tests in `tests/test_images.py`: physical render size scales with DPI, the
  floor guard never shrinks below the request, and the reported logical size is
  unchanged.
- Full GUI suite (`tests/run_gui.py`) passes; 186 headless tests pass.

## Deferred

- **#305** — the text+icon `Button`/`MenuButton` icon double-scales at high DPI
  (cosmetic: crisp but ~40% oversized). Filed for its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
