### PR TITLE
fix(scaling): size the UI correctly on macOS with Tcl/Tk 9 (#375)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and from 0.1.0 onward the project adheres to
 
 <!-- release-notes-start -->
 
+## [Unreleased]
+
+### Fixed
+
+- **The interface is sized correctly on macOS with Tcl/Tk 9.** Tk 9 changed
+  the resolution macOS reports, and bootstack read that as a high-density
+  display — so on a Homebrew or conda Python, or any build linked against
+  Tk 9, the whole interface rendered about a third too large. Text, icons,
+  padding, and control sizes are all restored to their intended size, and
+  now match Tk 8.6 exactly. Windows and Linux are unaffected. (#375)
+
 ## [0.1.7] — Tcl/Tk 9 scroll support
 
 ### Fixed

--- a/src/bootstack/_runtime/utility.py
+++ b/src/bootstack/_runtime/utility.py
@@ -30,11 +30,18 @@ def _platform_baseline() -> float:
 
     Tk scaling is measured in pixels-per-point (72 points per inch).
     - Windows/Linux default DPI is 96  → baseline = 96/72 ≈ 1.334
-    - macOS default DPI is 72          → baseline = 72/72 = 1.0
+    - macOS default DPI is 72 on Tk 8.6 → baseline = 72/72 = 1.0
       (Retina pixel-doubling is handled by the OS, not Tk scaling)
+
+    Tk 9 changed Aqua's nominal resolution from 72 to 96 DPI, aligning it with
+    Windows/X11 (#375). The pixel grid is unchanged — only the physical-size
+    claim moved — so the baseline must key off the Tk version, not the platform
+    alone. Keying off platform alone reports ui_scale ~1.333 instead of 1.0 on
+    macOS + Tk 9 and inflates every DPI-derived measurement by a third.
     """
     import platform
-    if platform.system() == 'Darwin':
+    import tkinter
+    if platform.system() == 'Darwin' and tkinter.TkVersion < 9.0:
         return 1.0
     return 1.33398982438864281  # 96 DPI / 72
 
@@ -53,6 +60,11 @@ class _ScalingState:
     def get_scale_factor(cls) -> float:
         """Get the current global scale factor."""
         return cls._scale_factor
+
+    @classmethod
+    def get_baseline(cls) -> float:
+        """Get the platform's nominal Tk scaling (pixels per point)."""
+        return cls._baseline
 
     @classmethod
     def get_ui_scale(cls) -> float:

--- a/src/bootstack/style/typography.py
+++ b/src/bootstack/style/typography.py
@@ -8,6 +8,8 @@ from tkinter import Misc, font as tkfont
 from tkinter.font import Font as TkFont
 from typing import Any, Literal, NamedTuple
 
+from bootstack._runtime.utility import _ScalingState
+
 
 # =============================================================================
 # Token model
@@ -90,12 +92,19 @@ def build_desktop_tokens(
     elif system == "darwin":
         default_ui = "SF Pro Text"
         default_mono = "Menlo"
-        # Tk's pt-to-pixel conversion uses the active scaling factor.
-        # macOS defaults to 1.0 (72 DPI baseline) vs ~1.334 on Win/Linux,
-        # so the same point size renders ~25% smaller on Mac. Bump the
-        # base to keep visual parity across platforms and align with the
-        # macOS HIG default control text size (13pt).
-        base = _clamp_base_size(base + 2)
+        # Tk's pt-to-pixel conversion uses the active scaling factor. On Tk 8.6
+        # macOS defaults to 1.0 (72 DPI baseline) vs ~1.334 on Win/Linux, so
+        # the same point size renders ~25% smaller on Mac. Bump the base to
+        # align with the macOS HIG default control text size (13pt).
+        #
+        # Tk 9 moved Aqua to a 96 DPI baseline (#375), so a "point" is no
+        # longer the same physical size and the raw bump double-counts (a
+        # `body` label rendered at 20px linespace instead of 16px). The target
+        # is a physical size, so express it in the active point unit: divide by
+        # the baseline ratio. Tk 8.6 -> 13pt (unchanged), Tk 9 -> 10pt, which
+        # is the same rendered size and matches the point size Tk 9 itself
+        # picks for TkDefaultFont.
+        base = _clamp_base_size(round((base + 2) / _ScalingState.get_baseline()))
     else:
         default_ui = "DejaVu Sans"
         default_mono = "DejaVu Sans Mono"

--- a/tests/widgets/public/test_tk9_scaling_baseline.py
+++ b/tests/widgets/public/test_tk9_scaling_baseline.py
@@ -1,0 +1,73 @@
+"""Regression for #375: Tk 9 moved Aqua's nominal resolution from 72 to 96 DPI.
+
+bootstack keyed its scaling baseline off the *platform* alone, so on macOS + Tk 9
+`get_ui_scale()` reported ~1.333 instead of 1.0 and every DPI-derived measurement
+inflated by a third (icons re-rasterized 16px -> 22px, field height 42px -> 57px).
+Separately, the macOS `+2` font bump — written to compensate for the 72 DPI point
+unit — double-counted once Tk 9 converted points at 96 DPI, rendering `body` text
+at 20px linespace instead of 16px.
+
+The existing scaling tests could not catch either: they all *inject* a scale factor
+(`set_scale_factor` / monkeypatched `get_ui_scale`) and assert that consumers respond
+correctly. Nothing exercised the producer. These tests cover the producer, and they
+run identically on Tk 8.6 and Tk 9 — no version skips, which would report green while
+testing nothing (the trap the #373 touchpad tests fell into).
+"""
+from __future__ import annotations
+
+import tkinter
+
+import pytest
+
+from bootstack._runtime.utility import _ScalingState, _platform_baseline
+from bootstack.style.typography import build_desktop_tokens
+
+WIN_LINUX_BASELINE = 1.33398982438864281  # 96 DPI / 72
+
+
+@pytest.mark.parametrize("tk_version", [8.6, 9.0])
+def test_aqua_baseline_tracks_tk_version(monkeypatch, tk_version):
+    # Both branches are exercised on whichever Tk is installed, so this cannot
+    # silently skip. Tk 8.6 Aqua is 72 DPI; Tk 9 aligned it with Win/Linux at 96.
+    monkeypatch.setattr(tkinter, "TkVersion", tk_version)
+    monkeypatch.setattr("platform.system", lambda: "Darwin")
+
+    expected = 1.0 if tk_version < 9.0 else WIN_LINUX_BASELINE
+    assert _platform_baseline() == pytest.approx(expected)
+
+
+@pytest.mark.parametrize("tk_version", [8.6, 9.0])
+@pytest.mark.parametrize("system", ["Windows", "Linux"])
+def test_non_aqua_baseline_is_tk_version_independent(monkeypatch, tk_version, system):
+    # Win/X11 were already 96 DPI under both versions — the fix must not move them.
+    monkeypatch.setattr(tkinter, "TkVersion", tk_version)
+    monkeypatch.setattr("platform.system", lambda: system)
+
+    assert _platform_baseline() == pytest.approx(WIN_LINUX_BASELINE)
+
+
+@pytest.mark.parametrize(
+    "baseline, expected_pt",
+    [(1.0, 13), (WIN_LINUX_BASELINE, 10)],
+    ids=["tk8.6-aqua-72dpi", "tk9-aqua-96dpi"],
+)
+def test_macos_font_base_expressed_in_active_point_unit(monkeypatch, baseline, expected_pt):
+    """The macOS size bump targets a physical size, so it must track the point unit.
+
+    Tk 9 redefined what an Aqua "point" is worth in pixels, so the flat `+2` bump
+    double-counted and rendered `body` at 20px linespace instead of 16px. Dividing
+    by the baseline keeps the *rendered* size fixed: 13pt on Tk 8.6, 10pt on Tk 9 —
+    the same point size Tk 9 itself picks for `TkDefaultFont`.
+
+    Asserting on the token rather than a live font is deliberate: bootstack
+    reconfigures `TkDefaultFont`, so comparing a rendered label against it moves
+    both sides together and can never fail.
+    """
+    monkeypatch.setattr("platform.system", lambda: "Darwin")
+    monkeypatch.setattr(_ScalingState, "_baseline", baseline)
+
+    tokens = build_desktop_tokens(base_size=11)
+
+    assert tokens.body.size == expected_pt
+    # The invariant behind both numbers: rendered size is baseline-independent.
+    assert tokens.body.size * baseline == pytest.approx(13.0, abs=0.5)


### PR DESCRIPTION
Fixes #375

On macOS, the entire UI renders roughly a third too large under Tcl/Tk 9. This is
a second Tk 8.6 -> 9.0 contract break in the same family as #372 (the
`TouchpadScroll` / wheel-delta break fixed in #373): Tk 9 changed a platform
convention on Aqua, and bootstack had hardcoded the 8.6 behavior.

## What Tk changed

Tk 9 moved Aqua's nominal resolution from 72 DPI to 96, matching Windows/X11. The
pixel grid is unchanged — only the physical-size claim moved:

| | Tk 8.6.17 | Tk 9.0.4 |
|---|---|---|
| `tk scaling` | 0.999 | 1.333 |
| `winfo_fpixels('1i')` | 71.9 | 96.0 |
| `winfo_screenwidth()` | 1470 | 1470 |
| `winfo_screenmmwidth()` | 519 | 389 |

Because the pixel coordinate space is identical, every measurement below is
directly comparable.

## Two independent root causes

**1. `_platform_baseline()` keyed off platform, not Tk version.** It returned 1.0
for Darwin unconditionally, so `get_ui_scale()` reported ~1.333 instead of 1.0 and
every DPI-derived measurement inflated. Since `style_builder_base` runs each
nine-patch element size through `scale_size`, this reached real widget geometry.

**2. The macOS `+2` font bump in `typography.py` double-counted.** It compensated
for the old 72 DPI point unit; Tk 9 already converts points at 96 DPI.

The second is not caused by the first and is not fixed by correcting it. Tk absorbs
the change on its own by re-picking `TkDefaultFont`'s point size (13pt on 8.6, 10pt
on 9.0, same 16px linespace both) — bootstack loses that because it pins explicit
point sizes. The bump now divides by the baseline so it targets a *physical* size:
13pt on Tk 8.6, 10pt on Tk 9 — the same size Tk 9 itself picks.

Both gate on `tkinter.TkVersion`, which is importable without a root.

## Result

Measured on one machine across both interpreters:

| | Tk 8.6 | Tk 9.0 before | Tk 9.0 after |
|---|---|---|---|
| `ui_scale` | 0.999 | 1.333 | 0.999 |
| icon PhotoImage (16px icon) | 16x16 | 22x22 | 16x16 |
| `measure("Hello")` / linespace | 31 / 16 | 39 / 20 | 31 / 16 |
| `bs.Label` reqsize | 35x20 | 43x24 | 35x20 |
| `bs.Button` / `bs.TextField` height | 58x42 / 42 | 76x57 / 57 | 58x42 / 42 |

A screen capture of the same 360x140 window now differs by no pixel more than
1/255 between the two Tk versions; 6.71% of pixels differed materially before.

Windows and Linux are unaffected — their baseline was already 96 DPI under both Tk
versions. **Not measured** (no Win/X11 Tk 9 available here); reasoned from the
baseline being unchanged on those platforms.

## Tests

`tests/widgets/public/test_tk9_scaling_baseline.py` (8).

The existing scaling tests could not have caught this: `test_field_hidpi_padding.py`
and `test_button_icon_scale.py` both *inject* a scale factor
(`set_scale_factor` / monkeypatched `get_ui_scale`) and assert that consumers respond
correctly. Nothing exercised the producer. All 27 passed on Tk 9.0.4 with the bug
fully live.

The new tests are parametrized over both Tk versions via monkeypatch, so they
exercise both branches on whichever Tk is installed and **cannot silently skip** —
the failure mode that let #372 and #375 ship, and the same trap the #373 touchpad
tests fall into on Tk 8.6. Two of them fail before this change on *both*
interpreters.

One test was rewritten during review: it originally compared a `body` label against
`TkDefaultFont`, but bootstack *reconfigures* `TkDefaultFont`, so both sides moved
together and it passed pre-fix for the wrong reason. It now asserts on the token.

## Verification

- Full suite on Tk 8.6: only the 6 known-failing macOS tests, identical to `main`.
- Full suite on Tk 9: the shared-root leg crashes at `test_scrollview_events.py`.
  Confirmed **pre-existing** — `main` in a clean worktree crashes at the exact same
  point under Tk 9. That file passes in isolation with and without this change.
  Not filed yet; worth its own issue.

## Not included

The DataTable cell-padding regression found while verifying this is filed
separately as **#376** — it reproduces both before and after this fix, with
identical cell rectangles and padding values across Tk versions, so it is a
distinct Tk 9 break and is deferred to a later patch.
