### PR TITLE
fix(tooltip): cover container children added after attach (#260)

### DIFF
--- a/docs/widgets/tooltip.rst
+++ b/docs/widgets/tooltip.rst
@@ -31,6 +31,30 @@ The tooltip appears after 250 ms on hover and hides on mouse leave or click.
    btn = bs.Button("Save")
    bs.Tooltip(btn, "Save your changes to disk")
 
+Covering a container
+~~~~~~~~~~~~~~~~~~~~~
+
+When the target is a container, the tooltip shows while the pointer is anywhere
+inside it — including over its children. This covers the children that exist
+when the tooltip is created.
+
+.. code-block:: python
+
+   with bs.Card(gap=8) as card:
+       bs.Label("Disk usage")
+       bs.Label("82% full")
+   bs.Tooltip(card, "Hover anywhere on the card")
+
+Add children to the container *after* creating the tooltip and they are not
+covered automatically. Call ``refresh_bindings()`` to extend coverage to them —
+it is safe to call repeatedly.
+
+.. code-block:: python
+
+   tip = bs.Tooltip(card, "Hover anywhere on the card")
+   bs.Label("3.2 GB free", parent=card)   # added later
+   tip.refresh_bindings()                 # now covered too
+
 Anchor positioning
 ~~~~~~~~~~~~~~~~~~
 

--- a/src/bootstack/widgets/_impl/composites/tooltip.py
+++ b/src/bootstack/widgets/_impl/composites/tooltip.py
@@ -130,8 +130,22 @@ class ToolTip:
         # Tk events don't bubble, so hovering a child of a container target
         # would otherwise never reach these bindings. Extend them across the
         # subtree so the tip shows anywhere inside the container.
+        self.refresh_bindings()
+
+    def refresh_bindings(self) -> None:
+        """Re-cover the target's subtree after children were added post-attach.
+
+        `propagate_target_bindings` only tags the descendants present when it
+        runs, so children added to a container target after the tooltip was
+        created are not covered until this is called again. The call is
+        idempotent — already-tagged descendants are left untouched.
+        """
         from bootstack._runtime.utility import propagate_target_bindings
-        propagate_target_bindings(self._widget)
+        try:
+            if self._widget.winfo_exists():
+                propagate_target_bindings(self._widget)
+        except tk.TclError:
+            pass
 
     def destroy(self) -> None:
         """Cleanup tooltip resources and unbind all event handlers.

--- a/src/bootstack/widgets/tooltip.py
+++ b/src/bootstack/widgets/tooltip.py
@@ -1,4 +1,4 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 
 from typing import Any, Literal
 
@@ -19,7 +19,7 @@ class Tooltip:
         target: Widget to attach the tooltip to. Accepts any bootstack widget.
             When the target is a container, the tooltip shows while hovering
             anywhere inside it, including over its children present at attach
-            time.
+            time. For children added later, call `refresh_bindings()`.
         text: Tooltip text content. Defaults to `''`.
         delay: Milliseconds before the tooltip appears on mouse enter. Defaults
             to `250`.
@@ -68,6 +68,16 @@ class Tooltip:
             internal_kwargs["window_point"] = window_point
 
         self._internal = _InternalToolTip(tk_widget, **internal_kwargs)
+
+    def refresh_bindings(self) -> None:
+        """Re-cover a container target's subtree after adding children to it.
+
+        A tooltip on a container covers the children present when it was
+        created. Add more children later and call this so hovering them shows
+        the tip too. Safe to call repeatedly — already-covered children are
+        left untouched.
+        """
+        self._internal.refresh_bindings()
 
     @property
     def text(self) -> str:

--- a/tests/widgets/public/test_tooltip_review.py
+++ b/tests/widgets/public/test_tooltip_review.py
@@ -76,6 +76,47 @@ def test_user_enter_handler_survives_tooltip_destroy(app):
     assert fired == [1]  # the tooltip removed only its own binding
 
 
+# ----- container children added after attach (#260) -----
+
+def _covers(target, child) -> bool:
+    """True if `child` carries the target's bindtag (the tip reaches it)."""
+    return str(target.tk) in child.tk.bindtags()
+
+
+def test_child_present_at_attach_is_covered(app):
+    col = bs.Column(parent=app)
+    early = bs.Label("early", parent=col)
+    bs.Tooltip(col, "tip")
+    assert _covers(col, early)
+
+
+def test_child_added_after_attach_needs_refresh(app):
+    col = bs.Column(parent=app)
+    bs.Label("early", parent=col)
+    tip = bs.Tooltip(col, "tip")
+    late = bs.Label("late", parent=col)  # added after the tooltip was created
+    assert not _covers(col, late)  # not auto-covered (the #260 gap)
+    tip.refresh_bindings()
+    assert _covers(col, late)  # refresh extends coverage to it
+
+
+def test_refresh_bindings_is_idempotent(app):
+    col = bs.Column(parent=app)
+    early = bs.Label("early", parent=col)
+    tip = bs.Tooltip(col, "tip")
+    before = list(early.tk.bindtags())
+    tip.refresh_bindings()
+    assert list(early.tk.bindtags()) == before  # no duplicate tag
+
+
+def test_refresh_bindings_safe_after_target_destroyed(app):
+    btn = bs.Button("x")
+    tip = bs.Tooltip(btn, "tip")
+    btn.destroy()
+    app._tk_root.update_idletasks()
+    tip.refresh_bindings()  # must not raise
+
+
 # ----- normal lifecycle -----
 
 def test_construct_and_destroy(app):


### PR DESCRIPTION
Closes #260.

## Problem

A `Tooltip` on a container covers the container's children via
`propagate_target_bindings()`, which tags every descendant **present at attach
time** with the target's bindtag (Tk events don't bubble, so a child needs the
tag for a hover to reach the tooltip's handlers). Children added to the
container *after* the tooltip was created are never tagged, so hovering them
shows nothing.

## What this does

- Adds **`Tooltip.refresh_bindings()`** (public, delegating to a new internal
  method), mirroring `ScrollView.refresh_bindings()`. It re-runs
  `propagate_target_bindings` over the target subtree to cover children added
  after attach. The call is idempotent (already-tagged descendants are left
  untouched) and guarded against a destroyed target.
- Routes `__init__`'s initial subtree coverage through the same method (no
  duplicated logic).
- Documents the present-at-attach coverage and `refresh_bindings()` on the
  Tooltip widget page (new "Covering a container" section), and points the
  `target` arg docstring at it.
- Strips a stray leading byte + BOM from `tooltip.py` that broke the module
  import.

## Verification

New tests in `tests/widgets/public/test_tooltip_review.py`:

- child present at attach is covered
- a child added after attach is **not** covered until `refresh_bindings()`
  (proves both the gap and the fix)
- `refresh_bindings()` is idempotent (no duplicate bindtag)
- safe to call after the target is destroyed

10/10 pass; full GUI suite (`tests/run_gui.py`) passes; clean `-W` docs build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
