### PR TITLE
Set up GitHub Discussions routing and templates

### DIFF
--- a/.github/DISCUSSIONS.md
+++ b/.github/DISCUSSIONS.md
@@ -1,0 +1,58 @@
+# GitHub Discussions setup for bootstack
+
+Use this file as the maintainer checklist and source text for the pinned starter discussion.
+
+## Recommended categories
+
+Create these categories after enabling Discussions:
+
+| Emoji | Name | Format | Description |
+| --- | --- | --- | --- |
+| 📣 | Announcements | Announcement | Project updates, releases, migration notes, and important changes from the maintainer. |
+| ❓ | Q&A | Question and Answer | Usage questions, troubleshooting, and "how do I build this?" topics. |
+| 💡 | Ideas & Feedback | Open-ended discussion | Early ideas, API suggestions, design feedback, and feature exploration. |
+| 🧪 | Show and Tell | Open-ended discussion | Apps, examples, experiments, recipes, and patterns built with bootstack. |
+
+Avoid creating broad categories such as General, Bug Reports, Feature Requests, or Documentation. Keep those workflows separate:
+
+- Issues are for confirmed bugs, documentation defects, and accepted or scoped implementation work.
+- Discussions are for questions, early ideas, examples, and community feedback.
+
+## Pinned starter discussion
+
+Suggested title:
+
+```text
+Start here: Questions, bugs, ideas, and support
+```
+
+Suggested body:
+
+```markdown
+Welcome to bootstack Discussions.
+
+Please choose the right place so issues stay focused and actionable:
+
+- **Q&A** — usage questions, troubleshooting, and "how do I build this?" topics.
+- **Ideas & Feedback** — early feature ideas, API suggestions, and design feedback.
+- **Show and Tell** — apps, screenshots, examples, experiments, recipes, and patterns built with bootstack.
+- **Issues** — confirmed bugs, documentation defects, and scoped work items.
+
+Before posting, please check the documentation and search existing issues/discussions.
+
+If you have a reproducible bug, open a bug report issue and include your bootstack version, Python version, operating system, reproduction steps, and a minimal code sample.
+
+If you are not sure whether something is a bug, start in Q&A.
+```
+
+## Manual GitHub setup steps
+
+1. Open the repository settings.
+2. In the Features section, enable Discussions.
+3. Open the Discussions tab.
+4. Edit the default categories to match the recommended category list above.
+5. Make sure the category slugs match the discussion form filenames:
+   - Q&A -> `q-a`
+   - Ideas & Feedback -> `ideas-feedback`
+   - Show and Tell -> `show-and-tell`
+6. Create the pinned starter discussion from the text above.

--- a/.github/DISCUSSION_TEMPLATE/ideas-feedback.yml
+++ b/.github/DISCUSSION_TEMPLATE/ideas-feedback.yml
@@ -1,0 +1,56 @@
+title: "[Idea]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this category for early ideas, API suggestions, and design feedback.
+
+        Accepted and scoped ideas may later become issues.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: Describe the pain point or use case.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Widgets
+        - Layout
+        - Themes and styling
+        - Forms and validation
+        - DataSource
+        - Charts and visualization
+        - CLI and packaging
+        - Documentation
+        - Other
+    validations:
+      required: false
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What would you like to see?
+      description: Describe the API, behavior, example, or workflow you have in mind.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives or workaround
+      description: Describe anything you tried or considered.
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+    validations:
+      required: false

--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -1,0 +1,63 @@
+title: "[Q&A]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this category for usage questions, troubleshooting, and "how do I build this?" topics.
+
+        If you have a confirmed bug with a minimal reproduction, please open a bug report issue instead.
+
+  - type: textarea
+    id: goal
+    attributes:
+      label: What are you trying to build or understand?
+      description: Describe the UI, behavior, or pattern you are trying to implement.
+    validations:
+      required: true
+
+  - type: input
+    id: bootstack-version
+    attributes:
+      label: bootstack version
+      placeholder: "0.1.2"
+    validations:
+      required: false
+
+  - type: input
+    id: python-version
+    attributes:
+      label: Python version
+      placeholder: "Python 3.12"
+    validations:
+      required: false
+
+  - type: input
+    id: operating-system
+    attributes:
+      label: Operating system
+      placeholder: "Windows, macOS, or Linux"
+    validations:
+      required: false
+
+  - type: input
+    id: docs-page
+    attributes:
+      label: Relevant documentation page
+      placeholder: "https://bootstack.org/..."
+    validations:
+      required: false
+
+  - type: textarea
+    id: code
+    attributes:
+      label: Minimal code sample
+      render: python
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+    validations:
+      required: false

--- a/.github/DISCUSSION_TEMPLATE/show-and-tell.yml
+++ b/.github/DISCUSSION_TEMPLATE/show-and-tell.yml
@@ -1,0 +1,37 @@
+title: "[Show and Tell]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Share apps, examples, experiments, recipes, and patterns built with bootstack.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: What did you build?
+      description: Give a short overview of the app, demo, or pattern.
+    validations:
+      required: true
+
+  - type: textarea
+    id: demo
+    attributes:
+      label: Demo or links
+      description: Add links or visual examples if you have them.
+    validations:
+      required: false
+
+  - type: textarea
+    id: code
+    attributes:
+      label: Relevant code or repository
+      render: python
+    validations:
+      required: false
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes for other users
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,11 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Questions
-    url: https://github.com/israel-dryer/bootstack/discussions/new
-    about: "Ask a question in the discussion forum"
+  - name: Questions and troubleshooting
+    url: https://github.com/israel-dryer/bootstack/discussions/new?category=q-a
+    about: Ask usage questions in Discussions so issues stay focused on confirmed work.
+  - name: Ideas and API feedback
+    url: https://github.com/israel-dryer/bootstack/discussions/new?category=ideas-feedback
+    about: Start early ideas in Discussions before opening an issue.
   - name: Documentation
     url: https://bootstack.org/
-    about: "bootstack's documentation"
+    about: Read the bootstack documentation before opening a question or issue.

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,59 @@
+name: Documentation issue
+description: Report incorrect, outdated, missing, or broken documentation
+title: "[Docs]: "
+labels: ["documentation"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this for actionable documentation defects: broken examples, incorrect instructions, outdated pages, typos, or missing reference material.
+
+        If you are asking how to use bootstack, please start a Q&A discussion instead:
+        https://github.com/israel-dryer/bootstack/discussions/new?category=q-a
+
+  - type: input
+    id: page
+    attributes:
+      label: Documentation page
+      description: Link to the relevant documentation page, if applicable.
+      placeholder: "https://bootstack.org/..."
+    validations:
+      required: false
+
+  - type: dropdown
+    id: issue-type
+    attributes:
+      label: Issue type
+      options:
+        - Incorrect information
+        - Broken example
+        - Missing information
+        - Typo or wording
+        - Broken link
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What needs to be fixed?
+      description: Describe the documentation problem clearly.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Suggested correction
+      description: If you know the correct wording or behavior, describe it here.
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,42 +1,74 @@
-name: Feature request
-description: Suggest an idea for this project
-title: "enter title of enhancement here"
+name: Accepted feature request
+description: Track scoped implementation work after an idea has been discussed
+title: "[Feature]: "
 labels: ["enhancement"]
 assignees: israel-dryer
 
 body:
-  - type: textarea
-    id: what
+  - type: markdown
     attributes:
-      label: Is your feature request related to a problem? Please describe.
-      description: |
-        "A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]"
+      value: |
+        Please use this issue type for feature work that is already reasonably scoped.
+
+        If this is an early idea, API suggestion, or design discussion, start with an Ideas & Feedback discussion instead:
+        https://github.com/israel-dryer/bootstack/discussions/new?category=ideas-feedback
+
+  - type: input
+    id: discussion
+    attributes:
+      label: Related discussion
+      description: Link to the discussion where this idea was explored, if one exists.
+      placeholder: "https://github.com/israel-dryer/bootstack/discussions/..."
+    validations:
+      required: false
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or use case
+      description: What user problem does this solve?
     validations:
       required: true
 
   - type: textarea
-    id: extra
+    id: proposal
     attributes:
-      label: "Describe the solution you'd like"
-      description: |
-        A clear and concise description of what you want to happen.
+      label: Proposed behavior
+      description: Describe the expected API, behavior, or implementation direction.
     validations:
       required: true
 
-  - type: textarea
-    id: want
+  - type: dropdown
+    id: area
     attributes:
-      label: "Describe alternatives you've considered"
-      description: |
-        "A clear and concise description of any alternative solutions or features you've considered."
+      label: Area
+      options:
+        - Widgets
+        - Layout
+        - Themes and styling
+        - Forms and validation
+        - DataSource
+        - Charts and visualization
+        - CLI and packaging
+        - Documentation
+        - Other
     validations:
-      required: true
+      required: false
 
   - type: textarea
-    id: add
+    id: acceptance
     attributes:
-      label: "Additional context"
-      description: |
-        "Add any other context or screenshots about the feature request here."
+      label: Acceptance criteria
+      description: What would need to be true for this issue to be considered complete?
+      placeholder: |
+        - ...
+        - ...
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
     validations:
       required: false


### PR DESCRIPTION
## Summary

This adds a lightweight GitHub Discussions setup designed for a solo maintainer:

- Adds structured Discussion forms for Q&A, Ideas & Feedback, and Show and Tell
- Routes questions and early ideas away from Issues through the issue chooser contact links
- Clarifies that feature request issues are for accepted/scoped work
- Adds a documentation issue form for actionable docs defects
- Adds a maintainer setup guide with recommended Discussion categories and pinned starter text

## Recommended manual setup after merge

1. Enable Discussions in repository settings.
2. Create or edit categories:
   - 📣 Announcements — Announcement
   - ❓ Q&A — Question and Answer
   - 💡 Ideas & Feedback — Open-ended discussion
   - 🧪 Show and Tell — Open-ended discussion
3. Confirm category slugs match the form filenames:
   - `q-a`
   - `ideas-feedback`
   - `show-and-tell`
4. Create and pin the starter discussion from `.github/DISCUSSIONS.md`.

## Notes

GitHub requires Discussion category form filenames to match the category slug, so the category names/slugs should be created to match the files in `.github/DISCUSSION_TEMPLATE/`.