### PR TITLE
fix(select): a retired value displays instead of crashing the editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,18 @@ and from 0.1.0 onward the project adheres to
   form does not know falls back to a text field, but the `required` rule was
   dropped on the way, so a misspelled editor silently let an empty field
   submit. (#366)
+- **A searchable `Select` no longer changes its value when you just look.**
+  Opening the drop-down and dismissing it without typing or choosing anything
+  replaced the field's value with the first option in the list. (#355)
+- **`Select` validation rules run against the selected value, not its label.**
+  On a decoupled option list — where an option displays `'United States'` and
+  stores `'US'` — every rule saw the label, so a rule checking the value
+  rejected valid selections. (#355)
+
+### Added
+
+- **`Select.validate()`** — run a select's validation rules on demand, matching
+  the other field widgets. `add_validation_rule` already pointed at it. (#355)
 
 ### Changed
 
@@ -63,6 +75,16 @@ and from 0.1.0 onward the project adheres to
   cannot match the empty string — add `required` to keep that behavior.**
   `compare` and `custom` are unaffected; both still run on an empty value.
   (#366)
+- **A `Select` no longer rejects a value that is not in its option list.**
+  Opening an editor on a stored record whose option had since been retired
+  raised `ValueError: '…' is not one of the options` — in a `Form`, and in
+  `DataTable`'s add/edit dialog, on ordinary data drift. A later programmatic
+  write of the same value was silently dropped instead, so one value produced
+  two different wrong answers. Such a value is now displayed as given, reads
+  back with its own type, and is **not** added to the list, so a user cannot
+  pick it. Use a `'custom'` validation rule to report one. `SelectButton`,
+  which maps a value to an option's label and has no text entry, still
+  rejects. (#355)
 
 ## [0.1.5] — boolean control state fixes
 

--- a/docs/widgets/select.rst
+++ b/docs/widgets/select.rst
@@ -46,9 +46,30 @@ the value, not the label. The label currently shown is available as ``.text``.
 
    theme.options          # -> [{"text": "Light theme", "value": "light"}, ...]
 
-Setting ``.value`` to something that is not one of the options raises
-``ValueError`` (unless ``allow_custom_values=True``, where a typed value is kept
-as its own text).
+The option list controls what a *user* can pick — it is not a schema for the
+data you supply. Setting ``.value`` to something outside the list displays it
+without adding it to the list, so a stored record whose option has since been
+retired still opens in an editor, and reads back as the value you set (an
+``int`` stays an ``int``). Once the user picks something else the old value is
+gone, and it was never in the list to pick again. One edge: if the retired
+value renders as the same text as a live option's label, that option wins —
+the two are indistinguishable on screen. Use a validation rule to report a
+retired value:
+
+.. code-block:: python
+
+   country.add_validation_rule(
+       "custom",
+       func=lambda v: not v or v in current_codes,
+       message="That option is no longer available.",
+   )
+
+Rules run against the ``value``, not the label shown for it, so on a decoupled
+option list a rule sees ``"US"`` rather than ``"United States"``. A ``'custom'``
+rule runs on ``validate()`` and on form submit; pass ``trigger="always"`` to
+have it report as soon as the value changes. See :doc:`/reference/validation`.
+
+With ``allow_custom_values=True`` the user may also *type* a value of their own.
 
 Carrying extra data (the data bag)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/bootstack/widgets/_impl/composites/selectbox.py
+++ b/src/bootstack/widgets/_impl/composites/selectbox.py
@@ -39,7 +39,6 @@ class SelectBox(Field):
             label: str = None,
             message: str = None,
             allow_custom_values: bool = False,
-            strict_value: bool = False,
             show_dropdown_button: bool = True,
             dropdown_button_icon: str = None,
             enable_search: bool = False,
@@ -49,8 +48,8 @@ class SelectBox(Field):
     ):
         """Args:
             master: Parent widget. If None, uses the default root window.
-            value: Initial selected value (value-space). Should match one of the
-                options unless `allow_custom_values` is set.
+            value: Initial selected value (value-space). A value that is not in
+                the options is displayed but not added to the list.
             items: Options to present in the popup — each a string,
                 `(text, value)` tuple, or `{'text', 'value'}` dict. The popup
                 and field display each option's text; the selected value is
@@ -106,7 +105,6 @@ class SelectBox(Field):
         # so a plain option is treated like a decoupled one (display != value).
         self._records = normalize_options(items)
         self._allow_custom_values = allow_custom_values
-        self._strict_value = strict_value
         self._rebuild_option_maps()
 
         # Forward an explicit localize mode to Field so the label/message follow
@@ -116,6 +114,14 @@ class SelectBox(Field):
 
         # Seed the entry with the display form of the initial value.
         super().__init__(master, value=self._resolve_display(value), label=label, message=message, **kwargs)
+
+        # Decode the entry's LIVE text into value-space before rules see it. A
+        # decoupled option shows a label ("United States") whose value ("US") is
+        # what a rule means, so validating the label would reject every valid
+        # selection. Keep the part's own live parse as the fallback: it reads
+        # what is currently typed, which is what key/blur triggers must judge.
+        self._entry_live_validation_value = self._entry._get_validation_value
+        self._entry._get_validation_value = self._validation_value
 
         # Re-translate the displayed text + option maps on a live locale switch.
         self.winfo_toplevel().bind('<<LocaleChanged>>', self._on_locale_changed_refresh, add='+')
@@ -201,6 +207,10 @@ class SelectBox(Field):
         """
         self._value_by_text: dict[str, Any] = {}
         self._text_by_value: dict[Any, str] = {}
+        # A retired value registered by `_resolve_display` lives only in these
+        # maps, so rebuilding from the records drops it — a new option list
+        # supersedes whatever the field was holding.
+        self._retired_text: str | None = None
         for rec in self._records:
             display = self._record_display(rec)
             self._value_by_text.setdefault(display, rec.value)
@@ -220,7 +230,13 @@ class SelectBox(Field):
         """
         current_text = self.entry_widget.get()
         value = self._value_by_text.get(current_text) if current_text else None
+        retired = self._retired_text
         self._rebuild_option_maps()
+        if retired is not None and retired == current_text:
+            # Rebuilding drops the registration for a value that is not in the
+            # list, but a translation change does not retire a value the field
+            # is still holding — re-register it so it keeps its own type.
+            self._register_retired_value(value)
         if value is None:
             return
         new_display = self._text_by_value.get(value, current_text)
@@ -250,9 +266,22 @@ class SelectBox(Field):
         - A known plain option, a custom value, or a typed value (e.g. a
           `datetime.time`) -> the value itself, so the entry's `value_format`
           parses/formats it.
-        - An unknown value, when `strict_value` is set and custom values are
-          off -> raises `ValueError`.
+        - An unknown value -> the value itself. A fixed option list constrains
+          what a *user* can pick; it is not a schema for the data the program
+          supplies. A stored record whose value has since left the list still
+          displays, rather than crashing the editor that opened it. The value
+          is shown but never added to the list, so it cannot be picked again
+          once changed. Use a `'custom'` validation rule to report one.
+
+        The entry holds text, so every value is coerced to a string on the way
+        in and decoded back through the display-text map on the way out. A
+        retired value has no option to decode from, so it is registered under
+        its own coerced text — otherwise it would come back as that string
+        instead of, say, the `int` it was.
         """
+        # Whatever was registered describes the OLD value; drop it first so a
+        # single registration always tracks what the field currently holds.
+        self._clear_retired_value()
         if value is None or value == "":
             return value
         try:
@@ -261,9 +290,45 @@ class SelectBox(Field):
                 return text if text != value else value
         except TypeError:
             pass
-        if self._strict_value and not self._allow_custom_values:
-            raise ValueError(f"{value!r} is not one of the options")
+        self._register_retired_value(value)
         return value
+
+    def _validation_value(self) -> Any:
+        """The value validation rules run against — decoded, not the label shown.
+
+        Reads the text currently in the entry (not the last committed value) so
+        a key or blur trigger judges what the user is actually typing, then maps
+        it back to the option's value when it names one.
+        """
+        text = self.entry_widget.get()
+        if text in self._value_by_text and self._value_by_text[text] != text:
+            return self._value_by_text[text]
+        return self._entry_live_validation_value()
+
+    def _register_retired_value(self, value: Any) -> None:
+        """Make a value that is not in the option list decodable.
+
+        Keyed on the text the entry will actually show. A display that already
+        belongs to an option is left alone: two different values rendering the
+        same text are indistinguishable to the widget *and* to the user, so the
+        option wins rather than being shadowed by a stale registration.
+        """
+        text = str(value)
+        if text in self._value_by_text:
+            return
+        self._retired_text = text
+        self._value_by_text[text] = value
+
+    def _clear_retired_value(self) -> None:
+        """Drop a previously registered retired value, if any.
+
+        Called before registering another and whenever the user picks from the
+        list, so a stale registration can never hijack a real option.
+        """
+        text = getattr(self, "_retired_text", None)
+        if text is not None:
+            self._value_by_text.pop(text, None)
+            self._retired_text = None
 
     def _on_dropdown_click(self):
         """Handle dropdown button click by focusing entry then showing popup."""
@@ -758,6 +823,9 @@ class SelectBox(Field):
         if enabled:
             popup_state['first_filtered_item'] = enabled[0].value
         popup_state['last_search_text'] = self.entry_widget.get().lower()
+        # Remember the text the popup opened on: an auto-select at close is only
+        # meaningful if the user actually typed a filter.
+        popup_state['opened_search_text'] = popup_state['last_search_text']
 
         # Bind KeyRelease for filtering (delegates to the testable method)
         keyrelease_binding = self.entry_widget.bind(
@@ -840,9 +908,16 @@ class SelectBox(Field):
         self._popup_state = None
 
         # Handle value selection for search mode without custom values
+        # A search popup commits its top match when the user typed a filter and
+        # dismissed without clicking. Without a filter there is no match to
+        # commit, and rewriting the field would silently replace a value the
+        # user only opened the list to look at.
         if self._search_enabled and not self._allow_custom_values:
-            if not popup_state['item_was_selected']:
+            typed = (popup_state.get('last_search_text')
+                     != popup_state.get('opened_search_text'))
+            if not popup_state['item_was_selected'] and typed:
                 if popup_state['first_filtered_item'] is not None:
+                    self._clear_retired_value()
                     self._last_selected_value = popup_state['first_filtered_item']
                     self.value = popup_state['first_filtered_item']
 
@@ -851,6 +926,9 @@ class SelectBox(Field):
         if selected_value is None:
             return
 
+        # The user picked from the list, so any retired value it was holding is
+        # gone; drop its registration before it can shadow a real option.
+        self._clear_retired_value()
         self._last_selected_value = selected_value
         self.value = selected_value
         self._close_popup(toplevel, popup_state)
@@ -992,9 +1070,8 @@ class SelectBox(Field):
         """Select `value`, updating the displayed text and emitting `<<Change>>`.
 
         A decoupled option shows its text; a plain/typed/custom value is handed
-        to the entry, which owns the raw value <-> text formatting. An unknown
-        value raises `ValueError` when `strict_value` is set and custom values
-        are off.
+        to the entry, which owns the raw value <-> text formatting. A value that
+        is not in the list is displayed as given and is not added to the list.
         """
         prev_value = self.value
         display = self._resolve_display(value)

--- a/src/bootstack/widgets/select.py
+++ b/src/bootstack/widgets/select.py
@@ -111,9 +111,6 @@ class Select(PublicWidgetBase):
             "allow_custom_values": allow_custom_values,
             "group_by":            group_by,
             "max_visible_items":   max_visible_items,
-            # Public Select rejects an unknown value (unless custom values are
-            # allowed); internal/embedded SelectBoxes stay lenient.
-            "strict_value":        not allow_custom_values,
         }
         if value is not None:
             internal_kwargs["value"] = value
@@ -166,6 +163,20 @@ class Select(PublicWidgetBase):
                 - `func` *(custom)* — callable `(value) -> bool`.
         """
         self._internal.add_validation_rule(rule_type, **kwargs)
+
+    def validate(self) -> bool:
+        """Run validation rules against the current selection.
+
+        Rules run against the selected `value`, not the label shown for it, so
+        a rule on a decoupled option list sees `'US'` rather than
+        `'United States'`. A value outside the option list is displayed rather
+        than rejected, so a `custom` rule is how you report one.
+
+        Returns:
+            `True` if all rules pass, `False` otherwise.
+        """
+        entry = self._internal._entry
+        return entry.validate(entry._get_validation_value(), trigger="manual")
 
     # ----- Event routing -----
 

--- a/tests/widgets/public/test_select_options.py
+++ b/tests/widgets/public/test_select_options.py
@@ -216,10 +216,14 @@ def test_select_value_setter_is_value_space(app):
 # Unknown values
 # --------------------------------------------------------------------------
 
-def test_select_unknown_value_raises(app):
+def test_select_unknown_value_is_displayed_not_rejected(app):
+    # Was: raised ValueError. A fixed list constrains what a user can pick, so
+    # rejecting a value the PROGRAM supplies crashed editors opened on records
+    # whose option had been retired (#355). SelectButton, which maps a value to
+    # an option's label and has no text entry, still rejects.
     s = bs.Select(options=[("Big", "b")])
-    with pytest.raises(ValueError):
-        s.value = "nope"
+    s.value = "nope"
+    assert s.value == "nope"
 
 
 def test_selectbutton_unknown_value_raises(app):
@@ -228,9 +232,10 @@ def test_selectbutton_unknown_value_raises(app):
         sb.value = "nope"
 
 
-def test_select_unknown_initial_value_raises(app):
-    with pytest.raises(ValueError):
-        bs.Select(options=["a", "b"], value="z")
+def test_select_unknown_initial_value_is_displayed(app):
+    # Seeding and setting must agree; construction used to raise while a later
+    # write was silently dropped.
+    assert bs.Select(options=["a", "b"], value="z").value == "z"
 
 
 # --------------------------------------------------------------------------
@@ -610,3 +615,215 @@ def test_group_runtime_add_blank_label_is_icon_only(app):
 def test_icon_only_selection_carries_bag(app):
     tg = bs.ToggleGroup(options=ICON_ONLY_OPTS, value="grid")
     assert tg.selection == {"text": "", "value": "grid", "icon": "grid"}
+
+
+# --- A value the list no longer offers (#355) ------------------------------
+
+def test_off_list_value_displays_without_joining_the_list(app):
+    # A fixed option list constrains what a USER can pick; it is not a schema
+    # for the data the program supplies. A stored record whose option has since
+    # been retired must still display — and must not become pickable again.
+    select = bs.Select(options=["US", "CA"])
+    app._tk_root.update_idletasks()
+    select.value = "MX"
+    app._tk_root.update_idletasks()
+    assert select.value == "MX"
+    assert [o["value"] for o in select.options] == ["US", "CA"]
+
+
+def test_form_seeds_and_sets_an_off_list_value(app):
+    # Construction used to raise and a later write was silently dropped, so the
+    # same value produced two different wrong answers. Both now round-trip.
+    form = bs.Form(data={"c": "MX"},
+                   items=[bs.FieldItem(key="c", editor="select",
+                                       editor_options={"values": ["US", "CA"]})])
+    app._tk_root.update_idletasks()
+    assert form.get()["c"] == "MX"          # seeded at construction
+
+    form.set_field_value("c", "BR")
+    app._tk_root.update_idletasks()
+    assert form.get()["c"] == "BR"          # and set programmatically
+
+
+def test_datatable_edit_form_opens_on_a_retired_option(app):
+    # The real-world case: opening the add/edit dialog on a legacy record.
+    table = bs.DataTable(rows=[{"country": "MX"}],
+                         columns=[{"key": "country", "editor": "select",
+                                   "editor_options": {"values": ["US", "CA"]}}])
+    app._tk_root.update_idletasks()
+    form = bs.Form(items=table._internal._build_form_items(), data={"country": "MX"})
+    app._tk_root.update_idletasks()
+    assert form.get()["country"] == "MX"
+
+
+def test_in_list_selection_is_unaffected(app):
+    select = bs.Select(options=["US", "CA"], value="US")
+    app._tk_root.update_idletasks()
+    select.value = "CA"
+    app._tk_root.update_idletasks()
+    assert select.value == "CA"
+
+
+def test_validate_reports_an_off_list_value(app):
+    # Reporting an out-of-list value is a validation rule's job — it reports
+    # rather than crashing the editor that opened the record.
+    allowed = {"US", "CA"}
+    select = bs.Select(options=sorted(allowed))
+    select.add_validation_rule("custom", func=lambda v: not v or v in allowed,
+                               message="That option is no longer available.")
+    app._tk_root.update_idletasks()
+    select.value = "MX"
+    app._tk_root.update_idletasks()
+    assert select.validate() is False
+    select.value = "US"
+    app._tk_root.update_idletasks()
+    assert select.validate() is True
+
+def test_off_list_value_keeps_its_type(app):
+    # The entry stores text, and the option list is what decodes it back to a
+    # real value. A retired value has no option, so without registering it the
+    # int 7 would come back as "7" — and Form.get() would hand a string to the
+    # caller's persistence layer.
+    select = bs.Select(options=[("One", 1), ("Two", 2)], value=1)
+    app._tk_root.update_idletasks()
+    select.value = 7
+    app._tk_root.update_idletasks()
+    assert select.value == 7 and isinstance(select.value, int)
+
+
+def test_off_list_value_keeps_its_type_through_a_form(app):
+    form = bs.Form(data={"s": 7},
+                   items=[bs.FieldItem(key="s", editor="select",
+                                       editor_options={"values": [("One", 1), ("Two", 2)]})])
+    app._tk_root.update_idletasks()
+    assert form.get()["s"] == 7
+
+
+def test_picking_an_option_supersedes_a_retired_value(app):
+    # The retired value is registered under its own display text. Selecting a
+    # real option must drop that registration, or it would shadow the option
+    # the next time the same text is shown.
+    select = bs.Select(options=[("One", 1), ("Two", 2)])
+    app._tk_root.update_idletasks()
+    select.value = 7
+    app._tk_root.update_idletasks()
+    select.value = 2
+    app._tk_root.update_idletasks()
+    assert select.value == 2
+    assert select._internal._retired_text is None
+
+
+def test_replacing_the_options_drops_a_retired_value(app):
+    select = bs.Select(options=["US", "CA"])
+    app._tk_root.update_idletasks()
+    select.value = "MX"
+    app._tk_root.update_idletasks()
+    select.options = ["GB", "FR"]
+    app._tk_root.update_idletasks()
+    assert select.value is None                      # the observable outcome
+    assert select._internal._retired_text is None    # and no stale decoder key
+    assert "MX" not in select._internal._value_by_text
+
+
+def test_off_list_value_that_matches_an_option_label_resolves_to_that_option(app):
+    # Two values rendering the same text are indistinguishable to the widget
+    # AND to the user, so the real option wins rather than being shadowed.
+    select = bs.Select(options=[{"text": "MX", "value": "mex"},
+                                {"text": "US", "value": "usa"}])
+    app._tk_root.update_idletasks()
+    select.value = "MX"
+    app._tk_root.update_idletasks()
+    assert select.value == "mex"
+
+
+def test_dismissing_a_search_popup_without_typing_keeps_the_value(app):
+    # Opening the list to look at it, then dismissing, must not rewrite the
+    # field — the user selected nothing and typed nothing.
+    select = bs.Select(options=["US", "CA", "GB"], searchable=True)
+    app._tk_root.update_idletasks()
+    select.value = "MX"
+    app._tk_root.update_idletasks()
+    inner = select._internal
+    inner._show_selection_options()
+    app._tk_root.update_idletasks()
+    inner._close_popup(inner._popup_frame.winfo_toplevel(), inner._popup_state)
+    app._tk_root.update_idletasks()
+    assert select.value == "MX"
+
+
+def test_dismissing_a_search_popup_after_typing_still_commits_the_match(app):
+    # The counterpart: type-to-filter then dismiss keeps committing the top
+    # match, so the guard above did not disable the feature.
+    select = bs.Select(options=["US", "CA", "GB"], searchable=True)
+    app._tk_root.update_idletasks()
+    inner = select._internal
+    inner._show_selection_options()
+    app._tk_root.update_idletasks()
+    inner.entry_widget.delete(0, "end")
+    inner.entry_widget.insert(0, "G")
+    inner._apply_search_filter(inner._popup_state)
+    app._tk_root.update_idletasks()
+    inner._close_popup(inner._popup_frame.winfo_toplevel(), inner._popup_state)
+    app._tk_root.update_idletasks()
+    assert select.value == "GB"
+
+
+def test_rules_run_against_the_value_not_the_label(app):
+    # A decoupled option shows "United States" but means "US". Validating the
+    # label would reject every valid selection.
+    select = bs.Select(options=[{"text": "United States", "value": "US"},
+                                {"text": "Canada", "value": "CA"}])
+    select.add_validation_rule("custom", func=lambda v: not v or v in {"US", "CA"},
+                               message="no longer available")
+    app._tk_root.update_idletasks()
+    select.value = "US"
+    app._tk_root.update_idletasks()
+    assert select.validate() is True
+    select.value = "MX"
+    app._tk_root.update_idletasks()
+    assert select.validate() is False
+
+
+def test_a_locale_change_keeps_a_retired_value(app):
+    # Re-translating the options rebuilds the decode map. A translation change
+    # does not retire a value the field is still holding, so its registration
+    # has to survive — otherwise an int would come back as a string.
+    select = bs.Select(options=[("One", 1), ("Two", 2)], value=1)
+    app._tk_root.update_idletasks()
+    select.value = 7
+    app._tk_root.update_idletasks()
+    select._internal.winfo_toplevel().event_generate("<<LocaleChanged>>")
+    app._tk_root.update_idletasks()
+    assert select.value == 7 and isinstance(select.value, int)
+
+
+# --- Validation reads LIVE text, decoded (guards the automatic triggers) ----
+
+def test_validation_sees_text_being_typed_not_the_committed_value(app):
+    # Rules must judge what the user is typing, not the last committed value —
+    # key/blur triggers fire mid-edit. TimeField shares this machinery (it is
+    # built on the same composite), so getting this wrong let an out-of-range
+    # time validate clean.
+    from datetime import time
+
+    field = bs.TimeField(value=time(9, 0))
+    field.add_validation_rule("range", min=time(8, 0), max=time(10, 0))
+    app._tk_root.update_idletasks()
+    entry = field._internal._entry
+    entry.delete(0, "end")
+    entry.insert(0, "11:45 PM")
+    app._tk_root.update_idletasks()
+    assert field.validate() is False
+
+
+def test_typing_into_a_custom_value_select_is_not_reported_as_empty(app):
+    # `required` fires on every keystroke, so reading the last committed value
+    # showed "required" while the user was part-way through typing.
+    select = bs.Select(options=["alpha", "beta"], allow_custom_values=True,
+                       required=True)
+    app._tk_root.update_idletasks()
+    entry = select._internal._entry
+    entry.delete(0, "end")
+    entry.insert(0, "gamma")
+    app._tk_root.update_idletasks()
+    assert entry._get_validation_value() == "gamma"


### PR DESCRIPTION
Fixes #355.

A `Select` decodes its value from the **text** in its entry, via the option list. That decode only works for values in the list — which is what the old `ValueError` was really guarding. It wasn't a policy about fixed option lists.

So a stored record whose option had since been retired could not be edited:

```python
bs.DataTable(rows=[{"country": "MX"}],
             columns=[{"key": "country", "editor": "select",
                       "editor_options": {"values": ["US", "CA"]}}])
# opening the add/edit dialog → ValueError: 'MX' is not one of the options
```

…while a later programmatic write of the same value was silently swallowed by `Form._apply_value_to_widget`. One value, two different wrong answers, on ordinary data drift — a discontinued category, a renamed status, an older schema.

## What changed

An option list constrains what a **user** can pick: the popup lists only options, and typing is gated by `allow_custom_values`. It is not a schema for the data your program supplies. A value outside the list is now **displayed as given** — and registered under its own coerced text, so the decode stays total:

| | before | after |
|---|---|---|
| construction on a retired value | `ValueError` | displays |
| programmatic set | silently dropped | displays |
| `Select.value` / `Form.get()` for `int` `7` | — | `7`, not `'7'` |
| popup options | — | unchanged; the value is never added |

When the retired value renders as an existing option's **label**, that option wins — two values that look identical on screen cannot be told apart by the widget or by the user. The registration tracks only the current value: replacing the options drops it, picking from the list drops it, and re-translating labels re-registers it so a locale change doesn't cost the value its type.

Use a `'custom'` rule to report a retired value — validation reports, where a raise crashes the editor that opened the record.

## Two bugs surfaced while making that safe

- **A searchable `Select` changed its value when you just looked.** Opening the drop-down and dismissing it — no typing, no click — committed the first option. It now commits only when a filter was actually typed.
- **Validation ran against the label.** On a decoupled option list every rule saw `'United States'` where it meant `'US'`, so a rule checking the value rejected valid selections. Rules now see the live text decoded into value-space.

Also adds **`Select.validate()`**, which `add_validation_rule`'s own docstring already pointed at.

## Note for review

`SelectBox._validation_value` is the one change that reaches beyond `Select` — `TimeEntry` is built on the same composite. An earlier revision of this branch replaced the entry's validation semantics outright and broke `bs.TimeField` (typed out-of-range input validated clean). It now decodes the **live** text and falls back to the part's own parse, so key/blur triggers still judge what is being typed. Regression tests for both cover it.

## Verification

91 tests in `test_select_options.py`; 13 of the 16 new/changed fail against `main` (the 3 that pass are deliberate controls). `python tests/run_gui.py` — all legs green; clean `-W` docs build. Two existing tests asserting the old raise-on-unknown contract were rewritten with the reason, not deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
