### PR TITLE
Fix splash progress docs example

### DIFF
--- a/docs/tasks/splash-screens.rst
+++ b/docs/tasks/splash-screens.rst
@@ -114,41 +114,55 @@ Showing real progress
 
 For genuine, determinate progress you must move the slow work off the main thread
 so the loop stays free to repaint. Run the work in a background thread, push
-fractions into a :class:`~bootstack.Signal` the bar is bound to, update a status
-label the same way, and call :meth:`~bootstack.Splash.dismiss` when the work is
-done. Use ``until="manual"`` so the splash waits for *your* signal, not the
-(instant) main-window build.
+``0`` to ``100`` values into a :class:`~bootstack.Signal` the bar is bound to,
+update a status label the same way, and call :meth:`~bootstack.Splash.dismiss`
+when the work is done. Use ``until="manual"`` so the splash waits for *your*
+signal, not the (instant) main-window build.
 
 .. code-block:: python
 
    import threading
+   import time
    import bootstack as bs
+   from bootstack.images import get_icon
 
-   with bs.App(title="My App") as app:
-       progress = bs.Signal(0.0)
+
+   def do_work(word):
+       """Simulate a time-consuming task."""
+       time.sleep(len(word) * 0.5)
+
+
+   with bs.App(title="My App", size=(500, 500), vertical_items="center") as app:
+       bs.Label("Welcome to bootstack!", font="heading-lg")
+
+       progress = bs.Signal(0)
        status = bs.Signal("Starting…")
 
-       splash = bs.Splash(until="manual")
+       splash = bs.Splash(until="manual", size=(500, 500))
        with splash:
-           bs.Picture(logo, width=140, height=140)
+           bs.Picture(get_icon("rocket", size=96, color="primary"), width=96, height=96)
+           bs.Label("My App", font="heading-lg")
            bs.ProgressBar(signal=progress)
            bs.Label(textsignal=status)
 
        def load():
            steps = ["settings", "plugins", "workspace"]
-           for i, step in enumerate(steps):
-               status(f"Loading {step}…")
-               progress(i / len(steps))
+           total = len(steps)
+
+           for i, step in enumerate(steps, start=1):
+               status.set(f"Loading {step}…")
                do_work(step)
-           progress(1.0)
-           splash.dismiss()                  # close when the real work finishes
+               progress.set(int(i / total * 100))
+
+           progress.set(100)
+           splash.dismiss()  # close when the real work finishes
 
        threading.Thread(target=load, daemon=True).start()
    app.run()
 
-Signals marshal updates back to the UI thread, so it is safe to call
-``progress(...)`` and ``status(...)`` from the worker. ``dismiss()`` is likewise
-safe to call from the thread.
+The progress bar uses the default ``max_value`` of ``100``, so the example sends
+integer percentages with ``progress.set(...)``. The status label is updated with
+``status.set(...)`` because calling a signal reads its current value.
 
 Reacting to dismissal
 ---------------------


### PR DESCRIPTION
## Summary

- Updates the “Showing real progress” splash docs example to use `Signal.set(...)` instead of calling signals directly.
- Changes the progress signal values to the `ProgressBar` default `0`–`100` range.
- Makes the example runnable by adding a simulated `do_work()` function and a rocket icon.
- Shows main app content behind the manual splash so the reveal behavior is clearer.

Fixes #347.