### PR TITLE
fix(widgets): keep a row of fields aligned when only some are validated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,27 @@ and from 0.1.0 onward the project adheres to
 
 ### Fixed
 
+- **Adding a validation rule no longer misaligns a row of fields.** A field
+  reserves space for its message as soon as it has a rule, and the fields
+  without one sat about nine pixels lower — both inside a `Form` and in a
+  hand-built `Row`. Two separate causes: the entry row absorbed the extra height
+  a form cell gave the field and centered itself in it, and a row centered the
+  shorter fields against their taller neighbors. Input fields — including
+  `Select` — now align to the top of a row on their own, so a row of them lines
+  up whether or not each one is validated. This applies to every container that
+  lays out as a row (`Row`, `Card`, `GroupBox`, `Expander`, `Tabs`, `PageStack`,
+  `SplitView` and an AppShell page), not just `Row`. Passing `vertical_items`
+  yourself still applies to every child, fields included. (#394)
+
+### Changed
+
+- **A field stretched taller than it needs now keeps its entry under its label.**
+  Where a field shares a grid row or a `'stretch'` cross axis with a taller
+  widget, the extra height used to be inserted *between* the label and the input,
+  leaving the input floating below its own caption; it now collects beneath the
+  field instead. Affects layouts that pair a field with something taller, such as
+  a `bs.Grid` row holding a field beside a multi-line `TextArea`. (#394)
+
 - **Choosing a date from the calendar reports the change.** The picker set the
   field but announced nothing, so a bound `Signal` kept its old date, an
   `on_change` handler never ran, and a `Form` did not register the edit — while

--- a/docs/tasks/layout.rst
+++ b/docs/tasks/layout.rst
@@ -237,6 +237,12 @@ A handful of behaviors trip people up the first time:
   set ``horizontal_items="stretch"``; to left-align, ``horizontal_items="left"``.
   The *stacking* axis still starts at the top/left — use ``horizontal_items`` /
   ``vertical_items`` or a ``Spacer`` to move the whole group.
+- **Input fields top-align in a Row instead.** A field grows taller the moment it
+  carries a validation rule, because it reserves a row for the message. Centering
+  would then drop its unvalidated neighbors by half a message row, so fields ask
+  for ``'top'`` on their own and a row of them lines up regardless of which ones
+  are validated. Passing ``vertical_items`` yourself applies to every child,
+  fields included.
 - **Data and canvas widgets collapse without `grow`.** A ``ListView`` or
   ``Tree`` with no ``grow``/``stretch`` shrinks to nothing — give it
   ``grow=True`` (and ``horizontal="stretch"`` in a Column).

--- a/src/bootstack/widgets/_core/container.py
+++ b/src/bootstack/widgets/_core/container.py
@@ -255,17 +255,74 @@ def grid_sticky(horizontal: str | None, vertical: str | None) -> str:
     return sticky
 
 
+def resolve_layout_items(
+    layout: str,
+    horizontal_items: str | None,
+    vertical_items: str | None,
+    *,
+    column_horizontal: str | None = None,
+) -> tuple[str | None, str | None]:
+    """Fill in a multi-mode container's unset `*_items` for its layout mode.
+
+    Containers that can lay out as a column, a row, or a grid (`Card`, `GroupBox`,
+    `Expander`, `Tabs`, `PageStack`, `SplitView`, the AppShell page) take
+    `horizontal_items`/`vertical_items` as `None`-means-unset and need a default
+    that depends on the mode.
+
+    A **grid** gets concrete values, because the grid engine has no notion of an
+    unset axis — cells stretch unless told otherwise. A **column** or **row**
+    keeps `None` and lets `FlexFrame` resolve it: the engine's own defaults are
+    exactly what these containers used to hard-code (the stacking axis starts at
+    its leading edge, the cross axis centers), and leaving the cross axis unset is
+    what allows a child to contribute its own default — which is how a row of
+    input fields stays aligned whether or not each field carries a validation
+    message (#394). Pre-resolving to `'center'` here silently suppressed that.
+
+    Args:
+        layout: The container's layout mode — `'column'`, `'row'` or `'grid'`.
+        horizontal_items: The x-axis value as given, or None if unset.
+        vertical_items: The y-axis value as given, or None if unset.
+        column_horizontal: Cross-axis override for column mode, for a container
+            whose column should not center — the AppShell page stretches instead.
+            Defaults to None (use the engine default).
+
+    Returns:
+        The pair to hand the layout frame. Either element may be None in column or
+        row mode, meaning "unset — let the engine decide"; both are concrete for a
+        grid. The None is only ever passed to `FlexFrame`; the grid path
+        (`_merge_layout_options`) runs solely in grid mode, where both are set.
+    """
+    if layout == "grid":
+        return (horizontal_items or "stretch", vertical_items or "stretch")
+    if layout == "column" and horizontal_items is None:
+        horizontal_items = column_horizontal
+    return (horizontal_items, vertical_items)
+
+
 def _flex_child_opts(child: PublicWidgetBase, layout_kw: dict) -> dict:
     """Build the FlexFrame per-child opts dict from resolved layout kwargs.
 
     Expects `_expand_margin` to have already converted margins to padx/pady.
     Carries spacer metadata when `child` is a `Spacer` (duck-typed to avoid a
     circular import).
+
+    A widget may also declare its own preferred cross-axis alignment via a
+    `_flex_horizontal_default` / `_flex_vertical_default` class attribute (same
+    duck-typing). That is a *soft* default: it applies only when neither the
+    child nor the container was given an explicit alignment, so it can never
+    override an instruction the author actually wrote. The field family uses it
+    to sit top-aligned in a Row instead of centering, since a field carrying a
+    validation message is taller than one that isn't (#394).
     """
     opts: dict[str, Any] = {}
     for key in ("grow", "horizontal", "vertical", "padx", "pady"):
         if key in layout_kw:
             opts[key] = layout_kw[key]
+    for axis in ("horizontal", "vertical"):
+        if axis not in opts:
+            declared = getattr(child, f"_flex_{axis}_default", None)
+            if declared is not None:
+                opts[f"_{axis}_default"] = declared
     if getattr(child, "_is_spacer", False):
         opts["_spacer"] = True
         opts["_spacer_size"] = getattr(child, "_spacer_size", None)

--- a/src/bootstack/widgets/_core/field_mixin.py
+++ b/src/bootstack/widgets/_core/field_mixin.py
@@ -23,6 +23,13 @@ class FieldAddonMixin:
     #: field wrappers override it (`'number'`, `'date'`, `'time'`).
     _VALIDATION_KIND: str = "text"
 
+    #: Cross-axis alignment a field contributes when the author set none. A
+    #: field that shows a validation message is taller than one that doesn't, so
+    #: centering them in a Row leaves the shorter ones sitting low; top-aligning
+    #: lines their labels and entries up instead. Soft — an explicit `vertical`
+    #: on the field or `vertical_items` on the container still wins (#394).
+    _flex_vertical_default: str = "top"
+
     _ADDON_TYPES = {
         "button":  "bootstack.widgets._impl.primitives.button::Button",
         "label":   "bootstack.widgets._impl.primitives.label::Label",

--- a/src/bootstack/widgets/_impl/composites/field.py
+++ b/src/bootstack/widgets/_impl/composites/field.py
@@ -223,7 +223,13 @@ class Field(EntryMixin, Frame):
         if label:
             self._label_lbl.pack(side='top', fill='x', padx=(4, 0))
 
-        self._field.pack(side='top', fill='x', expand=True)
+        # No vertical expand: when a field is given more height than it needs —
+        # a form grid stretches every cell to the tallest field in the row — the
+        # slack must collect BELOW the stack, not inside the entry row. With
+        # expand=True the entry row absorbed it and centered itself, so a field
+        # without a reserved message row sat ~half a message lower than its
+        # validated neighbors (#394).
+        self._field.pack(side='top', fill='x')
         self._entry.pack(side='left', fill='x', expand=True, padx=(0, 6) if kind == "spinbox" else 0, pady=0)
 
         self._entry.bind('<<StateChanged>>', self._sync_addon_state, add=True)

--- a/src/bootstack/widgets/_impl/primitives/flexframe.py
+++ b/src/bootstack/widgets/_impl/primitives/flexframe.py
@@ -51,8 +51,8 @@ class FlexFrame(Frame):
         master: Master = None,
         *,
         direction: str = "horizontal",
-        horizontal_items: str = "left",
-        vertical_items: str = "top",
+        horizontal_items: str | None = "left",
+        vertical_items: str | None = "top",
         grow_items: bool = False,
         weights: list[int] | None = None,
         gap: int = 0,
@@ -74,11 +74,15 @@ class FlexFrame(Frame):
             horizontal_items: How children are positioned on the x axis. For a
                 Row (horizontal stacks) this arranges the group
                 (`left`/`center`/`right`/`space-*`); for a Column it aligns each
-                child (`left`/`center`/`right`/`stretch`). Defaults to `'left'`.
+                child (`left`/`center`/`right`/`stretch`). `None` means unset —
+                the stacking axis then starts at its leading edge and the cross
+                axis centers, and on the cross axis a child may contribute its
+                own default. Defaults to `'left'`.
             vertical_items: How children are positioned on the y axis. For a
                 Column (vertical stacks) this arranges the group
                 (`top`/`center`/`bottom`/`space-*`); for a Row it aligns each
-                child (`top`/`center`/`bottom`/`stretch`). Defaults to `'top'`.
+                child (`top`/`center`/`bottom`/`stretch`). `None` means unset,
+                as for `horizontal_items`. Defaults to `'top'`.
             grow_items: When True, every content child grows equally (uniform)
                 to share the main axis. Defaults to False.
             weights: Positional shorthand for per-child `grow` —
@@ -130,6 +134,8 @@ class FlexFrame(Frame):
         else:
             value = self._vertical_items
             start, end = "top", "bottom"
+        if value is None:
+            return "start"  # unset: children stack from the leading edge
         if value == start:
             return "start"
         if value == end:
@@ -137,8 +143,41 @@ class FlexFrame(Frame):
         return value  # center, space-between, space-around, space-evenly
 
     def _cross_default(self) -> str:
-        """The cross-axis (non-stacking) container alignment value."""
-        return self._vertical_items if self._row_dir else self._horizontal_items
+        """The cross-axis (non-stacking) container alignment value.
+
+        `None` means the author never said — the cross axis then centers, which
+        is the framework-wide default (see the layout redesign).
+        """
+        value = self._vertical_items if self._row_dir else self._horizontal_items
+        return "center" if value is None else value
+
+    def _cross_is_unset(self) -> bool:
+        """True when no container-level cross-axis alignment was given.
+
+        Only then may a child contribute its own default (see `_resolve_cross`);
+        an alignment the author actually wrote always wins.
+        """
+        value = self._vertical_items if self._row_dir else self._horizontal_items
+        return value is None
+
+    def _resolve_cross(self, opts: dict[str, Any]) -> str:
+        """The cross-axis alignment to use for one child, most specific first.
+
+        Precedence: the child's own explicit `vertical`/`horizontal` kwarg, then
+        the container's `*_items` when the author set one, then a default the
+        child *itself* declares, and finally the framework default. The
+        child-declared step is what lets a field family opt out of centering
+        without overriding an instruction the author wrote (#394).
+        """
+        cross_key = "vertical" if self._row_dir else "horizontal"
+        value = opts.get(cross_key)
+        if value is not None:
+            return value
+        if self._cross_is_unset():
+            declared = opts.get(f"_{cross_key}_default")
+            if declared is not None:
+                return declared
+        return self._cross_default()
 
     def _cross_sticky(self, value: str) -> str:
         """Map a cross-axis edge value to Tk sticky chars for this direction."""
@@ -239,9 +278,7 @@ class FlexFrame(Frame):
         cross_cfg(0, weight=1)        # cross track fills so alignment has room
         main_cfg(idx, weight=0)
 
-        cross_key = "vertical" if row_dir else "horizontal"
-        cross_val = opts.get(cross_key) or self._cross_default()
-        sticky = self._cross_sticky(cross_val)
+        sticky = self._cross_sticky(self._resolve_cross(opts))
 
         main_axis = "padx" if row_dir else "pady"
         cross_axis = "pady" if row_dir else "padx"
@@ -273,11 +310,34 @@ class FlexFrame(Frame):
         self._gap = value
         self._relayout()
 
+    def _resolved_items(self, axis: str) -> str:
+        """The effective `*_items` value for a screen axis, never `None`.
+
+        An axis the author left unset is stored as `None`; the public property
+        must still read as a real alignment, so resolve it the same way the
+        planner does — the stacking axis starts at its leading edge, the cross
+        axis centers.
+
+        Note this getter resolves while the setter stores verbatim, so feeding a
+        read straight back into `configure()` records an explicit alignment and
+        an unset axis cannot be restored (the configure protocol reads `None` as
+        "get", not as "unset"). Accepted: treating an explicit `configure()` as
+        an instruction is the correct reading, and nothing in the framework does
+        that round trip.
+        """
+        is_main = (axis == "horizontal") == self._row_dir
+        if is_main:
+            value = self._horizontal_items if axis == "horizontal" else self._vertical_items
+            if value is not None:
+                return value
+            return "left" if axis == "horizontal" else "top"
+        return self._cross_default()
+
     @configure_delegate('horizontal_items')
     def _delegate_horizontal_items(self, value=None) -> str:
         """Get or set how children are positioned on the x axis."""
         if value is None:
-            return self._horizontal_items
+            return self._resolved_items("horizontal")
         self._horizontal_items = value
         self._relayout()
 
@@ -285,7 +345,7 @@ class FlexFrame(Frame):
     def _delegate_vertical_items(self, value=None) -> str:
         """Get or set how children are positioned on the y axis."""
         if value is None:
-            return self._vertical_items
+            return self._resolved_items("vertical")
         self._vertical_items = value
         self._relayout()
 
@@ -414,13 +474,12 @@ class FlexFrame(Frame):
 
             # Cross-axis sticky from the child's cross alignment (+ main-axis
             # stretch when growing). The cross axis is vertical for a Row and
-            # horizontal for a Column, so the relevant per-child key flips.
-            cross_key = "vertical" if row_dir else "horizontal"
-            cross_val = o.get(cross_key) or self._cross_default()
+            # horizontal for a Column, so the relevant per-child key flips —
+            # `_resolve_cross` owns that and the precedence rules.
             sticky = ""
             if grows:
                 sticky += "ew" if row_dir else "ns"
-            sticky += self._cross_sticky(cross_val)
+            sticky += self._cross_sticky(self._resolve_cross(o))
 
             # Gap (leading, between content only) + per-child margins.
             main_axis = "padx" if row_dir else "pady"

--- a/src/bootstack/widgets/appshell.py
+++ b/src/bootstack/widgets/appshell.py
@@ -16,7 +16,7 @@ from bootstack.widgets._impl.primitives.flexframe import FlexFrame
 from bootstack.widgets._impl.primitives.gridframe import GridFrame
 from bootstack.widgets._core.container import (
     GRID_KEYS, grid_sticky, place_flex_child, _reject_legacy_child_kwargs,
-    _expand_margin,
+    resolve_layout_items, _expand_margin,
 )
 from bootstack.widgets._core.context import push_container, pop_container
 from bootstack.widgets._core.window_controls import WindowControlsMixin
@@ -80,10 +80,9 @@ class Page:
 
         # Page content fills the content area, so a column stretches its children
         # across the width by default (a standalone Column centers them).
-        if horizontal_items is None:
-            horizontal_items = "stretch" if layout in ("grid", "column") else "left"
-        if vertical_items is None:
-            vertical_items = "stretch" if layout == "grid" else "center" if layout == "row" else "top"
+        horizontal_items, vertical_items = resolve_layout_items(
+            layout, horizontal_items, vertical_items, column_horizontal="stretch",
+        )
         self._layout = layout
         self._horizontal_items = horizontal_items
         self._vertical_items = vertical_items

--- a/src/bootstack/widgets/card.py
+++ b/src/bootstack/widgets/card.py
@@ -7,7 +7,7 @@ from bootstack.widgets._impl.primitives.flexframe import FlexFrame
 from bootstack.widgets._impl.primitives.gridframe import GridFrame
 from bootstack.widgets._core.container import (
     PublicContainer, GRID_KEYS, place_flex_child, grid_sticky,
-    _reject_legacy_child_kwargs,
+    resolve_layout_items, _reject_legacy_child_kwargs,
 )
 from bootstack.widgets.types import (
     AccentToken, Padding, LayoutKind, AutoFlow,
@@ -77,16 +77,9 @@ class Card(PublicContainer):
         # One horizontal_items/vertical_items pair serves both modes; the sensible
         # default differs — grid cells fill (stretch), stacked children sit at the
         # leading edge (left/top).
-        if horizontal_items is None:
-            horizontal_items = (
-                "stretch" if layout == "grid"
-                else "center" if layout == "column" else "left"
-            )
-        if vertical_items is None:
-            vertical_items = (
-                "stretch" if layout == "grid"
-                else "center" if layout == "row" else "top"
-            )
+        horizontal_items, vertical_items = resolve_layout_items(
+            layout, horizontal_items, vertical_items
+        )
 
         tk_master = self._parent._child_master() if self._parent else None
 

--- a/src/bootstack/widgets/expander.py
+++ b/src/bootstack/widgets/expander.py
@@ -9,7 +9,7 @@ from bootstack.widgets._impl.primitives.flexframe import FlexFrame
 from bootstack.widgets._impl.primitives.gridframe import GridFrame
 from bootstack.widgets._core.container import (
     PublicContainer, GRID_KEYS, grid_sticky, place_flex_child,
-    _reject_legacy_child_kwargs, _expand_margin,
+    resolve_layout_items, _reject_legacy_child_kwargs, _expand_margin,
 )
 from bootstack.widgets._core.base import PublicWidgetBase
 from bootstack.widgets._core.context import push_container, pop_container
@@ -107,16 +107,9 @@ class Expander(PublicContainer):
         layout_kw = self._split_layout_kwargs(kwargs)
         layout_kw.setdefault("horizontal", "stretch")
 
-        if horizontal_items is None:
-            horizontal_items = (
-                "stretch" if layout == "grid"
-                else "center" if layout == "column" else "left"
-            )
-        if vertical_items is None:
-            vertical_items = (
-                "stretch" if layout == "grid"
-                else "center" if layout == "row" else "top"
-            )
+        horizontal_items, vertical_items = resolve_layout_items(
+            layout, horizontal_items, vertical_items
+        )
 
         tk_master = self._parent._child_master() if self._parent else None
 
@@ -253,16 +246,9 @@ class AccordionSection:
         self._key = key
         self._layout = layout
 
-        if horizontal_items is None:
-            horizontal_items = (
-                "stretch" if layout == "grid"
-                else "center" if layout == "column" else "left"
-            )
-        if vertical_items is None:
-            vertical_items = (
-                "stretch" if layout == "grid"
-                else "center" if layout == "row" else "top"
-            )
+        horizontal_items, vertical_items = resolve_layout_items(
+            layout, horizontal_items, vertical_items
+        )
 
         content = internal_expander._content_frame
         if layout in ("column", "row"):

--- a/src/bootstack/widgets/groupbox.py
+++ b/src/bootstack/widgets/groupbox.py
@@ -8,7 +8,7 @@ from bootstack.widgets._impl.primitives.flexframe import FlexFrame
 from bootstack.widgets._impl.primitives.gridframe import GridFrame
 from bootstack.widgets._core.container import (
     PublicContainer, GRID_KEYS, place_flex_child, grid_sticky,
-    _reject_legacy_child_kwargs,
+    resolve_layout_items, _reject_legacy_child_kwargs,
 )
 from bootstack.widgets.types import (
     AccentToken, Padding, LayoutKind, AutoFlow, LocalizeMode,
@@ -82,16 +82,9 @@ class GroupBox(PublicContainer):
         # One horizontal_items/vertical_items pair serves both modes; the sensible
         # default differs — grid cells fill (stretch), stacked children sit at the
         # leading edge (left/top).
-        if horizontal_items is None:
-            horizontal_items = (
-                "stretch" if layout == "grid"
-                else "center" if layout == "column" else "left"
-            )
-        if vertical_items is None:
-            vertical_items = (
-                "stretch" if layout == "grid"
-                else "center" if layout == "row" else "top"
-            )
+        horizontal_items, vertical_items = resolve_layout_items(
+            layout, horizontal_items, vertical_items
+        )
 
         tk_master = self._parent._child_master() if self._parent else None
 

--- a/src/bootstack/widgets/pagestack.py
+++ b/src/bootstack/widgets/pagestack.py
@@ -9,7 +9,7 @@ from bootstack.widgets._impl.primitives.gridframe import GridFrame
 from bootstack.widgets._core.base import PublicWidgetBase
 from bootstack.widgets._core.container import (
     GRID_KEYS, grid_sticky, place_flex_child, _reject_legacy_child_kwargs,
-    _expand_margin,
+    resolve_layout_items, _expand_margin,
 )
 from bootstack.widgets._core.context import push_container, pop_container
 from bootstack.widgets._core.events import register_widget_events
@@ -59,16 +59,9 @@ class StackPage:
         self._owner = owner
         self._layout = layout
 
-        if horizontal_items is None:
-            horizontal_items = (
-                "stretch" if layout == "grid"
-                else "center" if layout == "column" else "left"
-            )
-        if vertical_items is None:
-            vertical_items = (
-                "stretch" if layout == "grid"
-                else "center" if layout == "row" else "top"
-            )
+        horizontal_items, vertical_items = resolve_layout_items(
+            layout, horizontal_items, vertical_items
+        )
 
         if layout in ("column", "row"):
             self._layout_frame = FlexFrame(

--- a/src/bootstack/widgets/select.py
+++ b/src/bootstack/widgets/select.py
@@ -79,6 +79,13 @@ class Select(PublicWidgetBase):
             See :doc:`/tasks/layout`.
     """
 
+    #: Same soft cross-axis default the field family declares on
+    #: `FieldAddonMixin`. Select is the one Field-backed widget that does not
+    #: inherit that mixin, but it grows a validation-message row identically, so
+    #: without this a Select sat low beside the fields it shares a Row with
+    #: (#394).
+    _flex_vertical_default: str = "top"
+
     def __init__(
         self,
         options: list[Option] | None = None,

--- a/src/bootstack/widgets/splitview.py
+++ b/src/bootstack/widgets/splitview.py
@@ -10,7 +10,7 @@ from bootstack.widgets._impl.primitives.gridframe import GridFrame
 from bootstack.widgets._core.base import PublicWidgetBase, adapt_handler
 from bootstack.widgets._core.container import (
     GRID_KEYS, grid_sticky, place_flex_child, _reject_legacy_child_kwargs,
-    _expand_margin,
+    resolve_layout_items, _expand_margin,
 )
 from bootstack.widgets._core.context import push_container, pop_container
 from bootstack.events import SashMoveEvent, Subscription
@@ -55,16 +55,9 @@ class SplitPane:
         self._owner = owner
         self._layout = layout
 
-        if horizontal_items is None:
-            horizontal_items = (
-                "stretch" if layout == "grid"
-                else "center" if layout == "column" else "left"
-            )
-        if vertical_items is None:
-            vertical_items = (
-                "stretch" if layout == "grid"
-                else "center" if layout == "row" else "top"
-            )
+        horizontal_items, vertical_items = resolve_layout_items(
+            layout, horizontal_items, vertical_items
+        )
 
         if layout in ("column", "row"):
             self._layout_frame = FlexFrame(

--- a/src/bootstack/widgets/stacks.py
+++ b/src/bootstack/widgets/stacks.py
@@ -18,8 +18,8 @@ class _FlexBase(FlexContainer):
         self,
         *,
         parent: Any = None,
-        horizontal_items: str = "left",
-        vertical_items: str = "top",
+        horizontal_items: str | None = None,
+        vertical_items: str | None = None,
         grow_items: bool = False,
         weights: list[int] | None = None,
         gap: int = 0,
@@ -33,6 +33,12 @@ class _FlexBase(FlexContainer):
         # Shared implementation for Row/Column. Each subclass declares its own
         # __init__ so Sphinx renders the (axis-specific) params and value types
         # per class.
+        #
+        # Both axes default to None — "the author did not say" — rather than to
+        # the effective value, so the engine can tell a written alignment from an
+        # absent one and let a child contribute its own cross-axis default
+        # (#394). FlexFrame resolves None: stacking axis to its leading edge,
+        # cross axis to center, which reproduces the documented defaults.
         self._parent = self._resolve_parent(parent)
         layout_kw = self._split_layout_kwargs(kwargs)
 
@@ -84,7 +90,10 @@ class Row(_FlexBase):
             no effect once any child grows. Defaults to `'left'`.
         vertical_items: Vertical alignment of children — `'top'`, `'center'`,
             `'bottom'`, or `'stretch'` (fill the row's height). Override per child
-            with `vertical`. Defaults to `'center'`.
+            with `vertical`. Defaults to `'center'`, except that input fields
+            align to the top on their own so a row of fields lines up whether or
+            not each one carries a validation message; setting this explicitly
+            applies to every child, fields included.
         grow_items: When `True`, every child grows equally to fill the row.
             Defaults to `False`.
         weights: Explicit per-child width weights (e.g. `[1, 2, 1]`) — shorthand
@@ -114,8 +123,8 @@ class Row(_FlexBase):
         self,
         *,
         parent: Any = None,
-        horizontal_items: HArrange = "left",
-        vertical_items: VAlign = "center",
+        horizontal_items: HArrange | None = None,
+        vertical_items: VAlign | None = None,
         grow_items: bool = False,
         weights: list[int] | None = None,
         gap: int = 0,
@@ -187,8 +196,8 @@ class Column(_FlexBase):
         self,
         *,
         parent: Any = None,
-        horizontal_items: HAlign = "center",
-        vertical_items: VArrange = "top",
+        horizontal_items: HAlign | None = None,
+        vertical_items: VArrange | None = None,
         grow_items: bool = False,
         weights: list[int] | None = None,
         gap: int = 0,

--- a/src/bootstack/widgets/tabs.py
+++ b/src/bootstack/widgets/tabs.py
@@ -10,7 +10,7 @@ from bootstack.widgets._impl.primitives.gridframe import GridFrame
 from bootstack.widgets._core.base import PublicWidgetBase, adapt_handler
 from bootstack.widgets._core.container import (
     GRID_KEYS, grid_sticky, place_flex_child, _reject_legacy_child_kwargs,
-    _expand_margin,
+    resolve_layout_items, _expand_margin,
 )
 from bootstack.widgets._core.context import push_container, pop_container
 from bootstack.widgets._core.events import register_widget_events, resolve_event
@@ -61,16 +61,9 @@ class TabPage:
         self._owner = owner
         self._layout = layout
 
-        if horizontal_items is None:
-            horizontal_items = (
-                "stretch" if layout == "grid"
-                else "center" if layout == "column" else "left"
-            )
-        if vertical_items is None:
-            vertical_items = (
-                "stretch" if layout == "grid"
-                else "center" if layout == "row" else "top"
-            )
+        horizontal_items, vertical_items = resolve_layout_items(
+            layout, horizontal_items, vertical_items
+        )
 
         if layout in ("column", "row"):
             self._layout_frame = FlexFrame(

--- a/tests/widgets/public/test_field_row_alignment.py
+++ b/tests/widgets/public/test_field_row_alignment.py
@@ -1,0 +1,226 @@
+"""Adding a validation rule must not misalign a row of fields (#394).
+
+A field reserves a message row the moment it carries a validation rule, making
+it taller than a field without one. Reported as a single bug, it was two:
+
+  (a) In a `Form`, every grid cell is already stretched to the tallest field in
+      the row, and the entry row inside the field absorbed that slack and
+      centered itself in it — so an unvalidated field's entry sat ~half a
+      message row low.
+  (b) In a hand-built `bs.Row`, the field frames keep their natural heights and
+      the row's cross-axis default (`center`) dropped the shorter ones.
+
+(b) is fixed by letting the field family contribute `vertical='top'` as a *soft*
+default — one that an explicit `vertical_items` on the container or `vertical` on
+the child still overrides. Those precedence tests are the important half of this
+file: a widget's own default must never silently beat an argument the author
+actually wrote.
+"""
+from __future__ import annotations
+
+import bootstack as bs
+
+
+def _sticky(widget) -> str:
+    """The Tk sticky string the layout engine gave this child's cell."""
+    return widget._internal.grid_info().get("sticky", "")
+
+
+def _entry_top(field) -> int:
+    """Screen y of the field's entry row — what misalignment is visible as."""
+    return field._internal._field.winfo_rooty()
+
+
+def _require(field, message: str = "required") -> None:
+    field.add_validation_rule("required", message=message, trigger="blur")
+
+
+# ----- (b) the hand-built Row --------------------------------------------------
+
+def test_row_of_fields_stays_aligned_when_only_some_are_validated(app):
+    row = bs.Row(parent=app, gap=4)
+    first = bs.TextField(parent=row, label="First")
+    middle = bs.TextField(parent=row, label="Middle")
+    last = bs.TextField(parent=row, label="Last")
+    app._tk_root.update_idletasks()
+
+    _require(first, "First is required")
+    _require(last, "Last is required")
+    app._tk_root.update_idletasks()
+
+    # Precondition: the rule really did make those two fields taller. Without
+    # this the alignment assertion below could pass vacuously.
+    assert first._internal.winfo_reqheight() > middle._internal.winfo_reqheight()
+
+    tops = {_entry_top(f) for f in (first, middle, last)}
+    assert len(tops) == 1, f"entries misaligned across the row: {tops}"
+
+
+def test_field_in_a_row_declares_top_alignment(app):
+    row = bs.Row(parent=app, gap=4)
+    field = bs.TextField(parent=row, label="Name")
+    label = bs.Label("Plain", parent=row)
+    app._tk_root.update_idletasks()
+
+    assert _sticky(field) == "n"
+    # The soft default belongs to the field family only — everything else keeps
+    # the framework-wide centered cross axis.
+    assert _sticky(label) == ""
+
+
+def test_explicit_vertical_items_overrides_the_field_default(app):
+    # THE TRAP this fix had to avoid: a widget's own default must not win over
+    # an alignment the author wrote out.
+    row = bs.Row(parent=app, gap=4, vertical_items="center")
+    first = bs.TextField(parent=row, label="First")
+    second = bs.TextField(parent=row, label="Second")
+    app._tk_root.update_idletasks()
+
+    assert _sticky(first) == ""
+    assert _sticky(second) == ""
+
+
+def test_explicit_vertical_items_stretch_still_reaches_fields(app):
+    row = bs.Row(parent=app, gap=4, vertical_items="stretch")
+    field = bs.TextField(parent=row, label="Name")
+    app._tk_root.update_idletasks()
+
+    assert _sticky(field) == "ns"
+
+
+def test_per_child_vertical_overrides_the_field_default(app):
+    row = bs.Row(parent=app, gap=4)
+    bottom = bs.TextField(parent=row, label="Bottom", vertical="bottom")
+    plain = bs.TextField(parent=row, label="Plain")
+    app._tk_root.update_idletasks()
+
+    assert _sticky(bottom) == "s"
+    assert _sticky(plain) == "n"
+
+
+def test_field_default_applies_on_the_append_fast_path_and_on_relayout(app):
+    # `_grid_appended_plain` (O(1) append) and `_relayout` resolve the cross
+    # axis at two separate call sites; a `grow` child forces the second one.
+    # Missing either would make alignment depend on whether a relayout ran.
+    fast = bs.Row(parent=app, gap=4)
+    fast_field = bs.TextField(parent=fast, label="Fast")
+    app._tk_root.update_idletasks()
+    assert fast._internal._can_append_in_place()
+    assert _sticky(fast_field) == "n"
+
+    slow = bs.Row(parent=app, gap=4)
+    slow_field = bs.TextField(parent=slow, label="Slow")
+    bs.TextField(parent=slow, label="Grower", grow=1)
+    app._tk_root.update_idletasks()
+    assert not slow._internal._can_append_in_place()
+    assert _sticky(slow_field) == "n"
+
+
+def test_column_of_fields_is_unaffected(app):
+    # In a Column the cross axis is horizontal, so the field's vertical default
+    # must not leak into it — a Column still stretches/centers as documented.
+    column = bs.Column(parent=app, gap=4)
+    field = bs.TextField(parent=column, label="Name")
+    app._tk_root.update_idletasks()
+
+    assert _sticky(field) == ""
+
+
+def test_unset_items_read_back_as_the_effective_alignment(app):
+    # The axes now store None internally when unset, so the configure delegate
+    # (the only read path for them) must report the effective alignment rather
+    # than leaking the None. These four values are the documented defaults.
+    row = bs.Row(parent=app)
+    column = bs.Column(parent=app)
+    app._tk_root.update_idletasks()
+
+    assert row._internal.cget("vertical_items") == "center"
+    assert row._internal.cget("horizontal_items") == "left"
+    assert column._internal.cget("horizontal_items") == "center"
+    assert column._internal.cget("vertical_items") == "top"
+
+
+def test_select_aligns_with_the_field_family(app):
+    # Select is the one Field-backed widget outside `FieldAddonMixin`, so it was
+    # left behind by the first pass and sat low beside real fields.
+    row = bs.Row(parent=app, gap=4)
+    text = bs.TextField(parent=row, label="Text")
+    select = bs.Select(parent=row, label="Select", options=["x", "y"])
+    number = bs.NumberField(parent=row, label="Num")
+    app._tk_root.update_idletasks()
+
+    _require(text)
+    app._tk_root.update_idletasks()
+
+    tops = {_entry_top(w) for w in (text, select, number)}
+    assert len(tops) == 1, f"Select misaligned against the field family: {tops}"
+
+
+# ----- row-mode containers other than Row --------------------------------------
+
+def test_row_mode_containers_align_their_fields(app):
+    # Card/GroupBox/Expander/Tabs/PageStack/SplitView/the AppShell page all used
+    # to resolve an unset cross axis to 'center' themselves, which suppressed the
+    # field default and left the same 9px offset inside them.
+    for factory in (
+        lambda: bs.Card(parent=app, layout="row", gap=4),
+        lambda: bs.GroupBox(parent=app, layout="row", gap=4),
+    ):
+        container = factory()
+        first = bs.TextField(parent=container, label="First")
+        middle = bs.TextField(parent=container, label="Middle")
+        app._tk_root.update_idletasks()
+
+        _require(first)
+        app._tk_root.update_idletasks()
+
+        tops = {_entry_top(f) for f in (first, middle)}
+        assert len(tops) == 1, (
+            f"{type(container).__name__}(layout='row') misaligned fields: {tops}"
+        )
+
+
+def test_row_mode_container_still_honors_an_explicit_alignment(app):
+    card = bs.Card(parent=app, layout="row", gap=4, vertical_items="center")
+    first = bs.TextField(parent=card, label="First")
+    app._tk_root.update_idletasks()
+
+    assert _sticky(first) == ""
+
+
+def test_column_mode_container_keeps_its_documented_cross_default(app):
+    # Passing None through must not change what a column does: these containers
+    # center their children horizontally, and the AppShell page stretches them.
+    card = bs.Card(parent=app, layout="column", gap=4)
+    label = bs.Label("x", parent=card)
+    app._tk_root.update_idletasks()
+
+    assert _sticky(label) == ""
+
+
+def test_grid_mode_container_still_stretches_cells(app):
+    # Grid mode has no notion of unset, so it must keep receiving real values.
+    card = bs.Card(parent=app, layout="grid", columns=2, gap=4)
+    label = bs.Label("x", parent=card)
+    app._tk_root.update_idletasks()
+
+    assert set(_sticky(label)) == set("nesw")  # Tk normalizes the char order
+
+
+# ----- (a) the Form / grid half ------------------------------------------------
+
+def test_form_row_stays_aligned_when_only_some_fields_are_validated(app):
+    form = bs.Form(parent=app, col_count=4, items=[
+        bs.FieldItem(key="first", label="First"),
+        bs.FieldItem(key="middle", label="Middle"),
+        bs.FieldItem(key="last", label="Last"),
+        bs.FieldItem(key="suffix", label="Suffix"),
+    ])
+    app._tk_root.update_idletasks()
+
+    _require(form.field("first"), "First is required")
+    _require(form.field("last"), "Last is required")
+    app._tk_root.update_idletasks()
+
+    tops = {_entry_top(form.field(k)) for k in ("first", "middle", "last", "suffix")}
+    assert len(tops) == 1, f"form entries misaligned: {tops}"


### PR DESCRIPTION
Fixes #394

## The report

A user on 0.1.8 / Windows: *"When adding validation to a widget, it pre-adds space for the validation message, causing the widgets to be misaligned on load."* Four fields in a row, `required` on two of them, and the two **without** a rule sit 9px lower.

Reserving the message row is deliberate — it's what stops the layout jumping when a message appears. The bug is that it was reserved *asymmetrically*.

## It was two bugs under one report

**(a) In a `Form`.** `_build_items` grids every cell `sticky='nsew'`, so all cells were already stretched to the tallest field in the row — the cells were never the problem. Inside the `Field` composite the entry row was packed `expand=True`, so it absorbed that slack and **centered itself in it**, putting the extra height *between the label and its own input*. Fixed by dropping `expand=True` so slack collects below the stack.

**(b) In a row-mode container.** Different mechanism: the field frames keep their natural heights (61 vs 80) and the cross-axis default (`center`) drops the shorter ones. The (a) fix does nothing here.

Two notes on the diagnosis: the reporter's own suggestion (a `vertical_items` knob on `GroupItem`) isn't needed — (a) was a defect inside the field itself. And the handoff claim that `bs.Grid` shares the bug is wrong; it defaults both axes to `stretch`, so its cells align once the entry stops centering in the slack.

## Approach for (b)

Field widgets contribute `vertical='top'` as a **soft** default. Precedence, most specific first:

1. the child's explicit `vertical=`
2. the container's explicit `vertical_items=`
3. the child-declared default
4. the framework default (`center`)

Step 3 applies **only** when the container's cross axis is unset — a widget's default must never silently beat an argument the author wrote (cf. #381).

To express "unset", `Row`/`Column` move to `*_items: ... | None = None` and `FlexFrame` resolves it. That's the convention `Card`, `GroupBox`, `Expander` and the AppShell page already use for this same kwarg, so it aligns `Row`/`Column` with four existing containers rather than inventing anything. `None` resolves to exactly what was hard-coded before — stacking axis at its leading edge, cross axis centered — so non-field layouts are byte-identical.

One `_resolve_cross()` owns the precedence at **both** call sites: `_relayout` and the O(1) `_grid_appended_plain` append path. Covering only one would make alignment depend on whether a relayout happened to run.

## Widened after code review

Review caught two gaps that left the fix half-effective:

- **Every row-mode container except `Row`** pre-resolved its own unset default to `'center'`, suppressing the field default. Measured `Card(layout="row")` `[248, 257, 248]` — the identical 9px. Since `Card(layout="row")` around a form row is common, this would have shipped visibly unfixed. Eight copies of that block collapse into one `resolve_layout_items()` helper; grid mode still gets concrete values, column/row pass the unset through.
- **`bs.Select`** is the one `Field`-backed widget outside `FieldAddonMixin` and has had `add_validation_rule` since #357, so it sat low beside real fields (562 vs 553). It carries the marker directly.

One review finding was disproved: the docstrings state the *effective* default while the signature shows `None`, which matches how `Card`/`GroupBox`/`Expander` are already worded. One is accepted and documented in-source: the delegate getter resolves while the setter stores verbatim, so a read-modify-write records an explicit alignment — unreachable from framework code, and treating an explicit `configure()` as an instruction is the correct reading.

## Behavior change worth flagging

Where a field shares a grid row or a `'stretch'` cross axis with a **taller** widget, the extra height used to be inserted between the label and the input, leaving the input floating below its caption; it now collects beneath the field. Measured in a stretched 142px cell: entry offset 59px → 19px. Called out under `### Changed` in the CHANGELOG.

Also: `Row()` and `Row(vertical_items='center')` now differ, though the docs call `center` the default. Deliberate — the alternative is ignoring an explicit argument — but worth knowing.

## Tests

New `tests/widgets/public/test_field_row_alignment.py` (14 tests); #394 previously had none. **5 fail pre-fix behaviorally** — `entries misaligned across the row: {180, 189}`, the reporter's exact 9px — not with an `AttributeError`. Each geometry assertion carries a precondition proving the rule really did grow the field, so none can pass vacuously. Covers both engine call sites, `Select`, row-mode containers, and guards that column and grid modes keep their documented defaults.

## Verification

- Full GUI suite **exit 0**, 893 passed / 13 skipped (`py -3.12 tests/run_gui.py`). Matters here — this touches the composite behind all 7 field widgets plus eight containers.
- Clean `-W` docs build **exit 0**, zero warnings.
- Geometry probes on the reporter's verbatim code: `Form`, `Row` and `Card(row)` all pixel-identical; an explicit `vertical_items='center'` still centers.
- Windows / Tk 8.6 only — no platform-specific code paths involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
