### PR TITLE
feat(cli): scaffold builder functions instead of class-based views (#321, #320 P2)

### DIFF
--- a/docs/examples/appshell.py
+++ b/docs/examples/appshell.py
@@ -1,5 +1,13 @@
 import bootstack as bs
 
+
+def metric_card(label, value):
+    """A reusable builder — paints one metric card into the active container."""
+    with bs.Card(padding=16, gap=4):
+        bs.Label(label, font="caption")
+        bs.Label(value, font="heading-md")
+
+
 with bs.AppShell(title="My App", size=(800, 540)) as shell:
 
     # ── Toolbar ───────────────────────────────────────────────────────────────
@@ -14,15 +22,9 @@ with bs.AppShell(title="My App", size=(800, 540)) as shell:
             bs.Label("Dashboard", font="heading-lg")
             bs.Label("Welcome back. Here is your overview.")
             with bs.Grid(columns=3, gap=12, horizontal="stretch"):
-                with bs.Card(padding=16, gap=4):
-                    bs.Label("Revenue", font="caption")
-                    bs.Label("$12,400", font="heading-md")
-                with bs.Card(padding=16, gap=4):
-                    bs.Label("Users", font="caption")
-                    bs.Label("1,280", font="heading-md")
-                with bs.Card(padding=16, gap=4):
-                    bs.Label("Orders", font="caption")
-                    bs.Label("340", font="heading-md")
+                metric_card("Revenue", "$12,400")
+                metric_card("Users", "1,280")
+                metric_card("Orders", "340")
 
         with nav.add_page("inbox", text="Inbox", icon="inbox", padding=24, gap=8):
             bs.Label("Inbox", font="heading-lg")

--- a/docs/production/cli.rst
+++ b/docs/production/cli.rst
@@ -78,7 +78,8 @@ it in. The kinds:
    bootstack add i18n --languages en es  # translatable-text scaffolding
 
 `add page` is for `appshell` projects and `add view` for `basic` projects; each
-generates a class file and prints the lines to paste into `main.py`.
+generates a builder function (`def build_<name>(): ...`) and prints the lines to
+paste into `main.py`. See :doc:`/tasks/composing-with-builders` for the pattern.
 
 Packaging
 ---------

--- a/docs/tasks/composing-with-builders.rst
+++ b/docs/tasks/composing-with-builders.rst
@@ -97,6 +97,20 @@ it runs, so they nest naturally:
    with shell.add_page("people", text="People", icon="people"):
        page_body(records)
 
+Naming
+------
+
+Name a builder for what it makes. A *component* builder is named for the thing it
+builds — ``user_card``, ``action_bar``, ``search_box``. A builder that fills a
+whole page or region is conventionally named ``build_<name>`` — ``build_home``,
+``build_settings`` — which reads as an action at its single call site::
+
+   with shell.add_page("home", text="Home", icon="house"):
+       build_home()
+
+The CLI scaffolds (:doc:`/production/cli`) generate page builders in this
+``build_*`` form, so a generated project already models the pattern.
+
 The one rule
 ------------
 

--- a/src/bootstack/cli/add.py
+++ b/src/bootstack/cli/add.py
@@ -6,7 +6,12 @@ import argparse
 from pathlib import Path
 
 from bootstack.cli.config import TtkbConfig, find_config
-from bootstack.cli.templates import create_dialog, create_page, create_view
+from bootstack.cli.templates import (
+    _build_func_name,
+    create_dialog,
+    create_page,
+    create_view,
+)
 
 
 def add_parser(subparsers: argparse._SubParsersAction) -> None:
@@ -202,6 +207,7 @@ def run_add_page(args: argparse.Namespace) -> None:
     scrollable = args.scrollable
     file_path = create_page(class_name, target_dir, scrollable=scrollable)
 
+    func_name = _build_func_name(class_name)
     print(f"Created page: {file_path.relative_to(project_root)}")
     print()
     print("This created the file only - it is NOT yet shown in the sidebar.")
@@ -209,10 +215,11 @@ def run_add_page(args: argparse.Namespace) -> None:
     print("inside your shell.page_nav() block:")
     print()
     import_module = f"{module_name}.pages" if module_name else "<module>.pages"
-    print(f"  from {import_module}.{file_path.stem} import {class_name}")
+    print(f"  from {import_module}.{file_path.stem} import {func_name}")
     scrollable_arg = ", scrollable=True" if scrollable else ""
-    print(f'  with nav.add_page("<id>", text="<Label>", icon="<icon>"{scrollable_arg}):')
-    print(f"      {class_name}()")
+    print(f'  with nav.add_page("<id>", text="<Label>", icon="<icon>",')
+    print(f'                    padding=20, gap=12, horizontal_items="stretch"{scrollable_arg}):')
+    print(f"      {func_name}()")
 
 
 def run_add_dialog(args: argparse.Namespace) -> None:

--- a/src/bootstack/cli/templates/__init__.py
+++ b/src/bootstack/cli/templates/__init__.py
@@ -23,7 +23,7 @@ Run with: python -m {module_name}
 
 import bootstack as bs
 
-from {module_name}.views.main_view import MainView
+from {module_name}.views.main_view import build_main
 
 
 def main() -> None:
@@ -32,8 +32,13 @@ def main() -> None:
         title="{app_name}",
         theme="{theme}",
         size=(800, 600),
+        padding=20,
+        gap=10,
     ) as app:
-        MainView()
+        # `build_main` is a builder function: it paints its widgets into the
+        # active container (here, the App body). See the "Composing with
+        # Builders" guide.
+        build_main()
 
     app.run()
 
@@ -53,35 +58,21 @@ MAIN_VIEW_GRID_TEMPLATE = '''\
 import bootstack as bs
 
 
-class MainView:
-    """Main application view using a grid layout."""
-
-    def __init__(self, parent=None):
-        with bs.Grid(
-            parent=parent,
-            columns=["auto", 1],
-            gap=10,
-            padding=20,
-            grow=True,
-            horizontal="stretch",
-        ) as self.root:
-            self._build()
-
-    def _build(self) -> None:
+def build_main() -> None:
+    """Build the main view (a two-column grid form)."""
+    # The App body is a column, so open a Grid for the label/field columns.
+    # `horizontal="stretch"` lets the Grid fill the width so the field column grows.
+    with bs.Grid(columns=["auto", 1], gap=10, horizontal="stretch"):
         bs.Label("Welcome to {app_name}", font="heading-lg", columnspan=2)
         bs.Label("Name:")
-        self.name_field = bs.TextField()
+        name_field = bs.TextField()
         bs.Label("Email:")
-        self.email_field = bs.TextField()
-        bs.Button(
-            "Get Started",
-            accent="primary",
-            on_click=self._on_submit,
-            columnspan=2,
-        )
+        email_field = bs.TextField()
 
-    def _on_submit(self) -> None:
-        print(f"Name: {{self.name_field.value}}, Email: {{self.email_field.value}}")
+        def on_submit() -> None:
+            print(f"Name: {{name_field.value}}, Email: {{email_field.value}}")
+
+        bs.Button("Get Started", accent="primary", on_click=on_submit, columnspan=2)
 '''
 
 
@@ -91,27 +82,17 @@ MAIN_VIEW_PACK_TEMPLATE = '''\
 import bootstack as bs
 
 
-class MainView:
-    """Main application view using a vertical stack layout."""
+def build_main() -> None:
+    """Build the main view (a vertical stack of fields)."""
+    # Paints directly into the active container (the padded App body).
+    bs.Label("Welcome to {app_name}", font="heading-lg")
+    name_field = bs.TextField(label="Name:", horizontal="stretch")
+    email_field = bs.TextField(label="Email:", horizontal="stretch")
 
-    def __init__(self, parent=None):
-        with bs.Column(
-            parent=parent,
-            gap=10,
-            padding=20,
-            grow=True,
-            horizontal="stretch",
-        ) as self.root:
-            self._build()
+    def on_submit() -> None:
+        print(f"Name: {{name_field.value}}, Email: {{email_field.value}}")
 
-    def _build(self) -> None:
-        bs.Label("Welcome to {app_name}", font="heading-lg")
-        self.name_field = bs.TextField(label="Name:", horizontal="stretch")
-        self.email_field = bs.TextField(label="Email:", horizontal="stretch")
-        bs.Button("Get Started", accent="primary", on_click=self._on_submit)
-
-    def _on_submit(self) -> None:
-        print(f"Name: {{self.name_field.value}}, Email: {{self.email_field.value}}")
+    bs.Button("Get Started", accent="primary", on_click=on_submit)
 '''
 
 
@@ -120,57 +101,30 @@ class MainView:
 # =============================================================================
 
 VIEW_GRID_TEMPLATE = '''\
-"""
-{class_name} view.
-"""
+"""{title} view."""
 
 import bootstack as bs
 
 
-class {class_name}:
-    """{class_name} view."""
-
-    def __init__(self, parent=None):
-        with bs.Grid(
-            parent=parent,
-            columns=["auto", 1],
-            gap=10,
-            padding=20,
-            grow=True,
-            horizontal="stretch",
-        ) as self.root:
-            self._build()
-
-    def _build(self) -> None:
-        bs.Label("{class_name}", font="heading-lg", columnspan=2)
+def {func_name}() -> None:
+    """Build the {title} view (a two-column grid)."""
+    with bs.Grid(columns=["auto", 1], gap=10, horizontal="stretch"):
+        bs.Label("{title}", font="heading-lg", columnspan=2)
         # Add your widgets here
 '''
 
 
 VIEW_PACK_TEMPLATE = '''\
-"""
-{class_name} view.
-"""
+"""{title} view."""
 
 import bootstack as bs
 
 
-class {class_name}:
-    """{class_name} view."""
-
-    def __init__(self, parent=None):
-        with bs.Column(
-            parent=parent,
-            gap=10,
-            padding=20,
-            grow=True,
-            horizontal="stretch",
-        ) as self.root:
-            self._build()
-
-    def _build(self) -> None:
-        bs.Label("{class_name}", font="heading-lg")
-        # Add your widgets here
+def {func_name}() -> None:
+    """Build the {title} view."""
+    # Paints into the active container; the caller supplies padding/gap.
+    bs.Label("{title}", font="heading-lg")
+    # Add your widgets here
 '''
 
 
@@ -318,8 +272,8 @@ Run with: python -m {module_name}
 
 import bootstack as bs
 
-from {module_name}.pages.home_page import HomePage
-from {module_name}.pages.settings_page import SettingsPage
+from {module_name}.pages.home_page import build_home
+from {module_name}.pages.settings_page import build_settings
 
 
 def main() -> None:
@@ -332,12 +286,17 @@ def main() -> None:
     ) as shell:
 {chrome}
         # --- Navigation: a flat sidebar of pages ----------------------------
+        # Each page IS a layout container, so configure padding/gap/alignment on
+        # add_page() and let the page's builder paint straight into it.
         with shell.page_nav() as nav:
-            with nav.add_page("home", text="Home", icon="house"):
-                HomePage()
+            with nav.add_page("home", text="Home", icon="house",
+                              padding=20, gap=12, horizontal_items="stretch"):
+                build_home()
 
-            with nav.add_page("settings", text="Settings", icon="gear", pin_to_footer=True):
-                SettingsPage()
+            with nav.add_page("settings", text="Settings", icon="gear",
+                              pin_to_footer=True, padding=20, gap=12,
+                              horizontal_items="stretch"):
+                build_settings()
 
         shell.navigate("home")
 
@@ -358,10 +317,10 @@ Run with: python -m {module_name}
 
 import bootstack as bs
 
-from {module_name}.pages.home_page import HomePage
-from {module_name}.pages.reports_page import ReportsPage
-from {module_name}.pages.profile_page import ProfilePage
-from {module_name}.pages.settings_page import SettingsPage
+from {module_name}.pages.home_page import build_home
+from {module_name}.pages.reports_page import build_reports
+from {module_name}.pages.profile_page import build_profile
+from {module_name}.pages.settings_page import build_settings
 
 
 def main() -> None:
@@ -374,19 +333,26 @@ def main() -> None:
     ) as shell:
 {chrome}
         # --- Navigation: pages grouped under section headers ----------------
+        # Each page IS a layout container, so configure padding/gap/alignment on
+        # add_page() and let the page's builder paint straight into it.
         with shell.page_nav() as nav:
             nav.add_header("Workspace")
-            with nav.add_page("home", text="Home", icon="house"):
-                HomePage()
-            with nav.add_page("reports", text="Reports", icon="bar-chart"):
-                ReportsPage()
+            with nav.add_page("home", text="Home", icon="house",
+                              padding=20, gap=12, horizontal_items="stretch"):
+                build_home()
+            with nav.add_page("reports", text="Reports", icon="bar-chart",
+                              padding=20, gap=12, horizontal_items="stretch"):
+                build_reports()
 
             nav.add_header("Account")
-            with nav.add_page("profile", text="Profile", icon="person"):
-                ProfilePage()
+            with nav.add_page("profile", text="Profile", icon="person",
+                              padding=20, gap=12, horizontal_items="stretch"):
+                build_profile()
 
-            with nav.add_page("settings", text="Settings", icon="gear", pin_to_footer=True):
-                SettingsPage()
+            with nav.add_page("settings", text="Settings", icon="gear",
+                              pin_to_footer=True, padding=20, gap=12,
+                              horizontal_items="stretch"):
+                build_settings()
 
         shell.navigate("home")
 
@@ -408,7 +374,7 @@ Run with: python -m {module_name}
 import bootstack as bs
 from bootstack.data import MemoryDataSource
 
-from {module_name}.pages.detail_view import DetailView
+from {module_name}.pages.detail_view import build_detail
 
 # Sample records drive the sidebar list. Swap in your own data source.
 RECORDS = MemoryDataSource().load([
@@ -428,11 +394,13 @@ def main() -> None:
     ) as shell:
 {chrome}
         # --- Navigation: a record list drives a detail view -----------------
+        # `build_detail` is a builder: it paints the selected record into the
+        # detail region each time the selection changes.
         shell.list_nav(RECORDS)
 
         @shell.detail
         def show(record):
-            DetailView(record)
+            build_detail(record)
 
     shell.run()
 
@@ -451,9 +419,9 @@ Run with: python -m {module_name}
 
 import bootstack as bs
 
-from {module_name}.pages.home_page import HomePage
-from {module_name}.pages.reports_page import ReportsPage
-from {module_name}.pages.settings_page import SettingsPage
+from {module_name}.pages.home_page import build_home
+from {module_name}.pages.reports_page import build_reports
+from {module_name}.pages.settings_page import build_settings
 
 
 def main() -> None:
@@ -467,20 +435,25 @@ def main() -> None:
     ) as shell:
 {chrome}
         # --- Navigation: a labeled rail of workspaces -----------------------
+        # Each page IS a layout container, so configure padding/gap/alignment on
+        # add_page() and let the page's builder paint straight into it.
         with shell.add_workspace("home", text="Home", icon="house") as ws:
             with ws.page_nav() as nav:
-                with nav.add_page("overview", text="Overview", icon="speedometer2"):
-                    HomePage()
+                with nav.add_page("overview", text="Overview", icon="speedometer2",
+                                  padding=20, gap=12, horizontal_items="stretch"):
+                    build_home()
 
         with shell.add_workspace("reports", text="Reports", icon="bar-chart") as ws:
             with ws.page_nav() as nav:
-                with nav.add_page("monthly", text="Monthly", icon="calendar3"):
-                    ReportsPage()
+                with nav.add_page("monthly", text="Monthly", icon="calendar3",
+                                  padding=20, gap=12, horizontal_items="stretch"):
+                    build_reports()
 
         with shell.add_workspace("settings", text="Settings", icon="gear", pin_to_footer=True) as ws:
             with ws.page_nav() as nav:
-                with nav.add_page("general", text="General", icon="sliders"):
-                    SettingsPage()
+                with nav.add_page("general", text="General", icon="sliders",
+                                  padding=20, gap=12, horizontal_items="stretch"):
+                    build_settings()
 
     shell.run()
 
@@ -496,27 +469,26 @@ APPSHELL_HOME_PAGE_TEMPLATE = '''\
 import bootstack as bs
 
 
-class HomePage:
-    """Home page content."""
+def build_home():
+    """Build the Home page.
 
-    def __init__(self, parent=None):
-        with bs.Column(parent=parent, padding=20, gap=12, grow=True, horizontal="stretch") as self.root:
-            self._build()
-
-    def _build(self):
-        bs.Label("Welcome to {app_name}", font="heading-xl")
+    A builder function: it paints into the active container. The page region
+    (configured on `nav.add_page(...)` in main.py) supplies the padding and gap,
+    so there is no extra layout wrapper here.
+    """
+    bs.Label("Welcome to {app_name}", font="heading-xl")
+    bs.Label(
+        "This is your home page. Edit this file to get started.",
+        wrap_width=500,
+    )
+    with bs.GroupBox("Getting Started", grow=True, horizontal="stretch"):
         bs.Label(
-            "This is your home page. Edit this file to get started.",
-            wrap_width=500,
+            "Add your widgets here.\\n\\n"
+            "To add another page:\\n"
+            "  1. Run \\'bootstack add page <Name>\\' to generate the file.\\n"
+            "  2. In main.py, add a \\'with nav.add_page(...):\\' block inside\\n"
+            "     your \\'shell.page_nav()\\' and call the page's build_* function in it."
         )
-        with bs.GroupBox("Getting Started", grow=True, horizontal="stretch"):
-            bs.Label(
-                "Add your widgets here.\\n\\n"
-                "To add another page:\\n"
-                "  1. Run \\'bootstack add page <Name>\\' to generate the file.\\n"
-                "  2. In main.py, add a \\'with nav.add_page(...):\\' block inside\\n"
-                "     your \\'shell.page_nav()\\' and instantiate the page class in it."
-            )
 '''
 
 
@@ -526,20 +498,14 @@ APPSHELL_SETTINGS_PAGE_TEMPLATE = '''\
 import bootstack as bs
 
 
-class SettingsPage:
-    """Settings page content."""
-
-    def __init__(self, parent=None):
-        with bs.Column(parent=parent, padding=20, gap=12, grow=True, horizontal="stretch") as self.root:
-            self._build()
-
-    def _build(self):
-        bs.Label("Settings", font="heading-xl[bold]")
-        bs.Label("Configure your application preferences.", wrap_width=500)
-        with bs.GroupBox("Preferences", grow=True, horizontal="stretch"):
-            with bs.Row(gap=8):
-                bs.Label("Theme:")
-                bs.ThemeToggle()
+def build_settings():
+    """Build the Settings page."""
+    bs.Label("Settings", font="heading-xl")
+    bs.Label("Configure your application preferences.", wrap_width=500)
+    with bs.GroupBox("Preferences", grow=True, horizontal="stretch"):
+        with bs.Row(gap=8):
+            bs.Label("Theme:")
+            bs.ThemeToggle()
 '''
 
 
@@ -549,17 +515,11 @@ APPSHELL_PAGE_TEMPLATE = '''\
 import bootstack as bs
 
 
-class {class_name}:
-    """{page_title} page content."""
-
-    def __init__(self, parent=None):
-        with bs.Column(parent=parent, padding=20, gap=12, grow=True, horizontal="stretch") as self.root:
-            self._build()
-
-    def _build(self):
-        bs.Label("{page_title}", font="heading-lg")
-        with bs.GroupBox("Content", grow=True, horizontal="stretch"):
-            pass  # Add your widgets here
+def {func_name}():
+    """Build the {page_title} page."""
+    bs.Label("{page_title}", font="heading-lg")
+    with bs.GroupBox("Content", grow=True, horizontal="stretch"):
+        pass  # Add your widgets here
 '''
 
 
@@ -569,17 +529,11 @@ APPSHELL_CONTENT_PAGE_TEMPLATE = '''\
 import bootstack as bs
 
 
-class {class_name}:
-    """{page_title} page content."""
-
-    def __init__(self, parent=None):
-        with bs.Column(parent=parent, padding=20, gap=12, grow=True, horizontal="stretch") as self.root:
-            self._build()
-
-    def _build(self):
-        bs.Label("{page_title}", font="heading-lg")
-        with bs.GroupBox("Content", grow=True, horizontal="stretch"):
-            bs.Label("Add your widgets here.")
+def {func_name}():
+    """Build the {page_title} page."""
+    bs.Label("{page_title}", font="heading-lg")
+    with bs.GroupBox("Content", grow=True, horizontal="stretch"):
+        bs.Label("Add your widgets here.")
 '''
 
 
@@ -589,17 +543,15 @@ APPSHELL_DETAIL_VIEW_TEMPLATE = '''\
 import bootstack as bs
 
 
-class DetailView:
-    """Renders the record selected in the master list."""
+def build_detail(record):
+    """Build the detail view for the selected record.
 
-    def __init__(self, record, parent=None):
-        self.record = record
-        with bs.Column(parent=parent, padding=20, gap=12, grow=True, horizontal="stretch") as self.root:
-            self._build()
-
-    def _build(self):
-        bs.Label(self.record["title"], font="heading-lg")
-        bs.Label(self.record.get("text", ""), accent="secondary")
+    The detail region is a plain fill area, so this builder opens its own
+    padded `Column` to frame the content.
+    """
+    with bs.Column(padding=20, gap=12, horizontal_items="stretch"):
+        bs.Label(record["title"], font="heading-lg")
+        bs.Label(record.get("text", ""), accent="secondary")
         bs.Divider(horizontal="stretch")
         bs.Label("Detail content for this record goes here.")
 '''
@@ -629,9 +581,10 @@ bootstack run
 bootstack add page DashboardPage
 
 # Then wire it up in main.py, inside your shell.page_nav() block:
-#   from {module_name}.pages.dashboard_page import DashboardPage
-#   with nav.add_page("dashboard", text="Dashboard", icon="speedometer2"):
-#       DashboardPage()
+#   from {module_name}.pages.dashboard_page import build_dashboard
+#   with nav.add_page("dashboard", text="Dashboard", icon="speedometer2",
+#                     padding=20, gap=12, horizontal_items="stretch"):
+#       build_dashboard()
 ```
 
 ### Building for Distribution
@@ -688,17 +641,9 @@ def create_page(
     """
     file_name = _camel_to_snake(class_name) + ".py"
 
-    # Derive a readable title from the class name (e.g. "DashboardPage" -> "Dashboard")
-    page_title = class_name
-    if page_title.endswith("Page"):
-        page_title = page_title[:-4]
-    # Insert spaces before uppercase letters
-    import re
-    page_title = re.sub(r"([a-z])([A-Z])", r"\1 \2", page_title)
-
     content = APPSHELL_PAGE_TEMPLATE.format(
-        class_name=class_name,
-        page_title=page_title,
+        func_name=_build_func_name(class_name),
+        page_title=_readable_title(class_name),
     )
 
     file_path = target_dir / file_name
@@ -857,7 +802,7 @@ def _create_appshell_project(
 
     def _write_content_page(class_name: str, title: str) -> None:
         content = APPSHELL_CONTENT_PAGE_TEMPLATE.format(
-            class_name=class_name, page_title=title
+            func_name=_build_func_name(class_name), page_title=title
         )
         (pages_dir / f"{_camel_to_snake(class_name)}.py").write_text(
             content, encoding="utf-8"
@@ -923,7 +868,10 @@ def create_view(
     else:
         template = VIEW_PACK_TEMPLATE
 
-    content = template.format(class_name=class_name)
+    content = template.format(
+        func_name=_build_func_name(class_name),
+        title=_readable_title(class_name),
+    )
 
     file_path = target_dir / file_name
     file_path.write_text(content, encoding="utf-8")
@@ -960,3 +908,24 @@ def _camel_to_snake(name: str) -> str:
     # Insert underscore before uppercase letters and lowercase
     s1 = re.sub("(.)([A-Z][a-z]+)", r"\1_\2", name)
     return re.sub("([a-z0-9])([A-Z])", r"\1_\2", s1).lower()
+
+
+def _strip_kind_suffix(name: str) -> str:
+    """Drop a trailing `Page`/`View` from a CamelCase name (keep if it's all there is)."""
+    for suffix in ("Page", "View"):
+        if name.endswith(suffix) and len(name) > len(suffix):
+            return name[: -len(suffix)]
+    return name
+
+
+def _build_func_name(class_name: str) -> str:
+    """Derive a builder function name from a name (e.g. `DashboardPage` -> `build_dashboard`)."""
+    return "build_" + _camel_to_snake(_strip_kind_suffix(class_name))
+
+
+def _readable_title(class_name: str) -> str:
+    """Derive a readable title from a name (e.g. `DashboardPage` -> `Dashboard`)."""
+    import re
+
+    base = _strip_kind_suffix(class_name)
+    return re.sub(r"([a-z])([A-Z])", r"\1 \2", base)

--- a/tests/cli/test_templates.py
+++ b/tests/cli/test_templates.py
@@ -93,13 +93,17 @@ def test_create_basic_project(tmp_path: Path, container: str, simple: bool) -> N
     # subclass for the chosen container.
     main_src = (target / "src" / "myapp" / "main.py").read_text(encoding="utf-8")
     assert 'theme="cosmo"' in main_src
-    assert "from myapp.views.main_view import MainView" in main_src
+    assert "from myapp.views.main_view import build_main" in main_src
 
-    view_src = (target / "src" / "myapp" / "views" / "main_view.py").read_text(encoding="utf-8")
+    # The view is a builder function, not a class.
+    view_path = target / "src" / "myapp" / "views" / "main_view.py"
+    view_src = view_path.read_text(encoding="utf-8")
+    funcs = [n.name for n in ast.walk(_assert_python_parses(view_path)) if isinstance(n, ast.FunctionDef)]
+    assert "build_main" in funcs
     if container == "grid":
         assert "bs.Grid" in view_src
     else:
-        assert "bs.Column" in view_src
+        assert "bs.Column" not in view_src  # pack view paints directly, no wrapper
 
 
 # ---------------------------------------------------------------------------
@@ -136,7 +140,16 @@ def test_create_appshell_project(tmp_path: Path, simple: bool) -> None:
     main_src = (target / "src" / "myshell" / "main.py").read_text(encoding="utf-8")
     assert "bs.AppShell" in main_src
     assert 'theme="superhero"' in main_src
-    assert "HomePage" in main_src and "SettingsPage" in main_src
+    # Pages are wired in as builder functions, called inside add_page() blocks.
+    assert "build_home()" in main_src and "build_settings()" in main_src
+    home_path = target / "src" / "myshell" / "pages" / "home_page.py"
+    home_funcs = [
+        n.name for n in ast.walk(_assert_python_parses(home_path))
+        if isinstance(n, ast.FunctionDef)
+    ]
+    assert "build_home" in home_funcs
+    # The page builder paints directly into the page region — no inner wrapper.
+    assert "bs.Column" not in home_path.read_text(encoding="utf-8")
 
 
 # ---------------------------------------------------------------------------
@@ -168,10 +181,13 @@ def test_create_view(tmp_path: Path, container: str) -> None:
     out = create_view("ProfileView", tmp_path, container=container)
     assert out.name == "profile_view.py"
     mod = _assert_python_parses(out)
-    classes = [n.name for n in ast.walk(mod) if isinstance(n, ast.ClassDef)]
-    assert "ProfileView" in classes
+    funcs = [n.name for n in ast.walk(mod) if isinstance(n, ast.FunctionDef)]
+    assert "build_profile" in funcs
     src = out.read_text(encoding="utf-8")
-    assert ("bs.Grid" if container == "grid" else "bs.Column") in src
+    if container == "grid":
+        assert "bs.Grid" in src
+    else:
+        assert "bs.Column" not in src  # pack view paints directly
 
 
 def test_create_dialog(tmp_path: Path) -> None:
@@ -186,8 +202,9 @@ def test_create_page_camel_to_snake(tmp_path: Path) -> None:
     out = create_page("DashboardPage", tmp_path)
     assert out.name == "dashboard_page.py"
     mod = _assert_python_parses(out)
-    classes = [n.name for n in ast.walk(mod) if isinstance(n, ast.ClassDef)]
-    assert "DashboardPage" in classes
+    funcs = [n.name for n in ast.walk(mod) if isinstance(n, ast.FunctionDef)]
+    # Builder function strips the trailing 'Page' suffix
+    assert "build_dashboard" in funcs
     # Page title strips trailing 'Page' for the heading
     src = out.read_text(encoding="utf-8")
     assert '"Dashboard"' in src


### PR DESCRIPTION
Closes #321. Closes #320 (Part 2 — examples/demo audit; Part 1 + the `_resolve_parent` guard shipped in #329).

## #321 — CLI scaffolds: class → builder

Flip every page/view scaffold from a class (`__init__`/`_build`/`self.root`) to a `build_<name>()` builder function — the shape blessed by the **Composing with Builders** how-to. The widget resolves its parent from the active container at construction time, so a builder paints into whatever page/region is open when it's called; no `parent=` threading, no inner wrapper.

- **AppShell pages** paint directly into the page region — `padding`/`gap`/`horizontal_items` move onto `nav.add_page(...)` (the page *is* the column).
- **Basic pack view** paints into the padded App body; **grid view** opens a `bs.Grid` (a layout the column body doesn't provide — not redundant).
- **Master-detail** `build_detail(record)` opens its own padded `Column` (the detail region is a bare fill area).
- Stateful handlers become closures over local field refs (`on_submit`) instead of `self.*` methods — the documented "builder default, class is the escape hatch" story.
- `add page` / `add view` emit `build_<name>` (suffix-stripped: `DashboardPage` → `build_dashboard`) and print matching wiring hints. New `_build_func_name` / `_readable_title` helpers. READMEs + `production/cli.rst` updated.

**Naming convention (locked):** *component* builders are named for what they build (`user_card`, bare); *page/region* builders are `build_<name>`. A new **Naming** note in the how-to ties the scaffolds and the how-to into one system.

## #320 Part 2 — examples model the pattern

- `docs/examples/appshell.py` factors its 3 longhand metric cards into a reusable `metric_card(label, value)` builder — the flagship example now *demonstrates* the pattern.
- Nav examples were already clean from the navigation reshape (no class views remain anywhere in `docs/examples`/`docs/screenshots`).
- The `bootstack gallery` demo already uses `_build_*` builder functions; left as-is (its inner `Column` provides scroll-content padding for `scrollable=True` pages — a legitimate builder, not class-view redundancy).

## Verification

- All **6 scaffold variants** (basic grid/pack; appshell single/grouped/master-detail/workspaces) scaffolded and **built without error** in isolated subprocesses.
- `bootstack add page` / `add view` produce correct builders; the **printed wiring hint builds end-to-end**.
- `tests/cli/` + `test_public_surface.py`: **186 passed** (template tests updated to assert builder functions + absence of redundant wrappers).
- **Clean `-W` docs build: 0 warnings.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)