### PR TITLE
cleanup(shell): complete the ShellLayout visibility properties

### DIFF
--- a/src/bootstack/widgets/_impl/composites/shell/layout.py
+++ b/src/bootstack/widgets/_impl/composites/shell/layout.py
@@ -224,30 +224,6 @@ class ShellLayout(App):
 
     # ----- Region visibility -----
 
-    def set_statusbar_visible(self, visible: bool) -> None:
-        """Show or hide the bottom status band (and its full-width hairline)."""
-        if self._show_statusbar != visible:
-            self._show_statusbar = visible
-            self._relayout_window()
-
-    def set_rail_visible(self, visible: bool) -> None:
-        """Show or hide the workspace rail."""
-        if self._show_rail != visible:
-            self._show_rail = visible
-            self._relayout_body()
-
-    def set_sidebar_visible(self, visible: bool) -> None:
-        """Show or hide the sidebar slot."""
-        if self._show_sidebar != visible:
-            self._show_sidebar = visible
-            self._relayout_body()
-
-    def set_dock_visible(self, visible: bool) -> None:
-        """Show or hide the detail/inspector dock."""
-        if self._show_dock != visible:
-            self._show_dock = visible
-            self._relayout_body()
-
     # ----- Region sizing -----
 
     def set_rail_width(self, width: int) -> None:
@@ -312,24 +288,55 @@ class ShellLayout(App):
         """The detail/inspector dock slot (reserved)."""
         return self._dock
 
-    # ----- Visibility state (read-only) -----
+    # ----- Visibility state -----
+    #
+    # Read/write, rather than a getter here and a `set_*_visible(bool)` method
+    # elsewhere in the class. The region accessors above are already properties,
+    # and every caller assigns either a literal or a bool it computed — which
+    # verb pairs (`show_*`/`hide_*`, the idiom the public layer uses) would turn
+    # back into an if/else at each site. Assigning the value it already holds is
+    # a no-op, so a caller may write the flag unconditionally.
 
     @property
     def statusbar_visible(self) -> bool:
-        """Whether the status band is shown."""
+        """Whether the status band (and its full-width hairline) is shown."""
         return self._show_statusbar
+
+    @statusbar_visible.setter
+    def statusbar_visible(self, visible: bool) -> None:
+        if self._show_statusbar != visible:
+            self._show_statusbar = visible
+            self._relayout_window()
 
     @property
     def rail_visible(self) -> bool:
         """Whether the rail is shown."""
         return self._show_rail
 
+    @rail_visible.setter
+    def rail_visible(self, visible: bool) -> None:
+        if self._show_rail != visible:
+            self._show_rail = visible
+            self._relayout_body()
+
     @property
     def sidebar_visible(self) -> bool:
         """Whether the sidebar slot is shown."""
         return self._show_sidebar
 
+    @sidebar_visible.setter
+    def sidebar_visible(self, visible: bool) -> None:
+        if self._show_sidebar != visible:
+            self._show_sidebar = visible
+            self._relayout_body()
+
     @property
     def dock_visible(self) -> bool:
         """Whether the dock slot is shown."""
         return self._show_dock
+
+    @dock_visible.setter
+    def dock_visible(self, visible: bool) -> None:
+        if self._show_dock != visible:
+            self._show_dock = visible
+            self._relayout_body()

--- a/src/bootstack/widgets/_impl/composites/shell/layout.py
+++ b/src/bootstack/widgets/_impl/composites/shell/layout.py
@@ -222,8 +222,6 @@ class ShellLayout(App):
         if self._show_dock:
             self._dock.pack(side="right", fill="y")
 
-    # ----- Region visibility -----
-
     # ----- Region sizing -----
 
     def set_rail_width(self, width: int) -> None:

--- a/src/bootstack/widgets/_impl/composites/shell/shell.py
+++ b/src/bootstack/widgets/_impl/composites/shell/shell.py
@@ -424,9 +424,9 @@ class Shell(ShellLayout):
         if mode is None:
             mode = self._model.sidebar_mode
         if mode == "hidden":
-            self.set_sidebar_visible(False)
+            self.sidebar_visible = False
             return
-        self.set_sidebar_visible(True)
+        self.sidebar_visible = True
         ws = self.workspace
         compact = (
             mode == "compact"
@@ -461,7 +461,7 @@ class Shell(ShellLayout):
 
     def _sync_rail_visibility(self) -> None:
         # The rail widget is wired in step 6b; for now reflect model state only.
-        self.set_rail_visible(self._model.rail_visible)
+        self.rail_visible = self._model.rail_visible
 
     # ----- Lifecycle -----
 

--- a/src/bootstack/widgets/appshell.py
+++ b/src/bootstack/widgets/appshell.py
@@ -479,7 +479,7 @@ class _ShellBase(AppConfigMixin, WindowControlsMixin, ChromeHostMixin, PublicWid
             # the first frame (a content-driven band shows lazily on its first
             # segment; `show_statusbar=True` means "always on").
             _ = self.statusbar
-            self._internal.set_statusbar_visible(True)
+            self._internal.statusbar_visible = True
 
     @classmethod
     def from_store(cls, store: Any, **overrides: Any):
@@ -544,8 +544,8 @@ class _ShellBase(AppConfigMixin, WindowControlsMixin, ChromeHostMixin, PublicWid
         # was passed (an empty band shouldn't linger if the new body adds no
         # segment; a content-driven band re-shows lazily on the first segment).
         try:
-            self._internal.set_statusbar_visible(
-                getattr(self, "_show_statusbar_forced", False)
+            self._internal.statusbar_visible = getattr(
+                self, "_show_statusbar_forced", False
             )
         except Exception:
             pass
@@ -719,9 +719,13 @@ class _ShellBase(AppConfigMixin, WindowControlsMixin, ChromeHostMixin, PublicWid
         if self._statusbar is None:
             self._statusbar = StatusBar(
                 _toolbar=self._internal.statusbar,
-                _show=lambda: self._internal.set_statusbar_visible(True),
+                _show=self._reveal_statusbar,
             )
         return self._statusbar
+
+    def _reveal_statusbar(self) -> None:
+        """Show the status band — called by the band itself on its first segment."""
+        self._internal.statusbar_visible = True
 
     @property
     def pages(self) -> Any:

--- a/tests/widgets/test_shell_layout.py
+++ b/tests/widgets/test_shell_layout.py
@@ -37,20 +37,20 @@ def test_region_layout_construction_and_toggles():
         assert shell.dock_visible is False
 
         # Toggle each slot on.
-        shell.set_rail_visible(True)
-        shell.set_statusbar_visible(True)
-        shell.set_dock_visible(True)
+        shell.rail_visible = True
+        shell.statusbar_visible = True
+        shell.dock_visible = True
         assert shell.rail.winfo_manager() == "pack"
         assert shell.statusbar.winfo_manager() == "pack"
         assert shell.dock.winfo_manager() == "pack"
 
         # Hide the sidebar; content stays.
-        shell.set_sidebar_visible(False)
+        shell.sidebar_visible = False
         assert shell.sidebar.winfo_manager() == ""
         assert shell.content.winfo_manager() == "pack"
 
-        # Toggles are idempotent (no error, state unchanged).
-        shell.set_rail_visible(True)
+        # Assigning the value it already holds is a no-op, not an error.
+        shell.rail_visible = True
         assert shell.rail_visible is True
 
         # Width setters apply to the slot frames.


### PR DESCRIPTION
Closes #332.

## What the issue asked, and what was actually there

The issue asked to rename the internal `set_*_visible(bool)` family to the
framework idiom, leaving the convention open.

Looking at the class, it already held **each of these four flags twice**:

```python
# line ~227, under "Region visibility"
def set_statusbar_visible(self, visible: bool) -> None: ...
def set_rail_visible(self, visible: bool) -> None: ...
def set_sidebar_visible(self, visible: bool) -> None: ...
def set_dock_visible(self, visible: bool) -> None: ...

# line ~343, under "Visibility state (read-only)"
@property
def statusbar_visible(self) -> bool: ...
@property
def rail_visible(self) -> bool: ...
# ... and so on
```

So this is less a rename than finishing something half-built: the getters were
already the idiom, and the setters were the odd half. Giving the existing
properties setters and deleting the method family leaves one shape per flag.

## Why properties, not `show_*` / `hide_*`

Verb pairs are what the **public** layer uses (`show_sidebar()`,
`hide_sidebar()`, `toggle_sidebar()`), so they were the obvious candidate. They
are the wrong fit here:

- The getters are already properties, as is every sibling region accessor
  (`sidebar`, `rail`, `content`, `sidebar_surface`, ...).
- Every caller assigns a literal or a bool it computed. Two sites pass a
  computed flag — `self.rail_visible = self._model.rail_visible` and the
  dev-reload reset — which verb pairs would turn back into an `if/else`.

Behavior is unchanged: each setter body is the old method body verbatim, so
assigning the value a flag already holds is still a no-op.

## Call sites

`appshell.py` (3), `shell.py` (3), `tests/widgets/test_shell_layout.py` (5).

One needed more than a mechanical swap — `AppShell.statusbar` passed its reveal
hook as `lambda: self._internal.set_statusbar_visible(True)`, and a lambda
cannot hold an assignment. It is now a named `_reveal_statusbar` method, which
also gives that hook somewhere to be documented.

## Scope

Internal only. `ShellLayout` is not public; users reach this through
`show_sidebar()` / `hide_sidebar()` / `toggle_sidebar()` and the
`show_statusbar=` constructor argument, none of which change. No docs change.

The sibling `set_rail_width` / `set_sidebar_width` / `set_dock_width` family is
left alone — those are configuration with no getter counterpart, not state.

## Verification

- Full suite via `python tests/run_gui.py`: **756 passed**, all legs green,
  exit 0 — identical to the pre-change baseline.
- `tests/widgets/test_shell_layout.py` covers all four flags and passes.

⚠️ **Worth knowing:** that test file is in `tests/widgets/`, which is **not in
`testpaths`** (`tests/cli`, `tests/widgets/public`, `tests/data`) and is not run
by `run_gui.py` either. There are **12 such files, 25 tests total**, none of them
collected. I ran all 12 individually — every one passes, before and after this
change — so this is dead coverage rather than hidden breakage. It is the same
defect class as #365. Reporting it here; it belongs with the test-health work in
#379/#380 rather than this PR.

Verified on Windows + Tcl/Tk 8.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
