### PR TITLE
fix(icons): text+icon Button/MenuButton icon scaled twice at high DPI (#305)

### DIFF
--- a/src/bootstack/style/builders/utils.py
+++ b/src/bootstack/style/builders/utils.py
@@ -211,12 +211,21 @@ def icon_size(icon_only: bool, density: str) -> int:
     if icon_only:
         return 20 if density != 'compact' else 17
 
-    # Get icon size from font ascent for proper alignment with text
-    # Different buffers compensate for y_bias effect per density
+    # Size the icon to the label's cap height (font ascent) for alignment.
+    # Different buffers compensate for y_bias effect per density.
     font_name = 'caption' if density == 'compact' else 'body'
     f = font.nametofont(font_name)
     buffer = 4 if density == 'compact' else 3
-    return f.metrics()['ascent'] + buffer
+    ascent = f.metrics()['ascent'] + buffer
+
+    # The ascent is already in physical pixels (named Tk fonts render at the
+    # current scaling), but this value is handed to normalize_icon_spec, which
+    # re-applies DPI scaling. Return the logical size (divide the scaling back
+    # out) so the icon is scaled exactly once and tracks the cap height at any
+    # DPI, instead of double-scaling to ~ui_scale x too large (#305).
+    from bootstack._runtime.utility import _ScalingState
+    ui_scale = _ScalingState.get_ui_scale() or 1.0
+    return round(ascent / ui_scale)
 
 
 def button_font(density: str) -> str:

--- a/tests/widgets/public/test_button_icon_scale.py
+++ b/tests/widgets/public/test_button_icon_scale.py
@@ -1,0 +1,35 @@
+"""#305 — a text+icon Button/MenuButton icon must DPI-scale once, not twice.
+
+`icon_size()` (the text branch) sizes the icon to the font ascent, which is
+already physical. The value is then handed to `normalize_icon_spec`, which
+re-applies DPI scaling, so the icon must return a *logical* size or it ends up
+~ui_scale x too large at high DPI.
+"""
+from tkinter import font
+
+import pytest
+
+from bootstack._runtime.utility import _ScalingState, scale_size
+from bootstack.style.builders.utils import icon_size
+
+
+def test_icon_only_size_is_logical_and_dpi_invariant(app, monkeypatch):
+    # The icon-only branch returns a logical literal regardless of DPI;
+    # normalize_icon_spec applies the single scale.
+    monkeypatch.setattr(_ScalingState, "get_ui_scale", classmethod(lambda cls: 1.5))
+    assert icon_size(True, "default") == 20
+    assert icon_size(True, "compact") == 17
+
+
+@pytest.mark.parametrize("density", ["default", "compact"])
+def test_text_icon_scales_once_not_twice(app, monkeypatch, density):
+    monkeypatch.setattr(_ScalingState, "get_ui_scale", classmethod(lambda cls: 1.5))
+    font_name = "caption" if density == "compact" else "body"
+    buffer = 4 if density == "compact" else 3
+    ascent = font.nametofont(font_name).metrics()["ascent"] + buffer
+
+    # Re-scaling the logical result (as normalize_icon_spec does) lands back at
+    # ~the ascent — a single scale, not the ascent x ui_scale double-scale.
+    physical = scale_size(icon_size(False, density))
+    assert abs(physical - ascent) <= 1
+    assert physical < round(ascent * 1.5) - 1  # would fail on the double-scale


### PR DESCRIPTION
Closes #305.

## Problem

A `Button` or `MenuButton` with **both a text label and a leading icon**
(`icon_only=False`) rendered its icon at roughly **ui_scale²** on a high/
fractional-DPI display.

`icon_size()`'s text branch sizes the icon to the **font ascent** for cap-height
alignment. But named Tk fonts render at the current scaling, so the ascent is
already physical — and that value is handed to `normalize_icon_spec`, which
re-applies DPI scaling. Two scales instead of one.

## Fix

Return the **logical** size from the text branch (divide the scaling back out)
so `normalize_icon_spec` is the single scaler. Baseline (100% DPI) rendering is
unchanged; only the double-scale is removed. The change is in one function, so
it corrects every text+icon control routed through `icon_size` uniformly
(button / menubutton / buttongroup / togglegroup / toolbutton / sidenav /
calendar).

## Evidence (probe, ui_scale 1.0 → 1.5)

| Path | before | after |
|------|-------:|------:|
| Button (text+icon, `house`) | 19 → **40** | 19 → **26** |
| Button (icon-only, `gear`) | 20 → 29 | 20 → 29 (unchanged) |

## Row-height validation

Verified Button / MenuButton / TextField / Select heights match in a row at both
densities and DPI. This fix **resolves a real misalignment**: the compact
text+icon button was inflated to **65px** at 150% (among 52–55px siblings) — now
**55px**, matching the plain button and MenuButton.

| density | scaling | Button(text+icon) | Button(text) | MenuButton | TextField | Select |
|---------|--------:|------------------:|-------------:|-----------:|----------:|-------:|
| default | 1.0 | 43 | 43 | 43 | 43 | 43 |
| default | 1.5 | 64 | 64 | 64 | 63 | 63 |
| compact | 1.0 | 37 | 37 | 37 | 36 | 36 |
| compact | 1.5 | 55 | 55 | 55 | 52 | 52 |

## Tests

`tests/widgets/public/test_button_icon_scale.py`: the text branch round-trips to
~the font ascent (single scale, would fail on the double-scale); the icon-only
branch stays a logical literal. Full GUI suite passes.

## Note (out of scope)

Compact buttons run ~3px taller than inputs at high DPI (55 vs 52) — the *plain*
button shows this too, so it's a `button_height` vs `field_height` scaling
discrepancy independent of icons. Not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
