### PR TITLE
fix(widgets): emit a change event when a date is chosen in the picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and from 0.1.0 onward the project adheres to
 
 ### Fixed
 
+- **Choosing a date from the calendar reports the change.** The picker set the
+  field but announced nothing, so a bound `Signal` kept its old date, an
+  `on_change` handler never ran, and a `Form` did not register the edit — while
+  typing the same date and pressing Return worked. Picking now behaves like any
+  other commit. Date ranges were already correct. (#388)
+
 - **A date field can be cleared.** Setting `value` to `None` — and the field's
   own `clear()` method, which does exactly that — silently left the previous
   date in place, on screen and in `form.get()`. Clearing now works through

--- a/docs/widgets/datefield.rst
+++ b/docs/widgets/datefield.rst
@@ -125,13 +125,17 @@ initial value.
 Handling changes
 ~~~~~~~~~~~~~~~~
 
-``on_change()`` fires whenever the selected date changes — whether by keyboard
-input, picker selection, or ``value=`` assignment.
+``on_change()`` fires when the user commits a new date — by typing one and
+pressing Return or leaving the field, or by choosing one in the picker.
 
 .. code-block:: python
 
    df = bs.DateField(label="Appointment")
    df.on_change(lambda e: print("Selected:", e.value))
+
+Assigning ``value`` in code does not fire it, since nothing was committed. To
+observe both, bind a :class:`~bootstack.Signal` with ``signal=`` — it receives
+programmatic writes as well as user edits.
 
 Validation
 ~~~~~~~~~~

--- a/src/bootstack/widgets/_impl/composites/dateentry.py
+++ b/src/bootstack/widgets/_impl/composites/dateentry.py
@@ -269,6 +269,31 @@ class DateEntry(Field):
                 self.date_picker_button.pack_forget()
         return None
 
+    def _apply_picked(self, val) -> None:
+        """Apply a value chosen in the picker and announce it as a user commit.
+
+        Choosing a date is a commit, exactly like typing one and pressing
+        Return, so it has to emit `<<Change>>` — bound signals, `on_change`
+        handlers, and form change tracking all listen for that event. Assigning
+        `value` alone does not emit it: the event comes from the entry's own
+        change detection, which otherwise only runs on FocusOut and Return.
+
+        `_check_if_changed` also advances the entry's last-seen value, so a
+        later focus-out cannot fire a second `<<Change>>` for this same
+        selection — which hand-building the event here would allow whenever the
+        entry already held focus. It is safe to call twice: the second call
+        sees no difference and does nothing.
+
+        Range mode is left alone; `_set_range` already emits its own event.
+        """
+        if self._selection_mode == "range":
+            self.value = val
+            return
+        if isinstance(val, datetime):
+            val = val.date()
+        self.value = val
+        self._entry._check_if_changed()
+
     def _show_date_picker(self):
         """Open the calendar picker dialog.
 
@@ -336,10 +361,10 @@ class DateEntry(Field):
             result = payload.get('result') if isinstance(payload, dict) else payload
             if self._selection_mode == "range":
                 if isinstance(result, tuple) and len(result) == 2:
-                    self.value = result
+                    self._apply_picked(result)
             else:
                 if isinstance(result, (date, datetime)):
-                    self.value = result
+                    self._apply_picked(result)
 
         dialog.on_result(lambda x: _on_result(x))
         dialog.show(
@@ -366,12 +391,10 @@ class DateEntry(Field):
         selected = dialog.result
         if self._selection_mode == "range":
             if isinstance(selected, tuple) and len(selected) == 2:
-                self.value = selected
+                self._apply_picked(selected)
         else:
-            if isinstance(selected, datetime):
-                selected = selected.date()
-            if isinstance(selected, date):
-                self.value = selected
+            if isinstance(selected, (date, datetime)):
+                self._apply_picked(selected)
 
         # Return focus to the entry after dialog closes
         # Note: focus_force() is needed on Windows after override-redirect dialogs

--- a/tests/widgets/public/test_datepicker_change_event.py
+++ b/tests/widgets/public/test_datepicker_change_event.py
@@ -1,0 +1,187 @@
+"""Regression tests for the date picker emitting a change event (#388).
+
+Choosing a date from the calendar applied the value but emitted no
+`<<Change>>`, because the picker assigns `value` directly and that event is
+only produced by the entry's change detection on FocusOut/Return. Every
+consumer missed the selection: `on_change` handlers, a bound `Signal` (which
+`ValueSignalMixin` syncs off `on_change`), and `Form` change tracking.
+
+Range mode was already correct — `_set_range` emits its own event — so only
+single-selection mode was affected.
+
+These drive `_apply_picked`, the seam both picker call sites in
+`_show_date_picker` funnel through, since the dialog itself needs a user
+gesture. `development/verify_388_datepicker.py` covers the real click-through.
+
+Filed from discussion #386.
+"""
+from __future__ import annotations
+
+from datetime import date, datetime
+
+import bootstack as bs
+
+
+# --- The reported bug: a bound signal went stale ------------------------
+
+def test_picking_a_date_updates_a_bound_signal(app):
+    # Reported repro: after choosing a date in the picker, the signal still
+    # reported the previously set value.
+    signal = bs.Signal(date(2020, 1, 1))
+    field = bs.DateField(signal=signal)
+    app._tk_root.update_idletasks()
+
+    field._internal._apply_picked(date(2026, 7, 29))
+    app._tk_root.update_idletasks()
+
+    assert field.value == date(2026, 7, 29)
+    assert signal() == date(2026, 7, 29)
+
+
+def test_picking_a_date_fires_on_change(app):
+    seen = []
+    field = bs.DateField(value=date(2024, 1, 1))
+    field.on_change(lambda e: seen.append(e.value))
+    app._tk_root.update_idletasks()
+
+    field._internal._apply_picked(date(2026, 7, 29))
+    app._tk_root.update_idletasks()
+
+    assert seen == [date(2026, 7, 29)]
+
+
+def test_change_payload_carries_the_previous_value(app):
+    seen = []
+    field = bs.DateField(value=date(2024, 1, 1))
+    field.on_change(lambda e: seen.append((e.prev_value, e.value)))
+    app._tk_root.update_idletasks()
+
+    field._internal._apply_picked(date(2026, 7, 29))
+    app._tk_root.update_idletasks()
+
+    assert seen == [(date(2024, 1, 1), date(2026, 7, 29))]
+
+
+# --- No duplicate events ------------------------------------------------
+
+def test_applying_the_same_pick_twice_fires_once(app):
+    # `_show_date_picker` applies the result from the dialog callback and again
+    # from the post-show fallback, so the second application must be inert.
+    seen = []
+    field = bs.DateField(value=date(2024, 1, 1))
+    field.on_change(lambda e: seen.append(e.value))
+    app._tk_root.update_idletasks()
+
+    field._internal._apply_picked(date(2026, 7, 29))
+    field._internal._apply_picked(date(2026, 7, 29))
+    app._tk_root.update_idletasks()
+
+    assert seen == [date(2026, 7, 29)]
+
+
+def test_picking_the_current_value_fires_nothing(app):
+    seen = []
+    field = bs.DateField(value=date(2024, 1, 1))
+    field.on_change(lambda e: seen.append(e.value))
+    app._tk_root.update_idletasks()
+
+    field._internal._apply_picked(date(2024, 1, 1))
+    app._tk_root.update_idletasks()
+
+    assert seen == []
+
+
+def test_a_later_focus_out_does_not_repeat_the_event(app):
+    # The entry's last-seen value must advance with the pick, or blurring the
+    # field afterwards would announce the same selection a second time.
+    seen = []
+    field = bs.DateField(value=date(2024, 1, 1))
+    field.on_change(lambda e: seen.append(e.value))
+    app._tk_root.update_idletasks()
+
+    field._internal._apply_picked(date(2026, 7, 29))
+    field._entry_widget().event_generate("<FocusOut>")
+    app._tk_root.update_idletasks()
+
+    assert seen == [date(2026, 7, 29)]
+
+
+# --- Value normalization ------------------------------------------------
+
+def test_a_datetime_result_is_stored_as_a_date(app):
+    field = bs.DateField(value=date(2024, 1, 1))
+    app._tk_root.update_idletasks()
+
+    field._internal._apply_picked(datetime(2026, 7, 29, 13, 45))
+
+    assert field.value == date(2026, 7, 29)
+
+
+# --- Range mode keeps its own emit --------------------------------------
+
+def test_range_mode_fires_exactly_once(app):
+    seen = []
+    field = bs.DateField(selection_mode="range")
+    field.on_change(lambda e: seen.append(e.value))
+    app._tk_root.update_idletasks()
+
+    field._internal._apply_picked((date(2026, 1, 1), date(2026, 1, 31)))
+    app._tk_root.update_idletasks()
+
+    assert seen == [(date(2026, 1, 1), date(2026, 1, 31))]
+
+
+# --- The real picker path -----------------------------------------------
+
+def test_show_date_picker_emits_the_change(app, monkeypatch):
+    """Drive `_show_date_picker` itself, with the dialog stubbed out.
+
+    The tests above exercise `_apply_picked` directly, so they would still
+    pass if the picker stopped calling it. This one runs the actual method —
+    both the dialog-result callback and the post-show fallback — and so fails
+    if either call site regresses to a plain `value` assignment.
+    """
+    import bootstack.dialogs._impl.datedialog as datedialog_mod
+
+    picked = date(2026, 7, 29)
+
+    class _StubDateDialog:
+        def __init__(self, **kwargs):
+            self.result = picked
+            self._handler = None
+
+        def on_result(self, handler):
+            self._handler = handler
+
+        def show(self, **kwargs):
+            if self._handler is not None:
+                self._handler({"result": self.result})
+
+    monkeypatch.setattr(datedialog_mod, "DateDialog", _StubDateDialog)
+
+    seen = []
+    field = bs.DateField(value=date(2024, 1, 1))
+    field.on_change(lambda e: seen.append(e.value))
+    app._tk_root.update_idletasks()
+
+    field._internal._show_date_picker()
+    app._tk_root.update_idletasks()
+
+    assert field.value == picked
+    # Exactly once, despite the callback and the fallback both applying it.
+    assert seen == [picked]
+
+
+# --- Form change tracking sees it ---------------------------------------
+
+def test_form_data_reflects_a_picked_date(app):
+    form = bs.Form(items=[
+        bs.FieldItem(key="d", label="D", editor="datefield",
+                     editor_options={"value": date(2024, 1, 1)}),
+    ])
+    app._tk_root.update_idletasks()
+
+    form.field("d")._internal._apply_picked(date(2026, 7, 29))
+    app._tk_root.update_idletasks()
+
+    assert form.get()["d"] == date(2026, 7, 29)


### PR DESCRIPTION
Fixes #388. From discussion #386.

## The bug

Choosing a date from the calendar picker updated the field but announced nothing. A bound `Signal` kept its old value, `on_change` handlers never ran, and `Form` did not register the edit — while typing the same date and pressing Return worked. The two input paths disagreed.

The reporter noticed it as *"the Signal is no longer bound to the DateField"* after picking a date.

```
field value after picker-path set   -> date(1999, 12, 31)
sig after picker-path set           -> date(2020, 7, 28)   <-- stale
on_change fired by picker-path set? -> []                  <-- no event at all
```

## Root cause

`_show_date_picker` applied the result by assigning `value` (`dateentry.py`, in the dialog callback and again in the post-`show()` fallback). That sets `_value` and the display text, but `<<Change>>` is produced only by `_check_if_changed()`, which runs from `_handle_focus_out` and `_handle_return`.

Since `ValueSignalMixin` syncs field -> signal off `on_change`, the signal never learned. The write also bypassed the public wrapper's setter, so `_sync_value_set` did not run either.

**Range mode was already correct** — `_set_range` emits on both its set and clear paths. Single-selection mode was the outlier.

## The fix

Both call sites now route through one seam:

```python
def _apply_picked(self, val) -> None:
    if self._selection_mode == "range":
        self.value = val          # _set_range emits its own event
        return
    if isinstance(val, datetime):
        val = val.date()
    self.value = val
    self._entry._check_if_changed()
```

Reusing the entry's existing change detection rather than building a `ChangeEvent` by hand matters twice over:

- `_check_if_changed` **advances `_prev_changed_value` after emitting**, so a later focus-out cannot announce the same selection a second time — which hand-rolling the emit would allow whenever the entry already held focus.
- It makes the double application inert: the dialog callback applies the result, the post-`show()` fallback applies it again, and the second pass sees no delta.

Deliberately **not** making all programmatic writes emit `<<Change>>`. The framework treats that event as "user committed" — which is why `_sync_value_set` exists as a separate path — and a blanket change would double-fire with it. Picking a date is a commit; a scripted `field.value = x` is not.

## Docs correction

`docs/widgets/datefield.rst` claimed `on_change()` fires on "keyboard input, picker selection, or `value=` assignment". This PR makes the second clause true. The third was and remains false — verified:

```
on_change after public `.value =`: []
```

Rather than leave a false claim beside the one being corrected, the paragraph now describes `on_change` as a commit event and points at `signal=` for observing programmatic writes too.

## Verification

- **10 new tests.** Nine drive `_apply_picked`; the tenth stubs `DateDialog` and runs the real `_show_date_picker`, so it fails if either call site regresses to a plain assignment. Pre-fix it fails behaviorally, not by import error:

  ```
  assert field.value == picked      # passes — value applied
  assert seen == [picked]
  E   assert [] == [datetime.date(2026, 7, 29)]
  ```

- Full GUI suite: **864 passed**, exit 0.
- Docs: clean `sphinx-build -W --keep-going`, exit 0; the new `:class:` cross-reference resolves.
- Manually verified with the reporter's sample from #386.

## Not in scope

- **#389** — `Form.reset()` / `Form.clear()`.
- **#390** — signals still cannot represent an empty value, so clearing a field does not reach a bound signal.
- **#383** — `Slider.value = None` leaks a raw `TypeError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
