### PR TITLE
fix(scroll): support the Tk 9 scroll-event contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,22 @@ and from 0.1.0 onward the project adheres to
 
 ### Fixed
 
+- **Scrolling works again on Tcl/Tk 9.** A trackpad, Magic Mouse, or Magic
+  Trackpad reports precise scroll deltas, which Tk 9 delivers as a different
+  event than a mouse wheel. Every scrolling widget listened only for the
+  wheel, so on a Mac running Tk 9 — a Homebrew or conda Python, or any build
+  linked against Tk 9 — scrolling did nothing at all in `ScrollView`,
+  `ListView`, `Tree`, `TextArea`, `CodeEditor`, `Gallery`, and the `Tabs`
+  strip. Reported against Python 3.14.6 with Tcl/Tk 9.0.3; the same code runs
+  correctly on Python 3.13 only because it ships Tk 8.6.
+- **A wheel notch scrolls by one step on Tk 9, not by a hundred and twenty.**
+  Tk 9 normalized wheel deltas across platforms; on macOS the old reading
+  scrolled a full view per notch.
+- **Wheel scrolling works on Linux with Tk 9.** Tk 9 stopped delivering the
+  X11 wheel buttons to applications, and the affected widgets listened for
+  nothing else there.
+- **A wheel notch scrolls a `ScrollView` consistently across platforms.** On
+  Linux one notch moved the view ten times as far as it did elsewhere.
 - **A widget detached across a theme change is recolored when you attach it
   back.** Widgets that paint themselves — charts, gauges, and the other
   canvas-drawn widgets — skip a theme change while they are off screen and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and from 0.1.0 onward the project adheres to
   linked against Tk 9 — scrolling did nothing at all in `ScrollView`,
   `ListView`, `Tree`, `TextArea`, `CodeEditor`, `Gallery`, and the `Tabs`
   strip. Reported against Python 3.14.6 with Tcl/Tk 9.0.3; the same code runs
-  correctly on Python 3.13 only because it ships Tk 8.6.
+  correctly on Python 3.13 only because it ships Tk 8.6. (#372)
 - **A wheel notch scrolls by one step on Tk 9, not by a hundred and twenty.**
   Tk 9 normalized wheel deltas across platforms; on macOS the old reading
   scrolled a full view per notch.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,38 @@ Go from nothing to something fast. The user should never need to `import tkinter
 Pointers only — these shipped; rationale, detail, and gotchas live in the linked
 memories and git history.
 
+- **0.1.7 STAGED (NOT released) — Tk 9 scroll-event contract (branch
+  `fix/tk9-scroll-events`, commit `80b26b53`; 2026-07-23).** User report: scrolling
+  worked on Python 3.13.9, not 3.14.6. **It is NOT a Python change** — `tkinter`
+  is unchanged between those versions apart from docstrings, `after(**kw)`, and
+  `trace_variable` deprecation warnings. It is **Tcl/Tk 8.6 → 9.0** (reporter had
+  9.0.3; the python.org installer still ships **8.6.17**, which is why 3.13
+  "worked"). **Root cause, measured not inferred:** on Tk 9 + Aqua a trackpad
+  fires **only `<TouchpadScroll>`** — a probe logged **293 TouchpadScroll, ZERO
+  MouseWheel** — and every scrolling widget bound only `<MouseWheel>`. Two more
+  breaks in the same contract: Tk 9 normalizes wheel deltas to **±120** on all
+  platforms (so Aqua's `-event.delta` scrolled 120 units/notch), and X11
+  **Button-4/5 are no longer delivered to scripts** (TIP 474). **Fix:** new
+  **`_runtime/wheel.py`** (`wheel_sequences` / `wheel_notches` / `precise_deltas` /
+  `scale_num` / `PixelAccumulator`) replacing the delta branch **duplicated across
+  9 files**; bindings unconditional, X11 buttons kept only as a Tk ≤8.6 fallback
+  gated on **Tk version, not `winsys`**. Widgets copy Tk's **two** conventions:
+  *pixel* scrolling (ScrollView/TextArea/ScrolledText/Tabs) vs *accumulated whole
+  rows* (ListView/Tree/Gallery), plus a 40px/step throttle on the Spinbox/
+  NumberField steppers. **DataTable needed nothing** — Tk 9 binds TouchpadScroll on
+  the ttk Treeview class itself (verified). Incidental fix: a ScrollView notch moved
+  **10 canvas units on X11** vs 1 elsewhere; now 1 everywhere. Tests
+  **`test_scroll_events.py`** (25; 3 fail pre-fix). Verified on **Tk 9.0.4 AND
+  8.6.17** + confirmed live on a real trackpad. Full suite on Tk 9: **751 passed**,
+  only the 6 known pre-existing failures. `trace_variable`/`trace_vdelete`/
+  `trace_vinfo` (removed in Tcl 9) are **not used** anywhere — scrolling was the
+  only Tk 9 gap. Memory `reference_tk9_scroll_events`.
+  **Repro env:** `brew install python-tk@3.14` → `/opt/homebrew/opt/python@3.14/bin/python3.14`
+  (3.14.6 + Tcl/Tk 9.0.4). **⚠ The touchpad tests SKIP on Tk 8.6** — on the default
+  `.venv` the file reports "15 passed, 10 skipped" and looks green while testing
+  nothing about the fix. **There is no test workflow at all** (`.github/workflows/`
+  has only `docs.yml` + `release.yml`), so this can regress invisibly.
+
 - **0.1.6 STAGED (NOT yet released) — seven form/field/validation fixes
   (PRs #362–#368; 2026-07-21).** All merged to `main` under `## [Unreleased]`;
   **`pyproject.toml` is still `0.1.5`** — nothing is cut. Kicked off by the user
@@ -982,6 +1014,36 @@ maximized-drag re-anchors under the cursor. Memory `project_undecorated_window_c
 - **Code-review follow-ups #4–#10** — cleanup/altitude items recorded in
   `docs/_dev/widget-api-audit.md` (SelectButton stale value after `options=`; screenshot
   Win64 HWND hardening; group/window/date duplication; Calendar batch-redraw).
+
+### Known failing tests on macOS (triaged 2026-07-23 — NOT caused by the Tk 9 work)
+
+Seven failures on `main` on macOS. **Six are test defects, one is a real bug.**
+Verified by running them against unmodified `src` (identical set) — do not chase
+them as regressions.
+
+- **REAL BUG — `test_chart.py::test_theme_change_while_hidden_applies_on_return`.**
+  Reproduces in isolation (not order-dependent). A theme changed while a widget is
+  **`detach()`ed** is never applied on `attach()` — facecolor stays `#ffffff` under
+  a `#212529` theme. **Root cause:** the #338 repaint design drives
+  `apply_theme_walk(only_stale=True)` from **show-triggers**, and those exist ONLY
+  in `PageStack` (`pagestack.py:236`) and `Expander` (`expander.py:273`).
+  **`attach()` (`_core/base.py:312`) was never wired in** — the #123 detach/attach
+  feature and the #338 repaint unification never met. `Chart` correctly defines
+  `_bs_apply_theme`; it just never gets walked. Platform-independent (nothing
+  macOS-specific), so it likely fails everywhere. **Fix = fire the stale walk from
+  `attach()`.** Not filed yet.
+- **Test defects — assume the Win/Linux menu backend, no macOS guard** (on macOS
+  the backend is `_NativeContextMenu`, which has no `_toplevel`/`_items`):
+  `test_add_toolbar.py::test_bridge_inactive_on_non_macos` (asserts
+  `not _menus_are_native()` — literally named "non_macos", never skipped ON macOS),
+  `test_overlay_container_coverage.py::test_propagate_skips_nested_toplevels`,
+  `test_select_options.py::test_selectbutton_disabled_menu_item`,
+  `test_toolbar_menu.py::test_add_menu_builds_model_and_trigger`. All want a
+  macOS skip or a backend-agnostic assertion.
+- **Order-dependent — `test_pagestack.py::test_visited_pages_stay_mapped_on_macos`
+  + `::test_return_after_many_visits_does_not_remap_on_macos`.** Both **PASS alone**
+  (`4 passed` for the file) and fail only in the full shared-root run — state
+  pollution from an earlier test, not a product bug.
 
 **Throwaway demos `development/shell_*_demo.py` stay UNTRACKED** (scratch, not
 framework code). Side note logged: a future `Tabs` `variant='secondary'` (top

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1022,17 +1022,20 @@ Seven failures on `main` on macOS. **Six are test defects, one is a real bug.**
 Verified by running them against unmodified `src` (identical set) — do not chase
 them as regressions.
 
-- **REAL BUG — `test_chart.py::test_theme_change_while_hidden_applies_on_return`.**
-  Reproduces in isolation (not order-dependent). A theme changed while a widget is
-  **`detach()`ed** is never applied on `attach()` — facecolor stays `#ffffff` under
-  a `#212529` theme. **Root cause:** the #338 repaint design drives
-  `apply_theme_walk(only_stale=True)` from **show-triggers**, and those exist ONLY
+- **REAL BUG — FIXED (`fix/attach-theme-repaint`, commit `76e327b6`).**
+  `test_chart.py::test_theme_change_while_hidden_applies_on_return` reproduced in
+  isolation (not order-dependent). A theme changed while a widget was
+  **`detach()`ed** was never applied on `attach()` — facecolor stayed `#ffffff`
+  under a `#212529` theme. **Root cause:** the #338 repaint design drives
+  `apply_theme_walk(only_stale=True)` from **show-triggers**, and those existed ONLY
   in `PageStack` (`pagestack.py:236`) and `Expander` (`expander.py:273`).
   **`attach()` (`_core/base.py:312`) was never wired in** — the #123 detach/attach
   feature and the #338 repaint unification never met. `Chart` correctly defines
-  `_bs_apply_theme`; it just never gets walked. Platform-independent (nothing
-  macOS-specific), so it likely fails everywhere. **Fix = fire the stale walk from
-  `attach()`.** Not filed yet.
+  `_bs_apply_theme`; it just never got walked. Platform-independent, so it was
+  failing everywhere, not only on macOS. Fix = `_recolor_on_attach()` fires the
+  stale walk at idle from **both** `attach()` exit paths (the flex branch returns
+  early — wiring only the pack/grid/place tail would have missed every
+  `Row`/`Column` child). Applies to every self-painting widget, not just `Chart`.
 - **Test defects — assume the Win/Linux menu backend, no macOS guard** (on macOS
   the backend is `_NativeContextMenu`, which has no `_toplevel`/`_items`):
   `test_add_toolbar.py::test_bridge_inactive_on_non_macos` (asserts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,8 @@ Pointers only — these shipped; rationale, detail, and gotchas live in the link
 memories and git history.
 
 - **0.1.7 STAGED (NOT released) — Tk 9 scroll-event contract (branch
-  `fix/tk9-scroll-events`, commit `80b26b53`; 2026-07-23).** User report: scrolling
+  `fix/tk9-scroll-events`, commit `80b26b53`; 2026-07-23).** **#372** ("Scroll not
+  working on MacOS", user `cleonello`): scrolling
   worked on Python 3.13.9, not 3.14.6. **It is NOT a Python change** — `tkinter`
   is unchanged between those versions apart from docstrings, `after(**kw)`, and
   `trace_variable` deprecation warnings. It is **Tcl/Tk 8.6 → 9.0** (reporter had

--- a/src/bootstack/_runtime/wheel.py
+++ b/src/bootstack/_runtime/wheel.py
@@ -1,0 +1,152 @@
+"""Scroll-gesture normalization across Tk 8.6 and Tk 9.
+
+Tk 9 changed the scroll-event contract in two ways that break code written
+against Tk 8.6:
+
+* A precise-delta device — every Apple trackpad, Magic Mouse and Magic
+  Trackpad — now fires `<TouchpadScroll>` and **never** `<MouseWheel>`.
+  Binding only `<MouseWheel>` leaves those devices completely dead.
+* Wheel deltas are normalized to multiples of 120 on every windowing
+  system. On Aqua a notch used to report 1; it now reports 120.
+
+On X11, `<Button-4>`/`<Button-5>` are no longer delivered to scripts at
+all — Tk translates them to `<MouseWheel>` internally.
+
+This module hides all of that behind one vocabulary. Callers ask for the
+sequences to bind, then convert an incoming event to either wheel
+*notches* or precise *pixels*.
+
+Sign convention (matching Tk's own bindings): a positive value means the
+wheel rolled away from the user, i.e. the view should move toward the
+*start* of the content. Callers therefore negate to get a scroll amount.
+"""
+
+from __future__ import annotations
+
+import tkinter as tk
+
+TOUCHPAD_SCROLL = "<TouchpadScroll>"
+"""Sequence for precise-delta scroll gestures. Tk 8.7+ only."""
+
+_WHEEL_UNITS = 120.0
+"""Delta reported for one wheel notch on a normalized (Tk 8.7+) build."""
+
+_TOUCHPAD_TK = 8.7
+"""First Tk release generating `<TouchpadScroll>` and normalized deltas."""
+
+
+def _windowingsystem(widget: tk.Misc) -> str:
+    try:
+        return str(widget.tk.call("tk", "windowingsystem")).lower()
+    except Exception:
+        return ""
+
+
+def has_touchpad_scroll() -> bool:
+    """Whether the running Tk generates `<TouchpadScroll>` events."""
+    return tk.TkVersion >= _TOUCHPAD_TK
+
+
+def uses_x11_buttons(widget: tk.Misc) -> bool:
+    """Whether wheel input arrives as `<Button-4>`/`<Button-5>` here.
+
+    True only on legacy X11 builds. Tk 8.7+ translates those buttons to
+    `<MouseWheel>` and stops delivering them to scripts.
+    """
+    return not has_touchpad_scroll() and _windowingsystem(widget) == "x11"
+
+
+def wheel_sequences(widget: tk.Misc, *, shift: bool = False) -> tuple[str, ...]:
+    """Event sequences carrying wheel notches for `widget`.
+
+    Args:
+        widget: Any widget; used to resolve the windowing system.
+        shift: Request the horizontal (Shift-modified) sequences.
+    """
+    if uses_x11_buttons(widget):
+        if shift:
+            return ("<Shift-Button-4>", "<Shift-Button-5>")
+        return ("<Button-4>", "<Button-5>")
+    return ("<Shift-MouseWheel>",) if shift else ("<MouseWheel>",)
+
+
+def wheel_notches(widget: tk.Misc, event: tk.Event) -> float:
+    """Signed notch count for a wheel event.
+
+    Returns a positive value when the wheel rolled away from the user.
+    One physical notch is 1.0 on every platform and Tk version.
+    """
+    num = getattr(event, "num", None)
+    if num in (4, 6):
+        return 1.0
+    if num in (5, 7):
+        return -1.0
+
+    try:
+        delta = float(event.delta)
+    except (AttributeError, TypeError, ValueError):
+        return 0.0
+    if not delta:
+        return 0.0
+
+    # Tk 8.6 on Aqua reported one notch as 1; everything else uses 120.
+    if not has_touchpad_scroll() and _windowingsystem(widget) == "aqua":
+        return delta
+    return delta / _WHEEL_UNITS
+
+
+def precise_deltas(event: tk.Event) -> tuple[int, int]:
+    """Unpack a `<TouchpadScroll>` event into `(dx, dy)` pixels.
+
+    Tk packs both axes into the delta field as two signed 16-bit values.
+    This mirrors Tcl's `::tk::PreciseScrollDeltas`.
+    """
+    try:
+        packed = int(event.delta)
+    except (AttributeError, TypeError, ValueError):
+        return (0, 0)
+    dx = packed >> 16
+    low = packed & 0xFFFF
+    dy = low if low < 0x8000 else low - 0x10000
+    return (dx, dy)
+
+
+def scale_num(widget: tk.Misc, value: float) -> int:
+    """Scale a pixel amount for display density, like `::tk::ScaleNum`."""
+    try:
+        scaling = float(widget.tk.call("tk", "scaling"))
+    except Exception:
+        scaling = 1.0
+    return round(value * scaling * 0.75)
+
+
+class PixelAccumulator:
+    """Converts precise pixel deltas into whole discrete scroll steps.
+
+    A touchpad reports small deltas roughly sixty times a second. Widgets
+    that scroll by rows or canvas units cannot act on each one, so the
+    fractional remainder is carried forward until it adds up to a step.
+    """
+
+    __slots__ = ("_x", "_y")
+
+    def __init__(self) -> None:
+        self._x = 0.0
+        self._y = 0.0
+
+    def add(self, dx: float, dy: float, step_x: float, step_y: float) -> tuple[int, int]:
+        """Add a delta and return the whole `(x, y)` steps it completes."""
+        step_x = step_x if step_x and step_x > 0 else 1.0
+        step_y = step_y if step_y and step_y > 0 else 1.0
+        self._x += dx
+        self._y += dy
+        out_x = int(self._x / step_x)
+        out_y = int(self._y / step_y)
+        self._x -= out_x * step_x
+        self._y -= out_y * step_y
+        return (out_x, out_y)
+
+    def reset(self) -> None:
+        """Drop any carried remainder."""
+        self._x = 0.0
+        self._y = 0.0

--- a/src/bootstack/widgets/_impl/_parts/numberentry_part.py
+++ b/src/bootstack/widgets/_impl/_parts/numberentry_part.py
@@ -6,9 +6,13 @@ wheel support.
 """
 
 
+from bootstack._runtime import wheel
 from bootstack.events import ChangeEvent
 from bootstack.widgets._impl.mixins.configure_mixin import configure_delegate
 from bootstack.widgets._impl._parts.textentry_part import TextEntryPart
+
+_TOUCHPAD_STEP_PX = 40
+"""Trackpad travel, in pixels, that advances a stepper by one increment."""
 
 
 class NumberEntryPart(TextEntryPart):
@@ -111,12 +115,13 @@ class NumberEntryPart(TextEntryPart):
         self.bind('<Up>', self._handle_up_key, add=True)
         self.bind('<Down>', self._handle_down_key, add=True)
 
-        # Bind mouse wheel (Windows/macOS)
-        self.bind('<MouseWheel>', self._handle_mouse_wheel, add=True)
-
-        # Bind mouse wheel (Linux/X11)
-        self.bind('<Button-4>', self._handle_wheel_up, add=True)
-        self.bind('<Button-5>', self._handle_wheel_down, add=True)
+        # Bind wheel stepping. A wheel arrives as <MouseWheel> everywhere
+        # except legacy X11; a trackpad fires <TouchpadScroll> on Tk 8.7+.
+        for seq in wheel.wheel_sequences(self):
+            self.bind(seq, self._handle_mouse_wheel, add=True)
+        if wheel.has_touchpad_scroll():
+            self._touchpad = wheel.PixelAccumulator()
+            self.bind(wheel.TOUCHPAD_SCROLL, self._handle_touchpad_scroll, add=True)
 
         # Listen for increment/decrement events to invoke step
         self.bind('<<Increment>>', self._handle_increment_event, add=True)
@@ -137,33 +142,28 @@ class NumberEntryPart(TextEntryPart):
         return 'break'  # Prevent default behavior
 
     def _handle_mouse_wheel(self, event):
-        """Handle mouse wheel on Windows/macOS."""
+        """Handle a wheel notch by stepping the value once."""
         if not self._is_interactive():
             return 'break'
-        try:
-            delta = int(event.delta)
-        except (AttributeError, ValueError):
-            delta = 0
-
-        if delta != 0:
-            if delta > 0:
-                self.event_generate('<<Increment>>', data={'value': self._value})
-            else:
-                self.event_generate('<<Decrement>>', data={'value': self._value})
+        notches = wheel.wheel_notches(self, event)
+        if notches:
+            name = '<<Increment>>' if notches > 0 else '<<Decrement>>'
+            self.event_generate(name, data={'value': self._value})
         return 'break'
 
-    def _handle_wheel_up(self, event):
-        """Handle mouse wheel up on Linux/X11."""
-        if not self._is_interactive():
-            return 'break'
-        self.event_generate('<<Increment>>', data={'value': self._value})
-        return 'break'
+    def _handle_touchpad_scroll(self, event):
+        """Step once per `_TOUCHPAD_STEP_PX` of trackpad travel.
 
-    def _handle_wheel_down(self, event):
-        """Handle mouse wheel down on Linux/X11."""
+        A trackpad reports around sixty events a second; stepping on each
+        one would run the value away from the user.
+        """
         if not self._is_interactive():
             return 'break'
-        self.event_generate('<<Decrement>>', data={'value': self._value})
+        _dx, dy = wheel.precise_deltas(event)
+        _sx, steps = self._touchpad.add(0, dy, 1, _TOUCHPAD_STEP_PX)
+        name = '<<Increment>>' if steps > 0 else '<<Decrement>>'
+        for _ in range(abs(steps)):
+            self.event_generate(name, data={'value': self._value})
         return 'break'
 
     def _handle_increment_event(self, event):

--- a/src/bootstack/widgets/_impl/composites/gallery.py
+++ b/src/bootstack/widgets/_impl/composites/gallery.py
@@ -20,6 +20,7 @@ from PIL import Image as PILImage, ImageDraw
 from PIL.Image import Resampling
 from PIL.ImageTk import PhotoImage
 
+from bootstack._runtime import wheel
 from bootstack.data import MemoryDataSource, DataSourceProtocol
 from bootstack.style.style import get_style
 from bootstack.widgets._impl.composites._image_fit import (
@@ -223,6 +224,7 @@ class Gallery(Frame):
         self._start_row = 0
         self._ring_photo: PhotoImage | None = None
         self._row_h = self._th + 2 * _RING_PAD + (_CAPTION_H if caption_field else 0) + gap
+        self._touchpad = wheel.PixelAccumulator()
 
         sb_surface = getattr(self, '_surface', None)
         sb_kw = {'surface': sb_surface} if sb_surface else {}
@@ -450,20 +452,30 @@ class Gallery(Frame):
         self._update_tiles()
 
     def _bind_scroll(self, widget) -> None:
-        widget.bind("<MouseWheel>", self._on_wheel, add="+")
-        widget.bind("<Button-4>", self._on_wheel, add="+")
-        widget.bind("<Button-5>", self._on_wheel, add="+")
+        for seq in wheel.wheel_sequences(self):
+            widget.bind(seq, self._on_wheel, add="+")
+        if wheel.has_touchpad_scroll():
+            widget.bind(wheel.TOUCHPAD_SCROLL, self._on_touchpad_scroll, add="+")
 
     def _on_wheel(self, event) -> None:
-        if getattr(event, "num", None) == 4:
-            delta = 1
-        elif getattr(event, "num", None) == 5:
-            delta = -1
-        else:
-            delta = 1 if event.delta < 0 else -1
-        self._start_row += delta
+        notches = wheel.wheel_notches(self, event)
+        if not notches:
+            return "break"
+        self._start_row += -1 if notches > 0 else 1
         self._clamp()
         self._update_tiles()
+        return "break"
+
+    def _on_touchpad_scroll(self, event) -> None:
+        """Scroll by whole tile rows as a trackpad gesture accumulates pixels."""
+        _dx, dy = wheel.precise_deltas(event)
+        if not dy:
+            return "break"
+        _sx, rows = self._touchpad.add(0, dy, 1, self._row_h or 1)
+        if rows:
+            self._start_row -= rows
+            self._clamp()
+            self._update_tiles()
         return "break"
 
     def scroll_to_top(self) -> None:

--- a/src/bootstack/widgets/_impl/composites/list/listview.py
+++ b/src/bootstack/widgets/_impl/composites/list/listview.py
@@ -5,6 +5,7 @@ from tkinter import TclError
 from typing import Any, Callable, Literal
 from typing_extensions import Unpack
 
+from bootstack._runtime import wheel
 from bootstack.data import MemoryDataSource, DataSourceProtocol
 from bootstack.widgets._impl.composites.list.listitem import ListItem
 from bootstack.widgets._impl.primitives.frame import Frame, FrameKwargs
@@ -87,9 +88,8 @@ class ListView(Frame):
 
         self._accent = _user_accent or 'primary'
 
-        # Cache the windowing system so scroll bindings can dispatch
-        # platform-correctly: Aqua/Win send <MouseWheel>, X11 sends
-        # <Button-4>/<Button-5>.
+        # Cached for the platform branches elsewhere in this widget; scroll
+        # bindings resolve their own sequences through `_runtime.wheel`.
         self.winsys = self.tk.call('tk', 'windowingsystem')
 
         # Configuration
@@ -114,6 +114,7 @@ class ListView(Frame):
         self._prev_start_index = 0
         self._visible_rows = VISIBLE_ROWS
         self._row_height = ROW_HEIGHT
+        self._touchpad = wheel.PixelAccumulator()
         self._page_size = VISIBLE_ROWS + OVERSCAN_ROWS
 
         # Data source
@@ -570,15 +571,29 @@ class ListView(Frame):
     def _bind_scroll_events(self, widget) -> None:
         """Bind the platform-correct scroll-wheel events to `widget`.
 
-        On Aqua/Win the event is `<MouseWheel>` with `event.delta`
-        carrying direction and magnitude. On X11 there's no MouseWheel —
-        scroll up is `<Button-4>` and scroll down is `<Button-5>`.
+        A wheel arrives as `<MouseWheel>` everywhere except legacy X11,
+        where it is `<Button-4>`/`<Button-5>`. A trackpad or other
+        precise-delta device instead fires `<TouchpadScroll>` on Tk 8.7+.
         """
-        if self.winsys.lower() == 'x11':
-            widget.bind('<Button-4>', self._on_mousewheel, add='+')
-            widget.bind('<Button-5>', self._on_mousewheel, add='+')
-        else:
-            widget.bind('<MouseWheel>', self._on_mousewheel, add='+')
+        for seq in wheel.wheel_sequences(self):
+            widget.bind(seq, self._on_mousewheel, add='+')
+        if wheel.has_touchpad_scroll():
+            widget.bind(wheel.TOUCHPAD_SCROLL, self._on_touchpad_scroll, add='+')
+
+    def _pointer_within(self, event) -> bool:
+        """Whether the pointer is over this list or one of its descendants."""
+        widget_under_mouse = self.winfo_containing(event.x_root, event.y_root)
+        if widget_under_mouse is None:
+            return False
+        current = widget_under_mouse
+        while current is not None:
+            if current == self:
+                return True
+            try:
+                current = current.master
+            except AttributeError:
+                break
+        return False
 
     def _on_mousewheel(self, event):
         """Handle mouse wheel scrolling.
@@ -586,33 +601,32 @@ class ListView(Frame):
         Args:
             event: Tkinter mouse wheel event.
         """
-        # Check if mouse is over this widget
-        widget_under_mouse = self.winfo_containing(event.x_root, event.y_root)
-        if widget_under_mouse is None:
+        if not self._pointer_within(event):
             return
 
-        # Check if the widget under mouse is a child of this ListView
-        current = widget_under_mouse
-        is_child = False
-        while current is not None:
-            if current == self:
-                is_child = True
-                break
-            try:
-                current = current.master
-            except AttributeError:
-                break
+        notches = wheel.wheel_notches(self, event)
+        if not notches:
+            return
+        self._start_index += -1 if notches > 0 else 1
+        self._clamp_indices()
+        self._update_rows()
 
-        if not is_child:
+    def _on_touchpad_scroll(self, event):
+        """Scroll by whole rows as a trackpad gesture accumulates pixels.
+
+        Args:
+            event: Tkinter touchpad scroll event.
+        """
+        if not self._pointer_within(event):
             return
 
-        # Resolve scroll direction per platform: X11 carries it in event.num
-        # (4=up, 5=down) and has no event.delta; Aqua/Win use event.delta.
-        if self.winsys.lower() == 'x11':
-            delta = -1 if getattr(event, 'num', 0) == 4 else 1
-        else:
-            delta = -1 if event.delta > 0 else 1
-        self._start_index += delta
+        _dx, dy = wheel.precise_deltas(event)
+        if not dy:
+            return
+        _sx, rows = self._touchpad.add(0, dy, 1, self._row_height or 1)
+        if not rows:
+            return
+        self._start_index -= rows
         self._clamp_indices()
         self._update_rows()
 

--- a/src/bootstack/widgets/_impl/composites/scrolledtext.py
+++ b/src/bootstack/widgets/_impl/composites/scrolledtext.py
@@ -6,6 +6,7 @@ from bootstack.widgets._impl.primitives.frame import Frame
 from bootstack.widgets._impl.mixins.configure_mixin import configure_delegate
 from bootstack.widgets._impl.primitives.scrollbar import Scrollbar
 from bootstack.widgets.types import Master
+from bootstack._runtime import wheel
 
 ScrollDirection = Literal['horizontal', 'vertical', 'both']
 ScrollbarVisibility = Literal['always', 'never', 'hover', 'scroll']
@@ -176,14 +177,12 @@ class ScrolledText(Frame):
 
     def _setup_scroll_tag_bindings(self):
         """Setup bindings on our custom bind tag."""
-        if self.winsys.lower() == "x11":
-            self.bind_class(self._scroll_tag, "<Button-4>", self._on_mousewheel)
-            self.bind_class(self._scroll_tag, "<Button-5>", self._on_mousewheel)
-            self.bind_class(self._scroll_tag, "<Shift-Button-4>", self._on_shift_mousewheel)
-            self.bind_class(self._scroll_tag, "<Shift-Button-5>", self._on_shift_mousewheel)
-        else:
-            self.bind_class(self._scroll_tag, "<MouseWheel>", self._on_mousewheel)
-            self.bind_class(self._scroll_tag, "<Shift-MouseWheel>", self._on_shift_mousewheel)
+        for seq in wheel.wheel_sequences(self):
+            self.bind_class(self._scroll_tag, seq, self._on_mousewheel)
+        for seq in wheel.wheel_sequences(self, shift=True):
+            self.bind_class(self._scroll_tag, seq, self._on_shift_mousewheel)
+        if wheel.has_touchpad_scroll():
+            self.bind_class(self._scroll_tag, wheel.TOUCHPAD_SCROLL, self._on_touchpad_scroll)
 
     def _layout_widgets(self):
         """Layout the text widget and scrollbars."""
@@ -265,16 +264,7 @@ class ScrolledText(Frame):
                 self.after_cancel(self._hide_timer)
             self._hide_timer = self.after(self._autohide_delay, self._hide_scrollbars)
 
-        # Calculate delta based on platform
-        delta = 0
-        if self.winsys.lower() == "win32":
-            delta = -int(event.delta / 120)
-        elif self.winsys.lower() == "aqua":
-            delta = -event.delta
-        elif event.num == 4:
-            delta = -1
-        elif event.num == 5:
-            delta = 1
+        delta = -round(wheel.wheel_notches(self, event))
 
         # Scroll vertically
         if self._direction in ('vertical', 'both') and delta != 0:
@@ -289,20 +279,32 @@ class ScrolledText(Frame):
                 self.after_cancel(self._hide_timer)
             self._hide_timer = self.after(self._autohide_delay, self._hide_scrollbars)
 
-        # Calculate delta based on platform
-        delta = 0
-        if self.winsys.lower() == "win32":
-            delta = -int(event.delta / 120)
-        elif self.winsys.lower() == "aqua":
-            delta = -event.delta
-        elif event.num == 4:
-            delta = -1
-        elif event.num == 5:
-            delta = 1
+        delta = -round(wheel.wheel_notches(self, event))
 
         # Scroll horizontally
         if self._direction in ('horizontal', 'both') and delta != 0:
             self._text.xview_scroll(delta, 'units')
+
+    def _on_touchpad_scroll(self, event):
+        """Handle a precise-delta scroll gesture (trackpad).
+
+        A text widget scrolls by pixels directly, so the deltas are spent
+        as they arrive rather than accumulated into whole lines.
+        """
+        dx, dy = wheel.precise_deltas(event)
+        if not dx and not dy:
+            return
+
+        if self._scrollbar_visibility == 'scroll':
+            self._show_scrollbars()
+            if self._hide_timer:
+                self.after_cancel(self._hide_timer)
+            self._hide_timer = self.after(self._autohide_delay, self._hide_scrollbars)
+
+        if dy and self._direction in ('vertical', 'both'):
+            self._text.yview_scroll(wheel.scale_num(self, -dy), 'pixels')
+        if dx and self._direction in ('horizontal', 'both'):
+            self._text.xview_scroll(wheel.scale_num(self, -dx), 'pixels')
 
     def _add_scroll_binding(self, widget):
         """Add scroll bind tag to widget."""
@@ -325,14 +327,10 @@ class ScrolledText(Frame):
             self._hide_timer = None
 
         # Unbind class bindings for the scroll tag
-        if self.winsys.lower() == "x11":
-            self.unbind_class(self._scroll_tag, "<Button-4>")
-            self.unbind_class(self._scroll_tag, "<Button-5>")
-            self.unbind_class(self._scroll_tag, "<Shift-Button-4>")
-            self.unbind_class(self._scroll_tag, "<Shift-Button-5>")
-        else:
-            self.unbind_class(self._scroll_tag, "<MouseWheel>")
-            self.unbind_class(self._scroll_tag, "<Shift-MouseWheel>")
+        for seq in wheel.wheel_sequences(self) + wheel.wheel_sequences(self, shift=True):
+            self.unbind_class(self._scroll_tag, seq)
+        if wheel.has_touchpad_scroll():
+            self.unbind_class(self._scroll_tag, wheel.TOUCHPAD_SCROLL)
 
         # Call parent destroy
         super().destroy()

--- a/src/bootstack/widgets/_impl/composites/scrollview.py
+++ b/src/bootstack/widgets/_impl/composites/scrollview.py
@@ -8,6 +8,7 @@ from bootstack.widgets._impl.mixins.configure_mixin import configure_delegate
 from bootstack.widgets._impl.primitives.scrollbar import Scrollbar
 from bootstack.widgets.types import Master
 from bootstack.events import ScrollEvent
+from bootstack._runtime import wheel
 
 
 class ScrollView(Frame):
@@ -74,6 +75,7 @@ class ScrollView(Frame):
 
         # Create unique bind tag for this scrollview
         self._scroll_tag = f'ScrollView_{id(self)}'
+        self._touchpad = wheel.PixelAccumulator()
 
         # Detect windowing system
         self.winsys = self.tk.call("tk", "windowingsystem")
@@ -231,14 +233,12 @@ class ScrollView(Frame):
 
     def _setup_scroll_tag_bindings(self):
         """Setup bindings on our custom bind tag."""
-        if self.winsys.lower() == "x11":
-            self.bind_class(self._scroll_tag, "<Button-4>", self._on_mousewheel)
-            self.bind_class(self._scroll_tag, "<Button-5>", self._on_mousewheel)
-            self.bind_class(self._scroll_tag, "<Shift-Button-4>", self._on_shift_mousewheel)
-            self.bind_class(self._scroll_tag, "<Shift-Button-5>", self._on_shift_mousewheel)
-        else:
-            self.bind_class(self._scroll_tag, "<MouseWheel>", self._on_mousewheel)
-            self.bind_class(self._scroll_tag, "<Shift-MouseWheel>", self._on_shift_mousewheel)
+        for seq in wheel.wheel_sequences(self):
+            self.bind_class(self._scroll_tag, seq, self._on_mousewheel)
+        for seq in wheel.wheel_sequences(self, shift=True):
+            self.bind_class(self._scroll_tag, seq, self._on_shift_mousewheel)
+        if wheel.has_touchpad_scroll():
+            self.bind_class(self._scroll_tag, wheel.TOUCHPAD_SCROLL, self._on_touchpad_scroll)
 
     def _setup_keyboard_bindings(self) -> None:
         """Bind arrow / page / home / end keys to the canvas for keyboard scroll."""
@@ -501,16 +501,7 @@ class ScrollView(Frame):
                 self.after_cancel(self._hide_timer)
             self._hide_timer = self.after(self._autohide_delay, self._hide_scrollbars)
 
-        # Calculate delta based on platform
-        delta = 0
-        if self.winsys.lower() == "win32":
-            delta = -int(event.delta / 120)
-        elif self.winsys.lower() == "aqua":
-            delta = -event.delta
-        elif event.num == 4:
-            delta = -10
-        elif event.num == 5:
-            delta = 10
+        delta = -round(wheel.wheel_notches(self, event))
 
         # Scroll vertically
         if self._direction in ('vertical', 'both') and delta != 0:
@@ -538,22 +529,40 @@ class ScrollView(Frame):
                 self.after_cancel(self._hide_timer)
             self._hide_timer = self.after(self._autohide_delay, self._hide_scrollbars)
 
-        # Calculate delta based on platform
-        delta = 0
-        if self.winsys.lower() == "win32":
-            delta = -int(event.delta / 120)
-        elif self.winsys.lower() == "aqua":
-            delta = -event.delta
-        elif event.num == 4:
-            delta = -10
-        elif event.num == 5:
-            delta = 10
+        delta = -round(wheel.wheel_notches(self, event))
 
         # Scroll horizontally
         if self._direction in ('horizontal', 'both') and delta != 0:
             self.canvas.xview_scroll(delta, 'units')
 
         # Don't return 'break' - allow event to propagate if needed
+
+    def _on_touchpad_scroll(self, event):
+        """Handle a precise-delta scroll gesture (trackpad).
+
+        Tk reports these roughly sixty times a second in pixels, while the
+        canvas scrolls in units of a tenth of the viewport. Pixels are
+        accumulated and spent as whole units so a gesture stays smooth.
+        """
+        dx, dy = wheel.precise_deltas(event)
+        if not dx and not dy:
+            return
+
+        if self._scrollbar_visibility == 'scroll':
+            self._show_scrollbars()
+            if self._hide_timer:
+                self.after_cancel(self._hide_timer)
+            self._hide_timer = self.after(self._autohide_delay, self._hide_scrollbars)
+
+        # A canvas unit is a tenth of the viewport unless an increment is set.
+        step_x = self.canvas.winfo_width() / 10 or 1
+        step_y = self.canvas.winfo_height() / 10 or 1
+        units_x, units_y = self._touchpad.add(dx, dy, step_x, step_y)
+
+        if units_y and self._direction in ('vertical', 'both'):
+            self.canvas.yview_scroll(-units_y, 'units')
+        if units_x and self._direction in ('horizontal', 'both'):
+            self.canvas.xview_scroll(-units_x, 'units')
 
     def _add_scroll_binding(self, widget):
         """Recursively add scroll bind tag to widget and all descendants."""
@@ -750,14 +759,10 @@ class ScrollView(Frame):
             self.disable_scrolling()
 
         # Unbind class bindings for the scroll tag
-        if self.winsys.lower() == "x11":
-            self.unbind_class(self._scroll_tag, "<Button-4>")
-            self.unbind_class(self._scroll_tag, "<Button-5>")
-            self.unbind_class(self._scroll_tag, "<Shift-Button-4>")
-            self.unbind_class(self._scroll_tag, "<Shift-Button-5>")
-        else:
-            self.unbind_class(self._scroll_tag, "<MouseWheel>")
-            self.unbind_class(self._scroll_tag, "<Shift-MouseWheel>")
+        for seq in wheel.wheel_sequences(self) + wheel.wheel_sequences(self, shift=True):
+            self.unbind_class(self._scroll_tag, seq)
+        if wheel.has_touchpad_scroll():
+            self.unbind_class(self._scroll_tag, wheel.TOUCHPAD_SCROLL)
 
         # Call parent destroy
         super().destroy()

--- a/src/bootstack/widgets/_impl/composites/tabs/tabs.py
+++ b/src/bootstack/widgets/_impl/composites/tabs/tabs.py
@@ -8,6 +8,7 @@ from tkinter import Variable
 from typing_extensions import Unpack
 from typing import Any, Callable, Literal, TYPE_CHECKING
 
+from bootstack._runtime import wheel
 from bootstack.widgets._impl.primitives.packframe import PackFrame
 from bootstack.widgets._impl.primitives.frame import Frame, FrameKwargs
 from bootstack.widgets._impl.primitives.separator import Separator
@@ -773,12 +774,12 @@ class Tabs(Frame):
 
     def _setup_wheel_bindings(self) -> None:
         """Bind wheel scrolling along the strip axis via a private bindtag."""
-        winsys = self.tk.call('tk', 'windowingsystem')
-        if winsys == 'x11':
-            self.bind_class(self._wheel_tag, '<Button-4>', self._on_strip_wheel, add='+')
-            self.bind_class(self._wheel_tag, '<Button-5>', self._on_strip_wheel, add='+')
-        else:
-            self.bind_class(self._wheel_tag, '<MouseWheel>', self._on_strip_wheel, add='+')
+        for seq in wheel.wheel_sequences(self):
+            self.bind_class(self._wheel_tag, seq, self._on_strip_wheel, add='+')
+        if wheel.has_touchpad_scroll():
+            self.bind_class(
+                self._wheel_tag, wheel.TOUCHPAD_SCROLL, self._on_strip_touchpad, add='+'
+            )
         self._add_wheel_binding(self._tab_bar)
 
     def _add_wheel_binding(self, widget) -> None:
@@ -801,24 +802,28 @@ class Tabs(Frame):
         """Scroll the strip along its axis in response to the mouse wheel."""
         if not self._scrollable or not self._content_overflows():
             return None
-        winsys = self.tk.call('tk', 'windowingsystem')
-        if winsys == 'win32':
-            notches = -event.delta / 120
-        elif winsys == 'aqua':
-            notches = -event.delta
-        elif getattr(event, 'num', None) == 4:
-            notches = -1
-        elif getattr(event, 'num', None) == 5:
-            notches = 1
-        else:
-            notches = 0
+        notches = -wheel.wheel_notches(self, event)
         if not notches:
             return 'break'
+        return self._scroll_strip_pixels(60 * notches)
+
+    def _on_strip_touchpad(self, event) -> str | None:
+        """Scroll the strip by precise pixel deltas from a trackpad."""
+        if not self._scrollable or not self._content_overflows():
+            return None
+        dx, dy = wheel.precise_deltas(event)
+        # The strip is one-dimensional; take whichever axis the gesture used.
+        pixels = dx if abs(dx) > abs(dy) else dy
+        if not pixels:
+            return 'break'
+        return self._scroll_strip_pixels(wheel.scale_num(self, -pixels))
+
+    def _scroll_strip_pixels(self, step: float) -> str | None:
+        """Move the strip by `step` pixels along its scrolling axis."""
         content = self._content_size()
         view = self._viewport_size()
         if content <= view:
             return 'break'
-        step = 60 * notches
         lead = self._view_first() * content
         lead = max(0, min(lead + step, content - view))
         self._view_moveto(lead / content)

--- a/src/bootstack/widgets/_impl/composites/textarea/core.py
+++ b/src/bootstack/widgets/_impl/composites/textarea/core.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import tkinter as tk
 from typing import Callable, Literal
 
+from bootstack._runtime import wheel
 from bootstack.events import TextModifiedEvent
 from bootstack.widgets._impl.primitives.scrollbar import Scrollbar
 from bootstack.widgets._impl.composites.textarea.filter import EditFilter, FilterChain
@@ -212,26 +213,25 @@ class _MultilineCore(tk.Frame):
     # ── mousewheel ────────────────────────────────────────────────────────
 
     def _setup_mousewheel(self) -> None:
-        if self.winsys == "x11":
-            self.bind_class(self._scroll_tag, "<Button-4>", self._on_wheel)
-            self.bind_class(self._scroll_tag, "<Button-5>", self._on_wheel)
-        else:
-            self.bind_class(self._scroll_tag, "<MouseWheel>", self._on_wheel)
+        for seq in wheel.wheel_sequences(self):
+            self.bind_class(self._scroll_tag, seq, self._on_wheel)
+        if wheel.has_touchpad_scroll():
+            self.bind_class(self._scroll_tag, wheel.TOUCHPAD_SCROLL, self._on_touchpad_scroll)
         tags = list(self.text.bindtags())
         if self._scroll_tag not in tags:
             tags.insert(1, self._scroll_tag)
             self.text.bindtags(tuple(tags))
 
     def _on_wheel(self, event: tk.Event) -> None:
-        if self.winsys == "win32":
-            delta = -int(event.delta / 120)
-        elif self.winsys == "aqua":
-            delta = -event.delta
-        elif event.num == 4:
-            delta = -1
-        else:
-            delta = 1
-        self.text.yview_scroll(delta, "units")
+        delta = -round(wheel.wheel_notches(self, event))
+        if delta:
+            self.text.yview_scroll(delta, "units")
+
+    def _on_touchpad_scroll(self, event: tk.Event) -> None:
+        """Scroll by precise pixel deltas from a trackpad gesture."""
+        _dx, dy = wheel.precise_deltas(event)
+        if dy:
+            self.text.yview_scroll(wheel.scale_num(self, -dy), "pixels")
 
     # ── value / signal ────────────────────────────────────────────────────
 
@@ -486,10 +486,9 @@ class _MultilineCore(tk.Frame):
         self._unbind_signal()
         self._chain.destroy()
         try:
-            if self.winsys == "x11":
-                self.unbind_class(self._scroll_tag, "<Button-4>")
-                self.unbind_class(self._scroll_tag, "<Button-5>")
-            else:
-                self.unbind_class(self._scroll_tag, "<MouseWheel>")
+            for seq in wheel.wheel_sequences(self):
+                self.unbind_class(self._scroll_tag, seq)
+            if wheel.has_touchpad_scroll():
+                self.unbind_class(self._scroll_tag, wheel.TOUCHPAD_SCROLL)
         except Exception:
             pass

--- a/src/bootstack/widgets/_impl/composites/tree/treeview.py
+++ b/src/bootstack/widgets/_impl/composites/tree/treeview.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 from tkinter import TclError
 from typing import Any, Callable, Iterator, Literal, Optional
 
+from bootstack._runtime import wheel
 from bootstack.widgets._impl.composites.tree.treeitem import TreeItem, EMPTY
 from bootstack.widgets._impl.composites.tree.treenode import TreeNode
 from bootstack.widgets._impl.primitives.frame import Frame, FrameKwargs
@@ -91,6 +92,7 @@ class TreeView(Frame):
         self._prev_start_index = 0
         self._visible_rows = VISIBLE_ROWS
         self._row_height = ROW_HEIGHT
+        self._touchpad = wheel.PixelAccumulator()
         self._page_size = VISIBLE_ROWS + OVERSCAN_ROWS
         self._rows: list[TreeItem] = []
         self._mousewheel_bound: set = set()
@@ -301,11 +303,10 @@ class TreeView(Frame):
         self._update_rows()
 
     def _bind_scroll_events(self, widget) -> None:
-        if self.winsys.lower() == "x11":
-            widget.bind("<Button-4>", self._on_mousewheel, add="+")
-            widget.bind("<Button-5>", self._on_mousewheel, add="+")
-        else:
-            widget.bind("<MouseWheel>", self._on_mousewheel, add="+")
+        for seq in wheel.wheel_sequences(self):
+            widget.bind(seq, self._on_mousewheel, add="+")
+        if wheel.has_touchpad_scroll():
+            widget.bind(wheel.TOUCHPAD_SCROLL, self._on_touchpad_scroll, add="+")
 
     def _bind_mousewheel_recursive(self, widget) -> None:
         wid = str(widget)
@@ -318,26 +319,42 @@ class TreeView(Frame):
         except Exception:
             pass
 
-    def _on_mousewheel(self, event) -> None:
+    def _pointer_within(self, event) -> bool:
+        """Whether the pointer is over this tree or one of its descendants."""
         under = self.winfo_containing(event.x_root, event.y_root)
         if under is None:
-            return
-        cur, is_child = under, False
+            return False
+        cur = under
         while cur is not None:
             if cur == self:
-                is_child = True
-                break
+                return True
             try:
                 cur = cur.master
             except AttributeError:
                 break
-        if not is_child:
+        return False
+
+    def _on_mousewheel(self, event) -> None:
+        if not self._pointer_within(event):
             return
-        if self.winsys.lower() == "x11":
-            delta = -1 if getattr(event, "num", 0) == 4 else 1
-        else:
-            delta = -1 if event.delta > 0 else 1
-        self._start_index += delta
+        notches = wheel.wheel_notches(self, event)
+        if not notches:
+            return
+        self._start_index += -1 if notches > 0 else 1
+        self._clamp_indices()
+        self._update_rows()
+
+    def _on_touchpad_scroll(self, event) -> None:
+        """Scroll by whole rows as a trackpad gesture accumulates pixels."""
+        if not self._pointer_within(event):
+            return
+        _dx, dy = wheel.precise_deltas(event)
+        if not dy:
+            return
+        _sx, rows = self._touchpad.add(0, dy, 1, self._row_height or 1)
+        if not rows:
+            return
+        self._start_index -= rows
         self._clamp_indices()
         self._update_rows()
 

--- a/src/bootstack/widgets/_impl/primitives/spinbox.py
+++ b/src/bootstack/widgets/_impl/primitives/spinbox.py
@@ -4,6 +4,7 @@ from tkinter import ttk
 from typing import Any, TYPE_CHECKING
 from typing_extensions import Unpack
 
+from bootstack._runtime import wheel
 from bootstack._core.mixins.ttk_state import TtkStateMixin
 from bootstack._core.mixins.widget import WidgetCapabilitiesMixin
 from bootstack.widgets._impl._internal.wrapper_base import TTKWrapperBase
@@ -12,6 +13,9 @@ from ..mixins import TextSignalMixin, configure_delegate
 
 if TYPE_CHECKING:
     from bootstack.signals import Signal
+
+_TOUCHPAD_STEP_PX = 40
+"""Trackpad travel, in pixels, that advances a stepper by one increment."""
 
 
 class SpinboxKwargs(StyledKwargs, total=False):
@@ -71,15 +75,28 @@ class Spinbox(TextSignalMixin, TTKWrapperBase, WidgetCapabilitiesMixin, TtkState
         # Handle mousewheel explicitly so we can return "break" and stop the
         # event from leaking to parent scroll containers. Instance bindings run
         # before class bindings in Tk's chain, so we must do the spin ourselves.
-        self.bind("<MouseWheel>", self._on_mousewheel)
-        self.bind("<Button-4>", self._on_mousewheel)
-        self.bind("<Button-5>", self._on_mousewheel)
+        for seq in wheel.wheel_sequences(self):
+            self.bind(seq, self._on_mousewheel)
+        if wheel.has_touchpad_scroll():
+            self._touchpad = wheel.PixelAccumulator()
+            self.bind(wheel.TOUCHPAD_SCROLL, self._on_touchpad_scroll)
 
     def _on_mousewheel(self, event):
-        if event.delta > 0 or event.num == 4:
-            self.event_generate("<Up>")
-        else:
-            self.event_generate("<Down>")
+        notches = wheel.wheel_notches(self, event)
+        if notches:
+            self.event_generate("<Up>" if notches > 0 else "<Down>")
+        return "break"
+
+    def _on_touchpad_scroll(self, event):
+        """Step once per `_TOUCHPAD_STEP_PX` of trackpad travel.
+
+        A trackpad reports around sixty events a second; stepping on each
+        one would run the value away from the user.
+        """
+        _dx, dy = wheel.precise_deltas(event)
+        _sx, steps = self._touchpad.add(0, dy, 1, _TOUCHPAD_STEP_PX)
+        for _ in range(abs(steps)):
+            self.event_generate("<Up>" if steps > 0 else "<Down>")
         return "break"
 
 

--- a/tests/widgets/public/test_scroll_events.py
+++ b/tests/widgets/public/test_scroll_events.py
@@ -1,0 +1,216 @@
+"""Scroll-gesture coverage across Tk 8.6 and Tk 9.
+
+Tk 9 changed the scroll-event contract and every scrolling widget shipped
+code written against Tk 8.6:
+
+- A precise-delta device — every Apple trackpad, Magic Mouse and Magic
+  Trackpad — fires `<TouchpadScroll>` and never `<MouseWheel>`. Widgets
+  bound only `<MouseWheel>`, so scrolling was completely dead on a Mac
+  running Tk 9 (reported against Python 3.14.6 / Tcl-Tk 9.0.3).
+- Wheel deltas are normalized to multiples of 120 everywhere. On Aqua a
+  notch used to report 1, so the old `delta = -event.delta` scrolled 120
+  units per notch instead of one.
+- On X11 `<Button-4>`/`<Button-5>` are no longer delivered to scripts,
+  and widgets bound *only* those there.
+
+Normalization now lives in `bootstack._runtime.wheel`. The unit tests run
+everywhere; the integration tests need a Tk that actually generates
+`<TouchpadScroll>` and skip below 8.7.
+"""
+from __future__ import annotations
+
+import pytest
+
+import bootstack as bs
+from bootstack._runtime import wheel
+
+
+requires_touchpad = pytest.mark.skipif(
+    not wheel.has_touchpad_scroll(),
+    reason="Tk < 8.7 does not generate <TouchpadScroll>",
+)
+
+
+class _FakeEvent:
+    """Minimal stand-in so notch math is testable without a windowing system."""
+
+    def __init__(self, delta=0, num=None):
+        self.delta = delta
+        self.num = num
+
+
+def _packed(dx: int, dy: int) -> int:
+    """Pack precise deltas the way Tk does, for `event_generate(delta=...)`.
+
+    A positive `dy` scrolls toward the start of the content, so tests that
+    start at the top pass a negative one.
+    """
+    return ((dx & 0xFFFF) << 16) | (dy & 0xFFFF)
+
+
+# --- wheel notch normalization -------------------------------------------
+
+
+legacy_aqua = pytest.mark.skipif(
+    wheel.has_touchpad_scroll(),
+    reason="Tk 8.7+ normalizes Aqua deltas to multiples of 120",
+)
+
+
+@requires_touchpad
+@pytest.mark.parametrize(
+    "delta, expected",
+    [(120, 1.0), (-120, -1.0), (240, 2.0), (60, 0.5), (0, 0.0)],
+)
+def test_wheel_notches_normalizes_delta(app, delta, expected):
+    """On Tk 8.7+ every platform reports one notch as 120."""
+    assert wheel.wheel_notches(app._tk_root, _FakeEvent(delta=delta)) == expected
+
+
+@legacy_aqua
+@pytest.mark.parametrize("delta, expected", [(1, 1.0), (-1, -1.0), (3, 3.0)])
+def test_wheel_notches_reads_legacy_aqua_delta(app, delta, expected):
+    """Tk 8.6 on Aqua reported one notch as 1, and still must read as 1.0.
+
+    Skipped off legacy Aqua: elsewhere on Tk 8.6 a notch is already 120,
+    which the normalized path above covers.
+    """
+    if app._tk_root.tk.call("tk", "windowingsystem") != "aqua":
+        pytest.skip("legacy delta of 1 is Aqua-only")
+    assert wheel.wheel_notches(app._tk_root, _FakeEvent(delta=delta)) == expected
+
+
+@pytest.mark.parametrize("num, expected", [(4, 1.0), (5, -1.0), (6, 1.0), (7, -1.0)])
+def test_wheel_notches_handles_x11_buttons(app, num, expected):
+    """Legacy X11 wheel buttons still resolve to a signed notch count."""
+    assert wheel.wheel_notches(app._tk_root, _FakeEvent(num=num)) == expected
+
+
+def test_wheel_notches_survives_a_missing_delta(app):
+    """A malformed event yields no scroll rather than raising."""
+    assert wheel.wheel_notches(app._tk_root, _FakeEvent(delta="")) == 0.0
+
+
+# --- precise delta unpacking ---------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "packed, expected",
+    [
+        (30, (0, 30)),
+        ((2 << 16) | 36, (2, 36)),
+        (0xFFFF, (0, -1)),          # dy = -1
+        ((1 << 16) | 17, (1, 17)),
+        (0, (0, 0)),
+    ],
+)
+def test_precise_deltas_unpacks_both_axes(packed, expected):
+    """`%D` carries dx in the high 16 bits and signed dy in the low 16."""
+    assert wheel.precise_deltas(_FakeEvent(delta=packed)) == expected
+
+
+# --- pixel accumulator ----------------------------------------------------
+
+
+def test_accumulator_carries_the_remainder():
+    """Sub-step deltas add up instead of being dropped."""
+    acc = wheel.PixelAccumulator()
+    assert acc.add(0, 10, 1, 32) == (0, 0)
+    assert acc.add(0, 10, 1, 32) == (0, 0)
+    assert acc.add(0, 15, 1, 32) == (0, 1)  # 35 >= 32, 3px carried
+    assert acc.add(0, 29, 1, 32) == (0, 1)  # 3 + 29 == 32
+
+
+def test_accumulator_handles_a_zero_step():
+    """A widget reporting no row height still scrolls rather than dividing by zero."""
+    acc = wheel.PixelAccumulator()
+    assert acc.add(0, 5, 0, 0) == (0, 5)
+
+
+# --- integration: the widgets that were dead on Tk 9 ----------------------
+
+
+@requires_touchpad
+def test_scrollview_scrolls_on_touchpad(shown_app):
+    """A trackpad gesture moves a ScrollView. Fails pre-fix (no binding)."""
+    with bs.ScrollView(height=100) as sv:
+        for i in range(60):
+            bs.Label(f"row {i}")
+    shown_app._tk_root.update()
+
+    start = sv._internal.canvas.yview()[0]
+    for _ in range(40):
+        sv._internal.canvas.event_generate("<TouchpadScroll>", delta=_packed(0, -40))
+    shown_app._tk_root.update()
+
+    assert sv._internal.canvas.yview()[0] > start
+
+
+@requires_touchpad
+def test_scrollview_scrolls_on_wheel(shown_app):
+    """A wheel notch moves a ScrollView by one unit, not 120."""
+    with bs.ScrollView(height=100) as sv:
+        for i in range(60):
+            bs.Label(f"row {i}")
+    shown_app._tk_root.update()
+
+    sv._internal.canvas.event_generate("<MouseWheel>", delta=-120)
+    shown_app._tk_root.update()
+    after_one = sv._internal.canvas.yview()[0]
+
+    # One notch must not run the view to the very end.
+    assert 0.0 < after_one < 1.0
+
+
+@requires_touchpad
+def test_listview_scrolls_on_touchpad(shown_app, monkeypatch):
+    """A trackpad gesture advances a ListView's first visible row.
+
+    The pointer-containment guard (which stops a gesture over a nested
+    widget from scrolling the list underneath) cannot be simulated with a
+    synthetic event, so only that check is stubbed.
+    """
+    lv = bs.ListView(items=[{"label": f"item {i}"} for i in range(200)], height=120)
+    shown_app._tk_root.update()
+
+    view = lv._internal
+    monkeypatch.setattr(type(view), "_pointer_within", lambda self, event: True)
+
+    assert view._datasource.count > view._visible_rows, "list must overflow to scroll"
+    start = view._start_index
+    for _ in range(20):
+        view.event_generate("<TouchpadScroll>", delta=_packed(0, -40))
+    shown_app._tk_root.update()
+
+    assert view._start_index > start
+
+
+@requires_touchpad
+def test_textarea_scrolls_on_touchpad(shown_app):
+    """A trackpad gesture scrolls a TextArea.
+
+    Tk 9 binds `<TouchpadScroll>` on the `Text` class itself, so this
+    passes even without our handler. It guards the end-to-end behavior,
+    not the fix — the ScrollView and ListView cases cover the regression.
+    """
+    ta = bs.TextArea(value="\n".join(f"line {i}" for i in range(400)), height=5)
+    shown_app._tk_root.update()
+
+    text = ta._text_widget()
+    start = text.yview()[0]
+    for _ in range(20):
+        text.event_generate("<TouchpadScroll>", delta=_packed(0, -40))
+    shown_app._tk_root.update()
+
+    assert text.yview()[0] > start
+
+
+@requires_touchpad
+def test_touchpad_binding_is_registered(shown_app):
+    """Every scrolling widget binds the sequence, not just the wheel."""
+    with bs.ScrollView(height=80) as sv:
+        bs.Label("content")
+    shown_app._tk_root.update()
+
+    bound = sv._internal.bind_class(sv._internal._scroll_tag)
+    assert "<TouchpadScroll>" in bound


### PR DESCRIPTION
Fixes #372

## The problem

Reported as "scrolling works on Python 3.13.9 but not 3.14.6". It is **not a Python change** — `tkinter` is unchanged between those versions apart from docstrings, `after(**kw)`, and `trace_variable` deprecation warnings. It is **Tcl/Tk 8.6 → 9.0**. The reporter had Tk 9.0.3; the python.org installer still ships Tk 8.6.17, which is the only reason 3.13 looked fine.

Tk 9 changed the scroll contract in three ways:

1. **A precise-delta device fires `<TouchpadScroll>`, never `<MouseWheel>`.** That is every Apple trackpad, Magic Mouse, and Magic Trackpad. Every scrolling widget bound only the wheel, so on macOS + Tk 9 scrolling was dead — not degraded, dead. A probe on a matching setup logged **293 TouchpadScroll events and zero MouseWheel events**.
2. **Wheel deltas are normalized to ±120 on every platform.** Aqua previously reported 1, so the old `delta = -event.delta` scrolled 120 units per notch.
3. **X11 no longer delivers `Button-4`/`Button-5` to scripts** (TIP 474) — the only sequence bound on Linux.

## The fix

New `_runtime/wheel.py` — `wheel_sequences()`, `wheel_notches()`, `precise_deltas()`, `scale_num()`, `PixelAccumulator` — replacing a delta branch that was duplicated across nine files. Bindings are now unconditional; the X11 buttons remain as a Tk ≤ 8.6 fallback gated on **Tk version rather than windowing system**.

Widgets follow Tk's own two conventions:

- **Pixel scrolling** — `ScrollView`, `TextArea`, `ScrolledText`, the `Tabs` strip
- **Accumulated whole rows** — `ListView`, `Tree`, `Gallery`
- **40px-per-step throttle** — the `Spinbox` / `NumberField` steppers, so a gesture doesn't run the value away

`DataTable` needed no change: Tk 9 binds `<TouchpadScroll>` on the ttk `Treeview` class itself (verified, not assumed).

Incidental correction: one wheel notch moved **10 canvas units on X11** versus 1 everywhere else. Now 1 uniformly.

## Verification

- 25 tests in `test_scroll_events.py`, covering both Tk regimes. **Tk 9.0.4: 22 passed, 3 skipped. Tk 8.6.17: 15 passed, 10 skipped.**
- Three of them fail against unmodified `src` and pass with it.
- Confirmed live on a real trackpad under Tk 9.
- Full suite on Tk 9: **751 passed**, only the 6 known pre-existing failures.
- `trace_variable` / `trace_vdelete` / `trace_vinfo` (removed in Tcl 9) are not used anywhere, so scrolling was the only Tk 9 gap.

## Note for reviewers

**The touchpad tests skip on Tk 8.6.** On the default `.venv` this file reports "15 passed, 10 skipped" and looks green while testing nothing about the fix. There is no test workflow in CI, so this can regress invisibly. A Tk 9 environment is `brew install python-tk@3.14`.

The CLAUDE.md commit also triages the seven long-standing macOS test failures so they aren't re-investigated as regressions.
