### PR TITLE
fix(theme): readable, consistent text-on-accent across all themes

### DIFF
--- a/src/bootstack/style/style_builder_base.py
+++ b/src/bootstack/style/style_builder_base.py
@@ -345,12 +345,18 @@ class StyleBuilderBase:
                         accent_force_light = True
 
             # Never force white when white is actually unreadable. A bright but
-            # mid-luminance accent like cyan (info) has far higher contrast with
-            # black than white (~10:1 vs ~2:1), so it must take dark text — the
-            # luminance buckets alone would wrongly pick white. Gate the
-            # light-text bias on white clearing a real WCAG contrast threshold.
+            # mid-luminance accent like cyan (info) or yellow (warning) has far
+            # higher contrast with black than white, so it must take dark text —
+            # the luminance buckets alone would wrongly pick white. Gate the
+            # light-text bias on white clearing a real WCAG threshold.
+            #
+            # Use the large-text / UI threshold (3.0), not the normal-text 4.5:
+            # accent text is button/pill/badge labels (bold, >=14pt), so 3.0 is the
+            # correct WCAG bar. 4.5 was too strict and sent saturated mid-tone
+            # accents (e.g. dracula-light's purple primary, white ~3.7) to black,
+            # making them inconsistent with the same accent in dark mode (white).
             contrast_white = 1.05 / (lum + 0.05)  # ratio of #ffffff vs the color
-            white_ok = contrast_white >= 4.5
+            white_ok = contrast_white >= 3.0
 
             # Saturated / dark-ish accents prefer white text — but only when it
             # is legible; otherwise fall through to a contrast-chosen dark color.
@@ -381,7 +387,24 @@ class StyleBuilderBase:
             if c and c not in unique:
                 unique.append(c)
 
-        return best_foreground(color, unique)
+        chosen = best_foreground(color, unique)
+
+        # Safety floor (3.0 = the large/bold WCAG bar that accent labels meet).
+        # An accent sitting near a luminance-bucket boundary can land on a biased
+        # candidate that is actually unreadable (e.g. a light amber `warning` just
+        # under the dark-mode 0.45 cutoff takes white at ~2:1). If the biased pick
+        # misses the bar, fall back to the higher-contrast of pure black/white.
+        def _ratio(fg: str) -> float:
+            try:
+                lf = relative_luminance(fg)
+            except Exception:
+                return 0.0
+            hi, lo = max(lf, lum), min(lf, lum)
+            return (hi + 0.05) / (lo + 0.05)
+
+        if _ratio(chosen) < 3.0:
+            chosen = "#000000" if _ratio("#000000") >= _ratio("#ffffff") else "#ffffff"
+        return chosen
 
     def muted_foreground(self, background: str, min_contrast: float = 4.5) -> str:
         """Return a muted foreground color with adequate contrast against background."""

--- a/tests/test_on_color_contrast.py
+++ b/tests/test_on_color_contrast.py
@@ -1,0 +1,65 @@
+"""`on_color` (text-on-accent) is consistent and readable across themes.
+
+Accent text is button/pill/badge labels (bold, large), so the WCAG bar is 3.0,
+not 4.5. A saturated colored accent (blue/purple/green/red) takes WHITE in both
+light and dark themes; a genuinely light accent (bright yellow `warning`, bright
+cyan `info`) takes BLACK. The light-mode white gate previously used 4.5, which
+sent mid-tone colored accents (e.g. dracula-light's purple primary, white ~3.7)
+to black — inconsistent with the same accent in dark mode.
+"""
+import bootstack as bs
+from bootstack.style.style import get_style
+
+
+def _luminance(hex_color):
+    h = hex_color.lstrip("#")
+    r, g, b = (int(h[i:i + 2], 16) / 255 for i in (0, 2, 4))
+    f = lambda c: c / 12.92 if c <= 0.03928 else ((c + 0.055) / 1.055) ** 2.4
+    return 0.2126 * f(r) + 0.7152 * f(g) + 0.0722 * f(b)
+
+
+def _contrast(a, b):
+    la, lb = _luminance(a), _luminance(b)
+    hi, lo = max(la, lb), min(la, lb)
+    return (hi + 0.05) / (lo + 0.05)
+
+
+def _is_white(c):
+    return c.lower() in ("#ffffff", "#fff")
+
+
+def _is_black(c):
+    return c.lower() in ("#000000", "#000")
+
+
+def test_light_theme_colored_accent_takes_white(app):
+    # dracula-light primary is a mid-tone purple — white at ~3.7, which clears the
+    # 3.0 button bar; it must read white (it previously fell to black).
+    bs.set_theme("dracula-light")
+    b = get_style().style_builder
+    for token in ("primary", "secondary", "danger"):
+        assert _is_white(b.on_color(b.color(token))), token
+
+
+def test_light_accents_keep_black_text(app):
+    # Bright cyan info / bright yellow warning must keep dark text (white unreadable).
+    bs.set_theme("bootstrap-light")
+    b = get_style().style_builder
+    assert _is_black(b.on_color(b.color("info")))      # bright cyan
+    assert _is_black(b.on_color(b.color("warning")))   # bright yellow
+
+
+def test_on_color_clears_the_button_contrast_bar(app):
+    # Whatever on_color picks, it clears the 3.0 (large/bold) WCAG bar for every
+    # accent in every built-in theme.
+    from bootstack.style import get_themes
+
+    accents = ("primary", "secondary", "info", "success", "warning", "danger")
+    worst = 99.0
+    for theme in (t["name"] for t in get_themes()):
+        bs.set_theme(theme)
+        b = get_style().style_builder
+        for a in accents:
+            acc = b.color(a)
+            worst = min(worst, _contrast(b.on_color(acc), acc))
+    assert worst >= 3.0, f"an accent label is below the 3.0 bar ({worst:.2f})"


### PR DESCRIPTION
Fixes the text color on accent buttons/pills/badges (`on_color`), which had two contrast problems found while reviewing the built-in themes.

## 1. Light-mode colored accents wrongly went black
The light-mode branch gated white text on a **4.5** contrast floor. But accent labels are bold/large, so the correct WCAG bar is **3.0**. The strict 4.5 sent mid-tone colored accents to black — e.g. **dracula-light primary** (`#9776C7`, white = 3.66) rendered **black-on-purple**, inconsistent with the *same* accent rendering white in dark mode (and looking fine there).

Lowered the light-mode gate to 3.0 → saturated colored accents (blue/purple/green/red) take **white** in both light and dark themes; genuinely light accents (bright cyan `info`, bright yellow `warning`) still take **black**.

## 2. Both modes could pick an unreadable label near a bucket boundary
A luminance-bucket edge case forced white where it was unreadable — e.g. **catppuccin-dark `warning`** (`#E5A54A`, light amber at lum 0.44, just under the dark-mode 0.45 cutoff) took **white at ~2:1** (black would be ~9:1). Added a **contrast floor**: if the biased pick misses the 3.0 bar, fall back to the higher-contrast of black/white.

## Result
Every accent in every built-in theme now clears the 3.0 (large/bold) WCAG bar, and colored accents are consistent across light/dark.

## Test
`tests/test_on_color_contrast.py` locks all three properties: light-theme colored accents read white, bright `info`/`warning` keep black, and no accent in any built-in theme falls below 3.0.

## Notes
- Dark themes are otherwise untouched (the only change there is the floor rescuing the sub-3.0 edge cases).
- This is a theme-correctness fix, separate from the recently-merged theme-repaint unification (#338).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
