### PR TITLE
fix(deps): declare pygments as a runtime dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and from 0.1.0 onward the project adheres to
 
 <!-- release-notes-start -->
 
+## [0.1.1] — packaging fix
+
+### Fixed
+
+- **Declared `pygments` as a runtime dependency.** `CodeEditor` requires Pygments
+  for syntax highlighting, but it was not listed in the project dependencies, so a
+  clean `pip install bootstack` would raise `ModuleNotFoundError: No module named
+  'pygments'` when constructing a `CodeEditor` (including on the bundled demo's
+  editing page). Pygments is now installed automatically with bootstack.
+
 ## [0.1.0] — first stable release
 
 The first stable release of bootstack. The public **compose API** — everything

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,9 @@ classifiers = [
 dependencies = [
     "pillow>=10,<=12",
 
+    # Syntax highlighting for the CodeEditor widget
+    "pygments>=2.15",
+
     # Backported typing primitives (Self, Unpack, ParamSpec, etc.)
     "typing-extensions>=4.10",
 


### PR DESCRIPTION
## Summary

`CodeEditor` hard-imports `pygments` for syntax highlighting (via `_try_install_highlighter`), but `pygments` was declared **nowhere** in `pyproject.toml`. A clean `pip install bootstack` therefore crashes on any `CodeEditor(language=...)` — including the bundled demo's editing page:

```
ModuleNotFoundError: No module named 'pygments'
```

This adds `pygments>=2.15` to `[project].dependencies`. It is pure-Python with no transitive deps, and syntax highlighting is core to `CodeEditor` (a top-level `bs.*` widget), so a hard dependency matches the batteries-included philosophy.

## Dependency audit

Swept the full `src/` tree for third-party imports while here. **`pygments` was the only gap.** Everything else is correct:

- Optional extras (`matplotlib`/`viz`, `pyarrow`/`parquet`, `xlsxwriter`/`excel`, `pandas`+`tables`/`hdf5`, `seaborn`/`viz-seaborn`) are all lazy-imported inside functions and gated by `_require(...)` / `_require_matplotlib` with friendly errors — neither `import bootstack` nor core widget construction can crash.
- `PyInstaller` is a packaging-time tool, `try/except`-guarded in the CLI.
- `tomli` is a dead fallback (`tomllib` is stdlib on `requires-python >=3.12`).
- `cycler` is guarded and ships with matplotlib.

## Release

This is a packaging bug in the shipped `0.1.0` — the PyPI artifacts don't carry the dependency, so a **`0.1.1` patch release** is needed for the fix to reach users. CHANGELOG `## [0.1.1]` section added (release.yml extracts it as the GitHub Release body).

🤖 Generated with [Claude Code](https://claude.com/claude-code)