### PR TITLE
fix(macos): keep nav pages mapped + anchor toasts to the visible frame (#336, #337)

### DIFF
--- a/src/bootstack/_runtime/window_utilities.py
+++ b/src/bootstack/_runtime/window_utilities.py
@@ -52,6 +52,79 @@ class WindowPositioning:
         >>> # Returns adjusted coordinates within screen bounds
     """
 
+    # Per-process cache of the macOS visible frame (work area) per monitor rect,
+    # keyed by the full monitor bounds. Computed once via a clamped probe.
+    _work_area_cache: dict[Tuple[int, int, int, int], Tuple[int, int, int, int]] = {}
+
+    @staticmethod
+    def get_work_area(
+        root: Optional[tkinter.Misc],
+        monitor_rect: Tuple[int, int, int, int],
+    ) -> Tuple[int, int, int, int]:
+        """Return the usable area of a monitor, OS-reserved strips excluded.
+
+        On macOS the menu bar (top) and Dock sit *inside* the physical monitor
+        bounds, so anchoring a window to the raw monitor rect lands it under the
+        Dock. Tk exposes no `NSScreen.visibleFrame` accessor, so this clamps a
+        throwaway, fully transparent managed Toplevel to the monitor — Aqua snaps
+        a managed window to the visible frame — and reads back the realized
+        origin and size. The result is cached per monitor rect.
+
+        Off macOS the full `monitor_rect` is returned unchanged: the X11/Windows
+        transient path already clears the taskbar via a topmost overlay.
+
+        Args:
+            root: A live widget used to parent the probe. If None, the full
+                `monitor_rect` is returned unchanged.
+            monitor_rect: `(x, y, w, h)` full bounds of the target monitor.
+
+        Returns:
+            `(x, y, w, h)` of the usable work area within `monitor_rect`.
+        """
+        if root is None:
+            return monitor_rect
+        try:
+            if root.tk.call("tk", "windowingsystem") != "aqua":
+                return monitor_rect
+        except tkinter.TclError:
+            return monitor_rect
+
+        cached = WindowPositioning._work_area_cache.get(monitor_rect)
+        if cached is not None:
+            return cached
+
+        mx, my, mw, mh = monitor_rect
+        area = monitor_rect
+        probe: Optional[tkinter.Toplevel] = None
+        try:
+            probe = tkinter.Toplevel(root)
+            try:
+                probe.attributes("-alpha", 0.0)  # invisible — no flash
+            except tkinter.TclError:
+                pass
+            # Oversize and place at the monitor origin; a managed Aqua window is
+            # clamped to that monitor's visible frame, so the realized geometry
+            # is the work area (menu bar + Dock excluded).
+            probe.geometry(f"{mw * 2}x{mh * 2}+{mx}+{my}")
+            probe.update_idletasks()
+            x, y = probe.winfo_rootx(), probe.winfo_rooty()
+            w, h = probe.winfo_width(), probe.winfo_height()
+            # Guard a degenerate probe (e.g. 1x1 if it never mapped): only trust
+            # a result that fills most of the monitor.
+            if w >= mw // 2 and h >= mh // 2:
+                area = (x, y, w, h)
+        except tkinter.TclError:
+            pass
+        finally:
+            if probe is not None:
+                try:
+                    probe.destroy()
+                except tkinter.TclError:
+                    pass
+
+        WindowPositioning._work_area_cache[monitor_rect] = area
+        return area
+
     @staticmethod
     def _get_monitor_at_point(x: int, y: int) -> Optional[Tuple[int, int, int, int]]:
         """Find the monitor containing the given point.

--- a/src/bootstack/style/style.py
+++ b/src/bootstack/style/style.py
@@ -363,6 +363,12 @@ class Style(ttkStyle):
         stack = [root_widget]
         while stack:
             w = stack.pop()
+            # A PageStack keeps inactive pages mapped (so re-showing one doesn't
+            # blank-flash on macOS) but flags them hidden; prune the whole subtree
+            # so a theme change repaints only the visible page. A hidden page's
+            # widgets stay stale and are repainted on its next show (only_stale).
+            if getattr(w, '_bs_nav_hidden', False):
+                continue
             try:
                 stack.extend(w.winfo_children())
             except Exception:

--- a/src/bootstack/widgets/_impl/composites/pagestack.py
+++ b/src/bootstack/widgets/_impl/composites/pagestack.py
@@ -55,6 +55,19 @@ class PageStack(Frame):
         self._current: str | None = None
         self._history: list[tuple[str, dict]] = []
         self._index: int = -1
+        # macOS (Aqua) only: re-mapping a previously-unmapped page paints blank
+        # for one display cycle, so swapping pages with pack_forget/pack flashes
+        # white. There we instead keep every visited page mapped, stacked in a
+        # single grid cell, and switch with lift()/lower() — no remap, no flash.
+        # A page must stay *full size* while hidden for this to hold (a shrunk
+        # page re-expands with the same blank flash), so each mapped page does
+        # reflow on a window resize; that cost is the deliberate trade. Other
+        # platforms don't have the flash and keep the cheaper one-page-mapped
+        # pack path unchanged.
+        try:
+            self._stacked: bool = self.tk.call('tk', 'windowingsystem') == 'aqua'
+        except tkinter.TclError:
+            self._stacked = False
 
     def add(self, key: str, page: tkinter.Widget = None, **kwargs) -> tkinter.Widget:
         """Add a page to the stack, optionally creating a Frame.
@@ -80,8 +93,16 @@ class PageStack(Frame):
             page = Frame(self, **kwargs)
 
         self._pages[key] = page
-        page.pack(fill='both', expand=True)
-        page.pack_forget()
+        if self._stacked:
+            # Stacked layout: every page shares grid cell (0, 0); navigate()
+            # maps/lifts the active one. Left unmapped here — it maps on first
+            # show (the initial render always paints fresh, flash or not).
+            self.grid_rowconfigure(0, weight=1)
+            self.grid_columnconfigure(0, weight=1)
+            page._bs_nav_hidden = True
+        else:
+            page.pack(fill='both', expand=True)
+            page.pack_forget()
         return page
 
     def remove(self, key: str) -> None:
@@ -161,8 +182,16 @@ class PageStack(Frame):
             self._history.append((key, data))
             self._index += 1
 
-        # Unmount previous page
-        if self._current is not None:
+        # Unmount the previous page. On Aqua keep it mapped (stacked behind the
+        # incoming page) so returning to it doesn't remap-flash; elsewhere unmap
+        # it for the cheaper one-page-mapped path.
+        if self._stacked:
+            if self._current is not None and self._current != key:
+                prev_page = self._pages[self._current]
+                prev_page.event_generate('<<PageUnmount>>', when="tail")
+                prev_page._bs_nav_hidden = True
+                prev_page.lower()
+        elif self._current is not None:
             # Pre-size the target page while the current one is still mounted, so
             # the swap doesn't briefly collapse the content area (a freshly built
             # page is otherwise unsized at mount time and the view jumps when it
@@ -189,7 +218,15 @@ class PageStack(Frame):
         # Mount and notify
         page = self._pages[key]
         page.event_generate('<<PageWillMount>>', data=payload, when="tail")
-        page.pack(fill='both', expand=True)
+        if self._stacked:
+            page._bs_nav_hidden = False
+            # Map into the shared cell (the first show maps it; later shows are a
+            # no-op reconfigure of an already-mapped page) and lift it above the
+            # stack. Pages are never unmapped again, so a return never remaps.
+            page.grid(row=0, column=0, sticky='nsew')
+            page.lift()
+        else:
+            page.pack(fill='both', expand=True)
         self._current = key
         # A theme change that arrived while this page was hidden left its widgets
         # stale (the walk skips off-screen widgets); recolor the now-visible page.

--- a/src/bootstack/widgets/_impl/composites/toast_stack.py
+++ b/src/bootstack/widgets/_impl/composites/toast_stack.py
@@ -39,7 +39,12 @@ def _alive(top: tkinter.Toplevel) -> bool:
 
 
 def _monitor_rect() -> tuple[int, int, int, int]:
-    """`(x, y, w, h)` of the monitor the app window is on; full screen fallback."""
+    """`(x, y, w, h)` usable work area of the monitor the app window is on.
+
+    On macOS this is the visible frame (menu bar + Dock excluded) so a corner
+    toast never lands under the Dock; elsewhere it is the full monitor bounds.
+    Falls back to the full screen, then a fixed default.
+    """
     root = get_default_root()
     if root is not None:
         try:
@@ -47,9 +52,9 @@ def _monitor_rect() -> tuple[int, int, int, int]:
             cx = root.winfo_rootx() + root.winfo_width() // 2
             cy = root.winfo_rooty() + root.winfo_height() // 2
             rect = WindowPositioning._get_monitor_at_point(cx, cy)
-            if rect:
-                return rect
-            return (0, 0, root.winfo_screenwidth(), root.winfo_screenheight())
+            if rect is None:
+                rect = (0, 0, root.winfo_screenwidth(), root.winfo_screenheight())
+            return WindowPositioning.get_work_area(root, rect)
         except tkinter.TclError:
             pass
     return (0, 0, 1920, 1080)

--- a/tests/widgets/public/test_pagestack.py
+++ b/tests/widgets/public/test_pagestack.py
@@ -1,0 +1,93 @@
+"""PageStack navigation behavior.
+
+The macOS-specific tests cover the keep-mapped fix for the page-nav white flash
+(GitHub #336): on Aqua a remapped page paints blank for one display cycle, so
+PageStack keeps every visited page mapped (stacked in one grid cell) and switches
+with lift()/lower() instead of pack_forget/pack. Other platforms keep the cheaper
+one-page-mapped pack path, so these invariants are gated to Aqua.
+"""
+from __future__ import annotations
+
+import pytest
+
+import bootstack as bs
+
+
+def _is_aqua(app) -> bool:
+    return app._tk_root.tk.call("tk", "windowingsystem") == "aqua"
+
+
+def _build_three(app):
+    ps = bs.PageStack(grow=True)
+    for key in ("a", "b", "c"):
+        with ps.add(key):
+            bs.Label(f"page {key}")
+    return ps, ps._internal._pages
+
+
+def test_visited_pages_stay_mapped_on_macos(shown_app):
+    """macOS: navigating away keeps every visited page mapped (no remap flash)."""
+    if not _is_aqua(shown_app):
+        pytest.skip("keep-mapped navigation is macOS-only")
+
+    ps, pages = _build_three(shown_app)
+    for key in ("a", "b", "c"):
+        ps.navigate(key)
+        shown_app._tk_root.update()
+
+    # None was unmapped on hide — re-showing any of them never remaps (no flash).
+    assert pages["a"].winfo_ismapped()
+    assert pages["b"].winfo_ismapped()
+    assert pages["c"].winfo_ismapped()
+
+
+def test_only_active_page_exposed_to_theme_walk_on_macos(shown_app):
+    """macOS: hidden-but-mapped pages are flagged so the theme walk skips them."""
+    if not _is_aqua(shown_app):
+        pytest.skip("keep-mapped navigation is macOS-only")
+
+    ps, pages = _build_three(shown_app)
+    ps.navigate("a")
+    shown_app._tk_root.update()
+    ps.navigate("b")
+    shown_app._tk_root.update()
+
+    # The active page is walkable; the one left behind is pruned (stays mapped).
+    assert pages["b"]._bs_nav_hidden is False
+    assert pages["a"]._bs_nav_hidden is True
+
+
+def test_return_after_many_visits_does_not_remap_on_macos(shown_app):
+    """macOS: returning to an early page after others keeps everything mapped.
+
+    Unbounded keep-mapped — no eviction — so depth of navigation never
+    reintroduces the flash for a previously-visited page.
+    """
+    if not _is_aqua(shown_app):
+        pytest.skip("keep-mapped navigation is macOS-only")
+
+    ps, pages = _build_three(shown_app)
+    for key in ("a", "b", "c", "b", "a"):
+        ps.navigate(key)
+        shown_app._tk_root.update()
+
+    assert pages["a"]._bs_nav_hidden is False
+    assert pages["a"].winfo_ismapped()
+    assert pages["b"].winfo_ismapped()
+    assert pages["c"].winfo_ismapped()
+
+
+def test_navigation_and_history_work_everywhere(app):
+    """Cross-platform: navigate/back/forward and current() behave regardless."""
+    ps, _pages = _build_three(app)
+
+    ps.navigate("a")
+    assert ps._internal.current()[0] == "a"
+    ps.navigate("b")
+    ps.navigate("c")
+    assert ps._internal.can_back() is True
+
+    ps.back()
+    assert ps._internal.current()[0] == "b"
+    ps.forward()
+    assert ps._internal.current()[0] == "c"


### PR DESCRIPTION
Two macOS-only display fixes, both gated to Aqua so Windows/Linux keep their existing (working) paths unchanged.

## #336 — page/tab navigation flashed white when returning to a built page
**Root cause:** `PageStack` swapped pages with `pack_forget`/`pack`, and on Aqua a re-mapped view paints blank for one display cycle, so returning to an already-built page flashed white.

**Fix:** on Aqua, keep every *visited* page full-size and mapped, stacked in a single grid cell, and switch with `lift()`/`lower()` — no remap, no flash, at any navigation depth. A hidden page is flagged `_bs_nav_hidden` so the theme walk prunes it (theme toggle stays fast) and is recolored on its next show if a theme change arrived while it was hidden.

Keeping a page full-size while hidden is required (a shrunk page re-expands with the same blank flash), so each mapped page reflows on a window resize — the deliberate trade for flash-free navigation. Only visited pages map, so that cost scales with pages actually opened. **Other platforms keep the one-page-mapped `pack` path verbatim.**

## #337 — bottom-anchored toasts/notifications rendered under the Dock
**Root cause:** the corner reflow anchored to the full monitor bounds, which on macOS include the Dock and menu bar.

**Fix:** a cached `WindowPositioning.get_work_area()` clamps an invisible probe `Toplevel` to the monitor and reads back the visible frame (Dock + menu bar excluded); corner toasts anchor to that. The probe steals no focus and holds no grab. Off macOS the full monitor bounds are returned unchanged.

## Tests
Adds `tests/widgets/public/test_pagestack.py` — Aqua-gated keep-mapped invariants (visited pages stay mapped, only the active page is exposed to the theme walk, returning after many visits never remaps) plus a cross-platform navigate/history check. Full GUI suite green on macOS (the pre-existing failures are unrelated and present on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)