### PR TITLE
ci(release): use the curated CHANGELOG as the GitHub Release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,13 +48,32 @@ jobs:
     permissions:
       contents: write
     steps:
+      - uses: actions/checkout@v6
+
       - uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/
 
+      - name: Extract release notes for this tag from CHANGELOG
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          awk -v ver="$version" '
+            /^## \[/ { if (found) exit; if (index($0, "[" ver "]")) found=1 }
+            found { print }
+          ' CHANGELOG.md > RELEASE_NOTES.md
+          if [ -s RELEASE_NOTES.md ]; then
+            echo "Using curated CHANGELOG notes for $version ($(wc -l < RELEASE_NOTES.md) lines)."
+          else
+            echo "No CHANGELOG section for $version; using auto-generated notes only."
+          fi
+
+      # The curated CHANGELOG section becomes the release body; GitHub's
+      # auto-generated "What's Changed" + Full Changelog link are appended below
+      # it (and stand alone for an alpha tag with no CHANGELOG section).
       - uses: softprops/action-gh-release@v3
         with:
+          body_path: RELEASE_NOTES.md
           generate_release_notes: true
           prerelease: ${{ contains(github.ref_name, 'a') || contains(github.ref_name, 'b') || contains(github.ref_name, 'rc') }}
           files: dist/*


### PR DESCRIPTION
GitHub Releases were a generic auto-generated list of merged PRs instead of useful notes, because the release job used `generate_release_notes: true` on its own.

Now the `release` job:
1. checks out the repo,
2. extracts the `CHANGELOG.md` section matching the tag (`v0.1.0` → the `## [0.1.0]` block) into `RELEASE_NOTES.md`,
3. passes that as the release **body**.

GitHub's auto **"What's Changed" + Full Changelog** link are still appended *below* the curated notes (best of both — readable summary on top, detailed PR list beneath). For an alpha tag with no CHANGELOG section the extract is empty, so the behavior falls back to exactly what it is today (auto notes only).

Verified the extraction locally against the real `CHANGELOG.md` — it pulls the full 0.1.0 section (Highlights · Provisional · Migrating). This needs to be on `main` **before** the `v0.1.0` tag is pushed so the stable release picks it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
