### PR TITLE
fix(fields): a visible placeholder no longer counts as content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,13 @@ and from 0.1.0 onward the project adheres to
 - **A `ButtonGroup` button given both a caption and an icon renders as both.**
   Supplying the caption as `text` produced an icon-only button with its label
   crammed into zero padding.
+- **A required field with a placeholder no longer passes validation while
+  empty.** A field showing only its placeholder was treated as though the hint
+  had been typed, so `required` reported it valid — and a form with an
+  untouched required field validated and submitted.
+- **`text` no longer reports the placeholder as content.** A field showing only
+  its placeholder returned the hint from `text` while `value` reported empty;
+  the two now agree on whether the field holds anything.
 
 ## [0.1.5] — boolean control state fixes
 

--- a/src/bootstack/widgets/_impl/_parts/numberentry_part.py
+++ b/src/bootstack/widgets/_impl/_parts/numberentry_part.py
@@ -272,9 +272,10 @@ class NumberEntryPart(TextEntryPart):
         A plain numeric field parses to a string when no display format is set,
         so coerce it the same way the public value does — validation rules and a
         `custom` func receive a real `int`/`float` (or `None` for empty/invalid
-        input), never the display string.
+        input), never the display string. A visible placeholder is not input,
+        so it reads as empty here — same rule as the text field this overrides.
         """
-        text = self.get()
+        text = '' if self._showing_placeholder else self.get()
         try:
             raw = self._parse_or_none(text)
         except Exception:

--- a/src/bootstack/widgets/_impl/_parts/textentry_part.py
+++ b/src/bootstack/widgets/_impl/_parts/textentry_part.py
@@ -288,11 +288,17 @@ class TextEntryPart(ValidationMixin, Entry):
         last-committed value. This keeps a manual `validate()`, the automatic
         blur/key validation, and a form-level validate in agreement on the same
         live, typed input.
+
+        A visible placeholder is not input. It is inserted into the entry to
+        render it, so reading the raw text would hand the placeholder string to
+        the rules and `required` would pass on an untouched field — the field
+        reads as empty here, exactly as it does through `value`.
         """
+        text = "" if self._showing_placeholder else self.get()
         try:
-            return self._parse_or_none(self.get())
+            return self._parse_or_none(text)
         except Exception:
-            return self.get()
+            return text
 
     def text(self, value=None):
         """Get or set the raw display text without committing.

--- a/src/bootstack/widgets/_impl/composites/field.py
+++ b/src/bootstack/widgets/_impl/composites/field.py
@@ -273,8 +273,13 @@ class Field(EntryMixin, Frame):
         self._entry.value(value)
 
     def get(self) -> str:
-        """Return the raw text from the underlying entry widget."""
-        return self._entry.get()
+        """Return the display text from the underlying entry widget.
+
+        Reads the entry's own text rather than its raw contents, so a field
+        showing only its placeholder reports an empty string — `text` and
+        `value` are a pair and must agree on whether the field is empty.
+        """
+        return self._entry.text()
 
     @property
     def entry_widget(self) -> EntryWidget:

--- a/tests/widgets/public/test_field_placeholder_mask.py
+++ b/tests/widgets/public/test_field_placeholder_mask.py
@@ -1,6 +1,10 @@
-"""Regression guard for #195 — an input mask (`show=`, e.g. a password bullet)
-must NOT mask the placeholder text. The placeholder is a readable hint, not user
-input: it renders unmasked, and the mask reappears only for real, committed input.
+"""Guards for what a visible placeholder is — and is not.
+
+A placeholder is a readable hint, never user input. Two consequences are pinned
+here: it renders unmasked under an input mask (#195 — a password bullet must not
+turn the hint into dots), and it reads as EMPTY everywhere a field reports its
+contents, so `required` does not pass on an untouched field and `text` agrees
+with `value`.
 """
 import pytest
 
@@ -81,3 +85,75 @@ def test_textfield_placeholder_unaffected_without_mask(app):
     assert entry._showing_placeholder is False
     assert entry.cget("show") == ""
     assert entry.get() == "query"
+
+
+# --- A visible placeholder is not input, for validation either --------------
+
+def test_required_field_with_placeholder_is_invalid_while_empty(app):
+    # The placeholder is inserted into the entry to render it, and validation
+    # read that raw text — so `required` saw the hint, passed, and an untouched
+    # field submitted empty. `required=` + `placeholder=` is a common pairing,
+    # so this silently defeated required across forms.
+    field = bs.TextField(placeholder="Enter a name", required=True)
+    app._tk_root.update_idletasks()
+    assert field.validate() is False
+
+
+def test_form_blocks_submit_on_empty_required_field_with_placeholder(app):
+    form = bs.Form(items=[bs.FieldItem(key="name", label="Name", required=True,
+                                       editor_options={"placeholder": "Enter a name"})])
+    app._tk_root.update_idletasks()
+    assert form.validate() is False
+    assert "name" in form.errors
+
+
+@pytest.mark.parametrize("rule, kwargs, expected", [
+    # `Hint` is 4 characters: a max of 2 rejects the placeholder text but
+    # accepts an empty field, so this rule diverges in BOTH directions and
+    # catches a fix that leaked the hint either way.
+    ("stringLength", {"max": 2}, True),
+    ("stringLength", {"min": 3}, False),
+])
+def test_placeholder_field_validates_like_an_empty_one(app, rule, kwargs, expected):
+    # The invariant: a field showing its placeholder behaves exactly as a
+    # genuinely empty one — for every rule, not just `required`. Assert the
+    # concrete outcome, not just that the two agree: comparing two fields that
+    # are both invalid for unrelated reasons proves nothing.
+    plain, holder = bs.TextField(), bs.TextField(placeholder="Hint")
+    plain.add_validation_rule(rule, **kwargs)
+    holder.add_validation_rule(rule, **kwargs)
+    app._tk_root.update_idletasks()
+    plain_result, holder_result = plain.validate(), holder.validate()
+    assert holder_result is expected
+    assert plain_result is holder_result, f"{rule} differs with a placeholder"
+
+
+def test_text_reports_empty_while_the_placeholder_shows(app):
+    # `text` and `value` are a contract pair. `text` read the widget's raw
+    # contents, which is where the hint physically lives, so it reported the
+    # hint as though the user had typed it while `value` said empty.
+    field = bs.TextField(placeholder="Enter a name")
+    app._tk_root.update_idletasks()
+    assert field.text == ""
+    assert field.value == ""
+    field.value = "Ada"
+    app._tk_root.update_idletasks()
+    assert field.text == "Ada"
+
+
+def test_real_input_still_validates_through_a_placeholder_field(app):
+    field = bs.TextField(placeholder="Hint", required=True)
+    app._tk_root.update_idletasks()
+    field.value = "Ada"
+    app._tk_root.update_idletasks()
+    assert field.validate() is True
+    assert field.value == "Ada"
+
+
+def test_masked_field_with_placeholder_validates_when_filled(app):
+    pf = bs.PasswordField(placeholder="Password", required=True)
+    app._tk_root.update_idletasks()
+    assert pf.validate() is False
+    pf.value = "hunter2"
+    app._tk_root.update_idletasks()
+    assert pf.validate() is True


### PR DESCRIPTION
A placeholder is a hint, not input — its presence implies the field is empty. Two accessors reported it as though the user had typed it.

## Validation: `required` passed on an untouched field

A placeholder is rendered by inserting its text into the field, and `_get_validation_value()` read those raw contents. Every validation path routes through that one method — a field's `validate()`, `Form.validate()`, and the automatic blur/key validation — so `required` judged an untouched field non-empty:

```python
bs.Form(items=[bs.FieldItem(key="name", required=True,
                            editor_options={"placeholder": "Enter a name"})])

form.validate()   # True, with empty errors — and it submits
```

`required=` plus `placeholder=` is a common pairing, so this silently defeated `required` wherever both were used. The numeric override carried the same bug and is fixed alongside it; it isn't reachable today only because `NumberField` doesn't expose `placeholder=`, which made it a trap waiting for the day it does.

## `text` reported the hint as content

`text` read raw contents too, so it returned the placeholder while `value` reported empty. `text` and `value` are **not** interchangeable — one is the formatted display, the other the raw datum — but they must agree on whether the field holds anything. `text` now reads the same placeholder-aware source `value` does.

The change is placeholder-scoped. The old and new sources are identical in every other state, including the formatted case that keeps them distinct:

| State | before | after | `value` |
|---|---|---|---|
| formatted, committed | `'1,000.00'` | `'1,000.00'` | `1000` |
| mid-typing, uncommitted | `'2500'` | `'2500'` | `None` |
| masked, filled | `'hunter2'` | `'hunter2'` | `'hunter2'` |
| **placeholder showing** | **`'Enter a name'`** | **`''`** | `''` |

## Verification

The invariant is that a field showing its placeholder behaves exactly like a genuinely empty one. Covered for `required`, `stringLength` in both directions (`max=2` rejects the 4-character hint but accepts empty, so it catches a leak either way), and the masked password path. New tests fail against the unfixed code; `python tests/run_gui.py` — all legs green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
