### PR TITLE
fix(widgets): option dicts no longer collide with framework kwargs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,16 @@ and from 0.1.0 onward the project adheres to
 - **A form no longer changes the type of the data it was given.** Values that
   are not text — a `Decimal`, a `date` — keep their type in `form.data`
   instead of being converted to strings at construction.
+- **Option dicts aimed at a built widget no longer collide with the
+  framework's own arguments.** The same defect appeared in
+  `MenuButton(menu_options=)`, `ButtonGroup.add()` / `add_all()`,
+  `RadioGroup.add()` / `ToggleGroup.add()`, and `Toolbar` / `StatusBar`
+  `add_widget()`. In each, your options now win; the few keys a widget must
+  own — where it is parented, how it tracks its selection, the callback that
+  emits its events — raise a clear error naming what to use instead.
+- **A `ButtonGroup` button given both a caption and an icon renders as both.**
+  Supplying the caption as `text` produced an icon-only button with its label
+  crammed into zero padding.
 
 ## [0.1.5] — boolean control state fixes
 

--- a/src/bootstack/widgets/_core/kwargs.py
+++ b/src/bootstack/widgets/_core/kwargs.py
@@ -1,8 +1,10 @@
 """Merging a caller's options dict over framework-built keyword arguments.
 
-Some widgets accept a bag of options aimed at a widget they build for you —
-`Form`'s `editor_options` names the editor widget's own public keyword
-arguments, so a caller may name a parameter the framework also fills.
+Several widgets accept a bag of options aimed at a widget they build for you —
+`Form`'s `editor_options`, `MenuButton`'s `menu_options`, the keyword
+passthrough on `ButtonGroup.add` / `RadioGroup.add` / `Toolbar.add_widget`.
+Those bags name the built widget's own public keyword arguments, so a caller
+may name a parameter the framework also fills.
 
 Splatting both into one call raises `TypeError: got multiple values for
 keyword argument`, which names an internal class the caller never wrote.
@@ -11,8 +13,9 @@ keyword argument`, which names an internal class the caller never wrote.
 - The caller's options WIN over the framework's defaults. Naming a parameter
   the framework also fills is how you override it.
 - A short list of keys is structural — the widget cannot do its job if they
-  are replaced (it would be parented somewhere else entirely). Supplying one
-  raises `BootstackError` naming the API you called and what to use instead.
+  are replaced (it would be parented elsewhere, or lose the command that emits
+  its events). Supplying one raises `BootstackError` naming the API you called
+  and what to use instead.
 """
 from __future__ import annotations
 
@@ -73,3 +76,10 @@ def merge_kwargs(
     reject_reserved(user, reserved, context)
     merged.update(user)
     return merged
+
+
+# Structural keys a bar's widget-options passthrough may not set — a toolbar or
+# status bar places every widget it builds.
+RESERVED_BAR_KWARGS = {
+    'parent': 'the bar places the widgets it builds.',
+}

--- a/src/bootstack/widgets/_core/selection_group.py
+++ b/src/bootstack/widgets/_core/selection_group.py
@@ -4,6 +4,13 @@ from typing import Any
 
 from bootstack.widgets._core.options import OptionRecord, record_to_dict, option_localize
 
+# Structural keys a per-option kwargs passthrough may not set — the group owns
+# each option's identity and tracks its own selection.
+RESERVED_OPTION_KWARGS = {
+    'text': 'set the caption with the label argument.',
+    'variable': 'the group tracks its own selection.',
+}
+
 
 class SelectionGroupMixin:
     """Shared item-management surface for the option-group widgets.

--- a/src/bootstack/widgets/_impl/composites/dropdownbutton.py
+++ b/src/bootstack/widgets/_impl/composites/dropdownbutton.py
@@ -7,7 +7,17 @@ from typing_extensions import Unpack
 from bootstack.widgets._impl.composites.contextmenu import ContextMenu, ContextMenuItem, ContextMenuItemResult
 from bootstack.widgets._impl.primitives._menubutton import MenuButton
 from bootstack.widgets._impl.mixins import configure_delegate
+from bootstack.widgets._core.kwargs import merge_kwargs
 from bootstack.widgets.types import Master, StyledKwargs, CompoundMode, WidgetState, WidgetDensity
+
+# Structural keys a menu_options bag may not set — the button owns the menu's
+# contents and the callback that emits its selection events.
+_RESERVED_MENU_OPTIONS = {
+    'items': 'pass the menu items to the button itself.',
+    'command': "use the button's on_select event.",
+    'trigger': 'the button opens its own menu when clicked.',
+    'target': 'the menu belongs to the button that opens it.',
+}
 
 if TYPE_CHECKING:
     from bootstack.signals import Signal
@@ -122,10 +132,13 @@ class DropdownButton(MenuButton):
             "offset": (offset_x, 0),
             "density": density,
         }
-        options.update(self._popdown_options)
         # DropdownButton manages its own activation (left-click, Return/
         # KP_Enter via show_menu), so opt out of ContextMenu's auto-trigger.
-        cm = ContextMenu(self, target=self, items=self._items, trigger=None, command=self._command, **options)
+        options["trigger"] = None
+        options = merge_kwargs(options, self._popdown_options,
+                               reserved=_RESERVED_MENU_OPTIONS,
+                               context='MenuButton menu_options')
+        cm = ContextMenu(self, target=self, items=self._items, command=self._command, **options)
         return cm
 
     @property

--- a/src/bootstack/widgets/buttongroup.py
+++ b/src/bootstack/widgets/buttongroup.py
@@ -5,9 +5,16 @@ from typing import Any, Callable, Literal, overload
 from bootstack.widgets._impl.composites.buttongroup import ButtonGroup as _InternalButtonGroup
 from bootstack.widgets._core.base import PublicWidgetBase
 from bootstack.widgets._core.events import register_widget_events
+from bootstack.widgets._core.kwargs import merge_kwargs
 from bootstack.events import ButtonGroupClickEvent, Subscription
 from bootstack.streams import Stream
 from bootstack.widgets.types import AccentToken, Event, WidgetDensity, Orient, IconPosition, ButtonVariant
+
+# Structural keys a per-button options dict may not set — the group owns each
+# button's command so it can emit the group's click event with that button's key.
+_RESERVED_ITEM_KWARGS = {
+    'command': "use the group's on_click event, which reports the button key.",
+}
 
 _BUTTONGROUP_EVENTS: dict[str, str] = {
     "click": "<<BsButtonGroupClick>>",
@@ -94,6 +101,10 @@ class ButtonGroup(PublicWidgetBase):
             disabled: If `True`, this button starts disabled.
             localize: Translation mode for this button's label, overriding the
                 group's `localize=`. Defaults to the group setting.
+            **kwargs: Further options for the rendered button, using its public
+                parameter names. These override what `add()` derives — pass the
+                caption as `text` if you prefer. `command` is owned by the
+                group; use `on_click()`, which reports the button key.
 
         Returns:
             The key assigned to this button.
@@ -102,22 +113,14 @@ class ButtonGroup(PublicWidgetBase):
             key = f"widget_{self._key_counter}"
             self._key_counter += 1
 
-        icon_only = icon is not None and not label
-
         btn_kwargs: dict[str, Any] = {}
         if icon is not None:
             btn_kwargs["icon"] = icon
-        if icon_only:
-            btn_kwargs["icon_only"] = True
-        elif icon is not None:
-            btn_kwargs["compound"] = icon_position
         if disabled:
             btn_kwargs["state"] = "disabled"
         item_localize = localize if localize is not None else self._localize
         if item_localize is not None:
             btn_kwargs["localize"] = item_localize
-        btn_kwargs.update(kwargs)
-
         _key = key
         _group = self
 
@@ -129,7 +132,18 @@ class ButtonGroup(PublicWidgetBase):
                 icon=btn.configure_style_options("icon"),
             ))
 
-        self._internal.add(label or None, key=key, command=_command, **btn_kwargs)
+        btn_kwargs["text"] = label or None
+        btn_kwargs = merge_kwargs(btn_kwargs, kwargs, reserved=_RESERVED_ITEM_KWARGS,
+                                  context='ButtonGroup.add()')
+        # Derive the icon-only rendering from the FINAL caption, not the `label`
+        # argument: a caller may supply the caption as `text=` (the name the
+        # rendered button uses), and an icon-only button with a label renders
+        # with zero padding — a visibly crammed button rather than a clean one.
+        if icon is not None and not btn_kwargs.get("text"):
+            btn_kwargs.setdefault("icon_only", True)
+        elif icon is not None:
+            btn_kwargs.setdefault("compound", icon_position)
+        self._internal.add(key=key, command=_command, **btn_kwargs)
         return key
 
     def add_all(self, items: list) -> list[str]:

--- a/src/bootstack/widgets/menubutton.py
+++ b/src/bootstack/widgets/menubutton.py
@@ -80,7 +80,10 @@ class MenuButton(IconProperty, PublicWidgetBase):
         show_arrow: If `True` (default), shows the dropdown chevron arrow.
             Pass `False` to hide it (useful when the icon implies the action).
         menu_options: Extra options forwarded to the underlying `ContextMenu`
-            at construction (e.g. `{'anchor': 'se', 'offset': 4}`).
+            at construction, using its public parameter names — e.g.
+            `{'anchor': 'se', 'offset': (4, 0)}`. The menu's contents, its
+            selection callback, and how it opens belong to the button, so
+            `items`, `command`, `target`, and `trigger` are not accepted here.
         disabled: If `True`, button is shown but non-interactive. Defaults
             to `False`.
         accent: Color intent token. Defaults to the theme default.

--- a/src/bootstack/widgets/radiogroup.py
+++ b/src/bootstack/widgets/radiogroup.py
@@ -5,7 +5,8 @@ from typing import overload, Any, Callable, Literal, TYPE_CHECKING
 
 from bootstack.widgets._impl.composites.radiogroup import RadioGroup as _InternalRadioGroup
 from bootstack.widgets._core.base import PublicWidgetBase
-from bootstack.widgets._core.selection_group import SelectionGroupMixin
+from bootstack.widgets._core.kwargs import merge_kwargs
+from bootstack.widgets._core.selection_group import SelectionGroupMixin, RESERVED_OPTION_KWARGS
 from bootstack.widgets._core.options import normalize_options, option_display
 from bootstack.widgets._core.events import register_widget_events
 from bootstack.events import Subscription, ChangeEvent
@@ -193,6 +194,10 @@ class RadioGroup(SelectionGroupMixin, PublicWidgetBase):
             disabled: If `True`, the option is dimmed and cannot be selected.
             localize: Translation mode for this option's label, overriding the
                 group's `localize=`. Defaults to the group setting.
+            **kwargs: Further options for the rendered button, using its public
+                parameter names. These override what `add()` derives from
+                `icon` and `disabled`. `text` is the caption — set it with
+                `label`; the group tracks its own selection.
         """
         resolved = value if value is not None else label
         add_kwargs, extras = self._option_render(icon, disabled, label)
@@ -201,7 +206,9 @@ class RadioGroup(SelectionGroupMixin, PublicWidgetBase):
             add_kwargs["localize"] = item_localize
         if localize is not None:
             extras["localize"] = localize
-        self._internal.add(text=label, value=resolved, **add_kwargs, **kwargs)
+        add_kwargs = merge_kwargs(add_kwargs, kwargs, reserved=RESERVED_OPTION_KWARGS,
+                                  context='RadioGroup.add()')
+        self._internal.add(text=label, value=resolved, **add_kwargs)
         self._add_option_record(label, resolved, extras)
 
     # ----- Event shorthands -----

--- a/src/bootstack/widgets/statusbar.py
+++ b/src/bootstack/widgets/statusbar.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, Literal
 from bootstack.widgets._impl.composites.toolbar import Toolbar as _InternalToolbar
 from bootstack.widgets._core.base import PublicWidgetBase
 from bootstack.widgets.types import SurfaceToken, WidgetDensity
+from bootstack.widgets._core.kwargs import RESERVED_BAR_KWARGS, reject_reserved
 
 if TYPE_CHECKING:
     from bootstack.signals import Signal
@@ -105,7 +106,8 @@ class StatusBar(PublicWidgetBase):
 
         Pass a widget **class** — the bar builds it, applying its own `density`
         and `surface` (for any the class accepts) so the widget matches the band,
-        and forwarding `kwargs` to the constructor:
+        and forwarding `kwargs` to the constructor (overriding those defaults;
+        `parent` is owned by the bar):
 
             status.add_widget(bs.ThemeToggle, side="right")
             status.add_widget(bs.ProgressBar, value=65)
@@ -133,6 +135,8 @@ class StatusBar(PublicWidgetBase):
         only for parameters the widget actually accepts (and not if the caller
         already passed them)."""
         import inspect
+
+        reject_reserved(kwargs, RESERVED_BAR_KWARGS, 'StatusBar.add_widget()')
 
         try:
             params = inspect.signature(widget_cls).parameters

--- a/src/bootstack/widgets/togglegroup.py
+++ b/src/bootstack/widgets/togglegroup.py
@@ -5,7 +5,8 @@ from typing import overload, Any, Callable, Literal, TYPE_CHECKING
 
 from bootstack.widgets._impl.composites.togglegroup import ToggleGroup as _InternalToggleGroup
 from bootstack.widgets._core.base import PublicWidgetBase
-from bootstack.widgets._core.selection_group import SelectionGroupMixin
+from bootstack.widgets._core.kwargs import merge_kwargs
+from bootstack.widgets._core.selection_group import SelectionGroupMixin, RESERVED_OPTION_KWARGS
 from bootstack.widgets._core.options import normalize_options, option_display
 from bootstack.widgets._core.events import register_widget_events
 from bootstack.events import Subscription, ChangeEvent
@@ -196,6 +197,10 @@ class ToggleGroup(SelectionGroupMixin, PublicWidgetBase):
             disabled: If `True`, the option is dimmed and cannot be selected.
             localize: Translation mode for this option's label, overriding the
                 group's `localize=`. Defaults to the group setting.
+            **kwargs: Further options for the rendered button, using its public
+                parameter names. These override what `add()` derives from
+                `icon` and `disabled`. `text` is the caption — set it with
+                `label`; the group tracks its own selection.
         """
         resolved = value if value is not None else label
         add_kwargs, extras = self._option_render(icon, disabled, label)
@@ -204,7 +209,9 @@ class ToggleGroup(SelectionGroupMixin, PublicWidgetBase):
             add_kwargs["localize"] = item_localize
         if localize is not None:
             extras["localize"] = localize
-        self._internal.add(text=label, value=resolved, **add_kwargs, **kwargs)
+        add_kwargs = merge_kwargs(add_kwargs, kwargs, reserved=RESERVED_OPTION_KWARGS,
+                                  context='ToggleGroup.add()')
+        self._internal.add(text=label, value=resolved, **add_kwargs)
         self._add_option_record(label, resolved, extras)
 
     # ----- Event shorthands -----

--- a/src/bootstack/widgets/toolbar.py
+++ b/src/bootstack/widgets/toolbar.py
@@ -5,8 +5,8 @@ from typing import TYPE_CHECKING, Any, Callable
 from bootstack.errors import BootstackError
 from bootstack.widgets._impl.composites.toolbar import Toolbar as _InternalToolbar
 from bootstack.widgets._core.base import PublicWidgetBase
+from bootstack.widgets._core.kwargs import RESERVED_BAR_KWARGS, merge_kwargs, reject_reserved
 from bootstack.widgets.types import AccentToken, WidgetDensity, SurfaceToken, ButtonVariant
-
 if TYPE_CHECKING:
     from bootstack.widgets._impl.composites.menu.model import MenuGroup
     from bootstack.widgets.button import Button
@@ -147,7 +147,9 @@ class Toolbar(PublicWidgetBase):
             kw["on_click"] = on_click
         if accent is not None:
             kw["accent"] = accent
-        kw.update(kwargs)  # explicit kwargs (incl. text=) win over the defaults
+        # Explicit kwargs (incl. text=) win over the bar's defaults.
+        kw = merge_kwargs(kw, kwargs, reserved=RESERVED_BAR_KWARGS,
+                          context='Toolbar.add_button()')
         return Button(parent=self, **kw)
 
     def add_menu(self, text: str, *, key: str | None = None) -> "MenuGroup":
@@ -201,7 +203,8 @@ class Toolbar(PublicWidgetBase):
             kw["icon"] = icon
         if font is not None:
             kw["font"] = font
-        kw.update(kwargs)
+        kw = merge_kwargs(kw, kwargs, reserved=RESERVED_BAR_KWARGS,
+                          context='Toolbar.add_label()')
         lbl = Label(parent=self, **kw)
         # On a draggable bar (e.g. a titlebar) the label doubles as a drag handle.
         self._internal._attach_drag(lbl._internal)
@@ -257,6 +260,8 @@ class Toolbar(PublicWidgetBase):
         `TypeError`, and injecting into ones that ignore it is a silent no-op.
         """
         import inspect
+
+        reject_reserved(kwargs, RESERVED_BAR_KWARGS, 'Toolbar.add_widget()')
 
         try:
             params = inspect.signature(widget_cls).parameters

--- a/tests/widgets/public/test_option_kwargs_merge.py
+++ b/tests/widgets/public/test_option_kwargs_merge.py
@@ -1,0 +1,123 @@
+"""A caller's option dict meeting the framework's own keyword arguments.
+
+Several widgets accept a bag of options aimed at a widget they build for you —
+`MenuButton`'s `menu_options`, the keyword passthrough on `ButtonGroup.add` /
+`RadioGroup.add` / `ToggleGroup.add`, and `Toolbar` / `StatusBar`
+`add_widget()`. Each used to splat that bag alongside its own explicit keyword
+arguments, so naming a parameter the framework also filled raised
+`TypeError: got multiple values for keyword argument` from an internal class
+the caller never wrote.
+
+The rule is now uniform: the caller's options win, except for structural keys
+that raise `BootstackError` naming the API called and what to use instead.
+"""
+from __future__ import annotations
+
+import pytest
+
+import bootstack as bs
+from bootstack.errors import BootstackError
+
+
+# --- The caller's options win over the framework's defaults --------------
+
+def test_menu_options_reach_the_menu(app):
+    # Asserting construction alone would pass even if the options were dropped
+    # on the floor, so read the value back off the menu it was aimed at.
+    mb = bs.MenuButton("Actions", items=[{"type": "command", "text": "X"}],
+                       menu_options={"anchor": "se"})
+    assert mb._internal.context_menu._anchor == "se"
+
+
+def test_button_group_add_all_accepts_text(app):
+    # add_all() documents its dicts as "keyword arguments accepted by add()",
+    # and `text` is what the rendered button calls its caption.
+    group = bs.ButtonGroup()
+    group.add_all([{"text": "Save"}, {"text": "Cancel"}])
+    assert group.query_item(group.keys[0], "text") == "Save"
+
+
+def test_button_group_caption_via_text_is_not_icon_only(app):
+    # `icon_only` is derived from the caption. Deriving it from the `label`
+    # argument instead of the merged text made a text+icon button icon-only,
+    # which renders with zero padding — a crammed, clipped button.
+    group = bs.ButtonGroup()
+    group.add_all([{"text": "Save", "icon": "star"}])
+    group.add("Save", icon="star")
+    by_label, by_text = group.keys[1], group.keys[0]
+    assert group.query_item(by_text, "icon_only") == group.query_item(by_label, "icon_only")
+
+
+def test_button_group_icon_without_caption_is_icon_only(app):
+    # The control for the test above: a genuine icon-only button still infers.
+    group = bs.ButtonGroup()
+    group.add("", icon="star")
+    assert group.query_item(group.keys[0], "icon_only") is True
+
+
+@pytest.mark.parametrize("factory", [bs.RadioGroup, bs.ToggleGroup])
+def test_option_group_accepts_derived_render_kwargs(app, factory):
+    # `icon_only` and `state` are derived from `icon`/`disabled`; passing them
+    # explicitly must override, not collide — and must actually take effect.
+    group = factory()
+    group.add("", value="a", icon="house", icon_only=True)
+    group.add("B", value="b", state="disabled")
+    assert group._internal.item("b").instate(("disabled",)) is True
+
+
+def test_toolbar_add_button_kwargs_win(app):
+    bar = bs.Toolbar()
+    button = bar.add_button("Go", text="Override")
+    assert button.text == "Override"
+
+
+# --- Structural keys raise a clear error, not a raw TypeError ------------
+
+def test_button_group_command_is_reserved(app):
+    group = bs.ButtonGroup()
+    with pytest.raises(BootstackError, match=r"ButtonGroup\.add\(\) does not accept command="):
+        group.add("Save", command=lambda: None)
+
+
+@pytest.mark.parametrize("factory", [bs.RadioGroup, bs.ToggleGroup])
+@pytest.mark.parametrize("key", ["text", "variable"])
+def test_option_group_structural_keys_are_reserved(app, factory, key):
+    # NB `value` is a named parameter of add(), so it can never arrive via
+    # **kwargs and needs no guard.
+    group = factory()
+    with pytest.raises(BootstackError, match=rf"\.add\(\) does not accept {key}="):
+        group.add("A", value="a", **{key: "x"})
+
+
+@pytest.mark.parametrize("key", ["items", "command", "target", "trigger"])
+def test_menu_options_structural_keys_are_reserved(app, key):
+    # `trigger` is reserved because the button already opens its own menu on
+    # click: a second trigger binds a rival handler that opens the menu at the
+    # pointer, so the two fire on one click.
+    with pytest.raises(BootstackError, match=rf"menu_options does not accept {key}="):
+        bs.MenuButton("Actions", items=[{"type": "command", "text": "X"}],
+                      menu_options={key: "click"})
+
+
+def test_toolbar_add_widget_parent_is_reserved(app):
+    bar = bs.Toolbar()
+    with pytest.raises(BootstackError, match=r"Toolbar\.add_widget\(\) does not accept parent="):
+        bar.add_widget(bs.Label, parent=bar)
+
+
+def test_toolbar_add_button_parent_is_reserved(app):
+    bar = bs.Toolbar()
+    with pytest.raises(BootstackError, match=r"Toolbar\.add_button\(\) does not accept parent="):
+        bar.add_button("Go", parent=bar)
+
+
+def test_toolbar_add_label_parent_is_reserved(app):
+    bar = bs.Toolbar()
+    with pytest.raises(BootstackError, match=r"Toolbar\.add_label\(\) does not accept parent="):
+        bar.add_label("Hi", parent=bar)
+
+
+def test_statusbar_add_widget_parent_is_reserved(app):
+    bar = bs.StatusBar()
+    with pytest.raises(BootstackError, match=r"StatusBar\.add_widget\(\) does not accept parent="):
+        bar.add_widget(bs.Label, parent=bar)


### PR DESCRIPTION
> **Stacked on #362** — targets that branch so the diff shows only this change's 11 files. GitHub will retarget it to `main` automatically when #362 merges.

#362 fixed this collision inside `Form`. The same defect exists in five other places: a widget accepts a bag of options aimed at a widget it builds for you, then splats that bag alongside its own explicit keyword arguments. Naming a parameter the framework also fills raised `TypeError: got multiple values for keyword argument`, pointing at an internal class you never wrote.

All of these raise on `main` today:

```python
bs.MenuButton("Actions", items=[...], menu_options={"trigger": "right-click"})
group.add("Save", command=save)
group.add_all([{"text": "Save"}])
radio.add("", value="a", icon="house", icon_only=True)
radio.add("A", value="a", disabled=True, state="disabled")
bar.add_widget(bs.Label, parent=bar)
```

## The rule

Every site now routes through `merge_kwargs`: **your options win** over the framework's defaults. A short list of structural keys — the ones a widget must own to function — raises a clear error naming the API you called and what to use instead:

```
ButtonGroup.add() does not accept command= — use the group's on_click event, which reports the button key.
MenuButton menu_options does not accept items= — pass the menu items to the button itself.
Toolbar.add_widget() does not accept parent= — the bar places the widgets it builds.
```

**No working call changes behavior** — every one of these paths raised before, so nothing that ran can regress. Verified by grepping every caller across `src/`, `docs/examples`, `docs/screenshots`, and `tests/`: none passes a reserved key.

`trigger` is reserved on `menu_options` rather than merged. The button already opens its own menu on click; a second trigger binds a rival handler that opens it at the pointer, so both fire on one click. A clear error beats that.

## One rendering bug the merge exposed

`ButtonGroup` derived `icon_only` from the `label` argument rather than the final caption, so a button given its caption as `text` plus an `icon` rendered icon-only — which sets padding to zero, cramming the label. Now derived after the merge.

## Verification

New `test_option_kwargs_merge.py` (25 tests). `python tests/run_gui.py` — all legs green; clean `-W` docs build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
