### PR TITLE
Fix: restore add_validation_rule on Select widget

### DIFF
--- a/src/bootstack/widgets/select.py
+++ b/src/bootstack/widgets/select.py
@@ -9,6 +9,7 @@ from bootstack.widgets._core.events import resolve_event, register_widget_events
 from bootstack.widgets._core.options import record_to_dict
 from bootstack.events import ChangeEvent, Subscription
 from bootstack.streams import Stream
+from bootstack.validation import RuleType
 from bootstack.widgets.textfield import _INNER_ENTRY_SEQUENCES
 from bootstack.widgets.types import AccentToken, Event, Option, OptionDict, WidgetDensity
 
@@ -142,22 +143,29 @@ class Select(PublicWidgetBase):
 
     # ----- Validation -----
 
-    def add_validation_rule(
-        self,
-        rule: str,
-        message: str | None = None,
-        trigger: str = "change",
-        **kwargs: Any,
-    ) -> None:
+    def add_validation_rule(self, rule_type: RuleType, **kwargs: Any) -> None:
         """Add a validation rule to the field.
 
+        Rules run automatically on blur or key events depending on the rule
+        type, or manually via `validate()`. Multiple rules can be added;
+        they are evaluated in order and stop at the first failure.
+
         Args:
-            rule: Validation rule name (e.g. ``'required'``).
-            message: Custom error message shown when the rule fails.
-            trigger: When to evaluate the rule (e.g. ``'blur'``, ``'change'``).
-            **kwargs: Extra rule-specific options.
+            rule_type: The kind of validation rule to apply — `'required'`,
+                `'stringLength'`, `'pattern'`, `'email'`, `'compare'`, or
+                `'custom'`.
+            **kwargs: Rule-specific options:
+
+                - `message` *(all rules)* — override the default error message.
+                - `trigger` *(all rules)* — when to run: `'always'` (key and
+                  blur), `'key'`, `'blur'`, or `'manual'`. Each rule type has
+                  its own sensible default.
+                - `min`, `max` *(stringLength)* — minimum/maximum character count.
+                - `pattern` *(pattern)* — regex string the value must match.
+                - `other_field` *(compare)* — field whose value must match.
+                - `func` *(custom)* — callable `(value) -> bool`.
         """
-        self._internal.add_validation_rule(rule, message=message, trigger=trigger, **kwargs)
+        self._internal.add_validation_rule(rule_type, **kwargs)
 
     # ----- Event routing -----
 

--- a/src/bootstack/widgets/select.py
+++ b/src/bootstack/widgets/select.py
@@ -140,6 +140,25 @@ class Select(PublicWidgetBase):
         self._internal = _InternalSelectBox(tk_master, **internal_kwargs)
         self._attach_to_parent(layout_kw)
 
+    # ----- Validation -----
+
+    def add_validation_rule(
+        self,
+        rule: str,
+        message: str | None = None,
+        trigger: str = "change",
+        **kwargs: Any,
+    ) -> None:
+        """Add a validation rule to the field.
+
+        Args:
+            rule: Validation rule name (e.g. ``'required'``).
+            message: Custom error message shown when the rule fails.
+            trigger: When to evaluate the rule (e.g. ``'blur'``, ``'change'``).
+            **kwargs: Extra rule-specific options.
+        """
+        self._internal.add_validation_rule(rule, message=message, trigger=trigger, **kwargs)
+
     # ----- Event routing -----
 
     def _entry_widget(self) -> tkinter.Misc:

--- a/tests/widgets/public/test_form_editor_options.py
+++ b/tests/widgets/public/test_form_editor_options.py
@@ -172,3 +172,57 @@ def test_value_roundtrip_across_editors(app):
     form.set({"name": "Grace", "age": 45, "active": False})
     app._tk_root.update_idletasks()
     assert form.get() == {"name": "Grace", "age": 45, "active": False}
+
+
+# --- add_validation_rule on the returned editor (#356) -------------------
+#
+# `field()` returns the public wrapper. That wrapper must still expose
+# `add_validation_rule`, or the documented pattern
+# `form.field(key).add_validation_rule("required", ...)` breaks. It regressed
+# for `select` in 0.1.3: the wrapper swap dropped the method the internal
+# SelectBox composite had inherited (the *Field wrappers keep it via the field
+# mixin, so only the select editor lost it).
+
+def test_select_field_exposes_add_validation_rule(app):
+    form = bs.Form(items=[bs.FieldItem(key="state", label="State", editor="select",
+                                       editor_options={"values": ["AL", "AK", "AZ"]})])
+    app._tk_root.update_idletasks()
+    assert hasattr(form.field("state"), "add_validation_rule")
+
+
+def test_select_field_validation_rule_is_enforced(app):
+    # The rule added on the returned Select must actually drive form.validate()
+    # and surface its custom message — not just avoid the AttributeError.
+    form = bs.Form(items=[bs.FieldItem(key="state", label="State", editor="select",
+                                       editor_options={"values": ["AL", "AK", "AZ"]})])
+    app._tk_root.update_idletasks()
+    form.field("state").add_validation_rule(
+        "required", message="State is required", trigger="blur")
+
+    # Empty -> invalid, with the custom message.
+    assert form.validate() is False
+    assert form.errors.get("state") == "State is required"
+
+    # Filled -> valid, error cleared.
+    form.set_field_value("state", "AK")
+    app._tk_root.update_idletasks()
+    assert form.validate() is True
+    assert "state" not in form.errors
+
+
+def test_select_rule_uses_live_default_trigger(app):
+    # A rule added without an explicit trigger must adopt the rule type's
+    # sensible live default (required -> "always"), matching the field family.
+    # Regression guard: a hardcoded "change" default (not a real trigger) made
+    # live blur/key validation a silent no-op on Select while every other field
+    # validated live.
+    form = bs.Form(items=[bs.FieldItem(key="state", label="State", editor="select",
+                                       editor_options={"values": ["AL", "AK", "AZ"]})])
+    app._tk_root.update_idletasks()
+    form.field("state").add_validation_rule("required", message="Required")
+
+    entry = form.field("state")._internal._entry
+    # Stored trigger is a real live trigger, not the bogus "change".
+    assert entry._rules[-1].trigger in ("always", "blur", "key")
+    # A blur-scoped run actually evaluates the rule (a no-op under "change").
+    assert entry.validate(entry._get_validation_value(), trigger="blur") is False


### PR DESCRIPTION
## Summary
The Select widget lost the add_validation_rule method that was present in 0.1.2, causing AttributeError when users try to add custom validation rules. The method should delegate to the internal SelectBox which supports validation.

**Fixes:** https://github.com/israel-dryer/bootstack/issues/356

---

### Changes Made
- `src/bootstack/widgets/select.py`
