### PR TITLE
refactor(theme): unify theme repaint onto a single walk

### DIFF
--- a/docs/_dev/theme-repaint-architecture.md
+++ b/docs/_dev/theme-repaint-architecture.md
@@ -1,0 +1,90 @@
+# Theme repaint — architecture
+
+How widgets recolor when the theme changes (`set_theme` / `toggle_theme`). The
+goal of this design is **one rule**, no per-widget visibility/`<Map>` bookkeeping.
+
+## The one rule
+
+- **A tree widget that needs to recolor defines `_bs_apply_theme(self)`.** It does
+  *all* of that widget's imperative theme work in one place — re-resolve colors
+  and redraw (canvas content, theme-colored PhotoImages, tag colors, etc.). The
+  widget's plain background is handled separately (see "surfaces" below), so the
+  hook owns only what the ttk/style engine doesn't.
+- **A non-tree or cross-cutting reactor binds `<<BsThemeChanged>>` on the root.**
+  Reserved for things that aren't tree widgets: the `Image` handle, the OS-level
+  DWM window chrome, and the app-level `on_theme_change` callback. (CodeEditor's
+  highlighting extensions also live here for now.)
+
+That's it. There is no `_enable_theme_repaint`, no STD publisher subscription, no
+per-widget `<Map>` deferral, and no widget registry.
+
+## The walk
+
+`Style.apply_theme_walk(root_widget, *, only_stale)` (in `style/style.py`) walks a
+subtree and, for each themed widget, calls `Style._apply_theme_to_widget`, which:
+
+1. re-applies the **surface background** for an autostyled Tk widget
+   (`call_builder(w, surface=w._surface)`), then
+2. calls the widget's **`_bs_apply_theme()`** hook if it has one, then
+3. stamps `w._bs_theme_version = self._theme_version`.
+
+Two triggers drive it — and **neither is `<Map>`**:
+
+- **On a theme change** (`theme_use`): `apply_theme_walk(root, only_stale=False)` —
+  recolor every *visible* widget now. Off-screen widgets are left stale.
+- **On a container-show**: `apply_theme_walk(shown_subtree, only_stale=True)` —
+  recolor every *stale* widget in the now-visible subtree, **ignoring
+  `winfo_viewable()`** (it is unreliable for a widget embedded in a scrollable
+  page's canvas — it can report `False` for an on-screen widget). Stale = the
+  widget's `_bs_theme_version` is behind the current `_theme_version`, so a
+  navigation *without* a theme change is a no-op (no flicker).
+
+Visibility is resolved at apply time; nothing is deferred to a hoped-for event.
+
+### Container-show triggers
+
+Any container that hides/shows children by un/re-`pack`ing must call the walk on
+show. Current call sites:
+
+- `PageStack._navigate` → covers AppShell/Workbench pages **and** `Tabs` (Tabs
+  routes its content through a `PageStack` — see `tabs/tabview.py`).
+- `Expander.expand` → covers `Accordion` sections.
+
+If you add another hide/show container, call
+`get_style().apply_theme_walk(shown_subtree, only_stale=True)` after you pack the
+content (deferred to `after_idle` so it is mapped first).
+
+## Surfaces — the frozen-hex gotcha
+
+The autostyle wrapper (`style/style_resolver.py`) stores a widget's `_surface`
+**token** (e.g. `'card'`) and applies the initial background. On a theme change
+the walk re-resolves that token. So a canvas widget must pass the **surface
+token**, never a resolved color:
+
+```python
+# WRONG — freezes a hex; the walk re-applies the OLD color forever.
+Canvas(self, background=self._resolved_surface)
+# RIGHT — the walk re-resolves the token each theme.
+Canvas(self, surface=self._surface_token)
+```
+
+This was the cause of the Meter canvas "background doesn't recolor" bug. (An
+explicit `surface=` now wins over inheritance in both the ttk and Tk autostyle
+paths.)
+
+## Known limitations
+
+- A widget hidden by `detach()` or sitting in a **withdrawn** Toplevel during a
+  theme change won't recolor until it is re-shown through one of the container
+  triggers (or the theme changes again while it is visible). These are rare; add
+  a trigger if a real case appears.
+
+## History
+
+Replaced three overlapping mechanisms (the STD publisher + `_enable_theme_repaint`
+for canvas content; a `register_tk_widget` WeakSet + `_rebuild_all_tk_widgets` +
+`<Map>` registry for Tk surfaces; per-widget hacks). All shared one fragile
+assumption — that an off-screen widget gets a usable `<Map>` when it reappears —
+which is false for canvas-embedded widgets, so each grew its own workaround. The
+walk + explicit container-show triggers removed that assumption (and the
+"`_tk_widgets` grows forever" leak).

--- a/src/bootstack/dev/_reloader.py
+++ b/src/bootstack/dev/_reloader.py
@@ -243,7 +243,6 @@ class _InProcessReloader(_BaseReloader):
                 self.app._dev_restore_route(route)
             except Exception:
                 pass
-        self._prune_style_registry()
 
     def _reinvoke_pages(self, modules: set[str]) -> bool:
         from bootstack.dev import _registry
@@ -253,8 +252,6 @@ class _InProcessReloader(_BaseReloader):
             for qualname in _registry.builders_in_module(module):
                 if _registry.reinvoke(qualname):
                     ran = True
-        if ran:
-            self._prune_style_registry()
         return ran
 
     def _builder_module_files(self) -> dict[str, str]:
@@ -283,31 +280,6 @@ class _InProcessReloader(_BaseReloader):
                 importlib.reload(module)  # exceptions surface as a banner
                 reloaded.add(name)
         return reloaded
-
-    def _prune_style_registry(self) -> None:
-        """Drop dead entries from the style registry (timing safety net).
-
-        Clean teardown self-prunes the WeakSet on GC; doing it eagerly removes
-        nondeterminism. A climbing count across reloads is the canary that a
-        reference is leaking — surfaced only when it grows suspiciously.
-        """
-        try:
-            from bootstack.style import style as style_mod
-
-            style = style_mod._style_instance
-            if style is None:
-                return
-            registry = getattr(style, "_tk_widgets", None)
-            if registry is None:
-                return
-            for widget in list(registry):
-                try:
-                    if not widget.winfo_exists():
-                        registry.discard(widget)
-                except Exception:
-                    registry.discard(widget)
-        except Exception:
-            pass
 
     # --- error banner --------------------------------------------------------
 

--- a/src/bootstack/style/style.py
+++ b/src/bootstack/style/style.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import tkinter
-import weakref
 from tkinter.ttk import Style as ttkStyle
 from typing import Dict, Optional, Set
 
@@ -76,10 +75,9 @@ class Style(ttkStyle):
         # Current theme tracking
         self._current_theme: Optional[str] = theme
 
-        # Track legacy Tk widgets for theme-change restyling
-        self._tk_widgets = weakref.WeakSet()
-
-        # Incremented on every theme change so widgets can detect a missed restyle
+        # Incremented on every theme change so a widget can detect a restyle it
+        # missed while off-screen (stamped on `_bs_theme_version`; see
+        # apply_theme_walk).
         self._theme_version: int = 0
 
         # Cached Tk builder — lazily initialized, reused across all widget creations
@@ -240,15 +238,9 @@ class Style(ttkStyle):
 
         self._rebuild_all_styles()
 
-        # Bump version so hidden widgets know they missed this theme change
+        # Bump version so off-screen widgets know they missed this theme change
+        # (they recolor when their container next shows them — see apply_theme_walk).
         self._theme_version += 1
-
-        # Re-apply Tk widget styling (legacy widgets)
-        self._rebuild_all_tk_widgets()
-
-        # Publish theme-change event for legacy subscribers
-        from bootstack._core.publisher import Channel, Publisher  # lazy import
-        Publisher.publish_message(Channel.STD, theme=name, mode=self._theme_provider.mode)
 
         # Fire the bootstack theme-change event after full rebuild so handlers
         # can safely read new colors. Uses get_default_root lazily to avoid
@@ -256,6 +248,12 @@ class Style(ttkStyle):
         try:
             from bootstack._runtime.app import get_default_root
             root = get_default_root()
+            # Unified theme walk: recolor every visible tree widget now; off-screen
+            # ones are left stale and recovered when their page/tab/section is next
+            # shown. Non-tree reactors (the Image handle, OS window chrome, the
+            # app-level on_theme_change callback) listen on <<BsThemeChanged>> below.
+            if root is not None:
+                self.apply_theme_walk(root, only_stale=False)
             root.event_generate(
                 "<<BsThemeChanged>>",
                 data={"theme": name, "mode": self._theme_provider.mode},
@@ -313,51 +311,75 @@ class Style(ttkStyle):
             )
         return self._cached_tk_builder
 
-    def _restyle_single_tk_widget(self, widget) -> None:
-        """Restyle one Tk widget and stamp it with the current theme version."""
-        try:
-            surface = getattr(widget, '_surface', 'content')
-            self._get_tk_builder().call_builder(widget, surface=surface)
-            widget._bs_theme_version = self._theme_version
-        except Exception:
-            pass
+    # ------------------------------------------------------------------ Unified theme walk
+    #
+    # The single mechanism for recoloring *tree widgets* on a theme change. A
+    # widget that needs theming exposes one method, ``_bs_apply_theme()``, doing
+    # all of its work (background + any canvas repaint). Two triggers drive it,
+    # and neither relies on ``<Map>``:
+    #   * a theme change walks from the root and applies every *visible* widget;
+    #   * a container showing a page/tab walks that subtree and applies the
+    #     *stale* ones (those that missed the change while hidden).
+    # Visibility is resolved at apply time, so nothing is deferred to a hoped-for
+    # event. Non-tree reactors (the Image handle, OS window chrome, the app-level
+    # on_theme_change callback) stay on the root ``<<BsThemeChanged>>`` binding.
 
-    def register_tk_widget(self, widget) -> None:
-        """Register a Tk widget to be restyled on theme changes."""
-        self._tk_widgets.add(widget)
+    def _apply_theme_to_widget(self, widget) -> None:
+        """Apply the current theme to one widget and stamp its version.
 
-        # Lazily restyle if a theme change happened while the widget was hidden.
-        # <Map> fires when a widget transitions from unmapped to mapped (e.g. when
-        # its page is shown after pack_forget), so this is the right hook point.
-        style = self
-
-        def _on_map(event):
-            w = event.widget
-            if getattr(w, '_bs_theme_version', -1) != style._theme_version:
-                style._restyle_single_tk_widget(w)
-
-        # Use BaseWidget.bind to bypass any bind() override on subclasses
-        # (e.g. _MultilineCore forwards bind() to self.text, which doesn't exist
-        # yet when this is called from inside __init__).
-        tkinter.BaseWidget.bind(widget, '<Map>', _on_map, add='+')
-
-    def _rebuild_all_tk_widgets(self) -> None:
-        """Restyle all currently visible Tk widgets on theme change.
-
-        Widgets that are hidden (winfo_viewable() == 0, e.g. on a background page)
-        are skipped here — their <Map> handler will restyle them the next time
-        their page is shown.
+        Re-applies the surface background for an autostyled Tk widget, then runs
+        the widget's ``_bs_apply_theme`` hook if it defines one (canvas painters
+        redraw there). Both are best-effort; a failure on one widget never aborts
+        the walk.
         """
-        version = self._theme_version
-        for widget in list(self._tk_widgets):
+        surface = getattr(widget, '_surface', None)
+        if surface is not None:
             try:
-                if not widget.winfo_viewable():
-                    continue  # deferred to <Map> handler
-                surface = getattr(widget, '_surface', 'content')
                 self._get_tk_builder().call_builder(widget, surface=surface)
-                widget._bs_theme_version = version
             except Exception:
                 pass
+        hook = getattr(widget, '_bs_apply_theme', None)
+        if hook is not None:
+            try:
+                hook()
+            except Exception:
+                pass
+        widget._bs_theme_version = self._theme_version
+
+    def apply_theme_walk(self, root_widget, *, only_stale: bool) -> None:
+        """Walk ``root_widget``'s subtree and theme each on-screen widget.
+
+        Args:
+            root_widget: Subtree root — the application root on a theme change, or
+                a freshly-shown page/tab on a container-show.
+            only_stale: When True (container-show), apply every widget in the
+                subtree that missed the current theme version — regardless of
+                ``winfo_viewable()``, which is unreliable for a widget embedded in
+                a scrollable page's canvas; the container is showing it now. When
+                False (theme change), apply every *visible* widget and leave the
+                off-screen ones stale for their next container-show.
+        """
+        version = self._theme_version
+        stack = [root_widget]
+        while stack:
+            w = stack.pop()
+            try:
+                stack.extend(w.winfo_children())
+            except Exception:
+                pass
+            themed = hasattr(w, '_bs_apply_theme') or getattr(w, '_surface', None) is not None
+            if not themed:
+                continue
+            if only_stale:
+                if getattr(w, '_bs_theme_version', -1) == version:
+                    continue
+            else:
+                try:
+                    if not w.winfo_viewable():
+                        continue
+                except Exception:
+                    continue
+            self._apply_theme_to_widget(w)
 
     @staticmethod
     def _parse_style_name(ttk_style: str) -> Optional[dict]:

--- a/src/bootstack/style/style_resolver.py
+++ b/src/bootstack/style/style_resolver.py
@@ -412,24 +412,28 @@ class StyleResolver:
             else:
                 parent_surface_token = 'content'
 
-            if inherit_surface:
-                surface_token = parent_surface_token
-            else:
-                surface_token = surface_token or 'content'
+            # An explicit `surface=` always wins; otherwise inherit from the
+            # parent (the default) or fall back to 'content'. (This mirrors the
+            # ttk autostyle path — the Tk path previously let inheritance clobber
+            # an explicit surface, freezing e.g. a meter canvas to a resolved hex.)
+            if surface_token is None:
+                surface_token = parent_surface_token if inherit_surface else 'content'
 
             setattr(self, '_surface', surface_token)
 
             if not auto_style:
                 return
 
-            # ==== Update widget style & register for theme changes =====
+            # ==== Apply the initial theme background =====
+            # `_surface` (the token, set above) is what the unified theme walk
+            # later re-resolves on a theme change; `_bs_theme_version` lets the
+            # walk tell whether this widget already matches the current theme.
 
             from bootstack.style.style import get_style
             style = get_style()
             surface = getattr(self, '_surface', 'content')
             style._get_tk_builder().call_builder(self, surface=surface)
             self._bs_theme_version = style._theme_version
-            style.register_tk_widget(self)
 
         return __init__wrapper
 

--- a/src/bootstack/widgets/_impl/composites/avatar.py
+++ b/src/bootstack/widgets/_impl/composites/avatar.py
@@ -70,7 +70,6 @@ class Avatar(Frame):
                               background=self._surface_color())
         self._canvas.pack()
         self._canvas.bind("<Button-1>", self._forward_click)
-        self._enable_theme_repaint(self._on_theme)
 
         self._render()
 
@@ -159,7 +158,7 @@ class Avatar(Frame):
         except Exception:
             return ""
 
-    def _on_theme(self, _event=None) -> None:
+    def _bs_apply_theme(self, _event=None) -> None:
         try:
             self._canvas.configure(background=self._surface_color())
         except TclError:

--- a/src/bootstack/widgets/_impl/composites/carousel.py
+++ b/src/bootstack/widgets/_impl/composites/carousel.py
@@ -140,7 +140,6 @@ class Carousel(Frame):
         self._stage.bind("<Button-1>", self._on_stage_click, add="+")
         self._stage.bind("<Left>", lambda e: self.previous())
         self._stage.bind("<Right>", lambda e: self.next())
-        self._enable_theme_repaint(self._on_theme)
 
         # Auto-refresh when the data source changes externally (parity with the
         # other record-native widgets); the subscription is released on destroy.
@@ -188,7 +187,7 @@ class Carousel(Frame):
         except Exception:
             return b.color("background")
 
-    def _on_theme(self, _event=None) -> None:
+    def _bs_apply_theme(self, _event=None) -> None:
         try:
             self._stage.configure(background=self._surface_color())
         except TclError:

--- a/src/bootstack/widgets/_impl/composites/chart.py
+++ b/src/bootstack/widgets/_impl/composites/chart.py
@@ -328,7 +328,6 @@ class Chart(Frame):
             self._canvas.draw_idle()
 
         self._first_paint_done = False
-        self._enable_theme_repaint(self._on_theme_changed)
         self._bind_signals()
         # First-paint + visibility gating. A chart is usually built while its
         # window is hidden (inside the `with App()/Workbench()` block), so the
@@ -633,7 +632,7 @@ class Chart(Frame):
             for text in legend.get_texts():
                 text.set_color(pal["fg"])
 
-    def _on_theme_changed(self) -> None:
+    def _bs_apply_theme(self) -> None:
         """Re-resolve theme colors and redraw (called after a theme rebuild).
 
         Runs regardless of ``themed=`` — the chrome always follows the theme so

--- a/src/bootstack/widgets/_impl/composites/expander.py
+++ b/src/bootstack/widgets/_impl/composites/expander.py
@@ -265,6 +265,13 @@ class Expander(Frame):
 
         self._expanded = True
         self._content_frame.pack(fill='both', expand=True)
+        # Recolor any widget that missed a theme change while this section was
+        # collapsed (the theme walk skips off-screen widgets; this is the
+        # genuine "now visible" trigger, like PageStack page navigation).
+        def _recolor(p=self._content_frame):
+            from bootstack.style.style import get_style
+            get_style().apply_theme_walk(p, only_stale=True)
+        self.after_idle(_recolor)
         self._toggle_button.configure(icon=self._current_chevron_icon)
         if self._highlight:
             self._header_frame.set_selected(True)

--- a/src/bootstack/widgets/_impl/composites/gallery.py
+++ b/src/bootstack/widgets/_impl/composites/gallery.py
@@ -258,13 +258,12 @@ class Gallery(Frame):
         # Tile surfaces + the accent ring are painted imperatively, so re-resolve
         # on a theme change — gated to on-screen by the Frame base hook (an
         # off-screen gallery defers its thumbnail-grid repaint to <Map>).
-        self._enable_theme_repaint(self._on_theme)
         # First render is driven by the container's <Configure> (bound above);
         # no init timer needed.
 
     # ----- theme / silence / source change ----------------------------------
 
-    def _on_theme(self, _event=None) -> None:
+    def _bs_apply_theme(self, _event=None) -> None:
         """Re-apply theme-dependent colors after a theme switch.
 
         The tile surface backgrounds and the accent selection ring are resolved

--- a/src/bootstack/widgets/_impl/composites/list/listview.py
+++ b/src/bootstack/widgets/_impl/composites/list/listview.py
@@ -160,7 +160,6 @@ class ListView(Frame):
         # so it must be re-resolved on theme change — gated to on-screen by the
         # Frame base hook (an off-screen list defers its per-row repaint to <Map>)
         # and released on destroy automatically.
-        self._enable_theme_repaint(self._on_theme_changed)
         self._bind_scroll_events(self)
         self._bind_scroll_events(self._container)
 
@@ -823,7 +822,7 @@ class ListView(Frame):
         # Fallback to original data if we can't fetch fresh state
         self.event_generate('<<ItemClick>>', data=event.data)
 
-    def _on_theme_changed(self, _event: Any = None) -> None:
+    def _bs_apply_theme(self, _event: Any = None) -> None:
         """Re-resolve theme-dependent per-row surfaces on a theme change.
 
         The striped background is applied imperatively (not via a ttk style), so

--- a/src/bootstack/widgets/_impl/composites/meter.py
+++ b/src/bootstack/widgets/_impl/composites/meter.py
@@ -146,13 +146,16 @@ class Meter(Frame):
         # Resolve styles first to get colors
         self._resolve_meter_styles()
 
-        # layout - use canvas for both meter and text
+        # layout - use canvas for both meter and text. Pass the surface *token*
+        # (not a resolved color) so the unified theme walk re-resolves the canvas
+        # background against the active theme on every change — a frozen hex would
+        # re-apply the old color forever.
         self._canvas = Canvas(
             master=self,
             width=self._size,
             height=self._size,
             highlightthickness=0,
-            background=self._surface
+            surface=self._surface_token,
         )
 
         # Canvas text items (will be created/updated in _draw_meter)
@@ -163,12 +166,10 @@ class Meter(Frame):
         self._subtitle_text_id = None
 
         # The meter face / track / arc / text are painted imperatively onto the
-        # canvas (outside the ttk style loop), so re-resolve + redraw on a theme
-        # change. The Frame base hook gates this to on-screen: an off-screen meter
-        # defers its (supersampled, expensive) redraw to the next <Map>, so a
-        # theme toggle repaints only visible gauges (#167 fixed the timing; this
-        # keeps it cheap with many gauges across pages).
-        self._enable_theme_repaint(self._repaint_theme)
+        # canvas (outside the ttk style loop), so the unified theme walk calls
+        # `_bs_apply_theme` to re-resolve + redraw them. The canvas *background*
+        # is handled by the walk's surface pass (the token above); the redraw owns
+        # only the painted content.
         self._bind_interactive_events()
         self._draw_base_meter_images()
         self._draw_meter()
@@ -771,15 +772,12 @@ class Meter(Frame):
 
         return int(normalized * self._arc_range + self._arc_offset)
 
-    def _repaint_theme(self):
-        """Re-resolve theme colors and repaint the canvas (face + arcs + text).
-
-        Invoked by the Frame base hook only while on screen; an off-screen meter
-        defers this to its next `<Map>`. Reconfigures the canvas background too,
-        since the face surface can be reset to the default during a re-map.
+    def _bs_apply_theme(self):
+        """Re-resolve theme colors and repaint the painted content (face + arcs +
+        text). Called by the unified theme walk when this gauge is on screen; the
+        canvas *background* is recolored separately by the walk's surface pass.
         """
         self._resolve_meter_styles()
-        self._canvas.configure(background=self._surface)
         self._draw_base_meter_images()
         self._draw_meter()
 

--- a/src/bootstack/widgets/_impl/composites/pagestack.py
+++ b/src/bootstack/widgets/_impl/composites/pagestack.py
@@ -191,6 +191,13 @@ class PageStack(Frame):
         page.event_generate('<<PageWillMount>>', data=payload, when="tail")
         page.pack(fill='both', expand=True)
         self._current = key
+        # A theme change that arrived while this page was hidden left its widgets
+        # stale (the walk skips off-screen widgets); recolor the now-visible page.
+        # Deferred to idle so the page is mapped first.
+        def _recolor_shown(p=page):
+            from bootstack.style.style import get_style
+            get_style().apply_theme_walk(p, only_stale=True)
+        self.after_idle(_recolor_shown)
         self.event_generate('<<PageMount>>', data=payload, when="tail")
         self.event_generate('<<PageChange>>', data=payload, when="tail")
 

--- a/src/bootstack/widgets/_impl/composites/picture.py
+++ b/src/bootstack/widgets/_impl/composites/picture.py
@@ -87,7 +87,6 @@ class Picture(Frame):
         self._canvas.pack(fill="both", expand=True)
         self._canvas.bind("<Configure>", self._on_configure)
         self._canvas.bind("<Button-1>", self._forward_click)
-        self._enable_theme_repaint(self._on_theme_changed)
 
         # Defer the initial load to idle so the constructor returns first: the
         # caller can bind on_load/on_error before the <<PictureLoad>> fires.
@@ -105,7 +104,7 @@ class Picture(Frame):
         except Exception:
             return builder.color("background")
 
-    def _on_theme_changed(self, _event=None) -> None:
+    def _bs_apply_theme(self, _event=None) -> None:
         self._surface_color = self._resolve_surface()
         try:
             self._canvas.configure(background=self._surface_color)

--- a/src/bootstack/widgets/_impl/composites/shell/nav_panel.py
+++ b/src/bootstack/widgets/_impl/composites/shell/nav_panel.py
@@ -105,7 +105,6 @@ class NavPanel(Frame):
         self._main = self._scroll.add(surface=surface)
         self._updating_overflow = False
         self._paint_canvas_surface()
-        self._enable_theme_repaint(self._paint_canvas_surface)
         # Re-evaluate the gutter/bar + footer divider whenever the content height
         # or viewport changes (items added/removed, sidebar resized, compaction).
         self._scroll.canvas.bind("<Configure>", lambda _e: self._update_overflow_state(), add="+")
@@ -256,6 +255,9 @@ class NavPanel(Frame):
             self._scroll.canvas.configure(background=color)
         except Exception:
             pass
+
+    # The unified theme walk re-applies the canvas surface on a theme change.
+    _bs_apply_theme = _paint_canvas_surface
 
     def _content_overflows(self) -> bool:
         """Whether the item content is taller than the scroll viewport.

--- a/src/bootstack/widgets/_impl/composites/slider/_shared.py
+++ b/src/bootstack/widgets/_impl/composites/slider/_shared.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 from PIL import Image, ImageDraw
 from PIL.ImageTk import PhotoImage
 
-# Highlight thickness for focus ring
-HL = 2
+# Focus-ring border thickness. Retired (0): the ring was never wired to an
+# actual keyboard-focus style and its frozen color did not track theme changes,
+# so it only ever showed as a stale 1-2px border. Kept as a named constant so
+# the geometry math (`cross_size + HL * 2`) and the highlight kwargs stay valid.
+HL = 0
 
 HANDLE_SIZE = 22   # handle diameter (px) — matches slider-handle.png at standard DPI
 TRACK_H = 6        # track height (px)
@@ -170,7 +173,12 @@ def resolve_colors(accent: str, surface: str, bg_override: str | None = None) ->
     bg = bg_override or b.color('background')
     accent_hex = b.color(accent)
     border = b.border(bg)
-    muted = b.color('foreground[muted]')
+    # A muted tone with guaranteed ≥4.5 contrast against the slider's own surface.
+    # (NOT `foreground[muted]`, which computes muted *relative to the foreground*
+    # and so lands near the background — faint everywhere, invisible in e.g.
+    # solarized-light. `muted_foreground(bg)` is the same value the public
+    # `'muted'` token resolves to.)
+    muted = b.muted_foreground(bg)
     return {
         'bg':              bg,
         'trough':          border,
@@ -182,6 +190,6 @@ def resolve_colors(accent: str, surface: str, bg_override: str | None = None) ->
         'handle_border':   border,
         'badge_bg':        b.color('foreground'),
         'badge_text':      b.on_color(b.color('foreground')),
-        'tick':            b.color('foreground[muted]'),
+        'tick':            muted,
         'focus':           b.color('foreground'),
     }

--- a/src/bootstack/widgets/_impl/composites/slider/rangeslider.py
+++ b/src/bootstack/widgets/_impl/composites/slider/rangeslider.py
@@ -303,15 +303,9 @@ class RangeSlider(ConfigureDelegationMixin, tk.Frame):
 
         self._lo_var.trace_add("write", self._on_lo_write)
         self._hi_var.trace_add("write", self._on_hi_write)
-        # Re-resolve track/handle colors on a theme change via the STD publisher
-        # (fires ONCE, after the rebuild) — NOT the ttk `<<ThemeChanged>>`, which
-        # re-fires per style reconfigure during the rebuild (×N styles × every
-        # slider on screen → thousands of redraws, the gallery's ~2s theme lag).
-        from bootstack._core.publisher import Channel, Publisher
-        name = str(self)
-        Publisher.subscribe(name=name, func=lambda *_a, **_k: self._on_theme_changed(),
-                            channel=Channel.STD)
-        self.bind("<Destroy>", lambda e, n=name: Publisher.unsubscribe(n), add="+")
+        # The unified theme walk re-resolves track/handle colors via
+        # `_bs_apply_theme` on a theme change. The <Map> flush also covers a
+        # redraw deferred while the slider was off-screen (value/size changes).
         self.bind("<Map>", lambda e: self._on_map(), add="+")
 
     # ------------------------------------------------------------------
@@ -748,10 +742,11 @@ class RangeSlider(ConfigureDelegationMixin, tk.Frame):
         if getattr(self, '_theme_update_pending', False):
             self._on_theme_changed()
 
-    def _on_theme_changed(self) -> None:
-        if not self.winfo_viewable():
-            self._theme_update_pending = True
-            return
+    def _bs_apply_theme(self) -> None:
+        """Theme walk hook — re-resolve colors and redraw track, handles, badge,
+        focus halo, and tick marks + tick labels. The walk owns visibility
+        gating, so this always repaints (no early-out).
+        """
         self._theme_update_pending = False
         self._colors = resolve_colors(self._accent, self._surface, get_widget_bg(self.master))
         colors = self._colors
@@ -765,8 +760,17 @@ class RangeSlider(ConfigureDelegationMixin, tk.Frame):
         # Recolor the focus halo to the new theme's focus color.
         self._focus_ring_photo = _make_focus_ring(self._focus_ring_diam, colors['focus'])
         self._canvas.itemconfig(self._focus_ring_item, image=self._focus_ring_photo)
-        self._setup_ticks()
+        self._setup_ticks()   # redraws ticks + tick labels with colors['tick']
         self._sync()   # _sync repositions/shows the halo as needed
+
+    def _on_theme_changed(self) -> None:
+        # Value/size redraws keep their own off-screen deferral (flushed on
+        # <Map>); a genuine theme change is driven through _bs_apply_theme by the
+        # unified theme walk.
+        if not self.winfo_viewable():
+            self._theme_update_pending = True
+            return
+        self._bs_apply_theme()
 
     # ------------------------------------------------------------------
     # Public API

--- a/src/bootstack/widgets/_impl/composites/slider/slider.py
+++ b/src/bootstack/widgets/_impl/composites/slider/slider.py
@@ -288,15 +288,9 @@ class Slider(ConfigureDelegationMixin, tk.Frame):
         self._canvas.bind("<Configure>", self._on_configure)
 
         self._var.trace_add("write", self._on_var_write)
-        # Re-resolve the track/handle colors on a theme change. Subscribe to the
-        # STD publisher (fires ONCE, after the rebuild) — NOT the ttk
-        # `<<ThemeChanged>>`, which re-fires per style reconfigure during the
-        # rebuild (×N styles × every slider on screen → thousands of redraws).
-        from bootstack._core.publisher import Channel, Publisher
-        name = str(self)
-        Publisher.subscribe(name=name, func=lambda *_a, **_k: self._on_theme_changed(),
-                            channel=Channel.STD)
-        self.bind("<Destroy>", lambda e, n=name: Publisher.unsubscribe(n), add="+")
+        # The unified theme walk re-resolves the track/handle colors via
+        # `_bs_apply_theme` on a theme change. The <Map> flush also covers a
+        # redraw deferred while the slider was off-screen (value/size changes).
         self.bind("<Map>", lambda e: self._on_map(), add="+")
 
     # ------------------------------------------------------------------
@@ -651,10 +645,11 @@ class Slider(ConfigureDelegationMixin, tk.Frame):
         if getattr(self, '_theme_update_pending', False):
             self._on_theme_changed()
 
-    def _on_theme_changed(self) -> None:
-        if not self.winfo_viewable():
-            self._theme_update_pending = True
-            return
+    def _bs_apply_theme(self) -> None:
+        """Theme walk hook — re-resolve colors and redraw track, handle, badge,
+        focus halo, and tick marks + tick labels. The walk owns visibility
+        gating, so this always repaints (no early-out).
+        """
         self._theme_update_pending = False
         self._colors = resolve_colors(self._accent, self._surface, get_widget_bg(self.master))
         colors = self._colors
@@ -672,8 +667,17 @@ class Slider(ConfigureDelegationMixin, tk.Frame):
             self._canvas.itemconfig(self._minlabel_item, fill=colors['tick'])
         if self._maxlabel_item is not None:
             self._canvas.itemconfig(self._maxlabel_item, fill=colors['tick'])
-        self._setup_ticks()
+        self._setup_ticks()   # redraws ticks + tick labels with colors['tick']
         self._sync()   # _sync repositions/shows the halo as needed
+
+    def _on_theme_changed(self) -> None:
+        # Value/size redraws keep their own off-screen deferral (flushed on
+        # <Map>); a genuine theme change is driven through _bs_apply_theme by the
+        # unified theme walk.
+        if not self.winfo_viewable():
+            self._theme_update_pending = True
+            return
+        self._bs_apply_theme()
 
     # ------------------------------------------------------------------
     # Public API

--- a/src/bootstack/widgets/_impl/composites/tableview/tableview.py
+++ b/src/bootstack/widgets/_impl/composites/tableview/tableview.py
@@ -492,11 +492,10 @@ class TableView(Frame):
             except Exception:
                 self._change_sub = None
         self.bind('<Destroy>', self._on_table_destroy, add='+')
-        # The alternating-row stripe is applied via imperative tag colors, which
-        # are NOT refreshed by the ttk style rebuild. Re-apply on a theme change —
-        # gated to on-screen by the Frame base hook (an off-screen table defers
-        # its per-row repaint to <Map>), and released on destroy automatically.
-        self._enable_theme_repaint(self._on_theme_changed)
+        # The alternating-row stripe + theme-colored marker/chevron/sort-arrow
+        # icons are imperative (not refreshed by the ttk style rebuild), so the
+        # unified theme walk re-applies them via `_bs_apply_theme` when the table
+        # is on screen.
 
     def _silence_source(self):
         """Context manager suppressing source change broadcasts for our own writes."""
@@ -2167,11 +2166,27 @@ class TableView(Frame):
             except Exception:
                 pass
 
-    def _on_theme_changed(self, _event: Any = None) -> None:
-        """Re-resolve the imperative stripe tag colors on a theme change (tag
-        colors aren't refreshed by the ttk style rebuild)."""
+    def _bs_apply_theme(self, _event: Any = None) -> None:
+        """Re-resolve imperatively-colored visuals on a theme change.
+
+        The ttk style rebuild refreshes neither the imperative stripe tag colors
+        nor the theme-colored marker / group-chevron / sort-arrow PhotoImages —
+        the latter are cached by color and held on rows, so without this they
+        keep their old-theme tint after a light/dark toggle.
+        """
         try:
             self._apply_row_alternation()
+        except Exception:
+            pass
+        # Drop the by-color icon cache and re-apply every theme-colored glyph so
+        # it re-renders against the new theme. Each call no-ops when its glyph
+        # isn't in play (e.g. markers only in multi-select, chevrons only in
+        # group mode), so this is safe regardless of the current configuration.
+        try:
+            self._marker_icons.clear()
+            self._update_selection_markers()
+            self._refresh_group_chevrons()
+            self._update_heading_icons()
         except Exception:
             pass
 

--- a/src/bootstack/widgets/_impl/primitives/combobox.py
+++ b/src/bootstack/widgets/_impl/primitives/combobox.py
@@ -76,9 +76,9 @@ class Combobox(TextSignalMixin, TTKWrapperBase, WidgetCapabilitiesMixin, TtkStat
         # Store original postcommand if provided
         self._original_postcommand = kwargs.get('postcommand')
 
-        # Set up popdown styling (also bound to theme changes)
+        # Set up popdown styling. A theme change re-styles an already-open
+        # popdown through the unified theme walk (`_bs_apply_theme`).
         self._setup_postcommand()
-        self._subscribe_theme_changes()
 
     @configure_delegate('density')
     def _delegate_density(self, value=None):
@@ -147,9 +147,10 @@ class Combobox(TextSignalMixin, TTKWrapperBase, WidgetCapabilitiesMixin, TtkStat
         except Exception:
             pass
 
-    def _subscribe_theme_changes(self) -> None:
-        """Re-style any already-created popdown when the theme changes."""
-        from bootstack._core.publisher import Channel, Publisher
-        name = str(self)
-        Publisher.subscribe(name=name, func=self._apply_popdown_style, channel=Channel.STD)
-        self.bind('<Destroy>', lambda _e, n=name: Publisher.unsubscribe(n), '+')
+    def _bs_apply_theme(self) -> None:
+        """Unified theme-walk hook — re-style an already-open popdown.
+
+        The ttk style engine handles the entry itself; this re-colors the
+        embedded Tk listbox/scrollbar of the popdown if one has been created.
+        """
+        self._apply_popdown_style()

--- a/src/bootstack/widgets/_impl/primitives/frame.py
+++ b/src/bootstack/widgets/_impl/primitives/frame.py
@@ -61,58 +61,10 @@ class Frame(TTKWrapperBase, WidgetCapabilitiesMixin, TtkStateMixin, ttk.Frame):
         kwargs['style_options'] = {**existing, **captured}
         super().__init__(master, **kwargs)
 
-    # ----- Theme repaint (for imperatively-painted / canvas widgets) -----
-
-    def _enable_theme_repaint(self, repaint) -> None:
-        """Repaint canvas-painted content on theme change, gated on visibility.
-
-        Widgets that paint colors directly onto a canvas live outside the ttk
-        style loop, so they must re-resolve and redraw when the theme changes.
-        Calling this once (after the drawing surface exists) wires that up the
-        right way:
-
-        - It subscribes to the `STD` publisher channel, which fires AFTER the
-          theme rebuild (so resolved colors are the new theme's) and calls back
-          directly (virtual events do not reach descendants).
-        - The redraw runs ONLY while the widget is on screen. A theme change that
-          arrives while it is off-screen (e.g. an inactive page) is deferred to
-          the next `<Map>` — so a theme toggle repaints just the visible widgets
-          instead of every canvas widget in the app.
-        - The subscription is released on `<Destroy>`.
-
-        Args:
-            repaint: The widget's full re-resolve-and-redraw callback (no args).
-        """
-        from bootstack._core.publisher import Channel, Publisher
-
-        self._theme_repaint = repaint
-        self._theme_repaint_pending = False
-        name = str(self)
-        Publisher.subscribe(name=name, func=self._on_theme_notify, channel=Channel.STD)
-        self.bind('<Map>', self._on_theme_map, add='+')
-        self.bind('<Destroy>', lambda _e, n=name: Publisher.unsubscribe(n), add='+')
-
-    def _on_theme_notify(self, *_: Any, **__: Any) -> None:
-        """STD-publisher callback (after the rebuild): repaint now, or defer."""
-        if not self.winfo_exists():
-            return
-        if self.winfo_viewable():
-            self._theme_repaint_pending = False
-            self._theme_repaint()
-        else:
-            self._theme_repaint_pending = True
-
-    def _on_theme_map(self, _event: Any = None) -> None:
-        """On map, run a theme repaint that was deferred while off-screen."""
-        if getattr(self, '_theme_repaint_pending', False):
-            # Defer to idle so the repaint runs after the map cascade settles
-            # (a canvas background can be reset to the default during mapping).
-            self.after_idle(self._run_pending_theme_repaint)
-
-    def _run_pending_theme_repaint(self) -> None:
-        if getattr(self, '_theme_repaint_pending', False) and self.winfo_exists():
-            self._theme_repaint_pending = False
-            self._theme_repaint()
+    # A canvas-painting Frame subclass (Meter, Slider, …) recolors on a theme
+    # change by defining `_bs_apply_theme(self)`; the unified theme walk in
+    # `bootstack.style.style` calls it. There is no per-widget subscription or
+    # `<Map>` deferral — visibility is resolved by the walk at apply time.
 
     def configure_style_options(self, value=None, **kwargs):
         """Set style options and refresh descendant surfaces if needed."""

--- a/tests/widgets/public/test_datatable_theme_recolor.py
+++ b/tests/widgets/public/test_datatable_theme_recolor.py
@@ -1,0 +1,41 @@
+"""DataTable theme-colored glyphs recolor on a theme change, no interaction.
+
+The per-row selection-marker icons (and group chevrons / sort arrows) are
+theme-colored PhotoImages cached by color and held on the Treeview rows. The ttk
+style rebuild doesn't touch them, so without an explicit re-render they keep
+their old-theme tint until something (a selection/sort) re-triggers rendering.
+`_on_theme_changed` must re-render them on the theme toggle alone.
+"""
+import bootstack as bs
+
+
+def _marker_image(tv):
+    first = tv._tree.get_children("")[0]
+    return tv._tree.item(first, "image")
+
+
+def test_selection_marker_recolors_on_theme_change(app):
+    # The app fixture restores the theme on teardown.
+    bs.set_theme("bootstrap-light")
+    table = bs.DataTable(
+        rows=[{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}],
+        selection_mode="multi",
+        show_selection_controls=True,
+    )
+    tv = table._internal
+    tv.update_idletasks()
+    tv._tree.selection_set(tv._tree.get_children("")[0])
+    tv._update_selection_markers()
+    before_img = _marker_image(tv)
+    before_fg = tv._marker_icon_specs()[1]
+    assert before_img, "marker image should be set on the selected row"
+
+    # Toggle the theme and turn the loop once — NO table interaction.
+    bs.set_theme("bootstrap-dark")
+    app.tk.update_idletasks()
+    app.tk.update()
+
+    after_img = _marker_image(tv)
+    after_fg = tv._marker_icon_specs()[1]
+    assert before_fg != after_fg, "marker foreground color should change with theme"
+    assert before_img != after_img, "marker image should re-render on theme change"

--- a/tests/widgets/public/test_gauge_theme_bg.py
+++ b/tests/widgets/public/test_gauge_theme_bg.py
@@ -1,0 +1,39 @@
+"""The Gauge canvas background recolors with the theme (unified theme walk).
+
+The meter canvas takes the surface *token* (not a frozen color), so the unified
+theme walk re-resolves its background against the active theme on every change.
+The painted content (arcs/face/text) redraws via the widget's `_bs_apply_theme`.
+"""
+import bootstack as bs
+from bootstack.style.style import get_style
+
+
+def _expected_bg():
+    return get_style().style_builder.color("background")
+
+
+def test_gauge_canvas_background_recolors_across_themes(app):
+    bs.set_theme("gruvbox-light")
+    gauge = bs.Gauge(value=50, max_value=100)
+    m = gauge._internal
+    app.tk.update_idletasks()
+
+    # canvas carries the surface TOKEN, not a resolved hex — so the theme walk
+    # re-resolves it fresh each change instead of re-applying a frozen color.
+    assert getattr(m._canvas, "_surface", None) == "background"
+
+    # Apply each theme through the engine's per-widget hook (the harness window
+    # isn't mapped, so the viewable-gated walk is exercised in the GUI suite).
+    style = get_style()
+    for theme in ("tokyo-night-dark", "dracula-dark", "gruvbox-light"):
+        bs.set_theme(theme)
+        style._apply_theme_to_widget(m._canvas)
+        assert m._canvas.cget("background") == _expected_bg(), theme
+
+
+def test_gauge_uses_unified_apply_hook(app):
+    gauge = bs.Gauge(value=10)
+    m = gauge._internal
+    # migrated off the legacy per-widget repaint onto the unified hook
+    assert hasattr(m, "_bs_apply_theme")
+    assert not hasattr(m, "_theme_repaint")

--- a/tests/widgets/public/test_theme_walk.py
+++ b/tests/widgets/public/test_theme_walk.py
@@ -1,0 +1,62 @@
+"""The unified theme walk recolors tree widgets via `_bs_apply_theme`.
+
+`Style.apply_theme_walk` is the single mechanism: on a theme change it applies
+every *visible* widget from the root; on a container-show it applies every
+*stale* widget in the shown subtree (regardless of `winfo_viewable()`, which is
+unreliable for a widget embedded in a scrollable page's canvas).
+"""
+import tkinter as tk
+
+import bootstack as bs
+from bootstack.style.style import get_style
+
+
+def _stub(parent):
+    """A tk widget exposing `_bs_apply_theme`, like a migrated canvas widget."""
+    w = tk.Frame(parent)
+    w._applied = 0
+    w._bs_apply_theme = lambda: setattr(w, "_applied", w._applied + 1)
+    return w
+
+
+def test_walk_applies_stale_widget_on_container_show(app):
+    container = tk.Frame(app.tk)
+    container.pack()
+    w = _stub(container)
+    style = get_style()
+    w._bs_theme_version = -1  # never themed → stale
+
+    style.apply_theme_walk(container, only_stale=True)
+
+    assert w._applied == 1
+    assert w._bs_theme_version == style._theme_version  # stamped
+
+
+def test_walk_skips_uptodate_widget_when_only_stale(app):
+    container = tk.Frame(app.tk)
+    container.pack()
+    w = _stub(container)
+    style = get_style()
+    w._bs_theme_version = style._theme_version  # already current
+
+    style.apply_theme_walk(container, only_stale=True)
+
+    assert w._applied == 0  # no redundant repaint when navigating without a theme change
+
+
+def test_datatable_recolors_via_apply_hook(app):
+    bs.set_theme("gruvbox-light")
+    table = bs.DataTable(
+        rows=[{"id": 1, "name": "Ada"}],
+        selection_mode="multi",
+        show_selection_controls=True,
+    )
+    tv = table._internal
+    tv._tree.selection_set(tv._tree.get_children("")[0])
+    tv._update_selection_markers()
+    before = tv._marker_icon_specs()[1]
+
+    bs.set_theme("tokyo-night-dark")
+    get_style()._apply_theme_to_widget(tv)  # the per-widget step the walk runs
+
+    assert tv._marker_icon_specs()[1] != before


### PR DESCRIPTION
Replaces the three overlapping theme-repaint mechanisms with **one**, fixing a class of "doesn't recolor when the theme changed off-screen" bugs and retiring a registry leak. (Theming verified working on macOS as well as Windows.)

## The problem

Three mechanisms recolored widgets on a theme change, all sharing one fragile assumption — *that an off-screen widget receives a usable `<Map>` when it reappears*:

- the **STD publisher** + `_enable_theme_repaint` (canvas-painted content),
- a `register_tk_widget` **WeakSet** + `_rebuild_all_tk_widgets` + `<Map>` registry (raw Tk widget surfaces),
- assorted per-widget hacks.

That assumption is false for a widget embedded in a **scrollable page's canvas** (`<Map>` doesn't reliably reach it, and `winfo_viewable()` can report `False` for an on-screen widget). So each mechanism grew a workaround, and widgets still failed to recolor after an off-screen toggle: DataTable **checkbox icons** and **alternating-row stripes**, the **gauge canvas background**, etc.

## The one rule now

- **A tree widget that recolors defines `_bs_apply_theme(self)`** — all of its imperative theme work in one place.
- **Non-tree reactors** (the `Image` handle, OS window chrome, the app `on_theme_change` callback) stay on the root `<<BsThemeChanged>>` event.

### Engine
`Style.apply_theme_walk(root, *, only_stale)` walks a subtree and, per widget, re-applies the surface background then calls `_bs_apply_theme`, stamping `_bs_theme_version`. **Two triggers, neither `<Map>`:**
- **theme change** → walk *visible* widgets from the root;
- **container-show** → walk the shown subtree for *stale* widgets, **ignoring `winfo_viewable()`** (the container is showing them; viewability is unreliable across a canvas boundary). Stale is version-gated, so navigating without a theme change is a no-op (no flicker).

Show-triggers are wired into **PageStack** (covers AppShell/Workbench pages **and** Tabs, which route content through a PageStack) and **Expander** (covers Accordion).

### Migrations
Every canvas widget moved onto `_bs_apply_theme`: meter, slider, rangeslider, avatar, carousel, gallery, chart, listview, picture, nav_panel, datatable — plus the combobox popdown. The meter canvas now takes the surface **token** (not a frozen hex) so the walk re-resolves it; **`style_resolver` now lets an explicit `surface=` win over inheritance** in the Tk path (it previously froze a resolved color) — the root of the gauge "background doesn't recolor" bug.

### Deletions
The STD publisher theme channel; the whole `_enable_theme_repaint`/`_on_theme_notify`/`_on_theme_map`/`_run_pending_theme_repaint`/`flush_pending_theme_repaints` block; the `register_tk_widget`/`_tk_widgets`/`_rebuild_all_tk_widgets`/`_restyle_single_tk_widget` + `<Map>` registry (**retires the "grows-forever" leak**); and the dev reloader's registry prune.

## Also in here (commit 2): slider color fix
- **Ticks/labels were invisible in some themes.** They used `foreground[muted]`, which the `[muted]` modifier computes as `muted_foreground(<foreground>)` — muted *relative to the foreground*, landing near the background (~1.0–1.8 contrast, **1.01 / invisible in solarized-light**). Switched to `muted_foreground(bg)` (= the public `'muted'` token), guaranteeing ≥4.5 contrast — verified 5.7–8.2 across solarized/gruvbox/tokyo-night/dracula/nord.
- Retired the dead slider **focus-ring border** (`HL` 2→0): never wired to a real focus style, and its frozen color didn't track the theme.

## Verification
- Theme-toggle smoke across Gauge/Slider/RangeSlider/Avatar/Carousel/ProgressBar/Select/ListView/DataTable through 4 themes incl. solarized-light.
- New tests: `test_theme_walk`, `test_gauge_theme_bg`, `test_datatable_theme_recolor`.
- **Full GUI suite green**; **theming confirmed on macOS**.

## Docs
`docs/_dev/theme-repaint-architecture.md` — the one rule, the walk, the triggers, the frozen-hex gotcha, and known limitations (detach/withdrawn-window edge cases).

## Out of scope
Two **pre-existing**, macOS-specific issues surfaced during Mac testing and are filed separately, not part of this change: #336 (slow page/tab navigation) and #337 (corner toast under the Dock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
