### PR TITLE
docs: drop the Qt licensing line from the homepage blurb

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,9 @@
 
 ### Desktop apps in pure Python — Tk underneath, none of the boilerplate.
 
-bootstack is built on Tk, so the install is light, there's no Qt license, and
-your app ships as a small standalone executable. But you'll never write a
-`StringVar` or call `.pack()` — the API is its own. 60+ widgets, reactive state,
-and a CLI that scaffolds and packages the whole thing.
+bootstack is built on Tk, so the install is light and your app ships as a small standalone executable. But you'll never
+write a `StringVar` or call `.pack()` — the API is its own. 60+ widgets, reactive state, and a CLI that scaffolds and
+packages the whole thing.
 
 <p align="center">
 <picture>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,10 +7,9 @@ bootstack
 
 Desktop apps in pure Python — Tk underneath, none of the boilerplate.
 
-bootstack is built on Tk, so the install is light, there's no Qt license, and
-your app ships as a small standalone executable. But you'll never write a
-``StringVar`` or call ``.pack()`` — the API is its own. 60+ widgets, reactive
-state, and a CLI that packages it all.
+bootstack is built on Tk, so the install is light and your app ships as a small standalone executable. But you'll
+never write a ``StringVar`` or call ``.pack()`` — the API is its own. 60+ widgets, reactive state, and a CLI that
+scaffolds and packages the whole thing.
 
 .. container:: hero-ctas
 


### PR DESCRIPTION
Leads with what bootstack gives you — a light install and a small standalone executable — rather than what another toolkit costs.

The docs homepage also picks up the README's fuller CLI phrasing (`a CLI that scaffolds and packages the whole thing`), so the two read the same.

Text-only; no code or build changes. Clean `-W` docs build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
