### PR TITLE
fix(form): tristate checkbox editor, editor_options collisions, falsy and typed values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@ and from 0.1.0 onward the project adheres to
 
 <!-- release-notes-start -->
 
+## [Unreleased]
+
+### Fixed
+
+- **`tristate` works on a `checkbox` form editor.** `0.1.5` fixed
+  `bs.Checkbox(tristate=True)` itself, but a checkbox built by a `Form` (or by
+  `DataTable`'s add/edit dialog) still started unchecked: the form supplied an
+  explicit `value=False` that overrode the indeterminate default. (#358)
+- **`editor_options` may set any of the editor's public keyword arguments.**
+  Naming one the form also fills — `label`, `options`, or a boolean editor's
+  caption — raised `TypeError: got multiple values for keyword argument`.
+  Those options now override the form's default instead of colliding with it.
+  A `value` option seeds the editor only when the form's `data` carries
+  nothing for that key. (#358)
+- **A falsy value no longer disappears from a text field.** `bs.TextField`,
+  `bs.PasswordField`, and `bs.PathField` tested the initial value for
+  truthiness, so `value=0` rendered an empty field — and in a `Form`, the
+  blank was written back over the record's value.
+- **A form no longer changes the type of the data it was given.** Values that
+  are not text — a `Decimal`, a `date` — keep their type in `form.data`
+  instead of being converted to strings at construction.
+
 ## [0.1.5] — boolean control state fixes
 
 ### Fixed

--- a/docs/widgets/forms.rst
+++ b/docs/widgets/forms.rst
@@ -154,6 +154,12 @@ options such as ``step`` and ``min_value``; for a ``textarea`` it means
        ],
    )
 
+An option that names something the form also fills — such as ``label``, or a
+select's choices — overrides the form's own default. Two behave differently:
+``value`` seeds the editor only when the form's ``data`` carries nothing for
+that key, so your record always wins; and ``parent`` is owned by the form,
+which places every editor in its own field container.
+
 Grouped fields
 ~~~~~~~~~~~~~~
 

--- a/src/bootstack/widgets/_core/kwargs.py
+++ b/src/bootstack/widgets/_core/kwargs.py
@@ -1,0 +1,75 @@
+"""Merging a caller's options dict over framework-built keyword arguments.
+
+Some widgets accept a bag of options aimed at a widget they build for you —
+`Form`'s `editor_options` names the editor widget's own public keyword
+arguments, so a caller may name a parameter the framework also fills.
+
+Splatting both into one call raises `TypeError: got multiple values for
+keyword argument`, which names an internal class the caller never wrote.
+`merge_kwargs` gives that meeting point one rule instead:
+
+- The caller's options WIN over the framework's defaults. Naming a parameter
+  the framework also fills is how you override it.
+- A short list of keys is structural — the widget cannot do its job if they
+  are replaced (it would be parented somewhere else entirely). Supplying one
+  raises `BootstackError` naming the API you called and what to use instead.
+"""
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from bootstack.errors import BootstackError
+
+
+def reject_reserved(
+    user: Mapping[str, Any] | None,
+    reserved: Mapping[str, str] | None,
+    context: str,
+) -> None:
+    """Raise if the caller set a key the framework owns.
+
+    Args:
+        user: The caller's options. `None` is treated as empty.
+        reserved: Structural keys the caller may not set, mapped to the
+            guidance shown when they try.
+        context: The API the caller invoked, e.g. `'ButtonGroup.add()'`.
+
+    Raises:
+        BootstackError: If `user` contains a key listed in `reserved`.
+    """
+    if not user or not reserved:
+        return
+    for key in user:
+        if key in reserved:
+            raise BootstackError(f"{context} does not accept {key}= — {reserved[key]}")
+
+
+def merge_kwargs(
+    defaults: Mapping[str, Any],
+    user: Mapping[str, Any] | None,
+    *,
+    reserved: Mapping[str, str] | None = None,
+    context: str = "this call",
+) -> dict[str, Any]:
+    """Merge a caller's options over framework-built keyword arguments.
+
+    Args:
+        defaults: Keyword arguments the framework derived for the call. Any
+            key also present in `user` is overridden.
+        reserved: Structural keys the caller may not set, mapped to the
+            guidance shown when they try.
+        context: The API the caller invoked, used in the error message.
+        user: The caller's options. `None` is treated as empty.
+
+    Returns:
+        The merged keyword arguments.
+
+    Raises:
+        BootstackError: If `user` contains a key listed in `reserved`.
+    """
+    merged = dict(defaults)
+    if not user:
+        return merged
+    reject_reserved(user, reserved, context)
+    merged.update(user)
+    return merged

--- a/src/bootstack/widgets/_impl/composites/form.py
+++ b/src/bootstack/widgets/_impl/composites/form.py
@@ -15,7 +15,14 @@ from bootstack.widgets._impl.primitives.label import Label
 from bootstack.widgets._impl.primitives.labelframe import LabelFrame
 from bootstack.widgets._impl.mixins import configure_delegate
 from bootstack.widgets._impl.composites.tabs.tabview import TabView
+from bootstack.widgets._core.kwargs import merge_kwargs
 from bootstack.widgets.types import EditorType, Master
+
+# Structural keys an editor_options bag may not set — the form's field
+# container owns where the editor is placed.
+_RESERVED_EDITOR_OPTIONS = {
+    'parent': 'the form places each editor in its own field container',
+}
 
 if TYPE_CHECKING:
     from bootstack.dialogs._impl.dialog import DialogButton
@@ -680,45 +687,76 @@ class Form(Frame):
         for internal_only in ("show_message", "validator"):
             opts.pop(internal_only, None)
 
+        # `value` in editor_options seeds the editor when the form data carries
+        # nothing for the key; the data wins when it does. Every editor below
+        # passes `value=` positionally-by-keyword, so leaving it in `opts` would
+        # raise "got multiple values for keyword argument 'value'".
+        seed_value = opts.pop('value', None)
+        if initial is None:
+            initial = seed_value
+
+        def build(cls, *args, **defaults):
+            """Construct `cls`, letting `editor_options` override the defaults."""
+            merged = merge_kwargs(defaults, opts, reserved=_RESERVED_EDITOR_OPTIONS,
+                                  context='Form editor_options')
+            merged['parent'] = container
+            return cls(*args, **merged)
+
+        def choice_list():
+            """Pop the documented `items`/`values` aliases for the option list."""
+            choices = opts.pop('items', None)
+            if choices is None:
+                choices = opts.pop('values', None)
+            return choices
+
+        # Test against None, not truthiness: a falsy-but-real datum (0, False)
+        # is a value, not an absent one, and blanking it here would write the
+        # blank straight back into the form data. Pass the datum through as it
+        # came, too — `data` is the caller's record, and stringifying it here
+        # would flip a Decimal or a date to `str` in `form.data` before the
+        # user has edited anything.
+        text_value = initial if initial is not None else ""
+
         if editor == 'textfield':
-            return TextField(value=initial or "", label=label_text, parent=container, **opts)
+            return build(TextField, value=text_value, label=label_text)
         if editor == 'numberfield':
-            numeric_value = initial if initial is not None else 0
-            return NumberField(value=numeric_value, label=label_text, parent=container, **opts)
+            return build(NumberField, value=initial if initial is not None else 0,
+                         label=label_text)
         if editor == 'passwordfield':
-            return PasswordField(value=initial or "", label=label_text, parent=container, **opts)
+            return build(PasswordField, value=text_value, label=label_text)
         if editor == 'datefield':
-            return DateField(value=initial, label=label_text, parent=container, **opts)
+            return build(DateField, value=initial, label=label_text)
         if editor == 'textarea':
-            text = str(initial) if initial is not None else ""
-            return TextArea(value=text, label=label_text, parent=container, **opts)
+            return build(TextArea, value=text_value, label=label_text)
         if editor == 'select':
-            choices = opts.pop('items', opts.pop('values', None)) or []
-            choices = [str(i) for i in choices]
-            return Select(options=choices, value=initial if initial is not None else "",
-                          label=label_text, parent=container, **opts)
+            choices = [str(i) for i in (choice_list() or [])]
+            return build(Select, options=choices, label=label_text,
+                         value=initial if initial is not None else "")
         if editor == 'spinnerfield':
-            choices = opts.pop('items', opts.pop('values', None))
+            choices = choice_list()
             if choices is not None:
                 opts['options'] = [str(i) for i in choices]
-            return SpinnerField(value=initial if initial is not None else "",
-                                label=label_text, parent=container, **opts)
-        if editor == 'checkbox':
-            text = opts.pop('text', None) or label_text
-            return Checkbox(text, value=bool(initial) if initial is not None else False,
-                            parent=container, **opts)
-        if editor == 'switch':
-            text = opts.pop('text', None) or label_text
-            return Switch(text, value=bool(initial) if initial is not None else False,
-                          parent=container, **opts)
+            return build(SpinnerField, value=initial if initial is not None else "",
+                         label=label_text)
+        if editor in ('checkbox', 'switch'):
+            # The boolean controls call their caption `label`, so pass it by
+            # keyword — passing it positionally would collide with a `label`
+            # option instead of letting it override, and `text` is the alias a
+            # caller reaches for first.
+            caption = opts.pop('text', None) or label_text
+            # `None` stays `None` so a tristate checkbox starts indeterminate;
+            # the widget maps `None` to unchecked when tristate is off.
+            cls = Checkbox if editor == 'checkbox' else Switch
+            return build(cls, label=caption,
+                         value=bool(initial) if initial is not None else None)
         if editor == 'slider':
             # Slider has no label parameter, so render a stacked caption above it
             # (the field wrappers render their own label internally).
             if label_text:
                 Label(container, text=label_text).pack(anchor='w', pady=(0, 2))
-            return Slider(value=initial if initial is not None else 0, parent=container, **opts)
+            return build(Slider, value=initial if initial is not None else 0)
         # Fallback: treat any unknown editor as a text field.
-        return TextField(value=initial or "", label=label_text, parent=container, **opts)
+        return build(TextField, value=text_value, label=label_text)
 
     def _build_buttons(self, parent: Frame, buttons: Sequence[ButtonInput]) -> None:
         parsed = self._normalize_buttons(buttons)

--- a/src/bootstack/widgets/passwordfield.py
+++ b/src/bootstack/widgets/passwordfield.py
@@ -86,7 +86,9 @@ class PasswordField(FieldAddonMixin, PublicWidgetBase):
             "show": mask,
             "show_visibility_toggle": show_visibility_toggle,
         }
-        if value:
+        # Test against the empty value, not truthiness: `0` or `False` is a
+        # value the caller passed, and dropping it here leaves the field blank.
+        if value is not None and value != "":
             internal_kwargs["value"] = value
         if placeholder is not None:
             internal_kwargs["placeholder"] = placeholder

--- a/src/bootstack/widgets/pathfield.py
+++ b/src/bootstack/widgets/pathfield.py
@@ -91,7 +91,9 @@ class PathField(FieldAddonMixin, PublicWidgetBase):
         tk_master = self._parent._child_master() if self._parent else None
 
         internal_kwargs: dict[str, Any] = {"mode": mode}
-        if value:
+        # Test against the empty value, not truthiness: `0` or `False` is a
+        # value the caller passed, and dropping it here leaves the field blank.
+        if value is not None and value != "":
             internal_kwargs["value"] = value
         if dialog_title is not None:
             internal_kwargs["dialog_title"] = dialog_title

--- a/src/bootstack/widgets/textfield.py
+++ b/src/bootstack/widgets/textfield.py
@@ -103,7 +103,9 @@ class TextField(FieldAddonMixin, PublicWidgetBase):
         tk_master = self._parent._child_master() if self._parent else None
 
         internal_kwargs: dict[str, Any] = {}
-        if value:
+        # Test against the empty value, not truthiness: `0` or `False` is a
+        # value the caller passed, and dropping it here leaves the field blank.
+        if value is not None and value != "":
             internal_kwargs["value"] = value
         if placeholder is not None:
             internal_kwargs["placeholder"] = placeholder

--- a/tests/widgets/public/test_form_editor_options.py
+++ b/tests/widgets/public/test_form_editor_options.py
@@ -9,7 +9,10 @@ could not accept ``show_border`` at all.
 """
 from __future__ import annotations
 
+import pytest
+
 import bootstack as bs
+from bootstack.errors import BootstackError
 
 
 # --- The two scenarios reported in discussion #353 -----------------------
@@ -226,3 +229,134 @@ def test_select_rule_uses_live_default_trigger(app):
     assert entry._rules[-1].trigger in ("always", "blur", "key")
     # A blur-scoped run actually evaluates the rule (a no-op under "change").
     assert entry.validate(entry._get_validation_value(), trigger="blur") is False
+
+# --- `tristate` and a `value` seed in editor_options (#358 follow-up) -----
+
+def test_checkbox_tristate_starts_indeterminate(app):
+    # Reported repro: a tristate checkbox editor rendered (and read) as
+    # unchecked because the Form coerced the absent form value to False,
+    # which the widget treats as an explicit "off" seed.
+    form = bs.Form(items=[bs.FieldItem(key="contact", editor="checkbox",
+                                       editor_options={"tristate": True})])
+    app._tk_root.update_idletasks()
+    field = form.field("contact")
+    assert field.value is None
+    assert field.checked is False
+
+
+def test_checkbox_without_tristate_starts_unchecked(app):
+    form = bs.Form(items=[bs.FieldItem(key="contact", editor="checkbox")])
+    app._tk_root.update_idletasks()
+    assert form.field("contact").value is False
+
+
+def test_editor_options_value_seeds_the_editor(app):
+    # Reported repro: any editor_options={'value': ...} raised
+    # "got multiple values for keyword argument 'value'".
+    form = bs.Form(items=[
+        bs.FieldItem(key="name", editor="textfield", editor_options={"value": "Ada"}),
+        bs.FieldItem(key="on", editor="checkbox", editor_options={"value": True}),
+    ])
+    app._tk_root.update_idletasks()
+    assert form.field("name").value == "Ada"
+    assert form.field("on").value is True
+
+
+def test_form_data_wins_over_editor_options_value(app):
+    form = bs.Form(data={"n": 41},
+                   items=[bs.FieldItem(key="n", editor="numberfield",
+                                       editor_options={"value": 7})])
+    app._tk_root.update_idletasks()
+    assert form.field("n").value == 41
+
+
+def test_falsy_data_value_is_not_blanked(app):
+    # A falsy-but-real datum is a value, not an absent one. Testing it for
+    # truthiness blanked it in the editor and then synced the blank back into
+    # the form data, silently destroying the record value.
+    form = bs.Form(data={"code": 0},
+                   items=[bs.FieldItem(key="code", editor="textfield")])
+    app._tk_root.update_idletasks()
+    assert form.field("code").value == "0"
+    assert form.data["code"] == "0"
+
+
+def test_falsy_value_survives_on_the_widget_itself(app):
+    # The blanking lived in the field wrapper, one layer below the form.
+    assert bs.TextField(value=0).value == "0"
+    assert bs.PasswordField(value=0).value == "0"
+
+
+def test_non_string_data_keeps_its_type(app):
+    # `data` is the caller's record. Stringifying it to dodge the falsy bug
+    # flipped a Decimal or a date to `str` in `form.data` at construction,
+    # before the user had edited anything — and DataTable's edit dialog is a
+    # Form, so a submit wrote the stringified value back to the source.
+    from datetime import date
+    from decimal import Decimal
+
+    form = bs.Form(data={"amount": Decimal("3.50"), "when": date(2020, 1, 2)},
+                   items=[bs.FieldItem(key="amount", editor="textfield"),
+                          bs.FieldItem(key="when", editor="textfield")])
+    app._tk_root.update_idletasks()
+    assert form.data["amount"] == Decimal("3.50")
+    assert form.data["when"] == date(2020, 1, 2)
+
+
+def test_switch_editor_defaults_to_off(app):
+    # The tristate fix seeds checkbox AND switch with `value=None`; Switch has
+    # no tristate, so it must fall through to its unchecked value.
+    form = bs.Form(items=[bs.FieldItem(key="s", editor="switch")])
+    app._tk_root.update_idletasks()
+    assert form.field("s").value is False
+    assert form.data["s"] is False
+
+
+def test_checkbox_editor_options_can_override_the_caption(app):
+    # The boolean controls call their caption `label`; passing it positionally
+    # made a `label` option collide instead of override.
+    form = bs.Form(items=[bs.FieldItem(key="c", label="Ignored", editor="checkbox",
+                                       editor_options={"label": "Contact me"})])
+    app._tk_root.update_idletasks()
+    assert form.field("c")._internal.cget("text") == "Contact me"
+
+
+def test_spinnerfield_items_alias_reaches_the_widget(app):
+    form = bs.Form(items=[bs.FieldItem(key="s", editor="spinnerfield",
+                                       editor_options={"items": [1, 2, 3]})])
+    app._tk_root.update_idletasks()
+    assert list(form.field("s")._internal.cget("values")) == ["1", "2", "3"]
+
+
+def test_select_items_alias_wins_over_values(app):
+    # Both aliases name the same list; `items` is documented first, so it wins
+    # and the redundant `values` must not leak into the editor's constructor.
+    form = bs.Form(items=[bs.FieldItem(key="s", editor="select",
+                                       editor_options={"items": ["a"], "values": ["b"]})])
+    app._tk_root.update_idletasks()
+    assert [o["value"] for o in form.field("s").options] == ["a"]
+
+
+def test_editor_options_override_form_defaults(app):
+    # editor_options are the editor's public kwargs, so an option naming a
+    # parameter the Form also fills must OVERRIDE it, not raise
+    # "got multiple values for keyword argument".
+    form = bs.Form(items=[
+        bs.FieldItem(key="n", label="Name", editor="textfield",
+                     editor_options={"label": "Full name"}),
+        bs.FieldItem(key="s", editor="select",
+                     editor_options={"options": ["a", "b"]}),
+    ])
+    app._tk_root.update_idletasks()
+    assert form.field("n")._internal.label_widget.cget("text") == "Full name"
+    assert [o["value"] for o in form.field("s").options] == ["a", "b"]
+
+
+def test_editor_options_cannot_reparent_the_field(app):
+    # `parent` is structural: the field container owns placement. Setting it
+    # raises a clear error naming the option, not a TypeError from an internal
+    # class the caller never wrote.
+    stray = bs.Column()
+    with pytest.raises(BootstackError, match="editor_options"):
+        bs.Form(items=[bs.FieldItem(key="n", editor="textfield",
+                                    editor_options={"parent": stray})])

--- a/tests/widgets/public/test_merge_kwargs.py
+++ b/tests/widgets/public/test_merge_kwargs.py
@@ -1,0 +1,47 @@
+"""Unit tests for the option-merging helper behind `editor_options`.
+
+The helper is where a caller's option dict meets the keyword arguments the
+framework derived for the same call. Splatting both into one call raised
+`TypeError: got multiple values for keyword argument` naming an internal class
+the caller never wrote; merging gives that meeting point one rule.
+
+These need no Tk root — they exercise the helper directly.
+"""
+from __future__ import annotations
+
+import pytest
+
+from bootstack.errors import BootstackError
+from bootstack.widgets._core.kwargs import merge_kwargs, reject_reserved
+
+
+def test_user_options_win_over_defaults():
+    assert merge_kwargs({"a": 1, "b": 2}, {"b": 3}) == {"a": 1, "b": 3}
+
+
+def test_tolerates_no_user_options():
+    assert merge_kwargs({"a": 1}, None) == {"a": 1}
+    assert merge_kwargs({"a": 1}, {}) == {"a": 1}
+
+
+def test_does_not_mutate_its_inputs():
+    defaults, user = {"a": 1}, {"b": 2}
+    merge_kwargs(defaults, user)
+    assert defaults == {"a": 1} and user == {"b": 2}
+
+
+def test_reserved_key_raises_with_guidance():
+    with pytest.raises(BootstackError) as excinfo:
+        merge_kwargs({}, {"parent": object()},
+                     reserved={"parent": "the form places each editor."},
+                     context="Form editor_options")
+    message = str(excinfo.value)
+    # The message names the API the caller invoked, the key they wrote, and
+    # what to do instead — none of which the old TypeError carried.
+    assert "Form editor_options" in message
+    assert "parent=" in message
+    assert "the form places each editor." in message
+
+
+def test_unlisted_keys_are_allowed_through():
+    reject_reserved({"anchor": "se"}, {"parent": "…"}, "Form editor_options")


### PR DESCRIPTION
Fixes #361 (follow-up to #358, reported there after `0.1.5` shipped).

`0.1.5` fixed `bs.Checkbox(tristate=True)` itself, but a checkbox built by a `Form` still started unchecked — the form passed an explicit `value=False` that overrode the widget's indeterminate default. `DataTable`'s add/edit dialog builds through the same path, so it was affected too.

## What changed

**Tristate reaches the widget.** The boolean editors now pass `None` through instead of coercing an absent value to `False`, so a tristate checkbox starts indeterminate and a non-tristate one still starts unchecked.

**`editor_options` may name any of the editor's public keyword arguments.** They previously collided with the ones the form fills itself:

```python
editor_options={"value": ...}    # TypeError: got multiple values for keyword argument 'value'
editor_options={"label": ...}    # same, on every editor
editor_options={"options": [...]}  # same, on select
```

Editors are now built through a small `merge_kwargs` helper: your options win over the form's defaults. `value` is the one exception — it seeds the editor only when `data` carries nothing for that key, so your record always wins. `parent` is structural (the field container owns placement) and raises a clear error instead of a `TypeError` from an internal class.

## Two value bugs found alongside it

- **A falsy value disappeared.** `bs.TextField`, `bs.PasswordField`, and `bs.PathField` gated the initial value on truthiness, so `value=0` rendered an empty field. In a form, the blank was then synced back over the record's value.
- **The form changed the type of your data.** Non-text values were stringified, so a `Decimal` or `date` in `data` became `str` in `form.data` at construction, before any edit — and since `DataTable`'s edit dialog is a `Form`, a submit wrote the stringified value back.

## Verification

New tests in `test_form_editor_options.py` and `test_merge_kwargs.py`. `python tests/run_gui.py` — all legs green; clean `-W` docs build.

Reported by @bLynnb2762.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
