### PR TITLE
feat(window): make windowtype cross-platform — win32 now honors it (#308)

### DIFF
--- a/src/bootstack/_runtime/toplevel.py
+++ b/src/bootstack/_runtime/toplevel.py
@@ -62,7 +62,13 @@ class Toplevel(BaseWindow, WidgetCapabilitiesMixin, tkinter.Toplevel):
             resizable: Whether the user may resize the window as (x, y).
             transient: Mark this window as transient for the given master.
             overrideredirect: If True, instruct the window manager to ignore this window.
-            windowtype: On X11, request a specific window manager type via `-type`.
+            windowtype: Request a native window type, resolved per platform from a
+                single switch. Values: `'splash'`, `'tooltip'`, `'dock'`, `'utility'`.
+                On X11 it sets `-type`; on macOS it maps to a `MacWindowStyle`; on
+                Windows the chromeless types (`'splash'`/`'tooltip'`/`'dock'`) resolve
+                to override-redirect (borderless, no taskbar button) and `'utility'`
+                resolves to a tool window. The caller does not also need to pass
+                `overrideredirect=True` to get a chromeless window on Windows.
             topmost: If True, keep this window above others (`-topmost`).
             toolwindow: On Windows, request a toolwindow style (`-toolwindow`).
             alpha: On Windows, the window alpha transparency (0.0–1.0) via `-alpha`.
@@ -124,6 +130,20 @@ class Toplevel(BaseWindow, WidgetCapabilitiesMixin, tkinter.Toplevel):
                 except tkinter.TclError:
                     pass
 
+        # Windows has no native window-type attribute, so translate windowtype
+        # to the matching primitive: the chromeless types resolve to
+        # override-redirect (borderless + no taskbar/Alt-Tab button), and
+        # 'utility' resolves to a tool window (minimal chrome). One switch then
+        # yields the right native window on all three platforms. (On Aqua the
+        # overrideredirect call is a no-op — MacWindowStyle handled it above.)
+        _effective_overrideredirect = overrideredirect
+        _effective_toolwindow = toolwindow
+        if windowtype is not None and self.winsys == "win32":
+            if windowtype in ("splash", "tooltip", "dock"):
+                _effective_overrideredirect = True
+            elif windowtype == "utility":
+                _effective_toolwindow = True
+
         # Setup icon (use default bootstack icon if no icon provided)
         self._setup_icon(icon, default_icon_enabled=True)
 
@@ -169,7 +189,7 @@ class Toplevel(BaseWindow, WidgetCapabilitiesMixin, tkinter.Toplevel):
             maxsize=maxsize,
             resizable=resizable,
             transient=_resolved_transient,
-            overrideredirect=overrideredirect,
+            overrideredirect=_effective_overrideredirect,
             alpha=alpha,
             window_style=window_style,
             center_on_parent=_center_parent,
@@ -188,7 +208,7 @@ class Toplevel(BaseWindow, WidgetCapabilitiesMixin, tkinter.Toplevel):
         if topmost:
             self.attributes("-topmost", 1)
 
-        if toolwindow and self.winsys == "win32":
+        if _effective_toolwindow and self.winsys == "win32":
             self.attributes("-toolwindow", 1)
 
         # Register on_close handler

--- a/tests/widgets/public/test_windowtype.py
+++ b/tests/widgets/public/test_windowtype.py
@@ -1,0 +1,61 @@
+"""Cross-platform `windowtype` mapping on the internal Toplevel (#308).
+
+`windowtype` is a single switch that resolves to the right native window on
+each platform: `-type` on X11, a `MacWindowStyle` on Aqua, and on Windows the
+chromeless types resolve to override-redirect while `'utility'` resolves to a
+tool window. These assert the Windows mapping (the platform this runs on) and
+the cross-platform back-compat for the existing chromeless callers.
+"""
+from __future__ import annotations
+
+import pytest
+
+from bootstack._runtime.toplevel import Toplevel
+
+
+def _winsys(app) -> str:
+    return app._tk_root.tk.call("tk", "windowingsystem")
+
+
+@pytest.mark.parametrize("windowtype", ["splash", "tooltip", "dock"])
+def test_chromeless_types_override_redirect_on_win32(app, windowtype):
+    """splash/tooltip/dock resolve to override-redirect (no chrome) on Windows."""
+    top = Toplevel(windowtype=windowtype)
+    try:
+        if _winsys(app) == "win32":
+            assert bool(top.overrideredirect()) is True
+            assert top.attributes("-toolwindow") == 0
+    finally:
+        top.destroy()
+
+
+def test_utility_type_is_toolwindow_not_chromeless_on_win32(app):
+    """'utility' is a minimal-chrome tool window, never override-redirect."""
+    top = Toplevel(windowtype="utility")
+    try:
+        if _winsys(app) == "win32":
+            assert top.attributes("-toolwindow") == 1
+            assert bool(top.overrideredirect()) is False
+    finally:
+        top.destroy()
+
+
+def test_plain_window_unchanged(app):
+    """No windowtype leaves the window fully decorated."""
+    top = Toplevel()
+    try:
+        assert bool(top.overrideredirect()) is False
+        if _winsys(app) == "win32":
+            assert top.attributes("-toolwindow") == 0
+    finally:
+        top.destroy()
+
+
+def test_explicit_overrideredirect_still_honored(app):
+    """The existing toast/tooltip path (windowtype + explicit override) is unchanged."""
+    top = Toplevel(windowtype="tooltip", overrideredirect=True)
+    try:
+        if _winsys(app) == "win32":
+            assert bool(top.overrideredirect()) is True
+    finally:
+        top.destroy()


### PR DESCRIPTION
## Summary

`Toplevel(windowtype=...)` was honored only on macOS (`MacWindowStyle`) and X11 (`-type`). On Windows it was **never read**, so `windowtype="splash"` produced a borderless window on Mac/Linux but a **fully decorated** one on win32.

This adds a **win32 branch** so one switch yields the right native window on **all three** platforms — the prerequisite for the planned `bs.Splash` widget (#310).

## Changes

- **win32 `windowtype` mapping** (`_runtime/toplevel.py`): chromeless types (`splash`/`tooltip`/`dock`) → `overrideredirect` (borderless + no taskbar/Alt-Tab button); `utility` → `-toolwindow` (minimal chrome). Per the maintainer's decision, this is a **single switch** — the caller does not also need to pass `overrideredirect=True` for a chromeless window on Windows.
- **macOS asymmetry preserved for free**: `overrideredirect()` already no-ops on Aqua (`base_window.py:637`), so the Mac path stays on `MacWindowStyle` and never goes override-redirect.
- **Docstring** updated to describe the cross-platform contract (was "On X11, request a specific window manager type").

## Back-compat

The existing chromeless callers — toast (`overrideredirect=True, windowtype='tooltip'`) and tooltip (same) — pass `overrideredirect=True` explicitly, so their behavior is unchanged. Verified: toast & tooltip test suites green.

## Testing

- New `tests/widgets/public/test_windowtype.py` (6 tests): asserts the win32 mapping (`splash`/`tooltip`/`dock` → override-redirect, no toolwindow; `utility` → toolwindow, not override-redirect; plain unchanged; explicit-override path unchanged).
- Full `tests/run_gui.py` suite: **all legs passed**.

## Acceptance (#308)

- ✅ `Toplevel(windowtype="splash")` yields a borderless, taskbar-suppressed window on Windows, macOS, and X11 from one switch.
- ✅ macOS continues to use `MacWindowStyle` (never `overrideredirect`).
- ✅ Existing toast behavior unchanged.

Closes #308.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
