### PR TITLE
chore: drop pre-release framing ahead of the 0.1.0 stable cut

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,9 @@
 Thanks for helping improve bootstack! This guide covers development setup, the
 pull-request workflow, and how to contribute translations.
 
-bootstack is in pre-release — the public API may still change before 1.0.
+The public `bootstack` API is stable and follows
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html) — breaking changes are
+reserved for a major release.
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@
 ![](https://img.shields.io/github/stars/israel-dryer/bootstack.svg)
 ![](https://img.shields.io/github/forks/israel-dryer/bootstack.svg)
 
-> **Pre-release.** The API may still change before 1.0. Full documentation is at
-> **[bootstack.org](https://bootstack.org)**.
+> Full documentation is at **[bootstack.org](https://bootstack.org)**.
 
 ### From idea to a shipped desktop app — fast.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,9 +29,10 @@ keywords = [
     "python-gui"
 ]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
     "Environment :: Win32 (MS Windows)",
-    "Environment :: X11 Applications :: GTK",
+    "Environment :: MacOS X",
+    "Environment :: X11 Applications",
     "Intended Audience :: Developers",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
Removes the "pre-release / API may still change" warnings and corrects package metadata, since the public API is freezing at 0.1.0.

- **README.md** — drop the `> **Pre-release.** The API may still change before 1.0.` callout (keep the docs link).
- **CONTRIBUTING.md** — replace the pre-release warning with a Semantic-Versioning stability statement.
- **pyproject.toml** classifiers:
  - **Development Status: `3 - Alpha` → `4 - Beta`** — feature-complete, API stable, approaching 1.0. (Beta over Production/Stable for a first cut with no production track record yet; bump to `5` once it has mileage — the pandas precedent shows `5` at 0.x is fine once earned.)
  - **Environment** — drop the inaccurate `X11 Applications :: GTK` (bootstack is **Tk**, not GTK) and add the missing platforms → `Win32 (MS Windows)`, `MacOS X`, `X11 Applications`.

The `description` was reviewed and left as-is (accurate). The version bump (`0.1.0a16` → `0.1.0`) and the tag are the release step, handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
