### PR TITLE
fix(widgets): let None clear a field, and scope Form.set() to the keys given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ and from 0.1.0 onward the project adheres to
 
 ### Fixed
 
+- **A date field can be cleared.** Setting `value` to `None` — and the field's
+  own `clear()` method, which does exactly that — silently left the previous
+  date in place, on screen and in `form.get()`. Clearing now works through
+  every path, including `Form.set({key: None})`. The same no-op affected
+  `None` on the other entry-backed fields (`TextField`, `NumberField`,
+  `PasswordField`, `PathField`, `SpinnerField`), which reached empty only when
+  given `""`; `None` and `""` now agree. (#387)
+
+- **`Form.set()` writes only the fields you name.** It walked every field and
+  blanked the ones absent from the dictionary — harmless only because blanking
+  was itself broken. A partial update such as `form.set({'date': value})` now
+  leaves the other fields, and the rest of the form data, untouched. (#387)
+
 - **A misspelled mode argument now tells you, instead of quietly doing
   something else.** Arguments that name a behavior mode — `selection_mode`,
   `sorting_mode`, `paging_mode`, `scrollbars`, `scroll_direction`,

--- a/docs/widgets/forms.rst
+++ b/docs/widgets/forms.rst
@@ -318,9 +318,10 @@ Reading and writing values
    values = form.value        # {'name': 'Alice', 'age': 30}
    values = form.get()        # equivalent
 
-   # Write all values
+   # Write values — only the keys you pass are changed
    form.value = {"name": "Bob", "age": 25}
    form.set({"name": "Bob", "age": 25})   # equivalent
+   form.set({"age": 26})                  # writes age; name is left alone
 
    # Read / write a single field
    name = form.get_field_value("name")

--- a/src/bootstack/widgets/_impl/_parts/spinnerentry_part.py
+++ b/src/bootstack/widgets/_impl/_parts/spinnerentry_part.py
@@ -13,6 +13,7 @@ from bootstack.i18n import MessageCatalog, IntlFormatter
 from bootstack.widgets._impl.primitives.spinbox import Spinbox
 from bootstack.widgets._impl.mixins import ValidationMixin
 from bootstack.widgets._impl.mixins.configure_mixin import configure_delegate
+from bootstack.widgets._impl._parts.textentry_part import _UNSET
 
 
 class SpinnerEntryPart(ValidationMixin, Spinbox):
@@ -307,16 +308,17 @@ class SpinnerEntryPart(ValidationMixin, Spinbox):
         """Remove callback from <<Change>> event."""
         self.unbind('<<Change>>', bind_id)
 
-    def value(self, value=None):
+    def value(self, value=_UNSET):
         """Get or set the parsed/committed value.
 
         Args:
-            value: If provided, sets the display text and internal value with formatting
+            value: If provided, sets the display text and internal value with
+                formatting. Pass `None` to clear the field.
 
         Returns:
             Current parsed value if no argument provided, None otherwise
         """
-        if value is None:
+        if value is _UNSET:
             return self._value
         else:
             # Store the value and format it for display

--- a/src/bootstack/widgets/_impl/_parts/textentry_part.py
+++ b/src/bootstack/widgets/_impl/_parts/textentry_part.py
@@ -7,6 +7,11 @@ from bootstack.widgets._impl.primitives.entry import Entry
 from bootstack.widgets._impl.mixins import ValidationMixin
 from bootstack.widgets._impl.mixins.configure_mixin import configure_delegate
 
+#: Sentinel marking "no argument passed" for the combined get/set accessors below.
+#: `None` cannot serve as that sentinel — it is a real value meaning "empty", and
+#: using it to mean "get" made `value(None)` a silent no-op instead of clearing.
+_UNSET: Any = object()
+
 
 class TextEntryPart(ValidationMixin, Entry):
     """Internationalization-aware entry widget with deferred parsing and formatting.
@@ -250,16 +255,17 @@ class TextEntryPart(ValidationMixin, Entry):
         """Unbind from `<<Change>>`."""
         self.unbind('<<Change>>', bind_id)
 
-    def value(self, value=None):
+    def value(self, value=_UNSET):
         """Get or set the parsed/committed value.
 
         Args:
-            value: If provided, sets the display text and internal value with formatting
+            value: If provided, sets the display text and internal value with
+                formatting. Pass `None` to clear the field.
 
         Returns:
             Current parsed value if no argument provided, None otherwise
         """
-        if value is None:
+        if value is _UNSET:
             return self._value
         else:
             # Store the value and format it for display

--- a/src/bootstack/widgets/_impl/composites/form.py
+++ b/src/bootstack/widgets/_impl/composites/form.py
@@ -509,15 +509,24 @@ class Form(Frame):
     def set(self, values: Mapping[str, Any]) -> None:
         """Set multiple field values from a dictionary.
 
+        Only the keys present in `values` are written — this is a partial
+        update, not a replacement. Keys that name no field are ignored, so a
+        whole record from a data source can be handed over even when it carries
+        columns the form does not show.
+
         Args:
             values: Dictionary mapping field keys to values.
         """
-        self._data = dict(values)
+        updates = dict(values)
+        # Merge rather than replace: a partial update must not drop the keys it
+        # doesn't mention, and must not write `None` over the fields it omits.
+        self._data.update(updates)
         self._suspend_sync = True
         try:
-            for key, item in self._items_by_key.items():
-                value = self._data.get(key)
-                self._apply_value_to_widget(key, item, value)
+            for key, value in updates.items():
+                item = self._items_by_key.get(key)
+                if item is not None:
+                    self._apply_value_to_widget(key, item, value)
         finally:
             self._suspend_sync = False
 
@@ -532,6 +541,9 @@ class Form(Frame):
 
     @configure_delegate('data')
     def _delegate_data(self, value: Mapping[str, Any] = None):
+        # Unlike `set()`, this is a whole-record write: it replaces the data and
+        # walks every field, so a key absent from `value` clears its field. That
+        # is the meaning of assigning the record wholesale.
         if value is None:
             return dict(self._collect_data())
         else:

--- a/src/bootstack/widgets/form.py
+++ b/src/bootstack/widgets/form.py
@@ -105,7 +105,11 @@ class Form(PublicWidgetBase):
         return self._internal.get()
 
     def set(self, values: Mapping[str, Any]) -> None:
-        """Set multiple field values from a dictionary."""
+        """Set multiple field values from a dictionary.
+
+        A partial update — only the keys present in `values` are written, and
+        keys naming no field are ignored.
+        """
         self._internal.set(values)
 
     def validate(self) -> bool:

--- a/tests/widgets/public/test_field_clear_none.py
+++ b/tests/widgets/public/test_field_clear_none.py
@@ -1,0 +1,148 @@
+"""Regression tests for clearing a field with `None` (#387).
+
+`TextEntryPart.value()` is a combined getter/setter that used `None` as its
+"no argument passed" sentinel, so `entry.value(None)` returned the current
+value instead of clearing. Every public path down to it inherited the no-op:
+`DateField.value = None`, `DateField.clear()` (which passes `None`), and
+`Form.set({key: None})`.
+
+Passing `''` worked and was the accidental workaround — it reaches the same
+set branch, which already mapped an empty string to a `None` value. The setter
+was never broken; only the door was locked.
+
+Filed from discussion #386.
+"""
+from __future__ import annotations
+
+from datetime import date, time
+
+import pytest
+
+import bootstack as bs
+
+
+# --- The reported bug: DateField cannot be cleared ----------------------
+
+def test_datefield_value_none_clears(app):
+    # Reported repro: `.value = None` left the previous date in place.
+    field = bs.DateField(value=date(2024, 5, 5))
+    app._tk_root.update_idletasks()
+
+    field.value = None
+
+    assert field.value is None
+
+
+def test_datefield_clear_method_clears(app):
+    # `clear()` is implemented as `self._internal.value = None`, so the public
+    # method was a silent no-op too.
+    field = bs.DateField(value=date(2024, 5, 5))
+    app._tk_root.update_idletasks()
+
+    field.clear()
+
+    assert field.value is None
+
+
+def test_datefield_clear_empties_the_display(app):
+    # A cleared value with stale text on screen would not be a usable clear.
+    field = bs.DateField(value=date(2024, 5, 5))
+    app._tk_root.update_idletasks()
+
+    field.clear()
+
+    assert field.text == ""
+
+
+# --- The whole family agrees on `None` ----------------------------------
+
+@pytest.mark.parametrize("factory, seed", [
+    (bs.DateField, date(2024, 5, 5)),
+    (bs.TimeField, time(9, 30)),
+    (bs.TextField, "hello"),
+    (bs.NumberField, 42),
+    (bs.PathField, "C:/tmp"),
+    (bs.SpinnerField, 3),
+])
+def test_value_none_clears_every_field(app, factory, seed):
+    field = factory(value=seed)
+    app._tk_root.update_idletasks()
+    assert field.value == seed or field.value is not None
+
+    field.value = None
+
+    assert field.value is None
+    assert field.text == ""
+
+
+@pytest.mark.parametrize("factory, seed", [
+    (bs.DateField, date(2024, 5, 5)),
+    (bs.TimeField, time(9, 30)),
+    (bs.TextField, "hello"),
+    (bs.NumberField, 42),
+    (bs.PathField, "C:/tmp"),
+    (bs.SpinnerField, 3),
+])
+def test_clear_method_empties_every_field(app, factory, seed):
+    field = factory(value=seed)
+    app._tk_root.update_idletasks()
+
+    field.clear()
+
+    assert field.value is None
+    assert field.text == ""
+
+
+# --- The `''` path must keep working ------------------------------------
+
+def test_empty_string_still_clears(app):
+    # The pre-fix workaround stays valid — `''` and `None` agree.
+    field = bs.DateField(value=date(2024, 5, 5))
+    app._tk_root.update_idletasks()
+
+    field.value = ""
+
+    assert field.value is None
+    assert field.text == ""
+
+
+# --- Reading still works with no argument -------------------------------
+
+def test_no_argument_still_reads_the_value(app):
+    # Deliberately exercises the internal accessor: the fix swapped its "no
+    # argument passed" sentinel, so the getter half needs its own cover. The
+    # public `.value` property below is the path users take.
+    field = bs.TextField(value="hello")
+    app._tk_root.update_idletasks()
+
+    assert field._entry_widget().value() == "hello"
+    assert field.value == "hello"
+
+
+# --- Form-level clearing (the reporter's `clear_form` loop) --------------
+
+def test_form_set_none_clears_a_date_field(app):
+    form = bs.Form(items=[
+        bs.FieldItem(key="d", label="D", editor="datefield",
+                     editor_options={"value": date(2024, 5, 5)}),
+    ])
+    app._tk_root.update_idletasks()
+
+    form.set({"d": None})
+
+    assert form.get()["d"] is None
+
+
+def test_form_clear_loop_empties_every_field(app):
+    # The shape of the reporter's clear_form(): read the keys, write None back.
+    form = bs.Form(items=[
+        bs.FieldItem(key="name", label="Name"),
+        bs.FieldItem(key="d", label="D", editor="datefield",
+                     editor_options={"value": date(2024, 5, 5)}),
+    ])
+    app._tk_root.update_idletasks()
+    form.set({"name": "Bob"})
+
+    form.set({key: None for key in form.get()})
+
+    assert form.get() == {"name": None, "d": None}

--- a/tests/widgets/public/test_form_partial_set.py
+++ b/tests/widgets/public/test_form_partial_set.py
@@ -1,0 +1,91 @@
+"""Regression tests for `Form.set()` partial-update semantics (#387).
+
+`set()` iterated *every* field and applied `self._data.get(key)`, which is
+`None` for keys absent from the passed mapping. Those writes were discarded
+only because setting `None` was itself a no-op — so partial updates appeared
+to work by accident. Repairing the `None` no-op without this change would have
+turned every partial `form.set()` into a destructive full-form overwrite.
+
+`set()` now writes only the keys it is given and merges them into the form
+data instead of replacing it.
+"""
+from __future__ import annotations
+
+from datetime import date
+
+import bootstack as bs
+
+
+def _form(app):
+    form = bs.Form(items=[
+        bs.FieldItem(key="name", label="Name"),
+        bs.FieldItem(key="city", label="City"),
+        bs.FieldItem(key="d", label="D", editor="datefield"),
+    ])
+    app._tk_root.update_idletasks()
+    form.set({"name": "Bob", "city": "Denver", "d": date(2024, 1, 1)})
+    return form
+
+
+def test_partial_set_leaves_other_fields_untouched(app):
+    form = _form(app)
+
+    form.set({"d": date(2030, 6, 6)})
+
+    data = form.get()
+    assert data["name"] == "Bob"
+    assert data["city"] == "Denver"
+    assert data["d"] == date(2030, 6, 6)
+
+
+def test_partial_set_can_still_clear_the_key_it_names(app):
+    # Omitting a key must not clear it, but naming it with None must.
+    form = _form(app)
+
+    form.set({"d": None})
+
+    data = form.get()
+    assert data["d"] is None
+    assert data["name"] == "Bob"
+
+
+def test_partial_set_merges_into_form_data(app):
+    # `_data` was replaced wholesale, so a partial update dropped the keys it
+    # did not mention; only re-reading the widgets papered over it.
+    form = _form(app)
+
+    form.set({"name": "Ada"})
+
+    assert form.data["city"] == "Denver"
+    assert form.data["name"] == "Ada"
+
+
+def test_unknown_keys_are_ignored_for_field_writes(app):
+    # A whole record from a data source may carry columns the form does not
+    # show; bulk writes stay tolerant (targeted `set_field_value` still raises).
+    form = _form(app)
+
+    form.set({"name": "Ada", "id": 17, "created_at": "2026-01-01"})
+
+    assert form.get()["name"] == "Ada"
+
+
+def test_unknown_keys_round_trip_through_the_form_data(app):
+    # Extra columns are carried, not dropped, so a record can be read back and
+    # saved with its identity intact.
+    form = _form(app)
+
+    form.set({"name": "Ada", "id": 17})
+
+    assert form.get()["id"] == 17
+
+
+def test_setting_every_key_still_replaces_all(app):
+    form = _form(app)
+
+    form.set({"name": "", "city": "", "d": None})
+
+    data = form.get()
+    assert data["d"] is None
+    assert not data["name"]
+    assert not data["city"]


### PR DESCRIPTION
Fixes #387. From discussion #386.

## The bug

`DateField.value = None` was a silent no-op, and so was the widget's own public `clear()` method — the field kept its previous date, on screen and in `form.get()`.

```
df initial value             -> date(2024, 5, 5)
df after `.value = None`     -> date(2024, 5, 5)   <-- no-op
df after `.clear()`          -> date(2024, 5, 5)   <-- no-op
df after `.value = ''`       -> None               <-- works
```

## Root cause

`TextEntryPart.value()` is a combined getter/setter that used `None` as its "no argument passed" sentinel:

```python
def value(self, value=None):
    if value is None:
        return self._value      # get branch
```

So `entry.value(None)` called the **getter**. Every public path down to it inherited the no-op — `DateField.value` -> `Field.value.fset` -> `self._entry.value(value)` — including `clear()`, which is implemented as `self._internal.value = None`.

The set branch already handled `None` correctly (`str(value) if value is not None else ''` -> `''` -> `self._value = None`). That is exactly why `.value = ''` worked: same code path. The setter was never broken; only the door was locked.

## The fix

Replace the sentinel with a module-level `_UNSET`, in `TextEntryPart` and in `SpinnerEntryPart` (which carries its own copy of the signature and the same defect).

Verified safe: `grep -rn "\.value(None)"` over `src/` returns no matches, so nothing relied on the get-by-None behavior.

Scope: this affected every field built on `TextEntryPart`. It surfaced on `DateField` because it is the only one whose `clear()` passes `None`; the others pass `""` and worked by accident. `TimeField` was unaffected — `TimeEntry` subclasses `SelectBox`, a different value path.

## `Form.set()` had to change in the same commit

`Form.set()` iterated **all** items and applied `self._data.get(key)`, which is `None` for keys absent from the passed mapping. Those writes were discarded by the very bug above — which is the only reason partial updates worked:

```
seeded                        -> {'name': 'Bob', 'city': 'Denver', 'd': date(2024,1,1)}
after PARTIAL set of 'd' only -> {'d': date(2030,6,6), 'name': 'Bob', 'city': 'Denver'}
```

Fixing the sentinel alone would have turned every partial `form.set()` into a destructive full-form overwrite — including the reporter's own `get_random_date`. `set()` now writes only the keys it is given and merges them into `_data` rather than replacing it (which also fixes a latent bug: a partial update used to *drop* the unmentioned keys from the form's own data dict, with `_collect_data` papering over it by re-reading the widgets).

Unknown keys stay ignored for field writes and are still carried in the data, so `form.set(record)` -> `form.get()` round-trips an `id` column. Bulk writes are tolerant; targeted `set_field_value` still raises `KeyError`.

## One deliberate behavior change to be aware of

`configure(data=...)` (`_delegate_data`) replaces the record wholesale and walks every field, so with `None` now working, a key absent from that dict **clears** its field where before it silently no-opped. Kept and documented, on the reading that `set()` is partial and `data=` is the whole record. It is only reachable through the internal configure path — construction sets `_data` directly, the public `data` property is read-only, and nothing in the codebase calls it.

## Verification

- **25 new tests** across `test_field_clear_none.py` and `test_form_partial_set.py`; **13 fail before the fix**.
- Full GUI suite: **854 passed**, exit 0, no regressions.
- Manually verified with the reporter's own sample from #386.

Docs build not run — `myst_parser` is not installed in this environment. The only docs change is one line inside an existing `code-block` (correcting "Write all values" for `set()`), with no new directives or cross-references.

## Not in scope

- **#388** — the date picker still fires no change event.
- **#389** — `Form.reset()` / `Form.clear()`, which build on this.
- **#390** — a bound `Signal` still will not receive the cleared value; signals cannot represent absence.
- **#383** — `Slider.value = None` still leaks a raw `TypeError`; reachable via `form.set({'slider_key': None})`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
