### PR TITLE
fix(i18n): a Decimal value respects value_format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,11 @@ and from 0.1.0 onward the project adheres to
   On a decoupled option list — where an option displays `'United States'` and
   stores `'US'` — every rule saw the label, so a rule checking the value
   rejected valid selections. (#355)
+- **A `Decimal` value now respects `value_format`.** It matched none of the
+  formatter's numeric branches, so the format was silently ignored: a currency
+  field seeded with a `Decimal` displayed the raw number and only started
+  formatting once you edited it. `Decimal` is handed to the formatter as-is
+  rather than converted, so a value keeps the precision it was given.
 
 ### Added
 

--- a/src/bootstack/i18n/intl_format.py
+++ b/src/bootstack/i18n/intl_format.py
@@ -12,6 +12,7 @@ import locale
 import re
 import warnings
 from dataclasses import dataclass
+from decimal import Decimal
 from datetime import date, datetime, time
 from typing import Any, Literal, Mapping, Optional, TypedDict, Union, cast
 
@@ -148,7 +149,10 @@ SUFFIXES_EN = (
     Suffix(1_000, "K"),
 )
 _SUFFIX_TO_FACTOR = {"K": 1_000, "M": 1_000_000, "B": 1_000_000_000, "T": 1_000_000_000_000}
-_NUMBERISH = (int, float)
+# Values formatted as numbers. `Decimal` is passed to Babel as-is rather than
+# coerced: Babel formats it natively, and going through `float` would round
+# away the precision a caller chose `Decimal` to keep.
+_NUMBERISH = (int, float, Decimal)
 
 
 def _locale_to_languages(loc: str) -> list[str]:
@@ -208,7 +212,7 @@ class IntlFormatter:
         if value is None:
             return ""
         if isinstance(value, _NUMBERISH):
-            return self._format_number(float(value), spec)
+            return self._format_number(value if isinstance(value, Decimal) else float(value), spec)
         if isinstance(value, datetime):
             return self._format_datetime(value, spec)
         if isinstance(value, date):
@@ -238,7 +242,7 @@ class IntlFormatter:
         return self._parse_temporal(s, spec)
 
     # ---------- Numbers ----------
-    def _format_number(self, x: float, spec: LooseSpec) -> str:
+    def _format_number(self, x: float | Decimal, spec: LooseSpec) -> str:
         opt = self._normalize_number_spec(spec)
 
         if opt["type"] == "custom":

--- a/tests/test_intl_format.py
+++ b/tests/test_intl_format.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import re
 from datetime import date, datetime, time
+from decimal import Decimal
 
 import pytest
 
@@ -97,3 +98,27 @@ def test_locale_wiring_smoke():
     assert f.format(1234.56, "decimal") == "1.234,56"
     long_date = f.format(date(2025, 9, 2), "longDate")
     assert "September" in long_date and "2025" in long_date
+
+
+# --- Decimal values format like any other number ---------------------------
+
+@pytest.mark.parametrize("spec", [
+    "decimal", "currency", "percent", "#,##0.00",
+    "thousands", "millions", "largeNumber", "exponential",
+])
+def test_decimal_formats_like_the_equivalent_float(spec):
+    # A Decimal matched no branch in `format()` and fell through to `str(value)`,
+    # so `value_format` was silently ignored — worst on `currency`, which is the
+    # format you reach for precisely when the value is a Decimal.
+    fmt = IntlFormatter(locale="en_US")
+    assert fmt.format(Decimal("12345.6789"), spec) == fmt.format(12345.6789, spec)
+
+
+def test_decimal_is_not_rounded_through_float():
+    # Babel formats a Decimal natively. Coercing to float first would round away
+    # the precision the caller chose Decimal to keep.
+    fmt = IntlFormatter(locale="en_US")
+    pattern = "#,##0.0000000000000000000"
+    exact = Decimal("0.1234567890123456789")
+    assert fmt.format(exact, pattern) == "0.1234567890123456789"
+    assert fmt.format(exact, pattern) != fmt.format(float(exact), pattern)

--- a/tests/widgets/public/test_field_text_value.py
+++ b/tests/widgets/public/test_field_text_value.py
@@ -198,3 +198,15 @@ def test_select_text_is_label_value_is_value(app):
     s = bs.Select(options=[("Dark Mode", "dark")], value="dark")
     assert s.value == "dark"        # value-space
     assert s.text == "Dark Mode"    # display label
+
+
+def test_decimal_seeded_field_displays_formatted(app):
+    # A currency field seeded with a Decimal showed the raw number until you
+    # edited it — the commit parsed to a float, which then formatted, so the
+    # field appeared to fix itself. The formatter ignored Decimal entirely.
+    from decimal import Decimal
+
+    field = bs.TextField(value=Decimal("3.50"), value_format="currency")
+    app._tk_root.update_idletasks()
+    assert field.text == "$3.50"
+    assert field.value == Decimal("3.50")


### PR DESCRIPTION
A `Decimal` matched none of `IntlFormatter.format()`'s branches and fell through to `str(value)`, so `value_format` was **silently ignored** — it raises nothing, so the caller's `except (ValueError, TypeError)` fallback never fired either.

The symptom is a field that appears to fix itself:

```python
bs.TextField(value=Decimal("3.50"), value_format="currency")
#   displays '3.50'  — unformatted
#   type 4.6 and Tab → '$4.60'   (the commit parses to a float, which does format)
```

| seed | displayed | |
|---|---|---|
| `float` `3.5` | `$3.50` | |
| `int` `3` | `$3.00` | |
| `str` `'3.5'` | `$3.50` | |
| `Decimal('3.50')` | `3.50` | ← the format is dropped |

`Decimal` is the type you reach for *because* the value is money, so the format was being dropped exactly where it was most wanted. This affects a standalone `TextField`, a `Form` editor with `editor_options={"value_format": ...}`, and `DataTable`'s edit dialog.

## The fix

`Decimal` joins the numeric branch and is handed to Babel **as-is** rather than coerced — Babel formats it natively, and going through `float` would round away the precision the caller chose `Decimal` to keep:

```
'#,##0.0000000000000000000' of Decimal('0.1234567890123456789')
  as Decimal → 0.1234567890123456789
  via float  → 0.1234567890123456800
```

The other numeric paths only divide by an `int` and take `abs()`, both `Decimal`-safe. All eight format types (`decimal`, `currency`, `percent`, a custom pattern, `thousands`, `millions`, `largeNumber`, `exponential`) now produce output identical to the equivalent float.

Parsing is unchanged — committing a currency field still yields a `float`. Only the display path is fixed.

## Note

**Pre-existing, not a regression** — verified identical on `771a1b9e` (before the 0.1.6 work). Found while building a manual test bench for the other 0.1.6 fixes, which is the first time a `Decimal` was put in front of a formatted field.

9 new tests fail on `main`. `python tests/run_gui.py` — all legs green; clean `-W` docs build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
