### PR TITLE
fix(theme): recolor a widget re-attached across a theme change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and from 0.1.0 onward the project adheres to
 
 <!-- release-notes-start -->
 
+## [Unreleased]
+
+### Fixed
+
+- **A widget detached across a theme change is recolored when you attach it
+  back.** Widgets that paint themselves — charts, gauges, and the other
+  canvas-drawn widgets — skip a theme change while they are off screen and
+  repaint when they next become visible. Returning one with `attach()` was not
+  treated as becoming visible, so a chart hidden with `detach()` across a theme
+  toggle came back with the old palette and kept it until something else forced
+  a repaint. Showing a page or expanding an accordion section already worked.
+
 ## [0.1.6] — form, field, and validation fixes
 
 ### Fixed

--- a/src/bootstack/widgets/_core/base.py
+++ b/src/bootstack/widgets/_core/base.py
@@ -355,6 +355,7 @@ class PublicWidgetBase:
                 options.update(_flex_child_opts(self, kwargs))
             master.add_child(self._internal, options, index=index)
             placement.options = options
+            self._recolor_on_attach()
             return
 
         if kwargs:
@@ -376,6 +377,29 @@ class PublicWidgetBase:
             options.update({k: v for k, v in kwargs.items() if k in PLACE_KEYS})
             self._internal.place(in_=master, **options)
         placement.options = options
+        self._recolor_on_attach()
+
+    def _recolor_on_attach(self) -> None:
+        """Recolor after a theme change that arrived while detached.
+
+        The theme walk skips off-screen widgets, so a widget detached across a
+        theme change comes back carrying the old palette. Attaching is the
+        genuine "now visible" trigger, matching PageStack navigation and
+        Expander expansion. Deferred to idle so the widget is mapped first.
+        """
+        widget = self._internal
+
+        def _recolor() -> None:
+            from bootstack.style.style import get_style
+            try:
+                get_style().apply_theme_walk(widget, only_stale=True)
+            except tkinter.TclError:
+                pass  # destroyed between attach and the idle callback
+
+        try:
+            widget.after_idle(_recolor)
+        except tkinter.TclError:
+            pass
 
     @overload
     def on_destroy(self) -> "Stream": ...

--- a/tests/widgets/public/test_attach_detach.py
+++ b/tests/widgets/public/test_attach_detach.py
@@ -383,3 +383,73 @@ def test_relayout_fires_no_spurious_sibling_events(app, pump):
     a.attach()
     pump()
     assert events == ["detach", "attach"]
+
+
+# --- theme repaint on re-attach ------------------------------------------
+
+
+def test_attach_recolors_after_a_theme_change_while_detached(app, pump, monkeypatch):
+    """Re-attaching triggers the stale-theme walk.
+
+    The theme walk skips off-screen widgets, so a widget detached across a
+    theme change comes back carrying the old palette. Before this was wired
+    up, `apply_theme_walk` ran only from PageStack navigation and Expander
+    expansion, never from `attach()` — a chart hidden with `detach()` across
+    a theme toggle stayed light on a dark theme.
+    """
+    from bootstack.style.style import get_style
+
+    calls: list[bool] = []
+    style = get_style()
+    original = style.apply_theme_walk
+
+    def spy(root_widget, *, only_stale):
+        calls.append(only_stale)
+        return original(root_widget, only_stale=only_stale)
+
+    monkeypatch.setattr(style, "apply_theme_walk", spy)
+
+    col = bs.Column()
+    btn = bs.Button("A", parent=col)
+    pump()
+
+    btn.detach()
+    pump()
+    calls.clear()
+
+    btn.attach()
+    pump()
+
+    assert calls, "attach() did not trigger a theme walk"
+    assert all(only_stale for only_stale in calls), (
+        "the walk must be stale-only; a full walk on every attach is wasteful"
+    )
+
+
+def test_attach_recolors_in_a_grid_placement(app, pump, monkeypatch):
+    """The trigger covers the pack/grid/place path, not just the flex one."""
+    from bootstack.style.style import get_style
+
+    calls: list[bool] = []
+    style = get_style()
+    original = style.apply_theme_walk
+    monkeypatch.setattr(
+        style,
+        "apply_theme_walk",
+        lambda root_widget, *, only_stale: (
+            calls.append(only_stale) or original(root_widget, only_stale=only_stale)
+        ),
+    )
+
+    grid = bs.Grid(columns=2)
+    btn = bs.Button("A", parent=grid, row=0, column=0)
+    pump()
+
+    btn.detach()
+    pump()
+    calls.clear()
+
+    btn.attach()
+    pump()
+
+    assert calls, "attach() in a grid placement did not trigger a theme walk"


### PR DESCRIPTION
## The problem

The theme walk deliberately skips off-screen widgets, so a self-painting widget carries the old palette until it next becomes visible. Two triggers existed for "now visible":

- `PageStack` navigation (`pagestack.py:236`)
- `Expander` expansion (`expander.py:273`)

`attach()` was never wired in. The detach/attach API (#123) and the theme-repaint unification (#338) never met, so a widget hidden with `detach()` across a theme change came back with the old colors and kept them until something else forced a repaint.

This surfaced as a long-failing test — `test_chart.py::test_theme_change_while_hidden_applies_on_return`, facecolor `#ffffff` under a `#212529` theme. `Chart` already defined `_bs_apply_theme` correctly; it simply never got walked. The test was encoding the right expectation.

Nothing here is macOS-specific or chart-specific — it affects every canvas-drawn widget on every platform.

## The fix

`attach()` schedules the same stale-only walk at idle, via a new `_recolor_on_attach()`.

The one subtlety: **`attach()` has two exit paths.** The flex branch returns early; the pack/grid/place branch falls through. Both are wired — wiring only the fall-through would have left `Row`/`Column` children, the most common case, still broken.

## Verification

- `test_chart.py` — the failing test now passes (42 passed, 2 skipped).
- Two wiring tests added to `test_attach_detach.py`, one per exit path. They assert the walk fires **and** that it is `only_stale=True`, since a full walk on every attach would be a quiet performance regression.
- All three fail against unmodified `src`.
- Full suite: **773 passed, 6 failed**, down from 7, with no new failures. The remaining 6 are the known macOS test defects and the order-dependent `test_pagestack` pair, both triaged in CLAUDE.md on #373.
