### PR TITLE
fix(ship-gate): text=<Signal> guard + cli run double-cwd (#149)

### DIFF
--- a/src/bootstack/cli/run.py
+++ b/src/bootstack/cli/run.py
@@ -85,7 +85,7 @@ def run_run(args: argparse.Namespace) -> None:
 
     try:
         result = subprocess.run(
-            [sys.executable, str(entry_point)],
+            [sys.executable, str(entry_point.resolve())],
             cwd=str(project_root),
             env=env,
         )

--- a/src/bootstack/widgets/_core/base.py
+++ b/src/bootstack/widgets/_core/base.py
@@ -120,6 +120,23 @@ class PublicWidgetBase:
             layout["attached"] = kwargs.pop("attached")
         return layout
 
+    @staticmethod
+    def _reject_signal_text(text: Any) -> None:
+        """Guard against a `Signal` landing in the plain `text=` slot.
+
+        A `Signal` is truthy and stringifies to its name, so passing one as
+        `text=` silently renders something like `"SIG2"` instead of binding.
+        The supported path is `textsignal=` (two-way binding). Raise a clear
+        `TypeError` rather than render the name.
+        """
+        from bootstack._core.capabilities.signals import is_signal
+
+        if is_signal(text):
+            raise TypeError(
+                "text= expects a string; pass a Signal via textsignal= to bind "
+                "reactive text (text= would render the Signal's name)."
+            )
+
     def _attach_to_parent(self, layout_kw: dict) -> None:
         if not self._auto_place:
             return

--- a/src/bootstack/widgets/button.py
+++ b/src/bootstack/widgets/button.py
@@ -79,6 +79,7 @@ class Button(IconProperty, ImageProperty, PublicWidgetBase):
         parent: Any = None,
         **kwargs: Any,
     ) -> None:
+        self._reject_signal_text(text)
         self._parent = self._resolve_parent(parent)
         layout_kw = self._split_layout_kwargs(kwargs)
         tk_master = self._parent._child_master() if self._parent else None

--- a/src/bootstack/widgets/label.py
+++ b/src/bootstack/widgets/label.py
@@ -90,6 +90,7 @@ class Label(IconProperty, ImageProperty, PublicWidgetBase):
         # 'default'); it rides in via kwargs as the conduit for the Badge
         # subclass, which sets its own 'square'/'pill' on a Badge ttk class.
         variant = kwargs.pop("variant", None)
+        self._reject_signal_text(text)
         self._parent = self._resolve_parent(parent)
         layout_kw = self._split_layout_kwargs(kwargs)
         tk_master = self._parent._child_master() if self._parent else None

--- a/src/bootstack/widgets/menubutton.py
+++ b/src/bootstack/widgets/menubutton.py
@@ -114,6 +114,7 @@ class MenuButton(IconProperty, PublicWidgetBase):
         parent: Any = None,
         **kwargs: Any,
     ) -> None:
+        self._reject_signal_text(text)
         self._parent = self._resolve_parent(parent)
         layout_kw = self._split_layout_kwargs(kwargs)
         tk_master = self._parent._child_master() if self._parent else None

--- a/tests/widgets/public/test_text_signal_guard.py
+++ b/tests/widgets/public/test_text_signal_guard.py
@@ -1,0 +1,30 @@
+"""A `Signal` in the plain `text=` slot raises instead of rendering its name.
+
+A `Signal` is truthy and stringifies to its name, so passing one as `text=`
+silently renders something like `"SIG2"`. The text-bearing widgets that pair a
+`text=` caption with a `textsignal=` binding (`Label`, `Button`, `MenuButton`)
+guard against the mistake with a `TypeError` pointing at `textsignal=`.
+"""
+import pytest
+
+import bootstack as bs
+
+
+@pytest.mark.parametrize("cls", [bs.Label, bs.Button, bs.MenuButton])
+def test_signal_in_text_slot_raises(app, cls):
+    sig = bs.Signal("hello")
+    with pytest.raises(TypeError, match="textsignal="):
+        cls(sig)
+
+
+@pytest.mark.parametrize("cls", [bs.Label, bs.Button, bs.MenuButton])
+def test_plain_text_still_works(app, cls):
+    w = cls("plain")
+    assert w.text == "plain"
+
+
+@pytest.mark.parametrize("cls", [bs.Label, bs.Button, bs.MenuButton])
+def test_textsignal_binding_still_works(app, cls):
+    sig = bs.Signal("bound")
+    w = cls(textsignal=sig)
+    assert w.text == "bound"


### PR DESCRIPTION
Two concrete 0.1.0 ship-gate items folded into #149 (the public-surface audit will land separately).

## (a) `text=<Signal>` guard
A `Signal` is truthy and stringifies to its name, so passing one as `text=` silently rendered `"SIG2"` instead of binding. New shared `PublicWidgetBase._reject_signal_text()` (duck-typed via `is_signal`) raises a `TypeError` pointing at `textsignal=`, wired into the three widgets that pair a `text=` caption with `textsignal=`:

- **Label** (covers Badge)
- **Button**
- **MenuButton**

**Out of scope by decision:** the boolean controls (Checkbox/Switch/ToggleButton/Radio). They use `label=`/`text=` for the caption but bind value via `signal=` — there is no `textsignal=`, so the "did you mean textsignal=" remedy would be misleading. A separate generic guard could be added there later if wanted.

## (c) `cli/run.py` double-cwd
`run_run()` now passes `entry_point.resolve()` to the subprocess (was unresolved while `cwd=project_root`, so a relative entry resolved against the new cwd and could double-up the path). Mirrors the fix already shipped in `cli/dev.py`.

## Not changed
**(b) `__version__`** is already correct — it reads from `importlib.metadata`, not a hardcoded string. A stale runtime value is only the editable-install metadata cache; `pip install -e .` re-syncs it. The CHANGELOG note belongs in the audit follow-up.

## Verification
- `test_text_signal_guard.py` — 9 passed (raise on Signal; plain text + textsignal still bind, all three widgets)
- `test_button_review` + `test_label_badge` + `test_public_surface` — 178 passed
- `tests/cli/` — 24 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
