### PR TITLE
ship-gate: public-surface audit, Release Notes, stable install (#149)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,102 @@
+# Changelog
+
+All notable changes to bootstack are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and from 0.1.0 onward the project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+<!-- release-notes-start -->
+
+## [0.1.0] — first stable release
+
+The first stable release of bootstack. The public **compose API** — everything
+you import as `bootstack as bs` plus the curated submodules (`bootstack.data`,
+`bootstack.style`, `bootstack.events`, `bootstack.dialogs`, …) — is now **frozen**
+under Semantic Versioning. Breaking changes to it will not land before 1.0 except
+as documented, versioned migrations.
+
+### Highlights
+
+- **Applications and windows** — `App`, `Window`, and two navigation shells:
+  `AppShell` (single sidebar) and `Workbench` (two-tier rail + workspaces), plus
+  a borderless `Splash` intro screen. Undecorated windows auto-inject a draggable
+  titlebar and border.
+- **A full widget catalog** — layout (`Row`/`Column`/`Grid`/`Card`/`ScrollView`/
+  `SplitView`/`Accordion`), inputs (`TextField`/`NumberField`/`DateField`/
+  `TextArea`/`CodeEditor`/`Slider`/…), selection (`Checkbox`/`Switch`/`Select`/
+  `Calendar`/…), data display (`DataTable`/`Tree`/`ListView`/`Label`/`Badge`/
+  `Gauge`/…), media (`Picture`/`Gallery`/`Carousel`/`Avatar`/`Chart`), navigation
+  (`Tabs`/`PageStack`), and overlays (`Tooltip`/`toast`/`Notification`/`Snackbar`).
+- **Reactive state** — `Signal` for two-way widget binding; a typed event system
+  (`on_change()`/`on_click()`/… returning cancelable `Subscription`s or composable
+  `Stream`s); reactive `Form.valid`/`Form.errors`.
+- **Theming** — light/dark themes, `set_theme`/`toggle_theme`, `ThemeToggle`,
+  system-appearance following, and a public `bootstack.style` API.
+- **Data** — `bootstack.data` source protocol (memory/SQLite/file-backed) with a
+  filtering DSL (`col`/`any_of`/`all_of`), a non-scalar data bag carried across
+  `Tree`/`DataTable`/`ListView`, and large-file streaming.
+- **Dialogs** — verbs (`alert`/`confirm`/`ask_*`) at the top level plus dialog
+  classes in `bootstack.dialogs` (`Dialog`/`FormDialog`/…).
+- **Tooling** — a `bootstack` CLI (`start`/`run`/`add`/`doctor`/`appicon`/…) and
+  application packaging.
+
+### Provisional (excluded from the freeze)
+
+- **`bootstack.dev`** — the hot-reload workflow (`reloadable`, `is_dev_mode`, and
+  the `bootstack dev` command) is **experimental**. Its surface is carved out of
+  the 0.1.0 freeze and may change before a later release.
+
+### Migrating from the `0.1.0aN` alpha series
+
+Pre-1.0 alphas were never a stable contract; this summarizes the notable breaks
+for anyone who tracked an alpha. (If you are installing bootstack for the first
+time, you can ignore this section.)
+
+#### Renamed
+
+- Layout: `HStack` → `Row`, `VStack` → `Column`, `Separator` → `Divider`; added
+  `Spacer`. The layout vocabulary moved to screen-axis terms — `fill`/`expand`/
+  `anchor`/`sticky` are replaced by `horizontal`/`vertical`/`grow` with edge-name
+  values (`left`/`center`/`right`/`stretch`). The legacy kwargs now **raise**.
+- `Table` → `DataTable` (and decoupled from any specific data source).
+- `Toolbar` → `CommandBar` for the app-level bar (`app.commandbar`); `app.menu` →
+  `app.menubar`; the standalone `bs.MenuBar` was removed in favor of `app.menubar`.
+- `Signal.subscribe()` now returns a cancelable handle (was a string token).
+- Selection: per-widget `get_selected()` / `selected_rows` / `selected_nodes` were
+  unified into a single polymorphic `.selection` accessor across
+  `ListView`/`DataTable`/`Tree`.
+- Navigation: the single `AppShell` was split into `AppShell` (single sidebar) and
+  `Workbench` (two-tier workspaces); nav providers became `page_nav()` / `list_nav()`
+  / `tree_nav()` / `custom_nav()` (the old `panel()` is now `custom_nav()`).
+
+#### Removed / moved
+
+- **`AppSettings` and `settings=`** were removed. All former settings are now flat
+  `App(...)` / `AppShell(...)` keyword arguments (`theme`, `locale`,
+  `remember_window_state`, …), with symmetric `app.*` properties. Passing
+  `settings=` raises `TypeError`.
+- **Top-level namespace curated** to the compose surface only. Types you reference
+  to *configure* behavior moved to submodules — e.g. `Theme`/`get_theme_color`
+  (`bootstack.style`), `col`/`SqliteDataSource` (`bootstack.data`),
+  `ValidationRule` (`bootstack.validation`), `Event`/`Subscription`
+  (`bootstack.events`), `AccentToken` (`bootstack.types`). Dialog **classes**
+  (`Dialog`/`FormDialog`/…) moved to `bootstack.dialogs`; the dialog **verbs**
+  (`alert`/`confirm`/`ask_*`) stay top-level.
+- **`Toast`** was split into `toast()` (function), `Notification`, `Snackbar`, and
+  `snackbar()`.
+- `MessageCatalog`, `IntlFormatter`, `get_current_app`, and `Image` were demoted to
+  internal (import widgets/icons via the public `bootstack.images` API).
+- `Scale` and the `VariantToken` type were removed.
+
+#### Changed (behavior)
+
+- `TimeField` now starts **empty** (it previously defaulted to the current time,
+  which silently defeated `required=True`).
+- Field validation runs against the field's **typed value**; rules are type-aware
+  (a new `range` rule for number/date/time bounds), and `field.valid` / `field.error`
+  are reactive `Signal`s.
+- `Toolbar.add_widget` / `StatusBar.add_widget` are now class-based
+  (`add_widget(WidgetClass, **kwargs)`).
+
+[0.1.0]: https://github.com/israel-dryer/bootstack/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -60,10 +60,10 @@ state, and active page, so you never lose your spot.
 ## Installation
 
 Requires Python 3.12+ and Tk/Tcl (bundled with most Python distributions).
-bootstack is in pre-release, so opt in with `--pre`:
+Install with pip:
 
 ```bash
-python -m pip install --pre bootstack
+python -m pip install bootstack
 ```
 
 See the [installation guide](https://bootstack.org/getting-started/installation/)

--- a/docs/api-reference/application.rst
+++ b/docs/api-reference/application.rst
@@ -4,9 +4,10 @@ Application
 .. currentmodule:: bootstack
 
 The application object and top-level windows. ``App`` is the root of a simple
-happ; ``AppShell`` adds a toolbar stack, one navigation sidebar, and paged content;
+app; ``AppShell`` adds a toolbar stack, one navigation sidebar, and paged content;
 ``Workbench`` is the two-tier variant with a workspace rail. ``Window`` opens a
-secondary top-level window.
+secondary top-level window, and ``Splash`` shows a borderless intro screen while
+the app starts.
 
 .. autosummary::
    :toctree: generated
@@ -35,6 +36,13 @@ secondary top-level window.
    :template: toplevel
 
    Window
+
+.. autosummary::
+   :toctree: generated
+   :nosignatures:
+   :template: toplevel
+
+   Splash
 
 The :class:`AppShell <bootstack.AppShell>` reference documents its ``PageNav`` and
 ``Page`` handles, and :class:`Workbench <bootstack.Workbench>` its ``Workspace``

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,14 @@ extensions = [
     "sphinx.ext.autosummary",
     "sphinx_design",
     "sphinx_copybutton",
+    "myst_parser",
 ]
+
+# The Release Notes page supplies its own reStructuredText H1 and includes the
+# version entries from the root CHANGELOG.md, which begin at H2 — so myst's
+# "headings start at H2, not H1" lint fires on that fragment by design. It is the
+# only myst-parsed document, so silencing this one lint is precise.
+suppress_warnings = ["myst.header"]
 
 # ---------------------------------------------------------------------------
 # Autodoc

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -211,10 +211,6 @@ nitpick_ignore_regex = [
 html_theme = "pydata_sphinx_theme"
 
 html_theme_options = {
-    "announcement": (
-        "bootstack is in <strong>pre-release</strong> — the API may still "
-        "change before 1.0. Install with <code>pip install --pre bootstack</code>."
-    ),
     "github_url": "https://github.com/israel-dryer/bootstack",
     "logo": {
         "image_light": "_static/bootstack-logo-light.svg",

--- a/docs/getting-started/installation.rst
+++ b/docs/getting-started/installation.rst
@@ -11,25 +11,25 @@ extra to install — see :ref:`checking-tk` below if a window fails to appear.
 Install
 -------
 
-bootstack is in **pre-release**, so pass ``--pre`` to opt in to the latest alpha:
+Install bootstack with pip:
 
 .. code-block:: bash
 
-   python -m pip install --pre bootstack
+   python -m pip install bootstack
 
-Upgrade to the newest pre-release the same way:
+Upgrade to the latest release the same way:
 
 .. code-block:: bash
 
-   python -m pip install --upgrade --pre bootstack
+   python -m pip install --upgrade bootstack
 
-To pin an exact version — for a reproducible environment — name it directly
-(``--pre`` is then not required). Pick a version from the
+To pin an exact version — for a reproducible environment — name it directly.
+Pick a version from the
 `release history <https://pypi.org/project/bootstack/#history>`__:
 
 .. code-block:: bash
 
-   python -m pip install bootstack==0.1.0a11
+   python -m pip install bootstack==0.1.0
 
 .. _checking-tk:
 
@@ -77,11 +77,11 @@ adding the extra in brackets:
 
 .. code-block:: bash
 
-   python -m pip install --pre "bootstack[excel]"        # .xlsx export from DataTable
-   python -m pip install --pre "bootstack[parquet]"      # read and write Parquet and Feather
-   python -m pip install --pre "bootstack[hdf5]"         # read and write HDF5
-   python -m pip install --pre "bootstack[viz]"          # Chart — embed matplotlib figures
-   python -m pip install --pre "bootstack[viz-seaborn]"  # Chart, with seaborn added
+   python -m pip install "bootstack[excel]"        # .xlsx export from DataTable
+   python -m pip install "bootstack[parquet]"      # read and write Parquet and Feather
+   python -m pip install "bootstack[hdf5]"         # read and write HDF5
+   python -m pip install "bootstack[viz]"          # Chart — embed matplotlib figures
+   python -m pip install "bootstack[viz-seaborn]"  # Chart, with seaborn added
 
 Combine extras in one install — for example ``bootstack[excel,parquet]``. The
 data-format extras power the file reader/writer registry behind data sources and

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -145,3 +145,4 @@ gallery:
    user-guide/index
    widgets/index
    api-reference/index
+   release-notes

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -124,12 +124,11 @@ Start here
 Install
 -------
 
-bootstack requires Python 3.12 or newer. It is in pre-release, so opt in with
-``--pre``:
+bootstack requires Python 3.12 or newer. Install it with pip:
 
 .. code-block:: bash
 
-   pip install --pre bootstack
+   pip install bootstack
 
 To tour everything bootstack ships without writing a line of code, launch the
 gallery:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -145,3 +145,4 @@ gallery:
    widgets/index
    api-reference/index
    release-notes
+   roadmap

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -1,0 +1,11 @@
+Release Notes
+=============
+
+Notable changes to bootstack, newest first. The project follows
+`Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_ from 0.1.0 onward;
+the full file lives at
+`CHANGELOG.md <https://github.com/israel-dryer/bootstack/blob/main/CHANGELOG.md>`_.
+
+.. include:: ../CHANGELOG.md
+   :parser: myst_parser.sphinx_
+   :start-after: <!-- release-notes-start -->

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,3 +4,4 @@ sphinx-autodoc-typehints
 sphinx-design
 sphinx-autobuild
 sphinx-copybutton
+myst-parser

--- a/docs/roadmap.rst
+++ b/docs/roadmap.rst
@@ -1,0 +1,36 @@
+Roadmap
+=======
+
+Where bootstack is headed. This is **direction, not a commitment** — scope and
+ordering change as work lands. The authoritative, always-current view is the
+`GitHub milestones <https://github.com/israel-dryer/bootstack/milestones>`__
+page, which re-sorts itself as issues open and close; the themes below summarize
+those milestones.
+
+With **0.1.0**, the public ``bootstack`` compose API is frozen under Semantic
+Versioning. *Stable* means the API is settled, not that the framework is
+feature-complete — new widgets and integrations ship additively in later
+releases without breaking that surface. See the :doc:`/release-notes` for what
+has shipped.
+
+Planned milestones
+------------------
+
+`0.1.1 — Widget polish <https://github.com/israel-dryer/bootstack/milestone/2>`__
+   Low-risk fixes and small additions to existing widgets — context-menu
+   dismissal, cross-page DataTable selection, a top-line Tabs indicator.
+
+`0.2.0 — Guided flows <https://github.com/israel-dryer/bootstack/milestone/3>`__
+   Process and flow widgets. A ``Timeline`` status indicator lands first, and a
+   ``Wizard`` composes it for multi-step tasks.
+
+`0.3.0 — Power-user interactions <https://github.com/israel-dryer/bootstack/milestone/4>`__
+   Desktop-app interaction features — a command palette and a ``DropZone`` for
+   file drag-and-drop.
+
+`0.4.0 — Structured editing <https://github.com/israel-dryer/bootstack/milestone/5>`__
+   Structured value and config editing — a color-swatch select feeding a
+   schema-driven ``PropertyInspector`` panel.
+
+Have a request? Open an issue or join the discussion on
+`GitHub <https://github.com/israel-dryer/bootstack/issues>`__.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ docs = [
     "sphinx-design",
     "sphinx-copybutton",
     "sphinx-autobuild",
+    "myst-parser",
 ]
 
 [project.urls]

--- a/src/bootstack/dialogs/_impl/dialog.py
+++ b/src/bootstack/dialogs/_impl/dialog.py
@@ -12,6 +12,7 @@ import tkinter
 from tkinter import Widget
 from typing import Any, Callable, Iterable, Literal, Mapping, Optional, Tuple, TypedDict, Union
 
+from bootstack.widgets._core.base import PublicWidgetBase
 from bootstack.widgets._impl.primitives.button import Button as _Button
 from bootstack.widgets._impl.primitives.frame import Frame as _Frame
 from bootstack.widgets._impl.primitives.separator import Separator as _Separator
@@ -27,6 +28,21 @@ from bootstack._runtime.window_utilities import AnchorPoint, WindowPositioning
 # explicit handle can declare a single parameter (`def build(content): ...`).
 ContentBuilder = Callable[..., None]
 FooterBuilder = Callable[[Widget], None]
+
+# Where a dialog can anchor itself. A public widget anchors to that widget; the
+# string forms anchor to the screen, the cursor, or the parent window.
+AnchorTarget = Union["PublicWidgetBase", Literal["screen", "cursor", "parent"]]
+
+
+def _resolve_anchor_target(anchor_to: Any) -> Any:
+    """Unwrap a public widget to its underlying tk widget for positioning.
+
+    A public bootstack widget is a plain object holding `_internal`, not a tk
+    widget — so positioning (which reads `winfo_*`) needs the internal handle.
+    String forms (`'screen'`/`'cursor'`/`'parent'`) and `None` pass through.
+    """
+    internal = getattr(anchor_to, "_internal", None)
+    return internal if internal is not None else anchor_to
 
 
 def _call_builder(builder: Callable[..., None], content: Any) -> None:
@@ -96,7 +112,7 @@ class ShowOptions(TypedDict, total=False):
     Attributes:
         position (tuple[int, int] | None): Optional (x, y) coordinates.
         modal (bool | None): Override the mode's default modality.
-        anchor_to (Widget | str | None): Positioning target widget or string.
+        anchor_to (PublicWidgetBase | str | None): Positioning target widget or string.
         anchor_point (AnchorPoint): Point on the anchor target.
         window_point (AnchorPoint): Point on the dialog window.
         offset (tuple[int, int]): Additional (x, y) offset in pixels.
@@ -104,7 +120,7 @@ class ShowOptions(TypedDict, total=False):
     """
     position: Optional[Tuple[int, int]]
     modal: Optional[bool]
-    anchor_to: Optional[Union[Widget, Literal["screen", "cursor", "parent"]]]
+    anchor_to: Optional[AnchorTarget]
     anchor_point: AnchorPoint
     window_point: AnchorPoint
     offset: Tuple[int, int]
@@ -223,7 +239,7 @@ class Dialog:
             *,
             position: Optional[Tuple[int, int]] = None,
             modal: Optional[bool] = None,
-            anchor_to: Optional[Union[Widget, Literal["screen", "cursor", "parent"]]] = None,
+            anchor_to: Optional[AnchorTarget] = None,
             anchor_point: AnchorPoint = 'center',
             window_point: AnchorPoint = 'center',
             offset: Tuple[int, int] = (0, 0),
@@ -237,10 +253,10 @@ class Dialog:
             modal: Override the mode's default modality. When `None`, follows the
                 mode — `"modal"` grabs focus and waits for the dialog to close;
                 `"popover"` waits without grabbing.
-            anchor_to: Positioning target. A widget anchors to that widget;
-                `"screen"` anchors to the screen edges/corners; `"cursor"` anchors
-                to the mouse cursor; `"parent"` anchors to the parent window; and
-                `None` (default) centers on the parent.
+            anchor_to: Positioning target. A widget (e.g. a `bs.Button`) anchors to
+                that widget; `"screen"` anchors to the screen edges/corners;
+                `"cursor"` anchors to the mouse cursor; `"parent"` anchors to the
+                parent window; and `None` (default) centers on the parent.
             anchor_point: Point on the anchor target (n, s, e, w, ne, nw, se, sw, center).
                 Default 'center'.
             window_point: Point on the dialog window (n, s, e, w, ne, nw, se, sw, center).
@@ -266,7 +282,7 @@ class Dialog:
         self._build_content()
         self._position_dialog(
             position=position,
-            anchor_to=anchor_to,
+            anchor_to=_resolve_anchor_target(anchor_to),
             anchor_point=anchor_point,
             window_point=window_point,
             offset=offset,

--- a/src/bootstack/widgets/__init__.py
+++ b/src/bootstack/widgets/__init__.py
@@ -11,7 +11,8 @@ from typing import Any
 # Single source of truth for the runtime namespace below.
 _EXPORTS: dict[str, str] = {
     # Application & windows
-    "App": "app", "AppShell": "appshell", "Window": "window",
+    "App": "app", "AppShell": "appshell", "Workbench": "appshell",
+    "Window": "window", "Splash": "splash",
     # Layout
     "Row": "stacks", "Column": "stacks", "Spacer": "stacks",
     "Grid": "grid", "Card": "card",
@@ -31,33 +32,27 @@ _EXPORTS: dict[str, str] = {
     "EditFilter": "_impl.composites.textarea.filter",
     # Selection
     "Checkbox": "boolean_controls", "Switch": "boolean_controls",
-    "ToggleButton": "boolean_controls", "ToggleGroup": "togglegroup",
+    "ToggleButton": "boolean_controls", "ThemeToggle": "theme_toggle",
+    "ToggleGroup": "togglegroup",
     "Radio": "radio_variants", "RadioToggleButton": "radio_variants",
     "RadioGroup": "radiogroup", "Select": "select", "SelectButton": "selectbutton",
     "Calendar": "calendar",
     # Data display
     "Label": "label", "Badge": "label", "Picture": "picture", "Gallery": "gallery",
     "Carousel": "carousel", "Avatar": "avatar", "ProgressBar": "progressbar",
-    "Gauge": "gauge", "ListView": "listview", "DataTable": "datatable", "Tree": "tree",
-    "Chart": "chart",
+    "Gauge": "gauge", "ListView": "listview", "DataTable": "datatable",
+    "Tree": "tree", "TreeNode": "tree", "Chart": "chart",
     # Navigation
     "PageStack": "pagestack", "StackPage": "pagestack",
     "Tabs": "tabs", "TabPage": "tabs",
     # Overlays
-    "Tooltip": "tooltip", "Toast": "toast", "toast": "toast",
+    "Tooltip": "tooltip", "toast": "toast", "Notification": "toast",
+    "Snackbar": "toast", "snackbar": "toast",
     # Forms
     "Form": "form", "FormItem": "form", "FieldItem": "form", "GroupItem": "form",
     "TabsItem": "form", "TabItem": "form",
     # Extension base classes (for building custom public widgets)
     "PublicWidgetBase": "_core.base", "PublicContainer": "_core.container",
-    # Dialogs
-    "alert": "dialogs", "confirm": "dialogs", "ask_string": "dialogs",
-    "ask_integer": "dialogs", "ask_float": "dialogs", "ask_date": "dialogs",
-    "ask_date_range": "dialogs", "ask_item": "dialogs", "ask_color": "dialogs",
-    "ask_font": "dialogs", "ask_filter": "dialogs", "FormDialog": "dialogs",
-    "Dialog": "dialogs", "DialogButton": "dialogs", "ColorChooserDialog": "dialogs",
-    "ColorChoice": "dialogs", "FontDialog": "dialogs", "FontChoice": "dialogs",
-    "FilterDialog": "dialogs",
 }
 
 __all__ = sorted(_EXPORTS)

--- a/tests/test_dialog_anchor.py
+++ b/tests/test_dialog_anchor.py
@@ -1,0 +1,44 @@
+"""Dialog.show(anchor_to=) accepts a public widget, not a raw tk widget.
+
+The public positioning target is a `PublicWidgetBase` (e.g. a `bs.Button`); the
+dialog unwraps it to its internal tk handle for `winfo_*`-based positioning. The
+public signature must not leak `tkinter.Widget`.
+"""
+import inspect
+
+import bootstack as bs
+from bootstack.dialogs import Dialog
+from bootstack.dialogs._impl.dialog import _resolve_anchor_target
+
+
+def test_show_signature_has_no_tk_leak():
+    sig = str(inspect.signature(Dialog.show))
+    assert "tkinter" not in sig and "Widget" not in sig, sig
+
+
+def test_resolve_unwraps_public_widget(app):
+    import tkinter
+
+    btn = bs.Button("anchor")
+    resolved = _resolve_anchor_target(btn)
+    assert isinstance(resolved, tkinter.Misc)
+    assert resolved is btn._internal
+
+
+def test_resolve_passes_through_strings_and_none():
+    for value in ("screen", "cursor", "parent", None):
+        assert _resolve_anchor_target(value) == value
+
+
+def test_resolve_passes_through_raw_tk_widget(app):
+    btn = bs.Button("anchor")
+    raw = btn._internal
+    assert _resolve_anchor_target(raw) is raw
+
+
+def test_anchor_to_public_widget_end_to_end(app):
+    btn = bs.Button("target")
+    d = Dialog(title="t", mode="popover")
+    d.show(anchor_to=btn, anchor_point="se", window_point="nw")
+    assert d.toplevel is not None
+    d.toplevel.destroy()

--- a/tests/test_public_surface.py
+++ b/tests/test_public_surface.py
@@ -156,3 +156,37 @@ def test_internal_style_accessors_not_public():
     import bootstack.style as style
     for name in ("get_style", "get_style_builder", "get_theme_provider"):
         assert name not in style.__all__, f"{name} should not be public in bootstack.style"
+
+
+# ----- bootstack.widgets lazy namespace -----
+
+# Top-level names that are NOT composable widgets (verbs / reactive primitives /
+# version) — these have their own homes and are not re-exported by the widgets
+# package, so exclude them when comparing the two surfaces.
+_NON_WIDGET_TOPLEVEL = {
+    "__version__", "Signal", "set_theme", "toggle_theme",
+    "alert", "confirm", "ask_string", "ask_integer", "ask_float", "ask_date",
+    "ask_date_range", "ask_item", "ask_color", "ask_font", "ask_filter",
+    "ask_save_file", "ask_open_file", "ask_open_files", "ask_directory",
+}
+
+# Extension base classes importable from bootstack.widgets but intentionally not
+# top-level (you compose with them only when building a custom widget).
+_WIDGET_ONLY_EXTRAS = {"PublicWidgetBase", "PublicContainer", "EditFilter"}
+
+
+def test_widgets_all_resolves():
+    """Every name in bootstack.widgets.__all__ must lazily import (no broken
+    entries). This catches stale `_EXPORTS` mappings pointing at moved/renamed
+    modules — e.g. the dialog block that lingered after dialogs moved out."""
+    import bootstack.widgets as w
+    broken = [n for n in w.__all__ if not hasattr(w, n)]
+    assert broken == [], f"broken bootstack.widgets exports: {broken}"
+
+
+def test_widgets_namespace_mirrors_toplevel():
+    """bootstack.widgets exports exactly the composable widget set (mirroring
+    bs.*) plus the extension base classes — no drift in either direction."""
+    import bootstack.widgets as w
+    expected = (set(bs.__all__) - _NON_WIDGET_TOPLEVEL) | _WIDGET_ONLY_EXTRAS
+    assert set(w.__all__) == expected


### PR DESCRIPTION
The #149 public-surface audit + Release Notes + stable-install prep. (Builds on the merged #334, which landed the `text=<Signal>` guard and the `cli/run.py` double-cwd fix.)

## Surface audit + fixes
- **`widgets/_EXPORTS` drift** — the lazy widget namespace had drifted badly: **20 broken entries** (`Toast`, removed in the toast split, + all 19 dialog names still mapping to the deleted `bootstack.widgets.dialogs` module) and **7 missing widgets** (`Workbench`/`Splash`/`ThemeToggle`/`Notification`/`Snackbar`/`snackbar`/`TreeNode`). Now mirrors the top-level widget set + the 3 extension base classes exactly. Locked with two guards (`test_widgets_all_resolves`, `test_widgets_namespace_mirrors_toplevel`).
- **`Dialog.show(anchor_to=)` tk leak** — the one `tkinter.Widget` that rendered in public docs. Now accepts a public widget (unwrapped to its internal handle via `_resolve_anchor_target`) and is typed `AnchorTarget` (`PublicWidgetBase | "screen"/"cursor"/"parent"`); strings/None/raw-tk still pass through. +5 tests.
- **`application.rst`** — added the missing `Splash` api-reference stub (`splash.rst`'s `bootstack.Splash` xref dangled — a `-W` warning incremental builds had masked) + a `happ`→`app` typo fix.
- Every other public submodule `__all__` audited clean (no broken/dupe/omitted).

## Release Notes
- **`CHANGELOG.md`** (root, canonical) — first-release entry: highlights, a provisional `bootstack.dev` note, and a-series migration notes.
- **`docs/release-notes.rst`** — titled "Release Notes", includes the changelog body via **myst-parser**; added as the **4th navbar pillar** (User Guide · Widgets · API Reference · Release Notes). `conf.py` gains `myst_parser` + a precise `suppress_warnings=["myst.header"]`. `myst-parser` added to docs deps.

## Stable-install prep
- Dropped `--pre` / pre-release framing from `installation.rst`, `index.rst`, `README.md`, and removed the pre-release announcement banner in `conf.py`. Docs deploy only on release (#169) and the next release is stable `0.1.0`, so `pip install bootstack` resolves by the time these go live.

## Verification
- Clean `-W --keep-going` docs build (stubs regenerated): **0 warnings**; Release Notes renders, navbar shows 4 pillars.
- Full GUI suite green; `test_public_surface` + `test_dialog_anchor` + `cli`: **202 passed**.

Not in this PR: tagging the stable release; the pre-existing `-n` nitpick warnings on some generated stubs (`datetime`/`Path`/`AvatarShape`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
