### PR TITLE
fix: dismiss dropdown/context menus when their window moves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ and from 0.1.0 onward the project adheres to
 
 <!-- release-notes-start -->
 
+## [0.1.2] — widget polish
+
+### Fixed
+
+- **Dropdown and context menus now dismiss when their window moves.** On
+  Windows and Linux, an open menu — a toolbar `add_menu` dropdown, or any
+  right-click `ContextMenu`, `Select`, or `MenuButton` popup — stayed pinned to
+  its original screen position when the window was dragged, resized, or
+  minimized: it "hung in the air." Only clicks *outside* the menu dismissed it,
+  and dragging the title bar fires no click. Menus now also close on the owning
+  window's own move, resize, or minimize, matching native menu behavior. (macOS
+  already used the native system menu, which dismisses on its own.)
+
 ## [0.1.1] — packaging fix
 
 ### Fixed
@@ -109,4 +122,6 @@ time, you can ignore this section.)
 - `Toolbar.add_widget` / `StatusBar.add_widget` are now class-based
   (`add_widget(WidgetClass, **kwargs)`).
 
+[0.1.2]: https://github.com/israel-dryer/bootstack/releases/tag/v0.1.2
+[0.1.1]: https://github.com/israel-dryer/bootstack/releases/tag/v0.1.1
 [0.1.0]: https://github.com/israel-dryer/bootstack/releases/tag/v0.1.0

--- a/src/bootstack/widgets/_impl/composites/contextmenu.py
+++ b/src/bootstack/widgets/_impl/composites/contextmenu.py
@@ -158,6 +158,10 @@ class _ToplevelContextMenu(CustomConfigMixin):
         self._density = density
         self._command = command
         self._click_handler_ids: list[tuple[str, str]] = []
+        # Bindings that dismiss the menu when the owning window moves, resizes,
+        # or is minimized — otherwise an open menu floats at its old screen
+        # position while the window is dragged ("hangs in the air").
+        self._window_handler_ids: list[tuple[str, str]] = []
         self._click_binding_root = None
         self._click_bind_after_id = None
         # One-shot guard: the click that (re)opens the menu reaches the
@@ -881,10 +885,30 @@ class _ToplevelContextMenu(CustomConfigMixin):
                     for seq in ('<Button-1>', '<Button-2>', '<Button-3>'):
                         handler_id = root.bind(seq, on_click, add='+')
                         self._click_handler_ids.append((seq, handler_id))
+                    # Moving or resizing the window (e.g. dragging the native
+                    # title bar) fires no click, so also dismiss on the
+                    # window's own geometry changes.
+                    for seq in ('<Configure>', '<Unmap>'):
+                        handler_id = root.bind(seq, self._on_window_change, add='+')
+                        self._window_handler_ids.append((seq, handler_id))
 
         # Delay binding to avoid capturing the click that shows the menu
         self._cancel_click_outside_after()
         self._click_bind_after_id = self._toplevel.after(100, bind_click)
+
+    def _on_window_change(self, event) -> None:
+        """Hide the menu when its owning window moves, resizes, or unmaps.
+
+        Dragging the title bar (or resizing/minimizing) fires no click, so the
+        outside-click handler never sees it and the menu would otherwise float
+        at its old screen position. `<Configure>`/`<Unmap>` bubble up from
+        descendants through bindtags, so only act for the bound toplevel itself
+        — a child relayout must not close the menu.
+        """
+        if str(event.widget) != str(self._click_binding_root):
+            return
+        if self._toplevel.winfo_viewable():
+            self.hide()
 
     def _get_binding_root(self) -> Widget | None:
         """Return the widget to bind click-outside events to."""
@@ -897,18 +921,21 @@ class _ToplevelContextMenu(CustomConfigMixin):
         return None
 
     def _unbind_click_outside_handler(self) -> None:
-        """Remove the click-outside bindings if present."""
-        if not self._click_handler_ids or not self._click_binding_root:
+        """Remove the click-outside and window-change bindings if present."""
+        if not (self._click_handler_ids or self._window_handler_ids) or not self._click_binding_root:
             return
 
         try:
             if self._click_binding_root.winfo_exists():
                 for seq, handler_id in self._click_handler_ids:
                     self._click_binding_root.unbind(seq, handler_id)
+                for seq, handler_id in self._window_handler_ids:
+                    self._click_binding_root.unbind(seq, handler_id)
         except TclError:
             pass
         finally:
             self._click_handler_ids = []
+            self._window_handler_ids = []
             self._click_binding_root = None
 
     def _cancel_click_outside_after(self) -> None:

--- a/tests/widgets/public/test_toolbar_menu.py
+++ b/tests/widgets/public/test_toolbar_menu.py
@@ -68,3 +68,67 @@ def test_no_menu_model_without_add_menu(app):
     tb = bs.Toolbar(parent=app)
     tb.add_button(text="Save", icon="floppy")
     assert tb._internal.menu_model is None
+
+
+def _toplevel_menu(app):
+    """Build a toolbar menu and return its themed (Win/Linux) backend.
+
+    Skips on the macOS native backend, which has no Toplevel to dismiss —
+    the system menu already closes on window interaction.
+    """
+    import bootstack as bs
+    from bootstack.widgets._impl.composites.contextmenu import _ToplevelContextMenu
+
+    tb = bs.Toolbar(parent=app)
+    with tb.add_menu("File") as file:
+        file.add_action("Quit", on_click=lambda: None)
+    menu = tb._internal._menu_triggers["File"].context_menu._impl
+    if not isinstance(menu, _ToplevelContextMenu):
+        pytest.skip("native menu backend dismisses on its own")
+    return tb, menu
+
+
+class _Evt:
+    def __init__(self, widget):
+        self.widget = widget
+
+
+def test_menu_dismisses_on_owning_window_move(app):
+    """Dragging the title bar moves the window but fires no click, so the
+    dropdown must dismiss on the window's own `<Configure>`/`<Unmap>` — else it
+    floats at its old screen position ("hangs in the air"). Regression test."""
+    _tb, menu = _toplevel_menu(app)
+    root = app._tk_root
+
+    # Post-show state: the dismiss bindings are installed on the window root,
+    # and the popup is on screen.
+    menu._click_binding_root = root
+    menu._toplevel.winfo_viewable = lambda: True  # pretend it's mapped
+
+    hidden = []
+    menu.hide = lambda: hidden.append(True)
+
+    # A child relayout (event.widget is a descendant) must NOT dismiss it.
+    menu._on_window_change(_Evt(_tb._internal))
+    assert hidden == []
+
+    # The window itself moving/resizing/minimizing DOES dismiss it.
+    menu._on_window_change(_Evt(root))
+    assert hidden == [True]
+
+
+def test_window_dismiss_bindings_torn_down_on_hide(shown_app):
+    """The `<Configure>`/`<Unmap>` dismiss bindings are removed when the menu
+    hides, so a closed menu leaves no live handlers on the window root."""
+    app = shown_app
+    _tb, menu = _toplevel_menu(app)
+    root = app._tk_root
+
+    # Simulate installed window bindings (as bind_click would do post-show).
+    menu._click_binding_root = root
+    hid = root.bind("<Configure>", menu._on_window_change, add="+")
+    menu._window_handler_ids = [("<Configure>", hid)]
+
+    menu.hide()
+    assert menu._window_handler_ids == []
+    assert menu._click_binding_root is None


### PR DESCRIPTION
## Problem

A user reported (Windows 10) that a toolbar menu opened with `bar.add_menu("File")` does not close when you start interacting with the window — it "hangs in the air."

```python
import bootstack as bs

with bs.AppShell(title="My App") as shell:
    with shell.add_toolbar() as bar:
        with bar.add_menu("File") as file:
            file.add_action("Quit", shortcut="Mod+Q", on_click=shell.close)
        bar.add_spacer()
        bar.add_theme_toggle()
        bar.add_button(label="Save", icon="save", on_click=lambda: print("SAVE"))
shell.run()
```

## Root cause

On Windows/Linux the dropdown is a `_ToplevelContextMenu` (an `overrideredirect` Toplevel). Its only dismissal trigger was **outside mouse clicks** bound on the owning window. Dragging the title bar (or resizing/minimizing) generates no click in the Tk app — it fires `<Configure>`/`<Unmap>` on the toplevel — so the popup stayed pinned at its old screen coordinates while the window moved.

A self-driving repro confirmed: after a window move the menu was still `viewable=True` at its original screen position; clicking the body or a sibling toolbar button already dismissed correctly.

## Fix

While a menu is shown, also bind the owning window's `<Configure>` and `<Unmap>` (alongside the existing click bindings, reusing the same deferred-bind + teardown machinery) and dismiss on them. The handler guards on `event.widget` being the toplevel itself, so a child relayout does not spuriously close the menu.

- Lives in the shared `_ToplevelContextMenu`, so it fixes the toolbar `add_menu` dropdown **and** every other Win/Linux popup (right-click `ContextMenu`, `Select`, `MenuButton`).
- Verified for **decorated and undecorated** windows (both move the window via `wm geometry`, which fires `<Configure>`).
- macOS (`_NativeContextMenu`) is untouched — the native system menu already dismisses on window interaction.

## Tests

- `test_menu_dismisses_on_owning_window_move` — window-level event dismisses; a child event does not.
- `test_window_dismiss_bindings_torn_down_on_hide` — no live handlers remain on the window root after hide.

`test_toolbar_menu` / `test_add_toolbar` / `test_native_contextmenu` all green.

## Changelog

Added a `## [0.1.2] — widget polish` section, plus the previously-missing `[0.1.1]` release-link definition (so the 0.1.1 heading links to its release like 0.1.0 does).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
