### PR TITLE
test(events): guard that events.rst documents every public event name

### DIFF
--- a/tests/test_events_doc_coverage.py
+++ b/tests/test_events_doc_coverage.py
@@ -1,0 +1,32 @@
+"""Guard: every public event name is documented in the events API reference.
+
+`bootstack.events.__all__` is the event catalog's public surface; the
+`docs/api-reference/events.rst` page is its one autodoc home. New payloads are
+easy to add to `__all__` and forget on the page (it happened with
+`SashMoveEvent`/`ScrollEvent`), so this asserts the page lists every name —
+either in an `autosummary` group or, for the string-literal aliases, as a
+`.. py:type::` entry.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import bootstack.events as events
+
+EVENTS_RST = Path(__file__).resolve().parent.parent / "docs" / "api-reference" / "events.rst"
+
+
+def test_events_rst_documents_every_public_name():
+    text = EVENTS_RST.read_text(encoding="utf-8")
+    # Tokenize on non-identifier characters so each match is a WHOLE identifier
+    # ("ChangeEvent" stays one token — no substring false positives against
+    # "Event"), then check membership exactly.
+    tokens = set(re.findall(r"[A-Za-z_][A-Za-z0-9_]*", text))
+    missing = sorted(name for name in events.__all__ if name not in tokens)
+    assert not missing, (
+        f"{len(missing)} name(s) in bootstack.events.__all__ are not documented "
+        f"in docs/api-reference/events.rst: {missing}. Add each to the matching "
+        f"payload autosummary group, or — for a string-literal alias — as a "
+        f".. py:type:: entry under Enumerations."
+    )


### PR DESCRIPTION
## Summary

A small no-drift guard. `bootstack.events.__all__` is easy to extend and forget on the API-reference page — `SashMoveEvent`/`ScrollEvent` had drifted out of `docs/api-reference/events.rst`, and `SplashDismissEvent`/`SplashDismissReason` were nearly missed during the splash work (#310).

This adds a test that reads `events.rst` and asserts every name in `__all__` appears on it (in an `autosummary` group, or as a `.. py:type::` entry for the string-literal aliases). It tokenizes on identifier boundaries so `Event` isn't matched as a substring of `ChangeEvent`.

Pure module read — no GUI/`App` needed, runs under plain `pytest`.

## Testing

`pytest tests/test_events_doc_coverage.py` — passes (events.rst currently covers all of `__all__`). The same membership logic is what surfaced the four missing names earlier, so it fails loudly when a name is added to `__all__` but not the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
