### PR TITLE
fix(dev): hot-reload follow-ups #325, #326, #327 (+ #328 docs)

### DIFF
--- a/docs/production/hot-reload.rst
+++ b/docs/production/hot-reload.rst
@@ -174,6 +174,23 @@ session stays up and relaunches when you fix the file and save. For everyday UI
 work the default in-process reload is faster and more forgiving; prefer it unless
 you specifically need the cold start.
 
+Gating dev-only code
+--------------------
+
+``is_dev_mode()`` reports whether the app is running under ``bootstack dev``. Use
+it to gate instrumentation you only want while developing — extra logging, a debug
+panel, or seeded sample data:
+
+.. code-block:: python
+
+   from bootstack.dev import is_dev_mode
+
+   if is_dev_mode():
+       bs.Label("DEV BUILD", accent="warning")
+
+It returns ``False`` under a normal ``python app.py`` run, so the guarded code
+costs nothing in production.
+
 Platform support
 ----------------
 
@@ -186,9 +203,12 @@ cross-platform. A few platform notes:
   before the updated menus appear — the rebuild already happened.
 - **Restart fallback** works the same on Windows, macOS, and Linux — ``bootstack
   dev`` supervises the app and relaunches it on save.
-- **File watching** uses modification times polled a few times a second. On
-  filesystems with coarse timestamp resolution, two saves within the same tick
-  may coalesce into one reload; the next save always catches up.
+- **File watching** polls modification times and file sizes a few times a second
+  over your project's ``src/`` tree (or the entry file's directory when you run a
+  loose script outside a project), so edits to any module are picked up — not just
+  the entry file. On filesystems with coarse timestamp resolution, two saves within
+  the same tick may still coalesce into one reload; the next save always catches up.
+  Symlinked directories are not followed.
 
 See also
 --------

--- a/src/bootstack/dev/_reloader.py
+++ b/src/bootstack/dev/_reloader.py
@@ -33,6 +33,29 @@ from bootstack.dev._watcher import PollWatcher
 _PREFIX = "[bootstack dev]"
 
 
+def _project_watch_root(start: str) -> str:
+    """Widen the watch root from a starting file to the project tree.
+
+    Walks up from `start` looking for a `bootstack.toml`; when found, watches its
+    `src/` subtree if present (the conventional layout) else the project dir — so
+    edits to any module in the project, not just the entry file's directory, are
+    picked up. Falls back to the starting file's directory when no project marker
+    is found.
+    """
+    start = os.path.abspath(start)
+    cur = start if os.path.isdir(start) else os.path.dirname(start)
+    base = cur
+    for _ in range(40):  # bounded walk-up
+        if os.path.isfile(os.path.join(cur, "bootstack.toml")):
+            src = os.path.join(cur, "src")
+            return src if os.path.isdir(src) else cur
+        parent = os.path.dirname(cur)
+        if parent == cur:
+            break
+        cur = parent
+    return base
+
+
 def install_reloader(app: Any) -> None:
     """Install the appropriate reloader for the running app, if in dev mode."""
     if not is_dev_mode():
@@ -119,7 +142,7 @@ class _RestartReloader(_BaseReloader):
 
     def _watch_root(self) -> str:
         entry = sys.argv[0] if sys.argv and sys.argv[0] else os.getcwd()
-        return os.path.dirname(os.path.abspath(entry)) or os.getcwd()
+        return _project_watch_root(entry) or os.getcwd()
 
     def _handle(self, changed: set[str]) -> None:
         _log("change detected - restarting")
@@ -161,7 +184,7 @@ class _InProcessReloader(_BaseReloader):
         _log(f"hot reload active - editing {rel} updates the running app on save")
 
     def _watch_root(self) -> str:
-        return os.path.dirname(os.path.abspath(self.capture.filename))
+        return _project_watch_root(self.capture.filename)
 
     def _handle(self, changed: set[str]) -> None:
         entry = os.path.abspath(self.capture.filename)
@@ -170,17 +193,24 @@ class _InProcessReloader(_BaseReloader):
         page_files = changed_abs - {entry}
 
         try:
-            reloaded = self._reload_modules(page_files)
-
-            # Per-page fast path: only page module(s) changed and their builders
-            # are registered — rebuild just those regions, skip the entry body.
-            if not entry_changed and reloaded:
-                if self._reinvoke_pages(reloaded):
+            # Per-page fast path: the entry is unchanged AND every changed file is a
+            # module that holds registered @reloadable builders — rebuild just those
+            # regions, skip the entry body. A changed module WITHOUT a builder
+            # (constants/models with module-level state) must take the full path:
+            # importlib.reload would otherwise split object identity (fresh objects
+            # while live widgets still hold the old ones) without rebinding. (#326)
+            builder_files = set(self._builder_module_files())
+            if not entry_changed and page_files and page_files <= builder_files:
+                reloaded = self._reload_modules(page_files)
+                if reloaded and self._reinvoke_pages(reloaded):
                     self._clear_error()
                     self.app._dev_after_rebuild()
                     _log("reloaded " + ", ".join(sorted(reloaded)))
                     return
 
+            # Full reload: reload any changed project modules first (so the re-exec'd
+            # entry body rebinds to the fresh objects), then re-run the body.
+            self._reload_modules(page_files)
             self._full_reload()
             self._clear_error()
             _log("reloaded")
@@ -226,6 +256,17 @@ class _InProcessReloader(_BaseReloader):
         if ran:
             self._prune_style_registry()
         return ran
+
+    def _builder_module_files(self) -> dict[str, str]:
+        """Map abspath -> module name for loaded modules holding registered builders."""
+        from bootstack.dev import _registry
+
+        out: dict[str, str] = {}
+        for name, module in list(sys.modules.items()):
+            path = getattr(module, "__file__", None)
+            if path and _registry.builders_in_module(name):
+                out[os.path.abspath(path)] = name
+        return out
 
     def _reload_modules(self, files: set[str]) -> set[str]:
         """importlib.reload any loaded project module whose file changed."""

--- a/src/bootstack/dev/_watcher.py
+++ b/src/bootstack/dev/_watcher.py
@@ -32,7 +32,9 @@ class PollWatcher:
         self._suffixes = suffixes
         self._thread: threading.Thread | None = None
         self._stop = threading.Event()
-        self._snapshot: dict[str, float] = {}
+        # Per-file (mtime, size): size catches a same-tick save whose mtime did
+        # not advance past the filesystem's coarse resolution.
+        self._snapshot: dict[str, tuple[float, int]] = {}
 
     def start(self) -> None:
         """Take a baseline snapshot and begin watching on a daemon thread."""
@@ -56,8 +58,8 @@ class PollWatcher:
                 continue
             changed = {
                 path
-                for path, mtime in current.items()
-                if self._snapshot.get(path) != mtime
+                for path, stamp in current.items()
+                if self._snapshot.get(path) != stamp
             }
             # Deletions also count as changes worth a reload attempt.
             changed |= {p for p in self._snapshot if p not in current}
@@ -69,8 +71,9 @@ class PollWatcher:
                     # The watcher thread must never die on a callback error.
                     pass
 
-    def _scan(self) -> dict[str, float]:
-        result: dict[str, float] = {}
+    def _scan(self) -> dict[str, tuple[float, int]]:
+        result: dict[str, tuple[float, int]] = {}
+        # Symlinked directories are not followed (os.walk default) — avoids cycles.
         for dirpath, dirnames, filenames in os.walk(self._root):
             # Skip the usual noise so a save doesn't churn over caches/venvs.
             dirnames[:] = [
@@ -81,7 +84,8 @@ class PollWatcher:
                 if name.endswith(self._suffixes):
                     full = os.path.join(dirpath, name)
                     try:
-                        result[full] = os.path.getmtime(full)
+                        st = os.stat(full)
+                        result[full] = (st.st_mtime, st.st_size)
                     except OSError:
                         continue
         return result

--- a/src/bootstack/widgets/_core/window_menu.py
+++ b/src/bootstack/widgets/_core/window_menu.py
@@ -218,6 +218,22 @@ class ChromeHostMixin:
         except Exception:
             self._rebuild_native_menu()
 
+    def _cancel_native_menu_pending(self) -> None:
+        """Cancel a scheduled native-menu rebuild and clear the handle.
+
+        Used on teardown / dev-reload reset: an `after_idle` rebuild scheduled
+        just before a reset would otherwise fire against freshly-rebuilt chrome.
+        """
+        pending = getattr(self, "_native_menu_pending", None)
+        if pending is not None:
+            root = self._menu_root()
+            if root is not None:
+                try:
+                    root.after_cancel(pending)
+                except Exception:
+                    pass
+        self._native_menu_pending = None
+
     def _rebuild_native_menu(self) -> None:
         from bootstack.widgets._impl.composites.menu.render_native import NativeMenuBar
 

--- a/src/bootstack/widgets/app.py
+++ b/src/bootstack/widgets/app.py
@@ -317,7 +317,7 @@ class App(AppConfigMixin, WindowControlsMixin, ChromeHostMixin, FlexContainer):
         self._toolbar_stack = None
         self._chrome_toolbars = []
         self._native_menu_renderer = None
-        self._native_menu_pending = None
+        self._cancel_native_menu_pending()
         # Clear the native menu bar (macOS) so a rebuild doesn't double it.
         try:
             root = self._menu_root()

--- a/src/bootstack/widgets/appshell.py
+++ b/src/bootstack/widgets/appshell.py
@@ -472,9 +472,14 @@ class _ShellBase(AppConfigMixin, WindowControlsMixin, ChromeHostMixin, PublicWid
                 self._app_icon_photo = icon_image._materialize()
                 self._internal._setup_icon(self._app_icon_photo)
 
+        # Remember whether the band was forced on, so a dev reload can restore it.
+        self._show_statusbar_forced = bool(show_statusbar)
         if show_statusbar:
-            # Materialize the band now so it is present from the first frame.
+            # Materialize the band and force it visible now so it is present from
+            # the first frame (a content-driven band shows lazily on its first
+            # segment; `show_statusbar=True` means "always on").
             _ = self.statusbar
+            self._internal.set_statusbar_visible(True)
 
     @classmethod
     def from_store(cls, store: Any, **overrides: Any):
@@ -523,7 +528,7 @@ class _ShellBase(AppConfigMixin, WindowControlsMixin, ChromeHostMixin, PublicWid
             pass
         self._chrome_toolbars = []
         self._native_menu_renderer = None
-        self._native_menu_pending = None
+        self._cancel_native_menu_pending()
         try:
             self._internal["menu"] = ""
         except Exception:
@@ -535,6 +540,15 @@ class _ShellBase(AppConfigMixin, WindowControlsMixin, ChromeHostMixin, PublicWid
         except Exception:
             pass
         self._statusbar = None
+        # Reset the band to its forced state: hidden unless `show_statusbar=True`
+        # was passed (an empty band shouldn't linger if the new body adds no
+        # segment; a content-driven band re-shows lazily on the first segment).
+        try:
+            self._internal.set_statusbar_visible(
+                getattr(self, "_show_statusbar_forced", False)
+            )
+        except Exception:
+            pass
         # Tear down + rebuild the navigation substructure.
         self._internal._dev_reset()
         try:

--- a/tests/test_hot_reload.py
+++ b/tests/test_hot_reload.py
@@ -203,13 +203,49 @@ def test_pollwatcher_scan_detects_change(tmp_path):
     assert any(p.endswith("a.py") for p in snap)
     assert not any(p.endswith("note.txt") for p in snap)
 
-    # A changed mtime shows up against the snapshot.
-    import os, time
+    # The snapshot stamps each file with (mtime, size).
     target = str(tmp_path / "a.py")
-    os.utime(target, (snap[target] + 5, snap[target] + 5))
+    assert isinstance(snap[target], tuple) and len(snap[target]) == 2
+
+    # A changed mtime shows up against the snapshot.
+    import os
+    mtime, _size = snap[target]
+    os.utime(target, (mtime + 5, mtime + 5))
     snap2 = watcher._scan()
     changed = {p for p, m in snap2.items() if snap.get(p) != m}
     assert target in changed
+
+    # A same-mtime save that changes size is also detected (size catches it).
+    (tmp_path / "a.py").write_text("x = 1234567890", encoding="utf-8")
+    new_mtime, _ = snap2[target]
+    os.utime(target, (new_mtime, new_mtime))  # pin mtime back to the snapshot's
+    snap3 = watcher._scan()
+    changed2 = {p for p, m in snap3.items() if snap2.get(p) != m}
+    assert target in changed2
+
+
+def test_project_watch_root_widens_to_src(tmp_path):
+    from bootstack.dev._reloader import _project_watch_root
+
+    # A toml project with a src/ layout: watch the whole src/ tree, not just the
+    # entry file's directory (so edits to sibling packages are picked up). (#327)
+    (tmp_path / "bootstack.toml").write_text("[app]\nname='x'\n", encoding="utf-8")
+    entry = tmp_path / "src" / "myapp" / "main.py"
+    entry.parent.mkdir(parents=True)
+    entry.write_text("x = 1", encoding="utf-8")
+
+    assert _project_watch_root(str(entry)) == str(tmp_path / "src")
+
+
+def test_project_watch_root_falls_back_to_file_dir(tmp_path):
+    from bootstack.dev._reloader import _project_watch_root
+
+    # A loose script outside any project: watch its own directory (prior behavior).
+    loose = tmp_path / "scratch" / "app.py"
+    loose.parent.mkdir(parents=True)
+    loose.write_text("x = 1", encoding="utf-8")
+
+    assert _project_watch_root(str(loose)) == str(loose.parent)
 
 
 def test_pollwatcher_skips_pycache(tmp_path):


### PR DESCRIPTION
Closes #325. Closes #326. Closes #327. Addresses the docs half of #328 (the E2E multi-file reload test is deferred to a follow-up).

All changes are on the **provisional `bootstack.dev`** surface (excluded from the 0.1.0 freeze).

## #325 — dev-reset cleanup gaps

- **Stale status band.** `AppShell._dev_reset_region` now restores the band to its forced state (`set_statusbar_visible(False)` unless `show_statusbar=True`), so an empty hairline band no longer lingers after a reload whose new body adds no status segment. As part of this, `show_statusbar=True` now genuinely forces the band visible at construction (it was materialize-only before, contradicting the documented "force the band on").
- **Leaked native-menu timer.** App/AppShell reset now cancel a scheduled `after_idle` native-menu rebuild (new `ChromeHostMixin._cancel_native_menu_pending`) instead of just nulling the handle — a pending rebuild can no longer fire against freshly-rebuilt chrome (macOS).

## #326 — `_reload_modules` identity-split risk

The per-page fast path is now gated on **every** changed file being a module with registered `@reloadable` builders (`_builder_module_files`). A changed constants/model module (module-level state, no builder) takes the **full** reload (reload-then-reexec) instead of a selective `importlib.reload` that would split object identity — fresh objects while live widgets hold the old ones — without rebinding the UI.

## #327 — watcher scope + polling

- **Watch root** widens from the entry file's directory to the project's `src/` tree (via a `bootstack.toml` walk-up; falls back to the file's directory for a loose script), so edits to sibling packages are picked up.
- **Snapshot** stamps `(mtime, size)` so a same-tick save that changes file size is detected even when the coarse mtime doesn't advance.
- Symlinked dirs are still not followed (avoids cycles) — now documented.

## #328 (docs only)

Added a **"Gating dev-only code"** section to the hot-reload guide documenting `is_dev_mode()`. The E2E multi-file `@reloadable` reload test is filed as the remaining piece of #328 and deferred.

## Also

Filed **#332** — a low-priority internal cleanup to rename the `ShellLayout.set_*_visible` family to the framework idiom (internal-only; surfaced while writing the #325 fix).

## Verification

- New unit tests: watcher `(mtime, size)` + size-change detection; `_project_watch_root` widen + fallback. `tests/test_hot_reload.py` — 17 passed.
- Shell/hot-reload GUI legs green (appshell-reshape, workbench, hot-reload-app/shell, statusbar) each in its own process.
- Clean `-W` docs build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)