### PR TITLE
fix: Subscription.cancel() no longer silences the other handlers (#392)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,9 @@ and from 0.1.0 onward the project adheres to
   of behavior that unsubscribes as part of ordinary work: dialogs returning a
   result, field validation, meters, tab views, calendars, accordions,
   expanders, page stacks, and the theme toggle. Cancelling now removes exactly
-  the one handler it was asked to. (#392)
+  the one handler it was asked to — including when a handler cancels itself, or
+  cancels another handler for the same event, while that event is being
+  delivered. (#392)
 
 - **Adding a validation rule no longer misaligns a row of fields.** A field
   reserves space for its message as soon as it has a rule, and the fields

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ and from 0.1.0 onward the project adheres to
   expanders, page stacks, and the theme toggle. Cancelling now removes exactly
   the one handler it was asked to — including when a handler cancels itself, or
   cancels another handler for the same event, while that event is being
-  delivered. (#392)
+  delivered, and when a replacement handler is registered immediately after a
+  cancellation. (#392)
 
 - **Adding a validation rule no longer misaligns a row of fields.** A field
   reserves space for its message as soon as it has a rule, and the fields

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ and from 0.1.0 onward the project adheres to
 
 ### Fixed
 
+- **Cancelling one subscription no longer silences the others.** Calling
+  `cancel()` on a `Subscription` — or letting one fall out of a `with` block —
+  stopped every *other* handler listening to that same event on that widget,
+  with nothing raised to show for it. Two `on_click` handlers, cancel the first,
+  and neither ran again. It affected every bootstack event, and so a wide range
+  of behavior that unsubscribes as part of ordinary work: dialogs returning a
+  result, field validation, meters, tab views, calendars, accordions,
+  expanders, page stacks, and the theme toggle. Cancelling now removes exactly
+  the one handler it was asked to. (#392)
+
 - **Adding a validation rule no longer misaligns a row of fields.** A field
   reserves space for its message as soon as it has a rule, and the fields
   without one sat about nine pixels lower — both inside a `Form` and in a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,8 +72,9 @@ on the next statement, then grep the file.
 **Released:** `0.1.8` on PyPI, tag `v0.1.8` (2026-07-23); `pyproject.toml` is at
 `0.1.8`. **`main` is GREEN** (Windows, 893 passed, exit 0) with **no open PRs**.
 A failing test is a real signal — treat any red as a regression.
-**Working branch: `fix/392-subscription-cancel`** — green too (899 passed), all
-changes uncommitted. `main` itself is untouched.
+**Working branch: `fix/392-subscription-cancel`** — green too (**906 passed**),
+all changes uncommitted. `main` itself is untouched. The branch now carries
+**THREE logical changes** (see item 0) and wants a 3-way commit split.
 
 **⏭ THE ACTIVE TARGET IS `0.2.0`** — milestone **`0.2.0 — Form and field
 correctness`** (`gh` milestone **#6**). **A minor, not a patch, and that was a
@@ -81,62 +82,130 @@ deliberate maintainer call:** the project committed to SemVer at 0.1.0 and two
 merged changes are not backward compatible (**#381** raises where it used to
 accept; **#387** made `configure(data=)` genuinely clear absent keys). **#394**
 also moves pixels in any layout pairing a field with a taller widget on a stretch
-axis. Merged already: #332, #379, #381, #387, #388, #394. **#392 is FIXED but
-UNCOMMITTED on `fix/392-subscription-cancel`, awaiting the review in item 0
-below. Remaining after that: #389, #390.** Every themed milestone shifted OUT one
+axis. Merged already: #332, #379, #381, #387, #388, #394. **#392 is FIXED and
+REVIEWED but still UNCOMMITTED on `fix/392-subscription-cancel` — it is waiting
+on the maintainer's test pass, nothing else. Remaining after that: #389, #390.**
+Every themed milestone shifted OUT one
 minor —
 `0.2.x — Widget polish` (#2) · `0.3.0 — Guided flows` (#3) ·
 `0.4.0 — Power-user interactions` (#4) · `0.5.0 — Structured editing` (#5).
 Mapping + reasoning: memory `project_roadmap_milestones`.
 
-### ★ START HERE — CODE REVIEW the #392 branch, then #390 / #389, then cut 0.2.0
+### ★ START HERE — the #392 branch is REVIEWED; maintainer test pass, then #390 / #389, then cut 0.2.0
 
-0. **⇦ THE ASK FOR THIS SESSION: review `fix/392-subscription-cancel`.** The fix
-   is written, verified, and **UNCOMMITTED** — branch exists, nothing staged, the
-   maintainer wanted a review pass before any commit. `git diff` +
-   `git status --short` is the whole change:
-   - `src/bootstack/_runtime/events.py` — ~15 lines, the actual fix
-   - `tests/widgets/public/test_subscription_cancel.py` — NEW, 6 tests
-   - `CHANGELOG.md` — one `### Fixed` bullet under `## [Unreleased]`
-   - `development/verify_392_subscription_cancel.py` — NEW, hands-on demo
-     (untracked by convention, like the other `verify_*.py`; do NOT commit)
+0. **`fix/392-subscription-cancel` is DONE and REVIEWED — it needs the
+   maintainer's hands-on test pass and a commit split, not more analysis.**
+   Reviewed 2026-07-30 (`/code-review` + a follow-up pass); all four findings are
+   dispositioned below. **906 passed**, exit 0, clean `-W` docs build. Everything
+   is **UNCOMMITTED**; nothing staged.
 
-   The tree is otherwise clean, so **`git diff` really is just #392** — the
-   handoff-archive split that was sitting uncommitted alongside it was committed
-   first, on purpose, so this review is not reading a 1500-line docs diff.
+   **THREE logical changes on the branch — split into three commits:**
+   1. **The #392 fix itself** — `_runtime/events.py` `_patched_bind` emits stock's
+      exact script shape. Root cause below.
+   2. **Mid-dispatch cancel** — NEW `_patched_unbind` (`events.py:271`), wired
+      into `install/uninstall_enhanced_events`. Stock `unbind` deletes the Tcl
+      command immediately, but the copy of the concatenated script Tk is *running*
+      is not the one a removal rewrites — so cancelling a not-yet-run handler from
+      inside another handler for the same event hit the deleted command and
+      aborted the rest of that dispatch, just as silently as #392 itself. **This
+      was inherited stock-Tkinter behavior, reproduced on raw `tkinter`, NOT a
+      regression from change 1.** The patch neutralizes the command in place and
+      deletes it at the next idle point.
+   3. **`return 'break'` neutralized on the public surface** —
+      `adapt_handler` (`widgets/_core/base.py:16`) discards public handlers'
+      return values. See (a).
 
-   **Do not re-derive the root cause or re-run the baseline — both are recorded
-   below and were observed, not assumed.** Review altitude: the change is small
-   and green; spend the pass on whether emitting stock's script shape has
-   consequences nobody measured yet, not on restating what it does.
+   Files: `CHANGELOG.md`, `src/bootstack/_runtime/events.py`,
+   `src/bootstack/widgets/_core/base.py`,
+   `tests/widgets/public/test_subscription_cancel.py` (NEW, **14 tests**).
+   Untracked by convention, do NOT commit: `development/verify_392_*.py` (2),
+   `development/scan_392_break_handlers.py`,
+   `development/probe_392_unbind_gaps.py`.
 
-   **The four things actually worth attacking in review:**
-   (a) **`return 'break'` is now effective on virtual events** where it was
-   silently ignored — a real behavior change. An AST scan of all **75**
-   `return 'break'` sites in `src/` found exactly **two** bound to a `<<...>>`
-   sequence: `_handle_increment_event` / `_handle_decrement_event`
-   (`_impl/_parts/numberentry_part.py:127-128`), and both break **only** when the
-   field is non-interactive. Every gesture path and `numericentry.increment()`
-   already refuse to generate the event on a disabled field, so the only
-   reachable path is a hand-written `event_generate` on a disabled field — where
-   suppressing is arguably more correct. Scan script preserved at
-   **`development/scan_392_break_handlers.py`** (untracked, like the `verify_*`
-   scripts). **Re-run it rather than re-reading 75 sites.**
-   Deliberately NOT in the CHANGELOG: `break` is documented nowhere in `docs/`,
-   so advertising it would newly commit the project to it. Reviewer may disagree
-   — that's a legitimate call to reopen.
-   (b) The two omitted substitution codes: bootstack's list is stock's plus `%d`,
-   minus `%f` and `%W`. `%W` is unused because the wrapper recovers the widget
-   from a weakref. Confirm that's still true rather than assuming.
-   (c) The `wrapper` positional parameters must stay in lockstep with the
-   `subst` string — the fix keeps `%d` FIRST. There is no test that would catch a
-   reordering; consider whether one is worth adding.
-   (d) The new tests were checked to fail **pre-fix for behavioral reasons**
-   (5 of 6 — `{'c': 0} != {'c': 1}`, not `AttributeError`). The 6th
-   (cancel-everything) passes pre-fix **on purpose**: the bug silenced everything
-   too, so it guards the opposite error. Don't "fix" it as a dud.
+   **Review findings and their disposition — all four settled, don't reopen
+   without new evidence:**
+   (a) **`return 'break'` — DECIDED: not a public feature.** Change 1 made handler
+   return values significant where they had been discarded; a handler that merely
+   *computed* the string `'break'` would silently drop its siblings. `return
+   'break'` is also a quintessential Tk wart, and this project's whole premise is
+   that Tk is invisible — so adopting it (undocumented, but pinned by a test) was
+   the worst of both worlds. `adapt_handler` now returns `None`. **Internal
+   handlers are unaffected** — they bind through `self.bind(...)` and never pass
+   through `adapt_handler`, which is used at public `on()` boundaries only (the 12
+   retargeting wrappers + `base.py:214,223`). The AST scan still holds: of 26
+   `return 'break'` functions in `src/`, only `numberentry_part.py:127-128` bind to
+   a `<<...>>` sequence, and both are internal. **No CHANGELOG entry — the
+   behavior was never documented or reachable before this branch, so from a user's
+   view nothing changed** (explicit maintainer call). If suppressing later
+   handlers is ever wanted, it needs a native design (`event.stop()`), not an
+   inherited Tcl idiom. Scan script: `development/scan_392_break_handlers.py`.
+   (b) **`%W` omission — confirmed still correct.** `wrapper` recovers the widget
+   from `widget_ref()` (`events.py:209`) and never reads a `%W` path.
+   (c) **subst↔params lockstep test — deliberately NOT added.** A reorder moving
+   `%d` off first is caught by `test_a_surviving_handler_still_receives_its_payload`;
+   a count mismatch makes Tcl reject the call so every virtual-event test fails;
+   the other 17 codes are `??`/0 for virtual events, so a swap among them is inert.
+   (d) **Dialog `off_*` target drift → filed as #397** (not fixed here).
+   `on_dialog_result` binds to `self._dialog.toplevel or self._master` and
+   `off_dialog_result` *recomputes* it; `_toplevel` is `None` until `show()`, so
+   the two can resolve to different widgets. `message.py:239` ·
+   `datedialog.py:436` · `query.py:308` · `colorchooser.py:573` (which also uses
+   the opposite precedence). Latent — nothing in-repo calls these. `_patched_unbind`
+   already downgraded it from silent-catastrophe to silent-no-op.
 
-   **Root cause (settled, do not re-derive).** `_patched_bind` wrote its own Tcl
+   **⚠ `_patched_unbind` also changed one thing framework-wide, on purpose:** when
+   the funcid is **not found** in that widget's script it now deletes **nothing**
+   and returns. Stock deletes it anyway, which is what made (d) dangerous —
+   deleting a command you did not unbind orphans whatever *is* still bound to it.
+   Audited all ~95 `unbind` call sites in `src/`: no internal caller depends on the
+   old behavior, and two are *improved* by the guard (`contextmenu.py:931` and the
+   #397 dialog methods both unbind against a recomputed root/toplevel that can
+   drift). `_core/capabilities/bind.py:111` is a pure pass-through doc shim, so the
+   patch is reached through it.
+
+   **⚠ GOTCHA WORTH KEEPING — defer cleanup on the ROOT, never on the widget.**
+   `_patched_unbind` first scheduled its deferred `deletecommand` via
+   `self.after_idle(...)`. Destroying that widget tears down its own pending
+   callbacks, so **cancel-then-destroy** — an ordinary teardown order — left a
+   pending callback pointing at an already-swept command and emitted a *silent Tcl
+   background error*. Fixed by scheduling on `self._root()`, which outlives every
+   widget; when the root itself goes the callback goes with it and there is nothing
+   left to clean. The guard also catches `AttributeError`, because `destroy()`
+   nulls the widget's command bookkeeping and `deletecommand` then cannot update
+   it. Test: `test_cancelling_then_destroying_the_widget_is_quiet` — it reads the
+   interpreter's **background-error channel** directly, because the failure is
+   invisible to Python. **This class of bug has no public observable; if you defer
+   widget cleanup anywhere else, apply the same rule.**
+
+   **Measured, do NOT re-derive** (`development/probe_392_unbind_gaps.py` — re-run
+   it rather than rebuilding): 25 cancellations in ONE dispatch → 0 commands live
+   after idle; **200 bind/cancel cycles → 0 leaked**, `_tclCommands` empty, and
+   `update_idletasks` alone suffices (so the deferral does not need a full event
+   loop — it works under the shared-root harness); re-entrant dispatch (a handler
+   that emits a nested event and cancels during it) →
+   `['outer','inner-a','inner-b','outer-end','sibling']`, zero errors.
+   Cancel-ordering matrix (`development/verify_392_cancel_mid_dispatch.py`, all
+   five rows green): cancelling **self or an already-run handler is clean**;
+   cancelling a **not-yet-run** handler is what used to abort the remainder.
+
+   **#396 confirmed empirically, twice, while writing these tests.** A payload test
+   written on `bs.TextField` **passed vacuously** — `field.emit("change")` targets
+   `self._internal` while `on_change` binds the inner entry, so neither handler
+   ran. **Any test that pairs `emit()` with `on_*()` must use a widget where the
+   two agree** (`bs.Slider`, `bs.Button`) until #396 lands. Written into the test's
+   comment so it cannot rot back.
+
+   **Also found by the audit, unrelated → filed as #398.**
+   `on_visibility_alpha` never unbinds itself: `base_window.py:259` stores the
+   **funcid** in `alpha_bind`, `:43` passes it as the **sequence**. Measured — an
+   outright silent no-op, binding unchanged, no exception. X11-only, so it has
+   never run on either box. Issue also records two adjacent pre-existing shapes:
+   `textarea/sidebar.py:49` removes **every** `<<Change>>` handler on the shared
+   text widget including a user's, and `visual_focus.py:199` the same for root
+   `<Tab>`. **#397 and #398 are both UNMILESTONED — needs the maintainer's call**
+   (`0.2.x — Widget polish` looks right for both; internal-only, no compat break).
+
+   **Root cause of #392 (settled, do not re-derive).** `_patched_bind` wrote its own Tcl
    script for **virtual events** (`<<...>>` = every bootstack event) as a bare
    `<funcid> %d %# ...`, but **`unbind` was never patched to match**:
    `Misc._unbind` filters lines by the prefix `if {"[<funcid> ` that stock
@@ -159,10 +228,21 @@ Mapping + reasoning: memory `project_roadmap_milestones`.
    | after | `a=1 b=1 c=1` | `a=1 b=0 c=1` | `a=0 b=0 c=1` |
 
    **Verification already done — reproduce only if you distrust it:** full suite
-   `py -3.12 tests/run_gui.py` **exit 0**, main leg **899 passed** (893 + the 6
+   `py -3.12 tests/run_gui.py` **exit 0**, main leg **906 passed** (893 + the 13
    new), 18 legs, zero failures. Clean `-W` docs build succeeded warning-free
    (CHANGELOG is in the docs via `docs/release-notes.rst` — a CHANGELOG edit
    ALWAYS needs a docs build).
+
+   **Every new test was checked to fail PRE-FIX for a behavioral reason**, per
+   `feedback_tests_must_fail_for_the_right_reason` — `{'c': 0} != {'c': 1}`,
+   `{'b': 0} != {'b': 1}`, and for the teardown test the literal symptom
+   `assert ['invalid command name "..._delete_command"'] == []`. **FOUR tests pass
+   pre-fix ON PURPOSE and are annotated `PASSES PRE-FIX ON PURPOSE` in-place —
+   do NOT delete them as duds:** cancel-everything (the bug silenced everything
+   too), cancel-the-last-handler (nothing behind it to swallow), self-cancel (its
+   own line was already evaluated), and the no-leak guard (the old code deleted
+   immediately, so this guards the *cost* of deferring). Each guards the opposite
+   or the regression error.
 
    **Portability, established by measurement (don't re-litigate):** Tk's bind
    substitution codes are **identical in 8.6 and 9.0** — `%d` carries virtual-event
@@ -231,7 +311,8 @@ leak-fix.
   scene reset has been a no-op for content widgets for the entire life of the
   shared-root harness**, and every test's widgets pile up all session. Fixing it
   makes PageStack pass with no `isolated` marker and cuts the widget leg
-  **144s → 80s**. Held back because it exposes **#392** and a second latent bug
+  **144s → 80s**. Held back because it exposed **#392** — **now FIXED, so that
+  blocker is gone** — plus a second latent bug that is still open
   (`test_select_change_event_value_space` picking up 5 change events from earlier
   tests — looks like stale bindtag bindings surviving destroy while Tk recycles
   widget path names; not chased down). Own branch, after #392 lands.
@@ -260,7 +341,11 @@ leak-fix.
 ### Open, additive items (not ship-blockers)
 
 - **#396 — `emit()` and `on()` target DIFFERENT widgets on 11 wrappers.** Found
-  while writing the #392 tests. Milestoned `0.2.x — Widget polish`: it is
+  while writing the #392 tests, and **re-confirmed empirically during the #392
+  review** when a payload test written on `bs.TextField` passed vacuously. ⚠
+  **Until this lands, any test pairing `emit()` with `on_*()` must use a widget
+  where the two agree** (`bs.Slider`, `bs.Button`) or it proves nothing.
+  Milestoned `0.2.x — Widget polish`: it is
   **additive** (a silent no-op starts working), so unlike #369/#383 it is
   patch-safe and does NOT need a minor of its own. The 11 wrappers that
   override `on()` — `textfield`, `datefield`, `numberfield`, `passwordfield`,
@@ -438,6 +523,22 @@ AFTER its PR merged is **stranded** — verify it landed in `main`.
   `obj._cleanup_x = spy` set afterward never fires and reads as "cleanup never
   ran". **Patch the CLASS attribute before constructing**, or assert on the
   observable side effect.
+- **⚠ Some failures are INVISIBLE TO PYTHON — read the interpreter's
+  background-error channel.** A binding or `after` script that references a deleted
+  Tcl command raises nothing Python can see; the suite stays green and the symptom
+  is "handlers mysteriously stopped running". Install a collector
+  (`root.tk.createcommand('bgerror', collector)`, and `deletecommand` it in a
+  `finally` so the shared root is left clean) and assert the list is empty. This is
+  what #392 was, and it is what caught a scheduling defect in #392's own fix. When a
+  bug has no public observable, this channel IS the observable — reach for it before
+  concluding "cannot be tested".
+- **⚠ Defer widget cleanup on the ROOT, never on the widget.** `widget.after_idle(cb)`
+  registers `cb` as a command owned by that widget, so destroying the widget deletes
+  `cb` while the timer is still pending and Tcl fires an orphan. Use
+  `widget._root().after_idle(...)`: the root outlives every widget, and when the root
+  goes the pending callback goes with it. Guard the callback against both `TclError`
+  **and `AttributeError`** — `destroy()` sets `_tclCommands` to `None`, which
+  `deletecommand` then cannot update. Cost a real defect in the #392 follow-up.
 - **⚠ A bulk `pathlib` rewrite flips CRLF→LF** (repo is `core.autocrlf=true`) —
   same class as the `sed -i` trap. Prefer the Edit tool; if scripting, write bytes.
   Memory `reference_autocrlf_sed_gotcha`.
@@ -451,7 +552,7 @@ Full detail (root causes, decisions, gotchas) is in
 
 | Release | Contents |
 |---|---|
-| unreleased → **0.2.0** | #332 internal `set_*_visible` → properties · #379/#385 menu-backend test portability · #381 `InvalidChoiceError` on bad behavior-mode kwargs · #387 `DateField` clear + `Form.set()` merge · #388 date-picker `<<Change>>` · #394/#395 field row alignment |
+| unreleased → **0.2.0** | #332 internal `set_*_visible` → properties · #379/#385 menu-backend test portability · #381 `InvalidChoiceError` on bad behavior-mode kwargs · #387 `DateField` clear + `Form.set()` merge · #388 date-picker `<<Change>>` · #394/#395 field row alignment · #392 subscription cancel (script shape + mid-dispatch `unbind` + handler return values inert) |
 | **0.1.8** | macOS sizing on Tcl/Tk 9 (Aqua 72→96 DPI baseline broke `detect_scale_factor()`) |
 | **0.1.7** | Tk 9 scroll-event contract (`<TouchpadScroll>`, ±120 deltas, X11 TIP 474) + attach theme repaint |
 | **0.1.6** | Seven form/field/validation fixes (#362–#368, #371) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,1528 +11,464 @@ and ease of use, not compatibility with the raw tk/ttk surface.
 **Design philosophy:** Opinionated and configurable within a reasonable range.
 Go from nothing to something fast. The user should never need to `import tkinter`.
 
-**Working directory:** `D:\Development\bootstack`
+**Working directory:** `D:\Development\bootstack` (Windows box) — see Environment.
 **Branch strategy:** `feat/*` branches off `main`. PRs go `feat/*` → `main`.
+
+> 📓 **Session history lives in `docs/_dev/handoff-archive.md`** — every shipped
+> initiative with its full root-cause analysis, decisions, and gotchas. This file
+> keeps only what is OPEN plus the standing rules. **Read the archive when you
+> touch an area it covers** (it is indexed by issue/PR number); don't re-derive a
+> root cause that is already written down there.
+>
+> ⚠ The archive spent a while **untracked** — it was split out of this file on
+> 2026-07-30 and that session ended before committing either half. Committed
+> 2026-07-30 (`docs(claude): split session history…`). **Lesson worth keeping: a
+> handoff artifact only survives if it is IN THE REPO.** The same failure mode
+> already cost us #379's `leakfix.patch`, which was saved to a per-session temp
+> `scratchpad/` and is genuinely gone.
 
 ---
 
-## Recently completed (all merged to `main`)
+## Environment — TWO MACHINES. Check which one you are on first.
 
-Pointers only — these shipped; rationale, detail, and gotchas live in the linked
-memories and git history.
+**Windows box** (`D:\Development\bootstack`): the checked-in `.venv` is **STALE**
+— it points at a `Python314\python.exe` that fails with *"Access is denied"*. Use
+the launcher. **`py -3.12` for BOTH tests and docs** — **pytest is installed ONLY
+on 3.12** (9.0.3); `py -3.13 tests/run_gui.py` fails every leg with *"No module
+named pytest"* **while still printing a plausible-looking harness summary**. 3.13
+and 3.14 have neither pytest nor the docs deps. `py -3.13` (3.13.7, Tk 8.6) is
+fine for **running demo scripts**, which is all it is good for.
+`bootstack.__version__` reports a stale `0.1.0a9` from old install metadata —
+harmless, ignore it.
 
-- **#394 → PR #395 (MERGED 2026-07-29) — a validation rule misaligned a row of
-  fields.** Reporter `bLynnb2762` on 0.1.8/Windows: adding `required` to two of
-  four fields in a row left the other two sitting **9px lower**. **It was TWO bugs
-  under one report** — that split is the whole finding, don't re-derive it.
-  - **(a) In a `Form`.** `_build_items` grids every cell `sticky='nsew'`, so all
-    cells were **already** stretched to the tallest field — the cells were never
-    the problem. Inside the `Field` composite the entry row was packed
-    **`expand=True`**, so it absorbed the slack and **centered itself in it**,
-    putting the extra height *between the label and its own input*. Fix = drop
-    that one `expand=True` (`field.py`) so slack collects below the stack. ⚠ The
-    reporter's own diagnosis (a `vertical_items` knob on `GroupItem`) was **wrong**
-    and so was the first read here — **the Form needed no new alignment knob.**
-  - **(b) In a row-mode container.** Different mechanism: the field frames keep
-    their **natural** heights (61 vs 80) and the cross-axis default (`center`)
-    dropped the shorter ones; (a) does nothing here. Fix (maintainer's call) =
-    field widgets contribute **`vertical='top'` as a SOFT default**. Precedence,
-    most specific first: child's explicit `vertical=` → container's explicit
-    `vertical_items=` → **child-declared default (only when the container's cross
-    axis is unset)** → framework `center`. **That gate is the whole trap:** a
-    widget default must never silently beat an argument the author wrote (cf.
-    #381). To express "unset", `Row`/`Column` moved to `*_items: ... | None = None`
-    resolved inside `FlexFrame` — **the `None`-means-unset convention `Card`/
-    `GroupBox`/`Expander`/the AppShell page already used**, so this aligned
-    `Row`/`Column` with four existing containers rather than inventing anything.
-    `None` resolves to exactly what was hard-coded (stacking axis → leading edge,
-    cross axis → center), so non-field layouts are unchanged. One
-    **`_resolve_cross()`** owns precedence at **BOTH** call sites — `_relayout`
-    **and** the O(1) `_grid_appended_plain` append path; covering only one would
-    make alignment depend on whether a relayout happened to run.
-  - **Scope widened by `/code-review`, which caught two gaps that left the fix
-    half-effective.** (1) **Every row-mode container except `Row`** pre-resolved
-    its own unset default to `'center'`, suppressing the field default — measured
-    `Card(layout="row")` `[248, 257, 248]`, the identical 9px. Since
-    `Card(layout="row")` around a form row is common this would have **shipped
-    visibly unfixed**; eight copies of that block collapsed into one
-    **`resolve_layout_items()`** (`_core/container.py`) — grid mode still gets
-    concrete values (the grid engine has no "unset"), column/row pass it through.
-    (2) **`bs.Select`** is the ONE `Field`-backed public widget outside
-    `FieldAddonMixin` (its `SelectBox` subclasses `Field`) and has had
-    `add_validation_rule` since #357, so it sat low beside real fields (562 vs
-    553) — it carries `_flex_vertical_default` directly.
-  - **⚠ TWO CORRECTIONS to earlier notes.** (i) The prior handoff claimed
-    **`bs.Grid` has the same bug** — **it does not.** `Grid` defaults **both** axes
-    to `stretch`, so its cells align once the entry stops centering in the slack
-    (measured). There was never a Grid decision to make. (ii) A review finding
-    claimed the docstrings contradict the signature by stating the effective
-    default while rendering `| None = None` — **that is the house style**
-    (`card.py:33` already reads that way), so it was left alone.
-  - **Known asymmetry, accepted:** `Row()` and `Row(vertical_items='center')` now
-    behave **differently** even though the docs call `center` the default — an
-    author who writes the default out explicitly gets centered fields. Deliberate
-    (the alternative is ignoring an explicit argument) but it is a trap, and it is
-    the strongest argument against the soft-default approach if it is ever
-    revisited. Also **CHANGELOG `### Changed`:** where a field shares a grid row
-    or a `'stretch'` cross axis with a **taller** widget the entry moved from
-    centered to under its label (measured 59px → 19px in a 142px cell) — an
-    improvement (the input no longer floats below its own caption) but a real
-    visual change. Doc screenshot scenes were checked: they pair fields with
-    *shorter* siblings, so none needed regenerating.
-  - Tests **`test_field_row_alignment.py`** (14) — #394 had none. **5 fail pre-fix
-    BEHAVIORALLY** (`entries misaligned across the row: {180, 189}`), not with an
-    `AttributeError`, and each geometry assertion carries a precondition proving
-    the rule really grew the field so it cannot pass vacuously. Suite **893 passed,
-    exit 0**; clean `-W` docs build. **The geometry probes were far more decisive
-    than reading the layout code**, which is tangled across FlexFrame / GridFrame /
-    raw pack — rebuild one rather than reading, if this area comes up again (the
-    scratch probes and the reporter-repro demo were deleted once #394 shipped;
-    they were for visual validation only). Two rules that mattered: a
-    within-process measurement is required — `winfo_rooty()` is **not** comparable
-    across two runs (different window positions), so compare siblings in one run or
-    measure the entry's offset *inside* the field frame; and pair any alignment
-    assertion with a precondition proving the rule really grew the field, or it can
-    pass vacuously. Memory `reference_geometry_probe_same_process`.
-  - **Process gotcha that bit here:** a bulk `pathlib` rewrite of 6 files
-    **flipped CRLF→LF** (repo is `core.autocrlf=true`) — same class as the `sed -i`
-    trap in `reference_autocrlf_sed_gotcha`. Caught from the `git diff` warning and
-    restored; prefer the Edit tool, and if scripting, write bytes.
+**macOS box:** repo at **`/Users/israeldryer/PycharmProjects/bootstack`**. Here
+**`.venv` WORKS**: `.venv/bin/python` = **Python 3.14.0, Tk 8.6**, editable
+install, macOS **26.5.2**. `python tests/run_gui.py` runs the full GUI suite in
+~2 min with a real display. ⚠ Tk here is **8.6, not 9** — this box does NOT
+exercise the Tk 9 paths, so `test_scroll_events.py`'s touchpad tests SKIP.
+`python3.13` exists system-wide but does **NOT** have bootstack installed.
 
-- **0.1.x session 2026-07-29 — discussion #386 triaged into four issues, two
-  fixed and merged, plus #385.** User `bLynnb2762` filed **discussion #386** as an
-  *idea* ("let me reset a `DateField` to `None`"); investigation found **two real
-  bugs underneath it**, both now on `main`, and split the rest into a feature and
-  a design question. **All Windows + Tk 8.6.**
-  - **#387 → PR #391 (MERGED).** `DateField.value = None` **and its own public
-    `clear()`** were silent no-ops — the date stayed on screen and in
-    `form.get()`. **Root cause: `TextEntryPart.value()` (`_parts/textentry_part.py`)
-    is a combined getter/setter using `None` as its "no argument" sentinel**, so
-    `value(None)` called the *getter*. The set branch already handled `None`
-    correctly — which is exactly why the `.value = ''` workaround worked, same code
-    path. Fix = a module-level **`_UNSET`** sentinel (also in `spinnerentry_part.py`,
-    which carries its own copy). Verified no caller passed `None` expecting a get.
-    Affected **every** field on `TextEntryPart`; it surfaced on `DateField` only
-    because that is the one whose `clear()` passes `None` (the others pass `""` and
-    worked by accident). `TimeField` was immune — `TimeEntry` subclasses `SelectBox`.
-    ⚠ **The landmine:** `Form.set()` looped **all** items applying
-    `_data.get(key)` = `None` for absent keys, harmless ONLY because that write was
-    discarded — so **fixing the sentinel alone would have turned every partial
-    `form.set()` into a destructive overwrite**, including the reporter's own code.
-    `set()` now writes only the keys given and **merges** into `_data` instead of
-    replacing (which also fixed a latent bug: partial updates used to *drop* the
-    unmentioned keys from `_data`). Deliberate: `configure(data=)` stays a
-    whole-record write, so absent keys now genuinely clear.
-  - **#388 → PR #393 (MERGED).** Choosing a date in the picker emitted **no
-    `<<Change>>`** — a bound `Signal` stayed stale, `on_change` never ran, `Form`
-    never registered the edit, while typing the same date and pressing Return
-    worked. `_show_date_picker` assigned `value` directly; that event comes only
-    from `_check_if_changed()` on FocusOut/Return. **Range mode was already correct**
-    (`_set_range` emits) — single mode was the outlier. Fix = both call sites route
-    through **`_apply_picked`**, which assigns then calls the entry's **existing**
-    `_check_if_changed()`. Reusing it (not hand-building a `ChangeEvent`) is what
-    makes it safe: it advances `_prev_changed_value`, so a later focus-out cannot
-    re-announce the same pick, and the double application (dialog callback + the
-    post-`show()` fallback) is inert on the second pass. Also corrected the
-    DateField docs, which claimed `on_change` fires on a `value=` assignment — it
-    does not, by design.
-  - **#389 FILED** — `Form.reset()` (construction-time values) and `Form.clear()`
-    (`None`). **Maintainer decision: they are DIFFERENT verbs** — reset = originals,
-    clear = none. Both justified: `reset()` is **not user-implementable** (after an
-    edit, `get()` no longer knows the original), `clear()` is the data-entry case.
-    Slider clears to `min_value` (it has no null state, and that is already the
-    de-facto seeding behavior). Needs an `__init__` snapshot because `set()`
-    destroys `_data`; both must clear validation state.
-  - **#390 FILED (design, needs a decision)** — see the signal-emptiness entry
-    under "Next up".
-  - **#385 MERGED** — validated on Windows first (869 passed, exit 0, with `main`
-    merged in). Its `test_menu_backend_probe.py` runs **16 tests, zero skips** here.
-  - **#383** got the `Slider.value = None` → raw `TypeError` case added to its sweep.
+**Running tests:** `python tests/run_gui.py` (one root per process, `#150`).
+**Docs:** clean-build always — incremental builds MASK warnings.
+`rm -rf docs/_build && sphinx-build -b html docs docs/_build/html -W --keep-going`.
 
-- **0.1.8 PATCH SHIPPED — macOS sizing on Tcl/Tk 9 (PR #377 for #375;
-  2026-07-23).** `bootstack 0.1.8` is on **PyPI** + tagged **`v0.1.8`**. Tk 9
-  changed the resolution macOS reports (Aqua's **72 → 96 DPI** baseline), and
-  `detect_scale_factor()` (`winfo_fpixels('1i')/72`) read that as a high-density
-  display — so on any Tk 9-linked Python the whole UI rendered **~1/3 too
-  large**. Text, icons, padding, control sizes all restored; matches Tk 8.6
-  exactly. Win/Linux unaffected. Tests **`test_tk9_scaling_baseline.py`** (8) —
-  and note they **monkeypatch `platform.system()` + `tkinter.TkVersion`, so they
-  need no display and no Tk 9**, which is why #380 calls them the cheap CI win.
-  ⚠ **CHANGELOG/release gotcha bit this cut** — see the release-flow note under
-  "Next up".
+**⚠ `tests/widgets/*.py` NEVER RUNS.** `testpaths` is `tests/cli`,
+`tests/widgets/public`, `tests/data`, and `run_gui.py` passes those same paths —
+so **12 files / 25 tests** directly under `tests/widgets/` (`test_shell_*`,
+`test_icon_image_props`, `test_rebuild_regressions`, `test_toolbar_drag`) are
+collected by nothing. All 25 **pass** run individually (each builds its own root,
+so they'd need `isolated` treatment). Dead coverage — fold into #380.
 
-- **0.1.x session 2026-07-28 — three PRs merged/open, one issue filed.** Worked
-  the open-issue backlog. **All verified on Windows + Tk 8.6 only** (see the
-  environment note below).
-  - **#381 → PR #382 (MERGED).** A behavior-mode argument is read by comparing
-    against one literal, so `selection_mode="multiple"` silently turned
-    multi-select **off** — no error, no warning. New **`validate_choice`**
-    (`widgets/_core/choices.py`) + public **`InvalidChoiceError`**, applied to
-    `selection_mode` (DataTable/ListView/Tree/Gallery/Calendar/DateField),
-    DataTable `sorting_mode`/`paging_mode`, `mode` (ToggleGroup/PathField),
-    ScrollView `scroll_direction`/`scrollbar_visibility`, `scrollbars`
-    (TextArea/CodeEditor), sidebar-toggle `collapse`. `SELECTION_MODES =
-    get_args(SelectionMode)` so the check can't drift from the type.
-    **Two decisions worth remembering:** (1) the issue cited #367 as precedent
-    for raising on a bad `editor=` name — **that is wrong**, #367 made the
-    *fallback* safe and never raises; the real precedent is **`ValueError`**
-    (`ContextMenu(trigger=)`, RadioGroup), so `InvalidChoiceError` inherits
-    **both** `BootstackError` and `ValueError` and those older guards can migrate
-    later without breaking callers. (2) **Scope was measured, not guessed** — an
-    AST audit found **215** Literal-typed public `__init__` kwargs and a 24-case
-    probe found **17 silently accepting** garbage; a blanket sweep is wrong
-    because **`| str`-widened args (`accent`/`surface`) must NOT be guarded**
-    (`'primary[+1]'`, `'primary[500]'` aren't in the alias). Line drawn at
-    *behavior* modes. **Guards run BEFORE `_resolve_parent`** — it raises its own
-    "created outside any container" error, which buried the typo.
-  - **#332 → PR #384 (MERGED).** Not really a rename: `ShellLayout` held each
-    flag **twice** — read-only `statusbar_visible`/`rail_visible`/
-    `sidebar_visible`/`dock_visible` properties *and* a separate
-    `set_*_visible(bool)` family. Gave the existing properties setters, deleted
-    the methods. Properties (not `show_*`/`hide_*` verb pairs) because the
-    getters and every sibling region accessor already are, and callers assign
-    computed bools that verb pairs would turn back into if/else.
-    `AppShell.statusbar`'s reveal hook was a **lambda** (can't hold an
-    assignment) → named `_reveal_statusbar`. Internal only.
-  - **#379 → PR #385 (MERGED 2026-07-29, after a macOS run AND a Windows
-    re-validation).** Six macOS failures, none a
-    product bug. New **`menu_probe`** + **`menus_are_native`** fixtures in
-    `tests/conftest.py` so the four backend-assuming tests assert the same fact
-    on both `ContextMenu` backends instead of the Windows shape (a `skipif` would
-    have *preserved* the coverage hole — those are the only tests for menu
-    construction + overlay propagation). **Key technique: `_NativeContextMenu` is
-    constructible on Windows** (a `tk.Menu` is real everywhere; only the *choice*
-    of backend is platform-specific), so `test_menu_backend_probe.py` (16) drives
-    **both backend classes directly** and the macOS branch is exercised on
-    Win/Linux. That caught a real defect in the helper: **`entrycget(i,'state')`
-    raises `TclError` on a SEPARATOR** on the native backend while the themed one
-    returns `False`. Measured: both agree count=3 and index alignment for
-    `[command, separator, command]` — only the separator's state differed.
-    **PageStack order-dependence hypothesis (UNCONFIRMED):** `shown_app` did
-    `deiconify()` + **`update_idletasks()`, which does not process the map event
-    at all** (idle callbacks only), so `winfo_ismapped()` depended on what was
-    queued ahead; now pumps `update()` until mapped (bounded 100). **The PR body
-    carries step-by-step macOS tester instructions**, including what each failure
-    mode means if PageStack still fails.
-  - **#383 FILED** — the follow-up sweep: presentation kwargs still degrading
-    silently (`density`, `Tabs.orient`, `Slider.orient`, `Gauge.variant`) **plus**
-    args that raise but leak a **raw `TclError`/`AttributeError`**
-    (`Button.icon_position`, `Label.justify`, `Scrollbar.variant`,
-    `Expander.icon_position`, `ProgressBar.mode`). Suggests sweeping **by argument
-    name**, not by widget.
+**⚠ Never pipe a build/test command to `tail`** — you capture `tail`'s exit 0 and
+miss real failures (it once hid a failing test leg AND a broken docs build).
+**This bites in PowerShell too**: `pytest ... | Select-String ...` leaves
+`$LASTEXITCODE` from the *pipeline*. Redirect to a file, capture `$LASTEXITCODE`
+on the next statement, then grep the file.
 
-- **0.1.7 PATCH SHIPPED — Tk 9 scroll-event contract + attach theme repaint
-  (PRs #373, #374; 2026-07-23).** `bootstack 0.1.7` is on **PyPI** + tagged
-  **`v0.1.7`** ("Tcl/Tk 9 scroll support"); verified by installing the published
-  wheel into a clean Tk 9 venv. **#372** ("Scroll not
-  working on MacOS", user `cleonello`): scrolling
-  worked on Python 3.13.9, not 3.14.6. **It is NOT a Python change** — `tkinter`
-  is unchanged between those versions apart from docstrings, `after(**kw)`, and
-  `trace_variable` deprecation warnings. It is **Tcl/Tk 8.6 → 9.0** (reporter had
-  9.0.3; the python.org installer still ships **8.6.17**, which is why 3.13
-  "worked"). **Root cause, measured not inferred:** on Tk 9 + Aqua a trackpad
-  fires **only `<TouchpadScroll>`** — a probe logged **293 TouchpadScroll, ZERO
-  MouseWheel** — and every scrolling widget bound only `<MouseWheel>`. Two more
-  breaks in the same contract: Tk 9 normalizes wheel deltas to **±120** on all
-  platforms (so Aqua's `-event.delta` scrolled 120 units/notch), and X11
-  **Button-4/5 are no longer delivered to scripts** (TIP 474). **Fix:** new
-  **`_runtime/wheel.py`** (`wheel_sequences` / `wheel_notches` / `precise_deltas` /
-  `scale_num` / `PixelAccumulator`) replacing the delta branch **duplicated across
-  9 files**; bindings unconditional, X11 buttons kept only as a Tk ≤8.6 fallback
-  gated on **Tk version, not `winsys`**. Widgets copy Tk's **two** conventions:
-  *pixel* scrolling (ScrollView/TextArea/ScrolledText/Tabs) vs *accumulated whole
-  rows* (ListView/Tree/Gallery), plus a 40px/step throttle on the Spinbox/
-  NumberField steppers. **DataTable needed nothing** — Tk 9 binds TouchpadScroll on
-  the ttk Treeview class itself (verified). Incidental fix: a ScrollView notch moved
-  **10 canvas units on X11** vs 1 elsewhere; now 1 everywhere. Tests
-  **`test_scroll_events.py`** (25; 3 fail pre-fix). Verified on **Tk 9.0.4 AND
-  8.6.17** + confirmed live on a real trackpad. Full suite on Tk 9: **751 passed**,
-  only the 6 known pre-existing failures. `trace_variable`/`trace_vdelete`/
-  `trace_vinfo` (removed in Tcl 9) are **not used** anywhere — scrolling was the
-  only Tk 9 gap. Memory `reference_tk9_scroll_events`.
-  **Repro env:** `brew install python-tk@3.14` → `/opt/homebrew/opt/python@3.14/bin/python3.14`
-  (3.14.6 + Tcl/Tk 9.0.4). **⚠ The touchpad tests SKIP on Tk 8.6** — on the default
-  `.venv` the file reports "15 passed, 10 skipped" and looks green while testing
-  nothing about the fix. **There is no test workflow at all** (`.github/workflows/`
-  has only `docs.yml` + `release.yml`), so this can regress invisibly — the top
-  open item from that session.
-  **UPSTREAM: `ttkbootstrap` has the identical defect** — same code lineage, same
-  `winsys` branch in `widgets/scrolled.py` (binding 436-440, delta 546-556) and
-  `dialogs/colordropper.py:157-160`. Measured on 2.0.0 + Tk 9.0.4: a trackpad
-  gesture does nothing and ONE wheel notch jumps an 80-row `ScrolledFrame` to the
-  end (`0.0 → 0.813`). Filed as **israel-dryer/ttkbootstrap#1290** with the fix
-  shape; the #373 diff maps closely onto `scrolled.py`. **Repro gotcha:** the wheel
-  tag is only added to bindtags on mouse-enter, so synthetic events do nothing until
-  `enable_scrolling()` is called — and the content-fits guard silently returns
-  early until the scrollregion is actually computed. Both produce a convincing
-  false "dead" reading.
+---
 
-- **0.1.6 PATCH SHIPPED — seven form/field/validation fixes
-  (PRs #362–#368; released 2026-07-21).** On **PyPI** + tagged **`v0.1.6`**
-  (plus #371, a `Decimal`/`value_format` fix, folded into the cut). Kicked off by the user
-  `bLynnb2762` reporting on the CLOSED **#358** that tristate still failed; filed
-  fresh as **#361** (different root cause). **#362:** a checkbox built by a `Form`
-  ignored `tristate` — the form passed an explicit `value=False` over the widget's
-  indeterminate default; `editor_options` also COLLIDED with the kwargs the form
-  fills (`value`/`label`/`options`) → `TypeError` from an internal class. Two value
-  bugs alongside: `TextField`/`PasswordField`/`PathField` gated the initial value on
-  **truthiness** (so `value=0` rendered empty, and a form wrote the blank back over
-  the record), and the form **stringified** non-text data (a `Decimal`/`date` became
-  `str` in `form.data` at construction — a data-integrity regression *my own first
-  fix introduced*, caught by review). **#363:** the same collision existed in
-  `MenuButton(menu_options=)`, `ButtonGroup.add`/`add_all`,
-  `RadioGroup`/`ToggleGroup.add`, `Toolbar`/`StatusBar.add_widget` → all now route
-  through **`merge_kwargs`** (`widgets/_core/kwargs.py`); see the corrected Gotcha.
-  **#364:** a placeholder is rendered by INSERTING its text, and validation read the
-  raw entry, so **`required` passed on an untouched field** (a form with a required
-  placeholder field submitted empty); `field.text` also reported the hint while
-  `value` said empty. **#365:** deleted the 27 `tests/features/*` visual scripts
-  (never collected — `testpaths` covers only `tests/cli`, `tests/widgets/public`,
-  `tests/data`). **#367 (#366):** `email`/`pattern`/`stringLength` ran on EMPTY
-  values, so an **optional** field left blank blocked `Form.validate()` with no way
-  forward — now they pass on empty (matching `range`'s existing precedent); also
-  `required` was dropped for an unrecognized `editor=` name (a typo silently let an
-  empty field submit). **#368 (#355):** a `Select` REJECTED a value not in its
-  option list, so opening a `Form`/`DataTable` editor on a record whose option had
-  been retired **raised** — while a later programmatic write was silently dropped.
-  **Root cause:** `Select` stores display TEXT and decodes the value back through
-  the option list, so the `ValueError` was guarding *decodability*, not policy. Fix
-  = register the retired value under its own coerced text (`_register_retired_value`)
-  so the decode stays total (an `int` reads back an `int`); it is never added to
-  `_records`, so the popup is unchanged. Surfaced two more: a **searchable** Select
-  committed its top match when the popup was merely opened and dismissed, and
-  validation ran against the **label** (so a rule on a decoupled list rejected valid
-  selections). Added **`Select.validate()`** (every other field had one; its own
-  `add_validation_rule` docstring already promised it). **#369 filed** — the
-  selection family disagrees on off-list values (`SelectButton` raises both ways;
-  `RadioGroup` accepts at construction, raises on assignment; `ToggleGroup` accepts
-  both; and where accepted, `value` says `'MX'` while `selection` says `None`) —
-  wants ONE family decision, not four patches. **PROCESS (the session's real
-  lesson): adversarial review caught a defect in EVERY round**, including two
-  regressions I introduced — the `Decimal`→`str` coercion, and a
-  `_get_validation_value` override that broke **`bs.TimeField`** (`TimeEntry`
-  subclasses `SelectBox`, so typed out-of-range input validated clean). Tests that
-  only assert *construction doesn't raise* are what let #358 ship twice — and I
-  repeated it, writing a test that certified a **broken** documented example
-  (`menu_options={'offset': 4}` crashes on open; the docstring now says `(4, 0)`).
-  **CHANGELOG convention (I got this wrong on four branches):** a fix commit writes
-  `## [Unreleased]`; the `Release X` commit renames it AND adds the `[X]:` link
-  definition. Memory `feedback_pause_and_ask_when_stuck` — I over-complicated #355
-  for hours (heading toward a `Select` value-model rewrite) before the maintainer
-  pointed at the ~15-line map fix; **pause and ask when a fix outgrows its issue.**
+## Current state
 
-- **0.1.5 PATCH SHIPPED — boolean-control state reads + Checkbox tristate (PR #360;
-  2026-07-20).** `bootstack 0.1.5` is on **PyPI** + tagged **`v0.1.5`** ("boolean
-  control state fixes"). **Three bugs, one root cause (user `bLynnb2762`).** `Checkbox`,
-  `Switch`, `ToggleButton` share **`_BooleanControlBase`**, which read state by
-  comparing the backing Tk var's *coerced* value against the Python `checked_value`
-  (`self._internal.get() == self._checked_value`) — type-fragile, only correct when
-  the var type matched the value type. **(#358)** `Checkbox(tristate=True)` never went
-  indeterminate — `BooleanVar` can't hold a third value and the dash never rendered;
-  `.value` returned `False` not `None`. **(#359)** `ToggleButton(value=True).checked`
-  returned **`False`** (StringVar-backed → `'1' == True` is `False`). **Latent:** a
-  non-bool `checked_value`/`unchecked_value` (`"yes"`, ints) was silently coerced away
-  on Checkbox/Switch. **Fix = read the ttk `selected`/`alternate` STATE** (var-agnostic)
-  in `.value`/`.checked`/`_command`; a shared **`_apply_value`** maps the public value
-  onto on/off + the indeterminate flag. **Two gotchas the empirical probes caught:**
-  (1) **`configure(command=...)` RESETS ttk state** — so seeding must run AFTER it
-  (indeterminate `alternate` set earlier is wiped); (2) a **var write clears
-  `alternate`**, so indeterminate = set off-value THEN flag `state(('alternate',))`,
-  and the explicit `!alternate` clears elsewhere are redundant. **Var-type fix pushed
-  to the PRIMITIVE** (`checkbutton.py`), **consistent with RadioGroup/ToggleGroup**
-  (both do `StringVar(value=...)` explicitly — the precedent that made the tk import OK):
-  inject a `StringVar` **only when non-bool on/off values are given**, else keep the
-  `BooleanVar` so the **default control's auto-created `.signal` stays boolean** (the
-  code-review caught that always-StringVar leaked `'1'`/`'0'` strings through `.signal`,
-  where `"0"` is truthy — a real regression; conditional injection closes it). **Adversarial
-  `/code-review` (high) found 5, 2 real** — the `.signal`-type leak (fixed) + a redundant
-  `!alternate` (removed); the other 3 were non-issues (tristate+signal is documented;
-  `.value` fallback is more-correct; `_prev_value` staleness didn't reproduce). NB
-  **ToggleButton was ALREADY StringVar** (its `class_='Toolbutton'` dodges the
-  `TCheckbutton`→BooleanVar inference in `infer_default_value_for_widget`), so its
-  `.signal` was always string — no regression there. Tests **`test_boolean_controls.py`**
-  (the `.value`/`.checked`/tristate coverage these widgets NEVER had — which is why all
-  three shipped; 8 fail pre-fix). Docs: tristate scene added to the Full Example +
-  **regenerated `checkbox-tristate-*.png`** (old ones rendered indeterminate as
-  unchecked). **Process win: running empirical probes beat static reading repeatedly** —
-  the `configure(command)` reset, the var-write-clears-alternate rule, and the
-  ToggleButton-already-StringVar fact were all discovered by driving the widget, not
-  reading it.
-- **0.1.4 PATCH SHIPPED — `Select.add_validation_rule` restored (PR #357;
-  2026-07-20).** `bootstack 0.1.4` is on **PyPI** + tagged **`v0.1.4`** ("Select
-  validation fix"). Also re-worded the PyPI **`description`** (maintainer's pending
-  "built on Tk" tagline, folded into this cut). **Bug (user `bLynnb2762`, #356):** a
-  **0.1.3 regression** — `form.field(key).add_validation_rule(...)` on a `select`
-  editor raised `AttributeError: 'Select' object has no attribute
-  'add_validation_rule'`. **Root cause:** PR #354 (0.1.3) made `Form.field()` return
-  the **public wrapper** widget; the field-family wrappers carry `add_validation_rule`
-  via `field_mixin`, but `bs.Select` did **not** — and among the non-field editors its
-  internal `SelectBox` was the only one that had been inheriting it (from the `Field`
-  composite). So Select was the single casualty. **Fix (bounty PR #357 by external
-  contributor AnasBabari):** add `add_validation_rule` on `bs.Select`. **My review +
-  refactor:** the contributor's first pass hoisted `message`/`trigger` params with a
-  **`trigger="change"` default — but `'change'` is NOT a valid `RuleTriggerType`**
-  (`key`/`blur`/`always`/`manual`), so a rule added with no explicit trigger only ran
-  on manual `validate()`, never live. Refactored to **mirror the field-family
-  signature exactly** — `add_validation_rule(self, rule_type: RuleType, **kwargs)`
-  delegating straight through — which lets `ValidationRule`'s per-rule
-  `_default_trigger()` apply (required→`always`). Pushed onto the fork PR branch
-  (`maintainerCanModify`), squash-merged (contributor keeps authored credit + bounty).
-  Test added to `test_form_editor_options.py`. **CHANGELOG/close gotcha:** #356 used
-  `Fixes: <url>` (colon) which GitHub's auto-close does NOT parse → closed manually.
-- **0.1.3 PATCH SHIPPED — Form `editor_options` use public widget kwargs (PR #354,
-  #353; 2026-07-17, pre-session).** `bootstack 0.1.3` on **PyPI** + tagged **`v0.1.3`**.
-  Form built the **internal** impl widgets and forwarded `editor_options` raw, so users
-  had to pass Tk option names (`increment` not `step`) and `textarea` couldn't take
-  `show_border`. Rewrote `_build_field` to construct the **public wrapper** widgets via
-  `_construct_editor`, so `step`/`min_value`/`show_border`/`mask`/slider-bounds work as
-  documented; **`field()` now returns the public wrapper** (the change that regressed
-  Select validation — see 0.1.4). Also a homepage-tagline docs commit landed on `main`
-  the same day. **NB this predates the session** — recorded here because CLAUDE.md had
-  gone stale at 0.1.2.
-- **0.1.2 PATCH SHIPPED — dropdown/context menus dismiss on window move (PR #345;
-  2026-06-25).** `bootstack 0.1.2` is on **PyPI** + tagged **`v0.1.2`**. **Bug
-  (user-reported, Win10):** an open toolbar `add_menu` dropdown (and any Win/Linux
-  `ContextMenu`/`Select`/`MenuButton` popup) stayed pinned at its old screen
-  position when you dragged/resized/minimized the window — it "hung in the air."
-  The `_ToplevelContextMenu` (overrideredirect Toplevel backend) only dismissed on
-  **outside mouse clicks** bound on the owning window; dragging the native title
-  bar fires no click, only `<Configure>`/`<Unmap>` on the toplevel, which nothing
-  listened for. **Fix:** while shown, also bind the binding-root's
-  `<Configure>`/`<Unmap>` → new `_on_window_change` method dismisses (guarded to
-  `event.widget is the toplevel` so a child relayout doesn't close it); torn down
-  with the existing outside-click cleanup. Shared backend → fixes ALL Win/Linux
-  popups at once. Verified decorated AND undecorated (both move via `wm geometry`
-  → `<Configure>`); macOS `_NativeContextMenu` untouched (native menu self-dismisses).
-  **NB this is the window-MOVE bug — DISTINCT from #207** (the `'break'`-target
-  dismiss case, still OPEN; I confirmed a `'break'` toolbar widget already dismisses
-  here). Tests in `test_toolbar_menu.py` (window-change dismissal + binding
-  teardown). **Process:** empirical self-driving repro (move window, assert
-  `winfo_viewable()`) was decisive — static reading missed that no click fires on a
-  title-bar drag. Confirmed Py 3.12.10's `unbind(seq, funcid)` removes only that
-  funcid (not the unbind-wipes-all of older Tkinter), so binding `<Configure>` on
-  the app toplevel is safe. **CHANGELOG gotcha (fixed):** `## [0.1.1]` was a
-  bracketed link with NO `[0.1.1]:` definition (dead link); added `[0.1.1]:` +
-  `[0.1.2]:` defs. **Release-notes gotcha:** `release.yml` extracts ONLY the
-  `## [x]` section, so the bottom link-defs are excluded → `[0.1.2]` renders as
-  literal brackets in the GitHub Release body (see Next-up for the fix).
-- **0.1.1 PATCH SHIPPED — `pygments` declared as a runtime dependency (PR #344;
-  2026-06-24).** `bootstack 0.1.1` is on **PyPI** and tagged **`v0.1.1`** (GitHub
-  Release, notes from the CHANGELOG `## [0.1.1]` section). **Bug:** `CodeEditor`
-  hard-imports `pygments` (via `_try_install_highlighter`) for syntax highlighting,
-  but it was declared as a dependency **nowhere** in `pyproject.toml` — so a clean
-  `pip install bootstack` (no incidental pygments) crashed on any
-  `CodeEditor(language=...)`, including the bundled `bootstack` demo's editing page
-  (`ModuleNotFoundError: No module named 'pygments'`). Fix = add `pygments>=2.15`
-  to `[project].dependencies` (hard dep, per the maintainer — pure-Python, no
-  transitive deps, and highlighting is core to a top-level `bs.*` widget; matches
-  batteries-included). **Full dependency audit done while here — `pygments` was the
-  ONLY gap:** every optional extra (`viz`/matplotlib, `parquet`/pyarrow,
-  `excel`/xlsxwriter, `hdf5`/pandas+tables, `viz-seaborn`/seaborn) is lazy-imported
-  inside functions and gated by `_require(...)`/`_require_matplotlib` (so `import
-  bootstack` + core widget construction never crash); `PyInstaller` is a
-  packaging-time tool (`try/except` in the CLI); `tomli` is a dead fallback
-  (`tomllib` is stdlib on `requires-python >=3.12`); `cycler` is guarded + ships
-  with matplotlib. **Release process note (CORRECTED 2026-07-21):**
-  `bump-my-version` IS available — `.venv/Scripts/bump-my-version.exe`, v1.3.0 — so
-  the normal `bump-my-version bump patch` flow works. (The 0.1.1 session could not
-  reach it and replicated the config by hand: bump BOTH `version` (line 7) and
-  `[tool.bumpversion] current_version`, commit `Release X`, annotated tag `vX`.
-  That manual path is the fallback, not the norm.)
-- **0.1.0 STABLE SHIPPED — ship gate + theme-repaint unification + accent contrast
-  (2026-06-24).** `bootstack 0.1.0` is on **PyPI** (`pip install bootstack`, no
-  `--pre`) and tagged **`v0.1.0`** (stable GitHub Release, `prerelease=false`).
-  Verified on **Windows AND macOS**. **#149 ship gate (PR #335 — MERGED):**
-  public-surface audit + lock + CHANGELOG + Release Notes + Roadmap page; the
-  folded items shipped in **PR #334** (`text=<Signal>` → `TypeError` guard across
-  text-bearing widgets; `cli/run.py` double-cwd fix). `bootstack.__version__` is
-  already DYNAMIC (`importlib.metadata`), so the "stale 0.1.0a6" worry was moot.
-  **Pre-release framing removed (PR #342):** README/CONTRIBUTING warnings gone;
-  pyproject `Development Status` 3-Alpha→**4-Beta** (Beta over Production/Stable —
-  no production mileage yet; pandas precedent = bump to 5 once earned, not at 1.0)
-  + fixed the bogus `Environment :: X11 :: GTK` (it's **Tk**) → Win32/MacOS X/X11.
-  **GitHub Release notes now come FROM the CHANGELOG (PR #343):** `release.yml`
-  checks out the repo and extracts the `## [<version>]` section as the release
-  body (GitHub's auto "What's Changed" appended below; an alpha tag with no
-  section falls back to auto-only). **Theme-repaint unification (PR #338):**
-  replaced THREE overlapping mechanisms (STD-publisher + `_enable_theme_repaint`;
-  `register_tk_widget` WeakSet + `<Map>` registry — RETIRED the grows-forever
-  leak; per-widget hacks) with ONE rule — a tree widget defines
-  **`_bs_apply_theme(self)`**, driven by `Style.apply_theme_walk(root,
-  only_stale=)` (theme-change → walk VISIBLE from root; container-show → walk
-  STALE subtree IGNORING `winfo_viewable()`, unreliable across a canvas boundary);
-  show-triggers in PageStack (covers Tabs) + Expander (covers Accordion);
-  non-tree reactors (Image handle / window chrome / app `on_theme_change`) stay on
-  root `<<BsThemeChanged>>`. The meter canvas takes the surface TOKEN (not a frozen
-  hex) so the walk re-resolves it; `style_resolver` now lets an explicit `surface=`
-  win over inheritance (the gauge "bg doesn't recolor" root cause). Dev note
-  **`docs/_dev/theme-repaint-architecture.md`**. **Accent text-on-color fix (PR
-  #340):** `on_color` light-mode white gate 4.5→**3.0** (the large/bold WCAG bar
-  that button labels meet) so saturated colored accents read white in BOTH modes
-  (dracula-light purple primary was wrongly black) while bright cyan `info`/yellow
-  `warning` stay black; + a contrast FLOOR catching bucket-edge cases in either
-  mode (catppuccin-dark `warning` was white at ~2:1). Test `test_on_color_contrast.py`.
-  **macOS fixes (PR #339, local agent):** kept nav pages mapped (#336) + anchored
-  toasts to the visible frame above the Dock (#337). **Dead-test cleanup (PR
-  #341):** deleted stale `test_gauge_theme.py` (asserted #338-deleted mechanisms)
-  + fixed `test_icon_image_props.py`'s private-fixture/no-container setup. Milestone
-  **0.1.0 (stable) CLOSED** (11 issues); **#322** (provisional hot-reload umbrella,
-  E2E test still deferred to the maintainer) moved to **0.1.1**.
-- **Hot-reload follow-ups #325/#326/#327 + #328 docs (PR #333 — MERGED;
-  2026-06-24).** Four fixes on PROVISIONAL `bootstack.dev`, one PR. **#325:**
-  AppShell `_dev_reset_region` restores the status band to its forced state
-  (`set_statusbar_visible(False)` unless `show_statusbar=True`) so an empty band
-  doesn't linger after a no-segment reload — AND `show_statusbar=True` now genuinely
-  forces the band visible at construction (was materialize-only; stored
-  `self._show_statusbar_forced`); App/AppShell reset now CANCEL a scheduled
-  native-menu `after_idle` (new `ChromeHostMixin._cancel_native_menu_pending`) vs
-  nulling the handle (macOS double-fire). **#326:** the per-page fast path is gated
-  on EVERY changed file being a builder module (`_builder_module_files`) — a changed
-  non-builder/state module takes the full reload-then-reexec instead of a selective
-  `importlib.reload` that splits object identity without rebinding. **#327:** watch
-  root widens from the entry file's dir to the project `src/` tree
-  (`_project_watch_root` walks up to `bootstack.toml`; falls back to the file dir for
-  loose scripts); watcher snapshot stamps `(mtime, size)` to catch same-tick saves;
-  symlink/scope caveats documented. **#328 (docs only):** added a "Gating dev-only
-  code" section for `is_dev_mode()` — **the E2E multi-file `@reloadable` reload test
-  is the remaining #328 piece, DEFERRED** (the maintainer will do it). Tests: watcher
-  tuple + size-change; `_project_watch_root` widen/fallback; shell GUI legs green.
-  **Naming note (`set_*_visible` is INTERNAL):** `ShellLayout.set_statusbar_visible`
-  / `set_rail_visible` / `set_sidebar_visible` / `set_dock_visible` are an internal
-  family (public uses verbs `show_sidebar()`/`hide_sidebar()`/`toggle_sidebar()` +
-  `show_statusbar=`); **#332 filed** to rename the internal family to the idiom (low
-  priority). Memory `project_hot_reload` (followups thread).
-- **Docs-IA: fold Production into the User Guide + caption renames (#323/#324;
-  2026-06-24).** The docs navbar dropped from **4 pillars to 3** (**User Guide ·
-  Widgets · API Reference**). The former **Production** pillar folded into the User
-  Guide as a new **Developer tools** caption (`cli`/`hot-reload`/`debugging`/
-  `distribution`); **`App Configuration`** (`/production/app-settings`) moved to the
-  **Feature guides** caption (it's a subsystem guide, not tooling/shipping). **#324
-  decision = fold-into-User-Guide** (maintainer chose it over rename-in-place /
-  reorder). The **Topics** caption was renamed **Feature guides** (more descriptive of
-  the subsystem deep-dives; the locked constraint is only "not Concepts/Explanation").
-  **#323:** the `Composing Fields` how-to renamed → **`Customizing Fields`**
-  (`/tasks/composing-fields` → `/tasks/customizing-fields`) to kill the "Composing X"
-  clash with the new **Composing with Builders** how-to (it's about *specializing* a
-  field, not decomposition). Leaf pages STAY in `production/` (no URL churn — internal
-  dir name only); the one accepted churn is the #323 rename (no redirect mechanism →
-  dead old URL, fine per no-shims). `production/index.rst` DELETED. Inbound `:doc:`
-  refs + 6 widget See-also links repointed. Clean `-W` build, no orphans. Memory
-  `project_docs_ia_pillars`.
-- **Builder-function scaffolds + examples audit (PR #330 — MERGED; 2026-06-24).**
-  The staged builder-pattern work the roadmap flagged as "START HERE." **#321:**
-  every CLI page/view scaffold flipped from a class
-  (`__init__`/`_build`/`self.root`) to a **`build_<name>()` builder function**
-  (`cli/templates/__init__.py`). Layout moved onto the page region — AppShell pages
-  paint **directly** into the page (`padding`/`gap`/`horizontal_items` on
-  `nav.add_page(...)`; the page IS the column, no inner wrapper); basic **pack** view
-  paints into the padded App body, **grid** view opens a `bs.Grid` (a layout the
-  column body lacks — not redundant; needs `horizontal="stretch"` to fill);
-  **master-detail** `build_detail(record)` opens its **own** padded `Column` (the
-  detail region is a bare `ContentHost` fill area, no padding). Stateful handlers
-  became **closures over local field refs** (not `self.*` methods) — the documented
-  "builder default, class is the escape hatch" story. `add page`/`add view` emit
-  `build_<name>` (suffix-stripped: `DashboardPage`→`build_dashboard`) + matching
-  wiring hints (new `_build_func_name`/`_readable_title` helpers). **Naming
-  convention LOCKED:** *component* builders are bare (`user_card`), *page/region*
-  builders are `build_<name>` — a **Naming** note in the **Composing with Builders**
-  how-to ties scaffolds + how-to into one system. **#320 Part 2:** flagship
-  `docs/examples/appshell.py` factors its metric cards into a reusable
-  `metric_card()` builder; nav examples were already class-free (the reshape did it);
-  the `bootstack gallery` demo already uses `_build_*` builders (left as-is — its
-  inner `Column` is legit scroll-content padding for `scrollable=True` pages, NOT
-  class-view redundancy). **#320 Part 1 + the `_resolve_parent` guard shipped in
-  #329** (the guard at `base.py:97` raises a clear `BootstackError` when a builder is
-  called with no active container + no `parent=` — matches the how-to's "one rule").
-  Verified: all 6 scaffold variants build in isolated subprocesses, the printed
-  add-page wiring builds end-to-end, 186 cli/public-surface tests, clean `-W` docs
-  build. Memory `project_builder_scaffolds`.
-- **Hot reload — `bootstack dev` + feature-review fixes (PR #329 — MERGED;
-  2026-06-24).** The dev workflow (BUILT on `feat/hot-reload` in the prior
-  session) got a **4-reviewer adversarial audit + fixes**, then merged.
-  `bootstack dev app.py` re-execs the `with bs.App()` body in place on save
-  (window + module-level signals/sources/stores + active route survive; broken
-  edits show an in-window banner); `@reloadable` rebuilds just one page's region
-  (multi-file); a restart fallback covers function-wrapped apps (auto-selected;
-  `--restart` forces). New **PROVISIONAL** `bootstack.dev` (carved OUT of the
-  0.1.0 freeze): `reloadable` + `is_dev_mode`. **Blockers the review caught +
-  fixed:** 🔴 **win32 `os.execv` restart was BROKEN** — execv does NOT replace the
-  process in place on Windows (new PID + caller exits), so the supervisor died
-  after the FIRST reload (the prior session's "Verified Windows" missed it — it
-  only exercised in-process). Replaced execv with a **CLI `subprocess.run`
-  supervisor loop** on a sentinel exit code (`DEV_RESTART_EXIT_CODE`), made
-  **crash-resilient** (a broken edit waits-and-relaunches instead of ending the
-  session — surfaced by LIVE testing, not the static review). 🔴 **AppShell/
-  Workbench error banner was dead** (`_content_frame` is a method on shells, an
-  attr on App — reloader now resolves both). + `relative_to` guard on an
-  absolute/`..` entry. **Docs IA:** the builder-functions guide became the
-  **"Composing with Builders"** how-to (`docs/tasks/composing-with-builders.rst`
-  — goal-indexed, not a subsystem topic) + restart-mode "when to force
-  `--restart`" guidance + the demo video / README hero. Reviewers over-flagged
-  (the mount-accumulation suspicion was disproved — `reset_mounts` is wired).
-  Memories `reference_win32_execv_not_inplace`, `project_hot_reload`.
-  **Non-blocking follow-ups filed: #325** (reset-cleanup gaps), **#326**
-  (`_reload_modules` identity-split scoping), **#327** (watcher scope/polling),
-  **#328** (multi-file reload test + thin is_dev_mode docs). **Docs-IA spin-offs:
-  #323** (rename "Composing Fields" → "Customizing Fields") · **#324** (rethink the
-  "Production" pillar). Process note: **running it caught what reading it didn't.**
-- **Splash screen — cross-platform `windowtype` + `bs.Splash` (PRs #313, #318 —
-  MERGED; 2026-06-23).** Two-step feature, each its own branch→PR→`main`.
-  **#308 (PR #313):** `Toplevel(windowtype=...)` was honored only on macOS
-  (`MacWindowStyle`) and X11 (`-type`); **win32 never read it**. Added a win32
-  branch (`_runtime/toplevel.py`) translating the chromeless types
-  (`splash`/`tooltip`/`dock`) → `overrideredirect` and `utility` → `-toolwindow` —
-  **one switch, all three platforms** (maintainer chose the auto contract: the
-  caller need NOT also pass `overrideredirect=True`). macOS asymmetry preserved for
-  free (`overrideredirect()` already no-ops on Aqua). **#310 (PR #318):**
-  **`bs.Splash`** — a borderless intro screen (its own `Toplevel`,
-  `windowtype="splash"`) constructed inside the `App` context. **Registration, not
-  suppression:** construction resolves the ambient app and registers on it; the
-  internal `App.mainloop` gained ONE branch — if a splash is up, defer `show()`
-  until it dismisses (`_notify_app_ready`). **Shows at its own `__exit__`** (after
-  content authored, before the synchronous body build it precedes — so it genuinely
-  covers that cost) with `update()` to force paint; the `with` block scopes content
-  only, not lifetime. One dismiss knob `until=` (`'ready'`|`<float>`|`'manual'`) +
-  `skippable`/`dismiss()` on top + `min_duration` floor under all. Best-effort
-  `after()`-driven alpha fade (snaps where unsupported). Lean surface: `is_showing`,
-  `dismiss()`, `on_dismiss`→`SplashDismissEvent(reason)`; guards (no app / second
-  splash → `BootstackError`). Added `SplashDismissEvent`/`SplashDismissReason` to
-  `bootstack.events` + the events API ref; **re-homed the drifted `SashMoveEvent`/
-  `ScrollEvent`** there too. Docs: `widgets/splash.rst` + a `tasks/splash-screens.rst`
-  how-to (cover-startup, timed branding, welcome, **real progress via worker thread
-  + Signal**, and the **event-loop timing rule** — motion only shows while the loop
-  turns, so a `'ready'` splash over a synchronous build is a STILL image by design).
-  Tests `test_splash.py` (14). **Process catches (maintainer caught both):** a stray
-  "Tk" in the how-to broke the no-toolkit-in-docs rule; and `events.rst` had silently
-  drifted from `events.__all__` — fixed + added a coverage guard (PR #319,
-  `test_events_doc_coverage.py`). Memory `project_splash_widget`.
-- **Icon-DPI sizing + Tooltip subtree coverage (PRs #306, #307, #309 — MERGED;
-  2026-06-23).** Three small fixes off the 0.1.0 cleanup backlog, each its own
-  branch→PR→`main`. **#267 (PR #306):** the public `Image` handle (`get_icon` /
-  `image=`) and the MenuButton chevron rendered glyphs at their literal *logical*
-  size and so read soft at fractional/high DPI. Fix = new **`scale_icon_size(base)`**
-  (`_runtime/utility.py`, logical→physical, floored at base like
-  `scale_padding_floor`) applied in both `Image` render paths (`_load_pil`,
-  `_materialize`; reported `width`/`height` stay logical — public contract unchanged)
-  + the chevron routed through `b.scale()` to match combobox/spinbox. **Adversarial
-  verification overturned the issue's headline:** the Workbench rail was NOT soft (it
-  already scales 28→41 via `normalize_icon_spec`); the soft paths were only the public
-  handle + the chevron. **#305 (PR #309):** text+icon `Button`/`MenuButton` icons
-  *double-scaled* at high DPI — `icon_size()`'s text branch returned the font ascent
-  (already physical), then `normalize_icon_spec` re-scaled it. Fix = that branch now
-  returns logical (`round(ascent / ui_scale)`) so normalize is the single scaler.
-  **Validated row heights** at both densities × DPIs: this fixed a real ~10px
-  inflation of the COMPACT text+icon button at 150% (65→55, matching siblings).
-  **#260 (PR #307):** `Tooltip.refresh_bindings()` (public + internal, mirroring
-  `ScrollView`) re-covers a container target's subtree for children added *after*
-  attach (`propagate_target_bindings` only tags descendants present at attach time).
-  **#207 DEFERRED** (maintainer call): no API implication, low self-inflicted impact,
-  Win/Linux only; the risky grab fix breaks reopen-at-new-spot — agreed proportional
-  fix if revisited is an open-menu registry. Memory
-  `reference_icon_dpi_scaling_pipeline`. Process note: the empirical icon-size probe
-  (`development/probe_icon_sizes.py`, untracked) was decisive — static reading of the
-  4-mechanism scaling pipeline was too tangled to trust.
-- **Trust audit of the 2026-06-22 session + fixes (PRs #301, #302 — MERGED;
-  2026-06-22).** A prior agent (on another machine) shipped 14 PRs (#289, #291–#299
-  + releases `0.1.0a14`); the maintainer found repeated errors/hallucinations and
-  asked for a full review. Method: **5 parallel adversarial reviewers** (one per PR
-  cluster) + clean `-W` docs build + full GUI suite. Verdict: mostly sound but **not
-  trustworthy as-is**. Brief: **`docs/_dev/review-2026-06-22-trust-audit.md`**.
-  Fixed in **PR #301**: (1) 🔴 **#299 toolbar regression merged with a FAILING test**
-  — `_apply_bar_defaults` used "has `**kwargs`" as a proxy for "accepts
-  `density`/`surface`", crashing `add_widget(Checkbox/Switch/ToggleButton/Radio)` and
-  no-op for `TextField`/`Select`; fix = inject only **explicitly-declared** params;
-  (2) 🟠 **DataTable `iter_rows` clobbered the shared source** — the view-mutation CM
-  spanned a `yield`, leaking this view's filter/sort onto the shared source until GC;
-  fix = wrap each read, not the yield (+ regression test proven to fail pre-fix);
-  (3) 🟠 two **`lambda ok: btn.disabled = not ok`** docstrings (SyntaxError) →
-  named-handler; (4) the **`-W` docs build was broken** since PR #266
-  (`widget-sizing.rst` titles inside an include skipped a heading level) → `.. rubric::`;
-  (5) DataTable test hygiene (hallucinated `enable_search=` → `searchable=`; `_internal`
-  pokes → public); (6) `signals/README.md` rewritten (was pervasively stale —
-  `get()`/`unsubscribe()`/`bs.Entry`/`app.mainloop()`/the `master=` gotcha #292
-  overturned); (7) **CodeEditor #296/#297** (selection API, block indent/dedent) and
-  **ScrollView #298** (`on_scroll`/`scroll_position`/keyboard) shipped undocumented +
-  untested → docs + **20 new tests** + docstring fixes (incl. `scroll_position` no
-  longer claims `(1.0,1.0)` reachable); (8) **#262** — `Toolbar.add_button`/`add_label`
-  returned internal `_impl` primitives → now return public `bs.Button`/`bs.Label`
-  (live props); added **`surface=` to `bs.Button`** (construction-only — *build-time,
-  not a live property*; matches the surface a ghost/outline button sits on so it
-  blends; a toolbar sets `'chrome'` for the buttons it builds); preserved
-  draggable-titlebar label drag via internal `Toolbar._attach_drag`. **PR #302**:
-  documented `surface=` in `button.rst` (usage-only, no implementation detail).
-  **Verified clean (no over-flag corrections):** #292 Signal lazy-realization rewrite
-  is correct; #295 internal-access scrub, carousel #289, pyinstaller #291, new chart
-  example all check out. Two reviewer **over-flags disproved**: the #296 `read_only`
-  "fix" was a no-op rename, and `Toolbar._surface` is always defaulted by the base
-  Frame (no `AttributeError`). **Process gotchas (bit me):** piping a build/test
-  command to `tail` masks its exit code with `tail`'s 0 — *never pipe the command
-  whose status you need* (it hid both a failing test leg AND the broken docs build);
-  toolbar item spacing is now uniform `padx=2` (the pack-based bar has **no `gap`** —
-  a real gap migration is the unified-toolbars rework, `project_unified_toolbars`).
-  **Now-DONE issues (close them):** #246, #251, #252, #254, #255, #262, #263.
-- **Pre-release `0.1.0a12` shipped + demo rebuild + CONTRIBUTING + Topic-guide
-  review** (2026-06-21; all MERGED). Cut **`0.1.0a12`** to PyPI + GitHub Release
-  (`bump-my-version bump pre_n` → push `main` + tag → `release.yml` → `docs.yml`).
-  Landed in it: the **Topic-guide technical-writer review** (#155, PR **#268** —
-  verified all 12 `docs/reference/*` against the standard; the assessment agents
-  **over-flagged**, only **2 real fixes** came out: a typed-signal section in
-  `signals`, two missing imports in `typography`; the other 10 already met it —
-  *adversarially verify agent claims*); the **hero-first demo rebuild** (#269, PR
-  **#270** — `cli/demo.py` 995→564 lines, 18→12 hero pages, fixed the
-  `AppShell(nav_variant=)` launch crash, the "broken demo"); the **README** refresh
-  (centered screenshots, fixed the broken `shell.add_page` example, stale 8→real 10
-  theme list, +Workbench/Window/ThemeToggle, +`appicon`/`promote` CLI, demoted
-  `add i18n`, re-shot gallery + hero); and **`CONTRIBUTING.md`** (PR **#271** — dev
-  setup + feature-branch→`main` PR flow + localization-review section reusing #17's
-  language; **closed the localization issue fan-out** #17/#19–#37). Verified
-  pre-ship: CLI + all 6 templates scaffold/build/`add`/`doctor`/`icons`/`appicon`.
-- **Docs lead-in + screenshot-refresh pass — PR #266 (MERGED)** + the
-  **interactive-widget review initiative COMPLETE.** All interactive widgets are
-  now reviewed (Button #243/#244, ButtonGroup #245, TextArea #247/#248, CodeEditor,
-  ScrollView, SplitView, Tooltip, Toolbar, StatusBar — each its own merged PR). Then
-  **PR #266**: ~45 widget pages got a Usage **mental-model lead-in** (intro stays
-  definitional; teaching leads the Usage section; no bare Usage); the widget-sizing
-  include split **Row vs Column** (different cross-axis options — Column uses
-  `horizontal` for cross-align + `grow` fills vertical, Row the mirror); **dialogs
-  now capture like app windows** — routed the dialog target through the App/Window
-  DWM-extended-bounds + `inset=2` path so the native frame is cropped and a **single
-  CSS border + shadow** replaces it (`.bs-dialog-screenshot` shares the
-  `.bs-window-screenshot` rule; no native/CSS double border); two **broken dialog
-  scenes** (`message-dialogs`, `dialog`) fixed — they parented raw tk primitives
-  into the dialog's now-public-`Column` content area (rewritten with public widgets);
-  the **filter-dialog value list rebuilt on the managed `FlexFrame` content** the
-  public ScrollView uses (dropped the legacy raw `ttk.Frame`-in-canvas + a redundant
-  racing `<Configure>` width binding — fixed the clipped/deformed list); stale
-  screenshots regenerated (app/window/appshell/workbench/card/home-hero/navigation)
-  and the **workbench hero image** wired into its page. **Filed #267** — DPI-aware
-  icon sizing (icons render soft at fractional DPI: sizes hardcoded, **no `ui_scale`**
-  multiplier anywhere; rail worst at 28px; own branch). Investigation gotcha: the
-  workspaces nav shot's softness is the **icon DPI issue (#267)**, not capture width
-  — the Workbench renders the same 720px as the AppShell scenes, native capture, no
-  downscale (a `_capture_max_width`/size bump was tried and **reverted**).
-- **Widget-review initiative — Button · ButtonGroup · TextArea** (prior session;
-  all MERGED). Began the "finish reviewing the interactive widgets" sweep
-  (audit→fix→test→docs→follow-ups, one PR each). **Button** (#243; walk-backs
-  #244): activation-based `on_click` (class map → `<<Click>>` from a command
-  dispatcher → fires on mouse/keyboard/`click()`, honors disabled, Stream-composes)
-  + `text` setter routes through the bound var; **walked back** an over-eager
-  `disabled`/`text` getter change (only broke via an internal side-hack — test
-  public paths, not pokes). **ButtonGroup** (#245): no correctness bugs (disabled
-  propagation + `on_click` verified); docs (Events/Keyboard) + bare-`except` fix;
-  `accent/variant/density/orient` kept construction-only (not runtime needs).
-  **TextArea** (#247): read-only state desync (broke programmatic `value=`/`insert`),
-  placeholder flipping read-only off, and a **Tab focus-trap** all fixed; docs got
-  Validation+Keyboard sections. Native-bindings follow-up (#248): undo/redo now use
-  Tk's `<<Undo>>`/`<<Redo>>` virtual events (platform-correct keys; CodeEditor
-  benefits too). Swept the rest for hardcoded-key reinventions — none others (custom
-  shortcuts are intentional). Memories `project_button_review`,
-  `project_widget_review_initiative`, `feedback_live_properties_runtime_need`,
-  `feedback_prefer_native_bindings_dont_undo_conventions`. Also this session:
-  **#234 SpinnerField parity** (#241, increment/decrement methods only),
-  **#222 CLOSED won't-do** (live placeholder/mask).
-- **Typed-signal round-trip + high-DPI border fix** (this session; PRs **#238** +
-  **#239**, both MERGED). Two field follow-ups closed end-to-end:
-  - **#227 — `Signal` now round-trips object values** (PR **#238**). `Signal` chose
-    its Tk var from the initial value's type, so a `date`/`time`/object landed in a
-    StringVar and `sig()` read back the **string**. Fix = an **object mode** for
-    non-Tk-native values (anything not `bool`/`int`/`float`/`str`/`set`): the cached
-    Python object is the source of truth (`__call__` returns it), the StringVar is
-    just the write-trace bus (`set()` dedupes on the object, writes `str(value)` to
-    notify). **Native signals are byte-for-byte unchanged** (branch only activates for
-    objects → zero regression). Also fixed: `ValueSignalMixin._sync_value_set()`
-    (called from each field's `value` setter) pushes a **programmatic** `field.value=`
-    to the bound signal (was on_change-only). **`textsignal=` REMOVED from
-    `NumberField`/`DateField`/`TimeField`** (typed fields bind via `signal=`; guarded
-    with a `TypeError` since `**kwargs` would silently swallow it) — Date/Time docs
-    now feature typed `signal=` with a `.map()`-derived text signal for display. This
-    also resolved **#237** (the user report that kicked it off). Escape-hatch caveat:
-    `sig.var`/`sig.tk` returns the backing StringVar (string form); `sig()` is the
-    supported path. Memory `project_field_value_signal_dtype`.
-  - **#90 — high-DPI entry border washout** (PR **#239**). On high-DPI the resting
-    (unfocused) field border vanished (focus border fine; `hdpi=False` fixed it). The
-    visible border is a **`ttk_class="TField"` nine-patch whose slice scales with
-    DPI**, but the gap to the inner widget was a **hardcoded `padding=5`** — at high
-    DPI the slice outgrows the gap and the child **overpaints** the border. Fix =
-    **`scale_padding_floor(base)`** (`_runtime/utility.py` =
-    `max(base, round(base*ui_scale))`): **round** not truncate (1.5x kept clipping the
-    rounded corners with `int()`), **floor** at base (low DPI keeps tuned spacing).
-    Applied at both TField sites — the `Field` composite (all 7 field widgets) **and**
-    `TextArea`/`CodeEditor`. **Not** the image/LANCZOS path (probe proved the image
-    keeps full contrast; the cap idea was a dead end). **`show_border` widgets**
-    (context menus/toasts/snackbars/tooltips/Select popup) use a fixed ttk relief
-    border, **unaffected**. Repro without 4K hardware via `App(scaling=2.667)` (the
-    washout is driven by the scale *number*). Memory
-    `reference_hidpi_ninepatch_border_padding`.
-- **Field-family widget reviews + validation follow-ons** (this session; all
-  MERGED) — closed out the `TextField` review that spawned the validation rebuild,
-  then reviewed the whole **field family** one PR each (audit→fix→test→docs→
-  file-follow-ups). **Validation follow-ons first:** **#216** (PR **#219**) —
-  `NumberField(value=None)`/`value=""` crashed at construction (`float('')`; an
-  empty number field stores `''`, the guard only checked `is not None`) → normalize
-  empty→`None`, skip bounds. **#217 part 1** (PR **#220**) — reactive **`Form.valid`**
-  (`Signal[bool]` AND-ed over the member fields' `valid` signals via subscriptions)
-  + **`Form.errors`** (live `dict[str,str]` from the fields' `error` signals), on
-  internal+public `Form`; a submit button binds `form.valid`. **#217 part 2
-  (stream-based triggers) DEFERRED** — re-evaluated as pure internal churn (current
-  `_setup_validation_binds`/`after()` works, not Tk-coupled). **Docs cross-ref rule**
-  (PR **#221**) — added to `docs/_dev/widget-review-and-docs-standards.md`: a widget
-  section on a cross-cutting subject (validation/events/data/layout/…) must
-  `:doc:`-link the matching how-to/topic guide (the field-items *Validation* gap was
-  the trigger). **Then the 7 reviews:** TextField (#223), NumberField (#224),
-  PasswordField (#225 docs + **#229** read-only-reveal fix), DateField (#228),
-  TimeField (#230), PathField (#231), SpinnerField (#233). **Pattern:** NO wrapper
-  had correctness bugs (every audit-agent "critical" claim died under adversarial
-  verification — e.g. the "addon-state bypass" was false: `configure(state=)` routes
-  through `Field._delegate_state` which syncs addons; "`.text` needs a setter"
-  contradicts the locked read-only value/text contract). The yield was **docs** —
-  every page lacked the `/reference/validation` cross-link, the reactive
-  `field.valid`/`field.error` surface, and a fleshed See-also; each got a
-  mental-model lead, Date/Time/Path gained full Validation sections. **Two real code
-  changes (decided with maintainer):** PasswordField reveal toggle now `active_when_
-  readonly=True` (#229 — the flag postdates the widget; revealing only flips the mask
-  char, safe under read-only); **TimeField now starts EMPTY** (#230 — was
-  `datetime.now().time()` in `timeentry.py`, the only field not starting empty, which
-  silently **defeated `required=True`**; pre-release clean break). **Systemic bug
-  fixed across the family:** validation screenshot scenes called `field.validate("blur")`
-  but public `validate()` takes **no** arg (raised in the `after()` tick → error never
-  rendered); fixed to `field.validate()` + regenerated. **Open follow-ups (additive,
-  not bugs):** **#227** (`Signal` is StringVar-backed for objects → `Date/TimeField`
-  `signal=` reads back a *string*, and field→signal doesn't fire on programmatic
-  `.value=`; so Date/Time docs keep `textsignal=`; NumberField unaffected) · **#232**
-  (PathField dialog-config options as live properties) · **#234** (SpinnerField↔
-  NumberField parity: increment/decrement, live min/max/step). Memory
-  `project_field_family_review`. **Process gotcha:** a fix pushed to a branch AFTER
-  its PR merged is stranded — cherry-pick onto a fresh branch (bit us with #225→#229).
-- **Field validation redesign** (PR **#218**, MERGED) — started as a `TextField`
-  review (audit→fix→test→docs), surfaced that validation was **fundamentally
-  broken for typed fields**, and turned into a 4-phase rebuild. **Phase 1:**
-  validation now runs against the field's **typed value** via one resolver
-  (`TextEntryPart._get_validation_value` = `_parse_or_none(get())`;
-  `NumberEntryPart` override coerces to its numeric type) — all 7 field wrappers
-  route through it (was 4 passing the raw datum → `TypeError`, 2 passing text);
-  `add_validation_rule` guards the silent `ValidationRule`-object double-wrap with
-  a `TypeError`. **Phase 2:** type-aware rule taxonomy — text-rules
-  (`stringLength`/`pattern`/`email`) vs value-rules; new **`range`** rule
-  (number/date/time bounds with a message, vs silent `min_value`/`max_value`
-  clamping); an inapplicable rule is **rejected at attach time** with
-  `BootstackError`, keyed off a per-wrapper `_VALIDATION_KIND` class attr
-  (`number`/`date`/`time`; `text` default); redundant date/time
-  `add_validation_rule` overrides removed (they bypassed the guard). **Phase 3:**
-  reactive validity surface — the engine owns `_valid_signal`/`_error_signal`
-  (source of truth, set via `_set_validity` on every run); public **`field.valid`**
-  / **`field.error`** Signals (`bs.Label(textsignal=field.error)`); the Field
-  message label is now bound to the error signal (imperative `_show_error`/
-  `_clear_error` gone); `Form.validate()` routed through the entry's validator.
-  **Phase 4:** `docs/reference/validation.rst` rewritten (typed-value model,
-  `range`, type-aware behavior, reactive signals); api-ref `RuleType` += `range`.
-  Brief `docs/_dev/field-validation-system.md`; memory
-  `project_field_validation_redesign`. Tests `test_field_validation_typed.py`
-  (27). **Follow-ups BOTH DONE this session** (see the field-family entry above):
-  **#216** (PR #219) NumberField empty-construction crash · **#217 part 1** (PR #220)
-  reactive `Form.valid`/`Form.errors` (part 2 stream-triggers deferred). NB the
-  **string-only `add_validation_rule`** decision is locked (a `ValidationRule` object
-  carries no info the string form lacks).
-- **Slider/RangeSlider review** (PR **#212**, MERGED) — value clamps to range, disabled
-  honored on every key (incl. Home/End), Home/End emit `<<Commit>>`, tightening the range
-  re-clamps the value(s); widget pages gained Events + Keyboard sections + value/min-max
-  screenshots. (The `fix/slider-review` branch is merged — stale.) `step=` follow-up
-  (#213/#210) and the Tab focus-trap (#211) are under "Next up".
-- **Shell chrome divider + context-menu / DataTable interaction fixes** (this
-  session; PRs **#206** and **#209**, both MERGED to `main`) — two batches from
-  dogfooding the AppShell + DataTable demos:
-  - **#206 — persistent chrome→content border + softer inter-toolbar divider**
-    (`fix/shell-content-border`). The chrome→workspace boundary is now owned by
-    **`ShellLayout`** (a content-surfaced `_body_sep` at the soft
-    `DIVIDER_BORDER_STRENGTH=0.90`, always packed between the chrome stack and the
-    body, mirroring the bottom `_status_sep`) — authors no longer rely on
-    `add_toolbar(divider=True)` for it, and the stroke matches the rail/sidebar/
-    status dividers instead of reading heavy (the original complaint). The
-    per-toolbar `add_toolbar(divider=True)` hairline was **softened to 0.90 + kept
-    chrome-surfaced** (was the default heavy blend) so an inter-bar divider matches;
-    it's now reserved for separating stacked bars. `appshell.rst` notes the
-    auto-boundary. Plain `App`/`Window` keep `divider=` as their chrome separator
-    (no shell layout, no auto border).
-  - **#209 — context-menu dismissal + DataTable right-click/selection + FormDialog
-    action result** (`fix/contextmenu-outside-dismiss`). (a) **ContextMenu**: the
-    overrideredirect popup's outside-dismiss now watches **all mouse buttons**
-    (was `<Button-1>` only — a right-click to open another menu slipped past it);
-    a one-shot **`_suppress_next_outside`** guard set in `show()` kills the
-    reopen-race that widening introduced (right-click another row reopens, doesn't
-    self-dismiss); and **`hide()` now runs BEFORE an item's handler** (a modal
-    handler was blocking with the menu still visible). (b) **DataTable**:
-    right-click **no longer changes the selection** (it set `_context_iid`; the
-    row-menu commands target it via new **`_context_iids()`** = clicked row, or the
-    whole selection when the click is inside a multi-selection); a left-click on a
-    checkbox/group table now **dismisses an open menu through the `'break'`** path
-    (`_dismiss_context_menus()` at the top of `_on_header_click`, since the tree's
-    `'break'` stopped the toplevel outside handler); and **selection survives a
-    `_refresh_tree` rebuild** for still-visible rows (sort keeps all, search narrows
-    — was a full clear on every search/sort/page). (c) **FormDialog**: `show()` was
-    overwriting `result` with form data for any non-cancel close, discarding a
-    custom button's `result` — so the edit dialog's **Delete** (`{"result":
-    "delete"}`) returned data instead of `"delete"` and the row was updated, never
-    deleted; new **`_resolve_result()`** maps submit buttons→form data, action
-    buttons→their result, cancel→None. (d) **Docs**: fixed stale `event["text"]`
-    dict-subscript in ContextMenu/MenuButton examples+guides (`on_select` gets a
-    `MenuSelectEvent` dataclass → `event.text`). **Follow-up issues filed:**
-    **#207** (general grab-based dismiss so user-attached menus also dismiss when a
-    host widget returns `'break'`) · **#208** (persist DataTable selection by record
-    id across pages — the "keep visible matches" interim shipped here).
-- **Navigation API reshape — `AppShell` + `Workbench` (#200)** (this session; PR
-  **#202**, MERGED to `main`) — split the one polymorphic `AppShell` into two
-  honest classes along the **topology** axis: **`bs.AppShell`** = single-tier
-  *sidebar host*; new **`bs.Workbench`** = two-tier *workspace host*
-  (`add_workspace` + rail). Shared **`_SidebarHost`** mixin (on `AppShell` +
-  `Workspace`); a private **`_ShellBase`** carries window/chrome/lifecycle. The
-  **provider** axis is four parallel front doors — **`page_nav()`** (authored
-  pages), **`list_nav()`** / **`tree_nav()`** (data-bound master-detail),
-  **`custom_nav()`** (renamed from `panel()`); one per sidebar, only `page_nav`
-  authored (`add_page`/`add_header`/`add_divider`). Provider options live on the
-  provider: **`page_nav(variant='ghost'|'solid')`** (standalone-only; forced to the
-  wash under a rail) and the full `PageStack.add` **layout kwargs on `add_page`**
-  (a page IS a column — no inner wrapper). Footer = **`pin_to_footer=`** flag
-  (dropped `add_footer_page`/`add_footer_workspace`). Shell kwargs keep only app-wide
-  chrome (`nav_accent`, surfaces, `rail_*`). **Framework fix surfaced in review:
-  `ContentHost` now FILLS its child** — master-detail/custom content was shrinking
-  and centering (the apparent "extra padding"); detail panes left-aligned at
-  `padding=(16, 10)`. Internal `Shell`/`Workspace` keep `add_page`/`add_workspace`/
-  `panel`/`nav_selection` (public layer is the rename boundary). Built `Workbench`
-  doc page + screenshot scenes; AppShell page gained a "Sidebars at a glance" card
-  grid + ghost/solid + compact shots; Workbench compact is **not** a mode (rail is
-  the icon tier → sidebar is expanded/hidden, documented). **#189 nav_variant
-  (PR #199, MERGED) was folded in** — `nav_variant` ctor kwarg → `page_nav(variant=)`;
-  its `test_nav_selection.py` removed (superseded by `test_appshell_reshape.py`).
-  Tests: `test_appshell_reshape.py` (6) + `test_workbench.py` (2). Memory
-  `project_navigation_api_reshape`. **Follow-up: #201 — SHIPPED (sidebar
-  hamburger, see top of this list).**
-- **Sidebar hamburger toggle — `Toolbar.add_sidebar_toggle()` (#201)** (this
-  session; on `feat/nav-expandable-group`) — #201 was filed as an *expandable
-  sub-item nav group*, but the maintainer **reinterpreted it** as a built-in
-  **hamburger that collapses/expands the AppShell sidebar** (the accordion-style
-  sub-items stay parked per the nav-spec Revision-4 cut — compose `bs.Accordion`
-  in a `custom_nav`). The collapse machinery already existed (`toggle_sidebar()`/
-  `show_sidebar()`/`hide_sidebar()`/`sidebar_mode`, Ctrl-B); what was missing was
-  a control. Modeled on `ThemeToggle`/`add_theme_toggle()` but **NOT standalone**
-  (a sidebar toggle is meaningless outside one shell): an internal
-  `SidebarToggle(Button)` (`widgets/sidebar_toggle.py`, **not** in `bs.*`) built by
-  **`Toolbar.add_sidebar_toggle(**kwargs)`**, which wires it to the owning shell.
-  **AppShell-only** — the guard is `isinstance(host, AppShell)` (a `_SidebarHost`;
-  `Workbench` inherits `toggle_sidebar` from `_ShellBase` so a `hasattr` check is
-  too loose), raising `BootstackError` on `Workbench`/`App`/`Window`. Enabler:
-  `add_toolbar()` (ChromeHostMixin) now passes `_host=self` into the `Toolbar`;
-  `Toolbar.__init__` stores `self._host`. **Author places it wherever they want in
-  the bar — no auto-injection.** `collapse='compact'` is the **default** (the
-  desktop/Fluent convention: shrink to the icon rail, reusing the shell's
-  `_can_compact_active()` so it **falls back to hidden** for non-compactable
-  data-bound navs); `collapse='hidden'` always fully hides. **Mode-dependent
-  default icon** (`icon=None` resolves to `layout-sidebar` for compact, `list` for
-  hidden); single steady glyph unless the author passes a stateful pair
-  (`collapse_icon` shown while expanded, `expand_icon` while collapsed, each
-  falling back to `icon`). A ~6px toggle-vs-rail offset in compact is **left as-is
-  by decision** (only visible compacted; aligning would couple toolbar padding to
-  rail width). Tests `tests/widgets/public/test_sidebar_toggle.py` (8). Docs:
-  "Sidebar toggle" section in `docs/widgets/toolbar.rst` (full detail) + the
-  AppShell page's "Sidebar visibility" section (the user-facing control,
-  cross-linked). StatusBar deliberately **not** given the method (scope creep — a
-  hamburger belongs in a toolbar).
-- **Gallery/Carousel height-floor cleanup (#160)** (PR **#185**, MERGED) — added the
-  regression test + hardened two magic numbers into named constants; the floor itself
-  shipped in #161. Memory `project_picture_suite`.
-- **Tab overflow handling (#168)** (PR **#184**, MERGED) — clipped tabs scroll (wheel +
-  selected-tab auto-scroll) with a trailing chevron overflow menu; `max_tabs=`; always-on
-  (plain strip kept only for `tab_width='stretch'`). Three framework fixes: PackFrame
-  no-repack when `gap==0`, PageStack pre-size-on-swap, deferred `_scroll_into_view`.
-- **ContextMenu/Tooltip cover container children (#166)** (PR **#183**, MERGED) —
-  `propagate_target_bindings()` adds the container's path bindtag to every descendant so
-  the gesture fires anywhere inside. Memory `reference_bindtags_underused`.
-- **Theme-repaint cleanup (#177) + docstring-backtick sweep** (PRs **#181**/**#182**,
-  MERGED) — code-editor `StyleRegistry`/`SearchOverlay`/`IndentGuides` migrated onto
-  `<<BsThemeChanged>>`; dead `FloodGauge` deleted; 754 RST double→single backticks across
-  43 `src/` files. Memory `project_docstring_backticks`.
-- **Undecorated window chrome (#162/#165) + theme-repaint perf (#167)** (PRs #175/#176/
-  #178/#179/#180, MERGED) — undecorated App/Window/AppShell auto-inject titlebar+border;
-  canvas widgets re-resolve colors via the STD publisher (post-rebuild), gated on
-  visibility (gallery toggle ~2960ms→~580ms). Memories `project_undecorated_window_chrome`,
-  `reference_theme_repaint_mechanisms`.
-- **Pre-release `0.1.0a10` shipped + docs deploy fixed** (PRs #139/#140, MERGED) — Toast
-  split into `toast()`/`Notification`/`Snackbar`; gallery/demo widget coverage; released to
-  PyPI + GitHub Release; docs-deploy fixed (restored `docs/CNAME` + `html_extra_path`).
-  Memories `project_prerelease_readiness`, `project_toast_notification_split`.
-- **0.1.0 API-freeze pass — breaking changes drained + ThemeToggle + media floor** (PRs
-  #141–#161, MERGED) — workflow action bump (#141), ttkbootstrap naming purge (#142),
-  clipboard scope (#151), nav missing-key errors (#153), `Theme.from_existing` (#156),
-  `Signal.subscribe` cancelable handle (#157), VariantToken retirement (#158), `ThemeToggle`
-  (#159), media min-height floor (#161). Memories `project_clipboard_api_scope`,
-  `project_variant_type_revisit`, `project_picture_suite`.
-- **AppShell + navigation clean-slate rewrite** (PRs #133–#136, MERGED; later split into
-  AppShell + Workbench by #200/#202 — see top) — VS Code-style rail + swappable sidebar +
-  content; `bs.AppShell` swapped onto the new `Shell`, standalone `bs.SideNav` dropped.
-  Companions: theme/Bootstrap-alignment v2 (#137), thin-scrollbar exposure (#138),
-  nav-patterns docs (#136). Spec `docs/_dev/appshell-navigation-spec.md` (Revision 4).
-  Memories `project_appshell_sidenav_refactor`, `project_theme_bootstrap_alignment`,
-  `project_thin_scrollbar_initiative`, `project_nav_patterns_section`.
-- **Media widget suite — Picture / Gallery / Carousel / Avatar** (PRs #126–#132, MERGED) —
-  media-display widgets on the public `Image` handle: Picture (fit modes, animated GIF),
-  Gallery (record-native thumbnail grid), Carousel (one-at-a-time stepper), Avatar
-  (image-or-initials). Plus `on_select` rename (#130) + theme-aware demo videos (#131).
-  Memories `project_picture_suite`, `project_avatar_widget`, `project_doc_demo_videos`.
-- **Public Image/Icon API + AppIcon + field signals** (PR #125, MERGED) — `bootstack.images`
-  (`Image` handle, `get_icon`/`list_icons`, `AppIcon` → `.ico`/`.icns`/`.png`); `App`/`Window`
-  `icon=`; live `icon`/`image` setters; typed `signal=` on Number/Date/Time fields;
-  `bootstack.toml` scoped to build/scaffold; public file-dialog verbs; ships `bootstack appicon`.
-  Memories `project_image_icon_public_api`, `project_field_value_signal_dtype`.
-- **Menu bar + command bar** (PR #124, MERGED) — cross-platform `app.menubar` (themed strip on
-  Win/Linux, native `NSMenu` on macOS); `Toolbar`→`CommandBar`; legacy `bs.MenuBar` removed;
-  `app.menu`→`app.menubar`, `app.toolbar`→`app.commandbar`. Memory `project_menu_redesign`;
-  follow-up `project_macos_window_chrome`.
-- **Widget detach/attach** (PR #123, MERGED) — `detach()`/`attach()`/`is_attached` across
-  pack/grid/place; `on_attach`/`on_detach`; `attached=False` ctor; new `index=` pack knob.
-  Memory `project_widget_attach_detach`; backlog `project_inherited_base_api_docs`.
-- **Select grouping + popup height cap** (PR #122, MERGED) — `Select(group_by="field")` clusters
-  the popup under verbatim headers (names any bag field, presentational only); `max_visible_items=N`.
-  Memory `project_select_options_databag`.
-- **Universal `.selection` on ListView/DataTable/Tree** (PR #120, MERGED) — polymorphic by
-  `selection_mode` (dict/list, TreeNode handles); replaced `get_selected()`/`selected_rows`/
-  `selected_nodes` (clean break); `ListView.select_items`/`deselect_items`. Memory `project_option_databag`.
-- **Field value/text/label contract + option data bag** (PRs #113–#116, MERGED) — `label`=caption,
-  `text`=formatted display (public read-only), `value`=raw datum (never derived from text); shared
-  `Option = str | tuple | OptionDict` + `normalize_option` with a data bag; `.selection` accessor.
-  Memories `project_field_value_text_model`, `project_option_databag`.
-- **Widget API gap audit + documentation** (PR #111, MERGED) — audited ~49 widgets vs their
-  `_impl/` internals; added lifecycle (`destroy`/`on_destroy`), `WindowControlsMixin` on
-  App/AppShell/Window (AppShell is now a `PublicWidgetBase`), group management, live properties;
-  new **Application** widget category with full-window screenshots. Brief `docs/_dev/widget-api-audit.md`.
-- **Linked type aliases + widget-API consistency** (MERGED) — public aliases render as their
-  short NAME, linked to a `.. py:type::` entry (dropped `sphinx_autodoc_typehints`;
-  `autodoc_type_aliases` FQN map; `python_use_unqualified_type_names`; a `TypeAliasForwardRef`
-  patch). Memories `project_enum_option_typing`, `reference_typed_alias_linking`.
-- **Unified data bag** (PR #92) — non-scalar fields carried across Tree/DataTable/ListView
-  (SQLite `_bs_data` JSON column; `bs.SerializationError` on non-JSON). Memory `project_data_bag`.
-- **Large-file streaming** (PRs #93–#96) — chunked `load()`; pluggable reader/writer registries;
-  `FileDataSource` → SQLite working store; `export_formats`. Memory `project_file_source_streaming`.
-- **Tree public-API modernization** (PR #91) — recycle-view canvas Tree, `TreeNode` handles.
-  Memories `project_tree_row_model`, `reference_treeview_perrow_indicator_state`.
-- **Icon rendering + DataTable polish** — ink-metric icon renderer; `Table`→`DataTable` +
-  DataSource decoupling. Memories `project_icon_rendering`, `project_table_datasource_coupling`.
-- **Tree data-source backing** (PR #97) — `Tree(data_source=, parent_field=)` lazy hierarchy
-  from a flat adjacency-list source. Memory `project_tree_datasource_backing`.
-- **SqliteDataSource schema inference** (PR #98) — `load()` samples leading rows to infer column
-  types (fixes the TEXT-affinity-from-leading-NULL bug).
-- **Signal runtime cleanup** — `signal()` single getter; `is_signal()` duck-types. Memory
-  `reference_signal_duck_typing`.
-- **Preferences store `bs.Store`** — dict-like JSON file-backed prefs; shared `_core/paths.py`.
-  Memory `project_persistent_kv_store`.
-- **AppSettings flattening** (PR #101) — flat `App()`/`AppShell()` kwargs; `settings=`/`AppSettings`
-  gone. See the "FLAT kwargs" gotcha. Memory `project_app_settings_flattening`.
-- **Reference docs review pass** (PR #103) — enriched `docs/reference/*` + `localization.rst`;
-  `compare` rule; `Form.validate()` runs all rules.
-- **Top-level namespace curation + dialogs restructure** (PR #104) — `bootstack` slimmed to the
-  compose surface (~85 names); dialog classes → `bootstack.dialogs`. Memory `project_toplevel_api_surface`.
-- **Docs build warnings cleanup** (PR #106) — clean-build 40→0; keep it warning-free.
-- **API Reference restructure — Stages 1–3** (PR #107) — Diátaxis split: narrative (Widgets +
-  Guides) + by-module API Reference; templates/recipe in "## API Reference & Guide page pattern".
-  Memory `project_api_reference_restructure`. (Stage 4 homing DONE — see "History".)
+**Released:** `0.1.8` on PyPI, tag `v0.1.8` (2026-07-23); `pyproject.toml` is at
+`0.1.8`. **`main` is GREEN** (Windows, 893 passed, exit 0) with **no open PRs**.
+A failing test is a real signal — treat any red as a regression.
+**Working branch: `fix/392-subscription-cancel`** — green too (899 passed), all
+changes uncommitted. `main` itself is untouched.
 
-## Next up
+**⏭ THE ACTIVE TARGET IS `0.2.0`** — milestone **`0.2.0 — Form and field
+correctness`** (`gh` milestone **#6**). **A minor, not a patch, and that was a
+deliberate maintainer call:** the project committed to SemVer at 0.1.0 and two
+merged changes are not backward compatible (**#381** raises where it used to
+accept; **#387** made `configure(data=)` genuinely clear absent keys). **#394**
+also moves pixels in any layout pairing a field with a taller widget on a stretch
+axis. Merged already: #332, #379, #381, #387, #388, #394. **#392 is FIXED but
+UNCOMMITTED on `fix/392-subscription-cancel`, awaiting the review in item 0
+below. Remaining after that: #389, #390.** Every themed milestone shifted OUT one
+minor —
+`0.2.x — Widget polish` (#2) · `0.3.0 — Guided flows` (#3) ·
+`0.4.0 — Power-user interactions` (#4) · `0.5.0 — Structured editing` (#5).
+Mapping + reasoning: memory `project_roadmap_milestones`.
 
-> ⏭ **0.1.0 STABLE SHIPPED (2026-06-24) — see the top "Recently completed" entry.**
-> `bootstack 0.1.0` is on PyPI + tagged `v0.1.0`; the public compose API is FROZEN
-> under SemVer; the **0.1.0 (stable) milestone is CLOSED**. **#149 is DONE** — all
-> its folded items shipped (`text=<Signal>` guard + `cli/run.py` via PR #334;
-> `__version__` is dynamic; CHANGELOG via #335). `bootstack.dev` stays
-> **PROVISIONAL** (excluded from the freeze). The `0.1.x` line was a **rolling
-> series of patch releases**: `0.1.1` pygments packaging · `0.1.2` menu
-> window-move dismiss · `0.1.3` Form `editor_options` public kwargs (#354) ·
-> `0.1.4` `Select.add_validation_rule` restored (#357) · `0.1.5` boolean-control
-> state reads + Checkbox tristate (#360) · `0.1.6` seven form/field/validation
-> fixes (#362–#368) · `0.1.7` Tk 9 scroll contract (#373/#374) · **`0.1.8` macOS
-> sizing on Tk 9 (#377 — on PyPI 2026-07-23, the LATEST RELEASE)** — see the top
-> "Recently completed" entries.
->
-> **⏭ THE ACTIVE TARGET IS `0.2.0` (decided 2026-07-29).** Milestone **`0.2.0 —
-> Form and field correctness`** (`gh` milestone **#6**). **A minor, not a patch,
-> and that was a deliberate maintainer call** — the project committed to SemVer
-> from 0.1.0 and two merged changes are not backward compatible (#381 raises where
-> it used to accept; #387 made `configure(data=)` genuinely clear absent keys).
-> Content: merged **#332, #379, #381, #387, #388, #394** plus **#389, #390, #392**
-> to finish. **Every themed milestone shifted OUT one minor** and the rolling
-> patch line was renamed:
-> `0.2.x — Widget polish` (#2, was `0.1.x`) · `0.3.0 — Guided flows` (#3,
-> Timeline/Wizard) · `0.4.0 — Power-user interactions` (#4, DropZone/command
-> palette) · `0.5.0 — Structured editing` (#5, color-swatch/PropertyInspector).
-> **Full mapping + the reasoning: memory `project_roadmap_milestones`** (which now
-> exists — CLAUDE.md had been pointing at a dangling link, and the old inline
-> roadmap "0.2.0 Timeline/Wizard → 0.3.0 palette/DropZone" is OBSOLETE).
-> **#369 and #383 are deliberately un-milestoned:** both would raise where the
-> framework currently accepts, so they cannot ride the `0.2.x` patch line and need
-> a minor of their own. #352 and #328 are also homeless.
->
-> **★ START HERE NEXT SESSION (2026-07-29 handoff, session 3) — FINISH THE THREE
-> OPEN `0.2.0` ITEMS, THEN CUT THE RELEASE.** `main` is green on Windows, has **no
-> open PRs**, and the working tree is clean. The plan agreed with the maintainer:
-> land #392/#390/#389, then release **0.2.0** (milestones are already renumbered —
-> see the block above). Order of value:
-> 1. **#392 — `Subscription.cancel()` is BROKEN** (detailed below). A real
->    product bug that silently kills unrelated handlers, 58 affected call sites,
->    and **no regression test exists**. Highest value on the board. It also gates
->    the harness leak-fix (see #379-harness below).
-> 2. **#390 — decide whether signals should model emptiness at all** (design; the
->    four sub-decisions and a recommendation on each are below). It is the gate on
->    #389 shipping *whole*: without it, `Form.clear()` works but leaves a bound
->    `Signal` stale. **If the answer is no, close #390** and ship #389 with the
->    limitation documented.
-> 3. **#389 — `Form.reset()` / `Form.clear()`.** Unblocked (its dependency #387
->    merged), design fully settled, implementation sketch on the issue.
->
-> Then the standing items: **#380 (CI)**, **#383 (kwarg sweep)**, and the
-> harness leak-fix.
->
-> **Loose ends left by the #394 session (small, none blocking):**
-> - **`show_grid=True` is silently accepted on `Row` and does nothing.** It is not
->   a kwarg anywhere in `src/`, but it is swallowed into the layout kwargs without
->   error — the #394 reporter used it *while trying to diagnose the bug* and got no
->   feedback. Textbook **#383** material (silently degrading kwargs); fold it in.
-> - **If the #394 precedence rule ever needs documenting or demoing, don't use a
->   row of centered fields.** A `Row(vertical_items='center')` holding only fields
->   is the bug on purpose — the maintainer rightly noted nobody would write it. The
->   realistic case for the override is a **mixed-content** row, e.g.
->   `bs.Avatar(size=64)` beside a field, where top-aligning pins the field's *label*
->   to the avatar's top and centering is what you actually want.
->
-> **#379 harness leak-fix — NOT in #385, do it after #392.** The real root cause
-> of the order-dependence was found and deliberately left out: `conftest._region()`
-> returns `_region_root`, which on a decorated App **is the root**, so
-> `_snapshot`/`_reset_scene` never look inside the App's `_content_frame` — **the
-> scene reset has been a no-op for content widgets for the entire life of the
-> shared-root harness**, and every test's widgets pile up all session. Fixing it
-> makes PageStack pass with no `isolated` marker and cuts the widget leg
-> **144s → 80s**. It is held back because it exposes **#392** and a second latent
-> bug (`test_select_change_event_value_space` picking up 5 change events from
-> earlier tests — looks like stale bindtag bindings surviving destroy while Tk
-> recycles widget path names; not chased down). Patch preserved at
-> `scratchpad/leakfix.patch`; own branch, after #392 lands.
->
-> **#380 (CI test workflow), deferred 2026-07-28.**
-> `.github/workflows/` still has only `docs.yml` + `release.yml`, so **nothing
-> runs the suite**; every Tk 9 bug so far was found by a user or by hand. Branch
-> `ci/test-workflow` was created and deleted unused — recreate it. Plan agreed:
-> **(1)** headless `ubuntu-latest` logic job — `test_tk9_scaling_baseline.py`
-> monkeypatches `platform.system()`/`tkinter.TkVersion` so it needs **no display
-> and no Tk 9**, and would have caught #375; **(2)** an `xvfb-run` Linux job for
-> the widget suite; **(3)** fold in the `tests/widgets/*.py` never-collected gap
-> above. **DEFER the macOS/Tk 9 leg** — it is blocked on #378 (the suite cannot
-> complete on Tk 9 at all) and would be red from day one. Read the issue before
-> scoping: it carries measurements showing the naive "just run pytest" plan fails
-> (`-m "not gui"` selects 741 tests but yields **494 errors** headless — only
-> ~222 genuinely run without a display), and warns that `Treeview.bbox()` returns
-> `''` rather than erroring on an unmapped window, so geometry assertions
-> **vacuously pass** headless.
->
-> **Open, additive items (no longer ship-blockers) — candidates for the next 0.1.x patch:**
-> - **★ #392 — `Subscription.cancel()` is BROKEN (filed 2026-07-29; real product
->   bug, highest-value item here).** Cancelling one subscription **silences every
->   other handler on that event**. `_runtime/events.py`'s `_patched_bind` writes its
->   own Tcl script for **virtual events** (`<<...>>` = every bootstack event) in a
->   bare `<funcid> %d %# ...` format, but **`unbind` was never patched to match**:
->   `Misc._unbind` strips by the prefix `if {"[<funcid> ` that stock Tkinter emits,
->   so nothing is filtered (**the binding survives**) while `deletecommand(funcid)`
->   still runs (**the Tcl command is deleted**). The orphan then errors on every
->   dispatch, and since bindings use `add='+'` they are ONE concatenated script — so
->   the error **aborts every handler after it**. Silent: no Python-level exception.
->   Proven with public API only (`bs.Button` + two `on_click` subs → `a=0 b=0` after
->   cancelling `a`) plus a **control** (strip the orphan line by hand → `b=1`
->   restored) and reproduced on **stock Python 3.13.9 tkinter with no bootstack**.
->   **58 `unbind('<<...>>', funcid)` sites** are affected (dialog result plumbing,
->   `validation_mixin`, `compositeframe`, `meter`, `tabview`, `calendar`,
->   `accordion`, `expander`, `pagestack`, `ThemeToggle`). **Real events
->   (`<Configure>`/`<Unmap>`/`<Destroy>`) take `_original_bind` and are NOT
->   affected.** Suggested fix = emit stock Tkinter's
->   `if {"[<funcid> ...]" == "break"} break` wrapper (also restores `return "break"`
->   propagation for virtual events, impossible today); patching `unbind` to match the
->   custom format keeps two formats in play. **Needs a regression test — there is
->   none.** ⚠ This **contradicts the CLAUDE.md note that 3.12.10's `unbind(seq,
->   funcid)` removes only that funcid** — true only for *stock-format* bindings,
->   which is why it checked out when verified against `<Configure>`.
-> - **★ #390 — signals cannot represent an empty value (DESIGN, needs your call;
->   filed 2026-07-29 from #386).** `Signal.set(None)` raises unconditionally
->   (`signal.py:248` — strictly monomorphic, type inferred from the seed), so a
->   signal bound to a field can never reflect that field being empty; it silently
->   keeps its last value. **Four decisions, in order:** (1) **do it at all?** — the
->   alternative is documenting that signals don't model emptiness and letting
->   `Form.clear()` leave them stale; (2) **declared or automatic?** — recommend
->   **declared** (`Signal(v, nullable=True)`), because automatic-by-mode cannot
->   cover `int` and isn't safe to lean on: `Signal(0)` is Python-authoritative only
->   *while unrealized*, so the moment anything touches `.var`, `__call__` starts
->   reading the IntVar and a stored `None` is lost; (3) **what happens to a
->   non-nullable signal asked to go empty?** — recommend a public `Signal.nullable`
->   so `ValueSignalMixin` skips rather than crashing `Form.clear()`; (4) **what does
->   `map()` do over a nullable signal?** — it calls the transform unconditionally
->   and infers the derived type from the first result (`signal.py:295, 302`), so a
->   `None` source breaks the **documented** Date/Time pattern (typed `signal=` plus
->   a `.map()`-derived text signal); short-circuiting needs the derived signal to be
->   nullable, which the inference can't express. **No existing code is at risk
->   either way** — `set(None)` raises today, so nothing can currently receive it.
->   **THE KEY MEASURED FINDING (don't re-derive it):** the dividing line is
->   **attached-vs-not, not object-vs-native**. `NumberField(signal=)` and
->   `DateField(signal=)` are **unrealized** — `ValueSignalMixin` syncs via
->   `subscribe()` + `on_change` in pure Python and never touches `.var`, and the
->   widget's own `textvariable` is a *different* signal. So **for a number field's
->   value signal there is no IntVar at all.** `Checkbox(signal=)` and
->   `TextField(textsignal=)` **are** the widget's `variable`/`textvariable` — there
->   the var is live and rendered, and `None` either raises (`IntVar`) or **silently
->   corrupts**: `StringVar.set(None)` stores the literal `'None'`, the widget
->   displays `None`, `sig()` returns the 4-character string, and every subscriber
->   gets it. That last measurement is why a blanket guard relaxation must not ship.
->   **Per-type "empty" values were considered and rejected** — `empty(int) = 0`
->   contradicts the shipped `NumberField.clear()` decision ("`None`, not `0`, so a
->   cleared required field still reads as blank"), `empty(bool) = False` collapses
->   tristate (0.1.5 / #358), `date` has no empty value only a **sentinel**
->   indistinguishable from data, and it makes emptiness type-dependent at every call
->   site. The framework already runs both models in separate channels — `value` is
->   `None` when empty, `text` is `''` — and keeping them separate is what stops
->   either leaking into the other.
-> - **#389 — `Form.reset()` / `Form.clear()`** (filed 2026-07-29; unblocked now
->   that #387 merged). Design settled — see the session entry at the top and the
->   issue body, which carries the implementation sketch.
-> - **#383** (follow-up sweep from #381 — presentation kwargs still degrade
->   silently + raw `TclError`/`AttributeError` leaks; sweep BY ARGUMENT NAME).
->   **Added 2026-07-29: `Slider.value = None` leaks a raw
->   `TypeError: float() argument must be...`** — reachable from user code via
->   `form.set({'slider_key': None})`.
-> - **#208** (DataTable: persist selection by record id across search/sort/page).
-> - **#192** — color-swatch Select control (decision-gated; lock shape/naming first).
-> - **#207** — ContextMenu outside-dismiss vs a `'break'` target — **DEFERRED** (no
->   API implication, low/self-inflicted impact, Win/Linux only; agreed proportional
->   fix if revisited = a module-level open-menu registry + dismiss-all from
->   `DataTable._on_header_click`, NOT the risky grab). Analysis on the issue.
-> - **#222** (TextField live `placeholder`/`mask` props) and **#234** (SpinnerField↔
->   NumberField parity, decision-gated) remain open and additive — see the
->   field-family follow-ups section below.
-> - **Hot-reload follow-ups #325/#326/#327 — DONE (PR #333);** #328's docs DONE,
->   its **E2E multi-file `@reloadable` reload test is the one OPEN piece, DEFERRED**
->   (maintainer will write it). **#332** (rename the internal `set_*_visible` family)
->   is OPEN, low priority. All on PROVISIONAL `bootstack.dev` — see the "Recently
->   completed" entry.
-> - **Docs-IA spin-offs #323 + #324 — DONE** (folded into User Guide; see the
->   "Recently completed" entry). The docs navbar is now **3 pillars**.
->
-> **Latest RELEASE is `0.1.8`** (tag `v0.1.8`, on PyPI, 2026-07-23;
-> `pyproject.toml` is at `0.1.8`). **`main` has a GROWING `## [Unreleased]`
-> section** — the #381 mode guard (PR #382), PR #384 on top, then #387/#388/#393
-> and **#394/#395 (which also added the first `### Changed` entry)**. The next
-> patch cut must sweep all of them, and note the release-flow gotcha below:
-> promote `## [Unreleased]` to the version in its OWN commit *before*
-> `bump-my-version`, which touches only `pyproject.toml`.
->
-> **⚠ BEFORE CUTTING THE NEXT RELEASE — decide patch vs minor.** The staged work is
-> not purely additive, so `0.1.9` is a judgment call, not automatic:
-> - **#381 raises where it used to accept.** `selection_mode="multiple"` (invalid)
->   silently gave single-select before and now throws `InvalidChoiceError`. Code
->   that was quietly wrong starts failing loudly. Defensible as a fix, but it *is*
->   a behavior break for a working-ish program.
-> - **#387 changed `configure(data=)` semantics** — it stays a whole-record write,
->   so keys absent from the mapping now genuinely CLEAR rather than being ignored.
->   `set()` is the merge path. A caller relying on the old accidental no-op loses data.
-> - **#394 moves pixels** in any layout pairing a field with a taller widget on a
->   stretch axis (`### Changed`), plus the `Row()` vs `Row(vertical_items='center')`
->   asymmetry.
-> - **VERIFIED SAFE (2026-07-29):** clearing a **signal-bound** field after #387
->   does **not** raise — `Signal.set(None)` is never reached, so there is no new
->   crash path. It leaves the signal **stale** (`DateField` → `None` while the
->   signal still held `date(2026,1,1)`; `NumberField` → `None`, signal still `5`;
->   `TextField` correctly went to `''`). That is the **#390** gap, a known
->   limitation rather than a regression — but it means the #386 reporter's flow
->   (clear a field, read the bound signal) is only half-served until #390/#389
->   land. Document the limitation in the release notes if shipping before them.
->
-> **`main` is GREEN (2026-07-29).** #385 merged, so the six known-failing macOS
-> tests are gone and that section has been deleted — as intended, since keeping a
-> prose list of accepted failures is the fragility #379 was filed about. macOS:
-> `run_gui.py` exit 0 on macOS 26.5.2 / Tk 8.6 / Py 3.14.0 (**as of #385 — macOS
-> has NOT been re-run since #393/#394 landed**; neither touches platform-specific
-> paths). Windows after #395: **893 passed, exit 0**, all legs. **A failing test is
-> a real signal — treat any red as a regression.**
->
-> **⚠ ENVIRONMENT — TWO MACHINES. Check which one you are on first.**
->
-> **macOS box (2026-07-29):** repo at **`/Users/israeldryer/PycharmProjects/bootstack`**
-> (NOT the `D:\Development\bootstack` at the top of this file — that is the Windows
-> box). Here **`.venv` WORKS**: `.venv/bin/python` = **Python 3.14.0, Tk 8.6**,
-> editable install, macOS **26.5.2**. `python tests/run_gui.py` runs the full GUI
-> suite in ~2 min with a real display. `bootstack.__version__` reports `0.1.8`
-> correctly. ⚠ Tk here is **8.6, not 9** — this box does NOT exercise the Tk 9
-> paths, so the `test_scroll_events.py` touchpad tests still SKIP (see 0.1.7).
-> `python3.13` exists system-wide but does **NOT** have bootstack installed.
->
-> **Windows box (CORRECTED 2026-07-29):** the checked-in `.venv` is
-> **STALE** — it points at `C:\Users\Israel Dryer\...\Python314\python.exe` and
-> every call fails with *"Access is denied"*. Use the launcher instead.
-> **⚠ Use `py -3.12` for BOTH tests and docs.** The previous note said `py -3.13`
-> for tests; that is **wrong and wastes a cycle** — **pytest is installed ONLY on
-> 3.12** (9.0.3), and `py -3.13 tests/run_gui.py` fails every leg with
-> *"No module named pytest"* while still printing a plausible-looking harness
-> summary. 3.13 and 3.14 have neither pytest nor the docs deps. `py -3.13` (3.13.7,
-> Tk 8.6) is still fine for **running demo scripts**, which is all it is good for.
-> **`myst-parser` was missing** and the docs build died with
-> `ExtensionError: Could not import extension myst_parser` before reading a file —
-> installed 2026-07-29 (`py -3.12 -m pip install myst-parser`), so
-> `py -3.12 -m sphinx -b html docs docs/_build/html -W --keep-going` now works. It
-> is a declared dep in both `docs/requirements.txt` and the `docs` extra; it was
-> simply absent from this interpreter. `bootstack.__version__` reports a stale
-> `0.1.0a9` from old install metadata — harmless, ignore it.
->
-> **⚠ `tests/widgets/*.py` NEVER RUNS.** `testpaths` is `tests/cli`,
-> `tests/widgets/public`, `tests/data`, and `run_gui.py` passes those same paths
-> — so **12 files / 25 tests** directly under `tests/widgets/` (`test_shell_*`,
-> `test_icon_image_props`, `test_rebuild_regressions`, `test_toolbar_drag`) are
-> collected by nothing. All 25 **pass** when run individually (each builds its
-> own root, so they'd need `isolated` treatment). Dead coverage, same class as
-> #365. Fold into the #380 work.
-> **Release flow gotcha (bit me on 0.1.7):** `bump-my-version bump patch
-> --allow-dirty` commits **ONLY `pyproject.toml`** — it will NOT sweep the
-> CHANGELOG rename into the `Release X` commit, which ships a release whose notes
-> still say `## [Unreleased]` and breaks `release.yml`'s section extraction.
-> Either commit the rename first or `git commit --amend` + re-tag before pushing.
-> **CONFIRMED WORKING on 0.1.8** — that cut ran `docs(changelog): promote
-> Unreleased to 0.1.8` (`7c136b20`) *before* `Release 0.1.8` (`b2f37f0f`, which
-> again touched **only `pyproject.toml`**), and the `[0.1.8]:` link definition
-> landed with the rename. Keep doing it in that order.
-> **0.1.6 caveat that still stands:** its behavior CHANGES (format rules on empty
-> values; `Select` accepting off-list values) were only ever exercised by tests,
-> never dogfooded in a real app.
-> See the top "Recently completed" entry for 0.1.7 and 0.1.3–0.1.6 below.
-> `0.1.0` (STABLE) was released 2026-06-24 (tag `v0.1.0`). The prior `0.1.0a16`
-> pre-release (cut 2026-06-23) contained the
-> icon-DPI cluster #306/#307/#309 + cross-platform `windowtype` #313 +
-> `bs.Splash` #318. The splash session also added an **events-doc-coverage guard**
-> (PR #319, `test_events_doc_coverage.py`) after `events.rst` was found drifting from
-> `events.__all__`. Memory `project_splash_widget`. **Watch-out the splash session
-> surfaced:** the event loop must turn for a splash to show motion — a `until="ready"`
-> splash over a *synchronous* build is a STILL image (documented in the how-to); and
-> the maintainer caught a stray "Tk" in docs (no-toolkit rule) + the `events.rst`
-> drift, both now fixed/guarded.
->
-> **Standing principles** (apply in every review): live properties only for
-> *legitimate runtime needs* (`feedback_live_properties_runtime_need`) — e.g. `surface`
-> is **build-time, not live**; prefer Tk native/virtual-event bindings, don't undo a
-> convention without reason (`feedback_prefer_native_bindings_dont_undo_conventions`);
-> describe the clean public surface in docs, **no implementation/toolkit detail**
-> (`feedback_no_toolkit_internals_in_docs`); **adversarially verify reviewer claims** —
-> agents over-flag (the audit disproved 2 "bugs").
->
-> **Process reminders:** a fix pushed AFTER its PR merged is **stranded** — verify
-> it's in `main`. Test PUBLIC paths, not internal side-hacks. Run GUI tests via
-> `python tests/run_gui.py` (one root per process). **Never pipe a build/test command
-> to `tail`** — you capture `tail`'s exit 0 and miss real failures (bit the audit:
-> hid a failing test leg AND the broken docs build). **This bites in PowerShell
-> too**: `pytest ... | Select-String ...` leaves `$LASTEXITCODE` from the
-> *pipeline*. Redirect to a file, capture `$LASTEXITCODE` on the next statement,
-> then grep the file.
->
-> **Two techniques worth reusing (2026-07-28 session):**
-> - **Measure the surface before scoping a sweep.** An AST pass over public
->   `__init__` signatures + a construct-with-a-bogus-value probe turned "audit the
->   siblings" from guesswork into a table (215 kwargs, 17/24 silently accepting),
->   which is what justified drawing the line at behavior modes in #381.
-> - **A platform-specific backend is often constructible off-platform.**
->   `_NativeContextMenu` (macOS) is a `tk.Menu` wrapper and instantiates fine on
->   Windows, so macOS-only helper code got real test coverage here — and that
->   caught a `TclError`-on-separator bug that would otherwise have shipped. Ask
->   "can I build the other platform's object directly?" before accepting
->   "unverifiable from this box".
->
-> **Four techniques worth reusing (2026-07-29 macOS-verification session):**
-> - **Run the BASELINE before the fix.** Ran the six failures on `main` first, so
->   the before/after transition was *observed* rather than assumed — and that is
->   what made "the branch fixes only 2 of 6" a fact instead of a suspicion.
-> - **A control experiment separates causation from correlation.** For #392 it was
->   not enough that cancelling `sub_a` silenced `sub_b`; stripping the orphaned
->   binding line by hand and watching `sub_b` come back (`b=1`) is what proved the
->   orphan was the cause. Do this before filing any "X breaks Y" claim.
-> - **Bisect order-dependent failures; do not theorize.** A scripted prefix-bisect
->   over the collection order found the culprit file in 6 runs, and a **geometry
->   probe** (printing `winfo_ismapped`/size/reqheight in the passing vs failing
->   order) turned "state pollution" into "reqheight 1242 > window 828, so the
->   geometry manager unmapped it". The PR's static hypothesis was wrong.
-> - **⚠ Spying on an instance attribute is USELESS if the bound method was already
->   captured.** `self.on_destroy(self._cleanup_theme_toggle)` captures the bound
->   method at construction, so `obj._cleanup_x = spy` set afterward never fires and
->   reads as "cleanup never ran" — I briefly drew exactly that wrong conclusion.
->   **Patch the CLASS attribute before constructing**, or assert on the observable
->   side effect (here, the binding count) instead.
->
-> **Three techniques worth reusing (2026-07-29 discussion-#386 session):**
-> - **A test that fails pre-fix with `AttributeError` proves nothing.** My first
->   nine #388 tests drove the new `_apply_picked` helper directly, so they failed
->   before the fix only because the method did not exist — they would have passed
->   even if `_show_date_picker` never called it. Added a tenth that **stubs
->   `DateDialog`** (a tiny class with `on_result`/`show`/`result`) and runs the real
->   method, which fails *behaviorally*: `assert [] == [date(2026, 7, 29)]` with the
->   value correctly applied. **Ask what a test would catch, not just whether it goes
->   red.** Stubbing the dialog is the cheap way to drive a gesture-gated path.
-> - **Before fixing a silent no-op, find what is LEANING on it.** `Form.set()`
->   applied `None` to every field absent from the mapping and only worked because
->   that write was discarded — so repairing the no-op alone would have turned every
->   partial `form.set()` into a destructive overwrite. Grep for who depends on the
->   broken behavior *before* fixing it; a no-op that has been shipped for a while is
->   load-bearing somewhere.
-> - **Prefer re-entering an existing routine over re-emitting an event by hand.**
->   The #388 fix calls the entry's own `_check_if_changed()` rather than building a
->   `ChangeEvent`, which gets the `_prev_changed_value` bookkeeping for free — so no
->   duplicate event on a later focus-out, and the double application from two call
->   sites is inert. Hand-rolling would have been correct-looking and subtly wrong.
-> Hold commits until the user tests;
-> per-commit approval. **Release flow:** `bump-my-version bump pre_n` → push `main` +
-> the `v*` tag → `release.yml` (PyPI + GitHub Release) → `docs.yml` deploys. There is
-> **no `development` branch** (CONTRIBUTING.md + the localization workflow target `main`).
+### ★ START HERE — CODE REVIEW the #392 branch, then #390 / #389, then cut 0.2.0
 
-> The big breaking changes for the **0.1.0 (stable) — API freeze** milestone are
-> DRAINED (#141/#142/#151/#153/#156/#157/#158 merged; see the "0.1.0 API-freeze
-> pass" pointer in "Recently completed"). What's left below is the stable-cut
-> closeout + the pre-ship polish backlog + the standing backlog.
+0. **⇦ THE ASK FOR THIS SESSION: review `fix/392-subscription-cancel`.** The fix
+   is written, verified, and **UNCOMMITTED** — branch exists, nothing staged, the
+   maintainer wanted a review pass before any commit. `git diff` +
+   `git status --short` is the whole change:
+   - `src/bootstack/_runtime/events.py` — ~15 lines, the actual fix
+   - `tests/widgets/public/test_subscription_cancel.py` — NEW, 6 tests
+   - `CHANGELOG.md` — one `### Fixed` bullet under `## [Unreleased]`
+   - `development/verify_392_subscription_cancel.py` — NEW, hands-on demo
+     (untracked by convention, like the other `verify_*.py`; do NOT commit)
 
-### ★ NEXT — Pre-ship polish backlog (#186–#195, filed 2026-06-18)
+   The tree is otherwise clean, so **`git diff` really is just #392** — the
+   handoff-archive split that was sitting uncommitted alongside it was committed
+   first, on purpose, so this review is not reading a 1500-line docs diff.
 
-Ten maintainer-requested items to resolve before shipping 0.1.0 — all filed as
-tracked issues (each issue links the relevant impl file + has detail).
-**Nine of ten SHIPPED:** #186/#190/#193/#194 (PR **#196**), #195 (PR **#197**),
-#188 (PR **#198**), **#189 (PR #199 → folded into the nav reshape PR #202)**, **#187
-(PR #203)**, **#191 (PR #204 — themed color tab + `ask_color(value=)` rename)** — all
-merged to `main`. **One remains** (its own `feat/*` branch → PR → `main`):
+   **Do not re-derive the root cause or re-run the baseline — both are recorded
+   below and were observed, not assumed.** Review altitude: the change is small
+   and green; spend the pass on whether emitting stock's script shape has
+   consequences nobody measured yet, not on restating what it does.
 
-- **#189 `solid` sidebar selection variant — DONE.** Shipped as **`nav_variant`**
-  on `AppShell` (PR #199, gated to the standalone nav), then **superseded by the
-  navigation reshape (#200, PR #202)**: the variant now lives on
-  **`page_nav(variant='ghost'|'solid')`**, standalone-only. See the reshape pointer
-  at the top of "Recently completed".
-- **#187 StatusBar.add_widget class-only? — DONE (PR #203, MERGED).** Decision:
-  **class-only** on BOTH `Toolbar` AND `StatusBar` (`add_widget(WidgetClass, **kwargs)`).
-  The two were ALREADY polymorphic in lockstep (not StatusBar-only), so class-only on
-  both keeps them consistent while dropping the redundant instance branch (couldn't
-  inherit bar density/surface; required a manual attach). No flexibility lost — a
-  self-built widget drops in via the container protocol (`parent=bar`, auto-attaches).
-  `StatusBar` gained the `_apply_bar_defaults` helper it lacked. **NB the public param
-  is annotated `widget_cls: Any` not `: type`** — the bare builtin `type` renders an
-  ambiguous `ref.python` cross-ref under `python_use_unqualified_type_names` (collides
-  with the many `.type` attrs); the precise `: type` stays only on the private
-  `_apply_bar_defaults` (not rendered). Also fixed a stale `StatusBar(fill="x",
-  side="bottom")` docstring (would raise under the grid engine) → `horizontal="stretch"`,
-  and enriched `docs/tasks/composing-fields.rst` with a **"Subclassing for a reusable
-  type"** section (`SearchField(bs.TextField)` via `insert_addon`, justified by exactly
-  this change — a container can only build your field if it's a class). Test
-  `tests/widgets/public/test_statusbar.py` (3).
-- **#192 Color-swatch Select control (feature, larger)** — a `Select`-style
-  dropdown rendering color swatches inline (complements `ask_color()`). New widget
-  or Select variant — lock shape/naming with the maintainer first.
+   **The four things actually worth attacking in review:**
+   (a) **`return 'break'` is now effective on virtual events** where it was
+   silently ignored — a real behavior change. An AST scan of all **75**
+   `return 'break'` sites in `src/` found exactly **two** bound to a `<<...>>`
+   sequence: `_handle_increment_event` / `_handle_decrement_event`
+   (`_impl/_parts/numberentry_part.py:127-128`), and both break **only** when the
+   field is non-interactive. Every gesture path and `numericentry.increment()`
+   already refuse to generate the event on a disabled field, so the only
+   reachable path is a hand-written `event_generate` on a disabled field — where
+   suppressing is arguably more correct. Scan script preserved at
+   **`development/scan_392_break_handlers.py`** (untracked, like the `verify_*`
+   scripts). **Re-run it rather than re-reading 75 sites.**
+   Deliberately NOT in the CHANGELOG: `break` is documented nowhere in `docs/`,
+   so advertising it would newly commit the project to it. Reviewer may disagree
+   — that's a legitimate call to reopen.
+   (b) The two omitted substitution codes: bootstack's list is stock's plus `%d`,
+   minus `%f` and `%W`. `%W` is unused because the wrapper recovers the widget
+   from a weakref. Confirm that's still true rather than assuming.
+   (c) The `wrapper` positional parameters must stay in lockstep with the
+   `subst` string — the fix keeps `%d` FIRST. There is no test that would catch a
+   reordering; consider whether one is worth adding.
+   (d) The new tests were checked to fail **pre-fix for behavioral reasons**
+   (5 of 6 — `{'c': 0} != {'c': 1}`, not `AttributeError`). The 6th
+   (cancel-everything) passes pre-fix **on purpose**: the bug silenced everything
+   too, so it guards the opposite error. Don't "fix" it as a dud.
 
-**SHIPPED detail (this session):** #195 (PR #197) — placeholder renders unmasked
-under an input mask; `TextEntryPart` captures the mask char, clears `show` while
-the placeholder shows, restores it for real input; PasswordEntry eye-toggle no-ops
-while placeholder showing. Test `test_field_placeholder_mask.py`. NB `TextField`'s
-public mask kwarg is **`mask=`** (not `show=`). #188 (PR #198) — accented Card
-border now **`b.border(surface)`** (a soft stroke derived from the card's own
-`{accent}[subtle]` tinted surface), NOT `{accent}_emphasis` (the issue's original
-suggestion — rejected as too strong on review). Test `test_card_border.py`.
+   **Root cause (settled, do not re-derive).** `_patched_bind` wrote its own Tcl
+   script for **virtual events** (`<<...>>` = every bootstack event) as a bare
+   `<funcid> %d %# ...`, but **`unbind` was never patched to match**:
+   `Misc._unbind` filters lines by the prefix `if {"[<funcid> ` that stock
+   Tkinter's `_bind` emits, so nothing was filtered (**the binding survived**)
+   while `deletecommand(funcid)` still ran (**the Tcl command was deleted**). The
+   orphan errored on every dispatch, and because bindings use `add='+'` they are
+   ONE concatenated script — so the error **aborted every handler after it**.
+   Silent: no Python-level exception. Fix = emit stock's exact
+   `if {"[<funcid> ...]" == "break"} break\n` shape, keeping `%d`. **Real events
+   (`<Configure>`/`<Unmap>`/`<Destroy>`) take `_original_bind` and were never
+   affected.** ⚠ This **contradicts the old note that 3.12.10's
+   `unbind(seq, funcid)` removes only that funcid** — true only for
+   *stock-format* bindings, which is why it checked out against `<Configure>`.
 
-### Field-family review follow-ups
+   **Measured baseline → after** (3 subs on one `bs.Button`, public API only):
 
-The field family is fully reviewed (see the top "Recently completed" entries).
-**#227 (DONE, PR #238 — object-mode Signal) and #232 (DONE — PathField live dialog
-props) are merged; #237/#217 closed.** Two additive follow-ups remain OPEN — neither
-is a correctness bug:
+   | | all live | cancel B | cancel A |
+   |---|---|---|---|
+   | before | `a=1 b=1 c=1` | `a=1 b=0 c=0` | `a=0 b=0 c=0` |
+   | after | `a=1 b=1 c=1` | `a=1 b=0 c=1` | `a=0 b=0 c=1` |
 
-- **#222 — TextField live properties** (OPEN, ready to build). Expose `placeholder`
-  / `mask` (high value — runtime UX toggles) and `allow_blank` / `value_format`
-  (lower — the configure-delegate already works imperatively) as live get/set
-  properties. The underlying `TextEntryPart` already supports them
-  (`_placeholder_text`/`_show_char`/`_delegate_allow_blank`/`_delegate_value_format`).
-  Explicitly **NOT** a `.text` setter (read-only by the value/text contract — write
-  through `.value`). Clean, low-risk, no decision needed.
-- **#234 — SpinnerField↔NumberField parity** (OPEN, decision-gated) — live
-  `min_value`/`max_value`/`step` props, `increment()`/`decrement()` methods,
-  `on_increment`/`on_decrement` events. **May be won't-do** (SpinnerField is
+   **Verification already done — reproduce only if you distrust it:** full suite
+   `py -3.12 tests/run_gui.py` **exit 0**, main leg **899 passed** (893 + the 6
+   new), 18 legs, zero failures. Clean `-W` docs build succeeded warning-free
+   (CHANGELOG is in the docs via `docs/release-notes.rst` — a CHANGELOG edit
+   ALWAYS needs a docs build).
+
+   **Portability, established by measurement (don't re-litigate):** Tk's bind
+   substitution codes are **identical in 8.6 and 9.0** — `%d` carries virtual-event
+   `user_data` in both and dates to Tk **8.5** (TIP 165); nothing is new in 9,
+   nothing was dropped. `tkinter.Misc._subst_format` is identical across CPython
+   3.12/3.13/3.14 (Python does not vary it by Tk version), and `_bind`/`_unbind`
+   are **byte-identical** across those three — so the emitted format matches on
+   the macOS box's 3.14 too. What Tk 9 changed about events is `%D`'s *values*
+   (±120 deltas / `<TouchpadScroll>` / TIP 474, handled back in 0.1.7), not any
+   code's syntax. ⚠ **Neither box has Tk 9** — all three Pythons here report Tk
+   **8.6.15** and the macOS box is 8.6, so the Tk 9 claim is source- and
+   docs-based, NOT executed. Memory `reference_tk_bind_substitutions_86_vs_9`.
+
+2. **#390 — should signals model emptiness at all? (DESIGN, needs the
+   maintainer's call.)** Gates #389 shipping *whole*: without it `Form.clear()`
+   works but leaves a bound `Signal` stale. **If the answer is no, close #390**
+   and ship #389 with the limitation documented. `Signal.set(None)` raises
+   unconditionally (`signal.py:248` — strictly monomorphic, type inferred from the
+   seed). **Four decisions, in order:** (1) *do it at all?* (2) *declared or
+   automatic?* — recommend **declared** (`Signal(v, nullable=True)`), because
+   automatic-by-mode cannot cover `int` and isn't safe to lean on: `Signal(0)` is
+   Python-authoritative only *while unrealized*, so the moment anything touches
+   `.var`, `__call__` starts reading the IntVar and a stored `None` is lost;
+   (3) *what happens to a non-nullable signal asked to go empty?* — recommend a
+   public `Signal.nullable` so `ValueSignalMixin` skips rather than crashing
+   `Form.clear()`; (4) *what does `map()` do over a nullable signal?* — it calls
+   the transform unconditionally and infers the derived type from the first result
+   (`signal.py:295, 302`), so a `None` source breaks the **documented** Date/Time
+   pattern (typed `signal=` plus a `.map()`-derived text signal). **No existing
+   code is at risk either way** — `set(None)` raises today, so nothing can
+   currently receive it. **KEY MEASURED FINDING, don't re-derive it:** the
+   dividing line is **attached-vs-not, not object-vs-native**. `NumberField(signal=)`
+   / `DateField(signal=)` are **unrealized** — `ValueSignalMixin` syncs via
+   `subscribe()` + `on_change` in pure Python and never touches `.var`, so **for a
+   number field's value signal there is no IntVar at all**. `Checkbox(signal=)` and
+   `TextField(textsignal=)` **are** the widget's `variable`/`textvariable` — there
+   `None` either raises (`IntVar`) or **silently corrupts**: `StringVar.set(None)`
+   stores the literal `'None'`, the widget displays it, and every subscriber gets
+   the 4-character string. That is why a blanket guard relaxation must not ship.
+   **Per-type "empty" values were considered and REJECTED** — `empty(int) = 0`
+   contradicts the shipped `NumberField.clear()` decision, `empty(bool) = False`
+   collapses tristate (#358), `date` has only a **sentinel** indistinguishable from
+   data, and it makes emptiness type-dependent at every call site. The framework
+   already runs both models in separate channels (`value` is `None` when empty,
+   `text` is `''`) and keeping them separate is what stops either leaking into the
+   other. Memory `reference_signal_nullability_attached_vs_not`.
+
+3. **#389 — `Form.reset()` / `Form.clear()`.** Unblocked (#387 merged), design
+   settled, implementation sketch on the issue. **They are DIFFERENT verbs** —
+   reset = construction-time originals, clear = `None`. Both justified: `reset()`
+   is **not user-implementable** (after an edit, `get()` no longer knows the
+   original); `clear()` is the data-entry case. Slider clears to `min_value` (no
+   null state, and that is already the de-facto seeding behavior). Needs an
+   `__init__` snapshot because `set()` destroys `_data`; both must clear
+   validation state.
+
+Then the standing items: **#380 (CI)**, **#383 (kwarg sweep)**, and the harness
+leak-fix.
+
+### Then — standing infrastructure work
+
+- **#379 harness leak-fix — NOT in #385, do it after #392.** The real root cause
+  of the order-dependence was found and deliberately left out: `conftest._region()`
+  returns `_region_root`, which on a decorated App **is the root**, so
+  `_snapshot`/`_reset_scene` never look inside the App's `_content_frame` — **the
+  scene reset has been a no-op for content widgets for the entire life of the
+  shared-root harness**, and every test's widgets pile up all session. Fixing it
+  makes PageStack pass with no `isolated` marker and cuts the widget leg
+  **144s → 80s**. Held back because it exposes **#392** and a second latent bug
+  (`test_select_change_event_value_space` picking up 5 change events from earlier
+  tests — looks like stale bindtag bindings surviving destroy while Tk recycles
+  widget path names; not chased down). Own branch, after #392 lands.
+  ⚠ **The patch is LOST.** It was saved to a per-session temp `scratchpad/`, not
+  into the repo — searched every session dir under
+  `%LOCALAPPDATA%\Temp\claude\D--Development-bootstack\`, nothing. **It must be
+  re-derived from the root cause above, which is fully recorded.** Lesson: a
+  handoff artifact belongs in `development/` (persistent) — a bare `scratchpad/`
+  path in this file does NOT survive the session.
+
+- **#380 — CI test workflow.** `.github/workflows/` still has only `docs.yml` +
+  `release.yml`, so **nothing runs the suite**; every Tk 9 bug so far was found by
+  a user or by hand. Branch `ci/test-workflow` was created and deleted unused —
+  recreate it. Plan agreed: **(1)** headless `ubuntu-latest` logic job —
+  `test_tk9_scaling_baseline.py` monkeypatches `platform.system()`/
+  `tkinter.TkVersion` so it needs **no display and no Tk 9**, and would have caught
+  #375; **(2)** an `xvfb-run` Linux job for the widget suite; **(3)** fold in the
+  never-collected `tests/widgets/*.py` gap. **DEFER the macOS/Tk 9 leg** — blocked
+  on #378 (the suite cannot complete on Tk 9 at all), red from day one. Read the
+  issue before scoping: it carries measurements showing the naive "just run
+  pytest" plan fails (`-m "not gui"` selects 741 tests but yields **494 errors**
+  headless — only ~222 genuinely run without a display), and warns that
+  `Treeview.bbox()` returns `''` rather than erroring on an unmapped window, so
+  geometry assertions **vacuously pass** headless.
+
+### Open, additive items (not ship-blockers)
+
+- **#396 — `emit()` and `on()` target DIFFERENT widgets on 11 wrappers.** Found
+  while writing the #392 tests. Milestoned `0.2.x — Widget polish`: it is
+  **additive** (a silent no-op starts working), so unlike #369/#383 it is
+  patch-safe and does NOT need a minor of its own. The 11 wrappers that
+  override `on()` — `textfield`, `datefield`, `numberfield`, `passwordfield`,
+  `pathfield`, `select`, `spinnerfield`, `tabs`, `textarea`, `timefield`,
+  `codeeditor` — retarget inner-entry sequences to the inner entry widget
+  (`_INNER_ENTRY_SEQUENCES`, e.g. `textfield.py:169`), but **`emit()` is not
+  overridden** and still fires on `self._internal`. So
+  `field.emit("change", data=…)` **never reaches** a handler registered by
+  `field.on_change(…)` — measured, not inferred (`field.on_change` binds on
+  `.!textentry.!frame.!textentrypart` while `emit` generates on `.!textentry`).
+  That contradicts `emit()`'s own docstring, which says it takes "the same name
+  you pass to `on()`". Fix is presumably to override `emit()` alongside `on()`
+  (or hoist the retarget into one shared seam so they cannot drift again) — the
+  duplication IS the bug, so prefer the shared seam. Widgets whose `on`/`emit`
+  agree (e.g. `Slider`) are fine, which is why the suite never caught it.
+
+- **#383** — follow-up sweep from #381: presentation kwargs still degrading
+  silently (`density`, `Tabs.orient`, `Slider.orient`, `Gauge.variant`) **plus**
+  args that raise but leak a **raw `TclError`/`AttributeError`**
+  (`Button.icon_position`, `Label.justify`, `Scrollbar.variant`,
+  `Expander.icon_position`, `ProgressBar.mode`). Sweep **BY ARGUMENT NAME**, not
+  by widget. Also folds in: **`Slider.value = None`** leaks a raw
+  `TypeError: float() argument must be...` (reachable from user code via
+  `form.set({'slider_key': None})`), and **`show_grid=True` is silently accepted
+  on `Row` and does nothing** — not a kwarg anywhere in `src/`, but swallowed into
+  the layout kwargs without error (the #394 reporter used it *while trying to
+  diagnose the bug* and got no feedback).
+- **#369** — the selection family disagrees on off-list values (`SelectButton`
+  raises both ways; `RadioGroup` accepts at construction, raises on assignment;
+  `ToggleGroup` accepts both; and where accepted, `value` says `'MX'` while
+  `selection` says `None`). Wants ONE family decision, not four patches.
+- **#369 and #383 are deliberately un-milestoned** — both would raise where the
+  framework currently accepts, so they cannot ride the `0.2.x` patch line and need
+  a minor of their own. #352 and #328 are also homeless.
+- **#208** — DataTable: persist selection by record id across search/sort/page.
+- **#192** — color-swatch `Select` control (decision-gated; lock shape/naming with
+  the maintainer first). A `Select`-style dropdown rendering color swatches inline,
+  complementing `ask_color()`. New widget or Select variant?
+- **#222** — TextField live properties: expose `placeholder` / `mask` (high value
+  — runtime UX toggles) and `allow_blank` / `value_format` (lower — the
+  configure-delegate already works imperatively). `TextEntryPart` already supports
+  them (`_placeholder_text`/`_show_char`/`_delegate_allow_blank`/
+  `_delegate_value_format`). Explicitly **NOT** a `.text` setter (read-only by the
+  value/text contract — write through `.value`). Clean, low-risk, no decision needed.
+- **#234** — SpinnerField↔NumberField parity (live `min_value`/`max_value`/`step`,
+  `on_increment`/`on_decrement`). **May be won't-do** (SpinnerField is
   intentionally simpler) — get the maintainer's call before any code.
-
-### Slider follow-ups — DONE
-
-Slider `step=` snapping (#210, PR #213) and the RangeSlider `<Tab>` focus-trap
-(#211, PR #215) both MERGED. Nothing open here.
-
-### ✅ SHIPPED — Layout redesign (screen-axis grid engine) — MERGED #170
-
-Replaced the Tk pack stack with a **screen-axis** vocabulary on the Tk grid manager:
-`horizontal`/`vertical`/`grow` (bare = self, `*_items` = children); edge-name values
-(`left`/`center`/`right`/`stretch`) + `space-between`/`-around`/`-evenly`; `HStack`/`VStack`
-→ `Row`/`Column`, `Separator`→`Divider`, new `Spacer`; **cross-axis default `center`**;
-legacy `fill`/`expand`/`anchor`/`sticky` now RAISE. Post-merge: #171 (GridFrame O(N) build),
-#169 (deploy docs on release only), #172 (README/docs-home refresh), #173 (CLI icons on the
-public layer + Gallery/MemoryDataSource fixes). Memories `project_layout_redesign`,
-`feedback_layout_conversion_rules`, `project_layout_crossaxis_default`, `project_divider_rename`,
-`project_dialog_content_builder_native`.
-
-**Live follow-ups (not blockers):**
+- **#207** — ContextMenu outside-dismiss vs a `'break'` target — **DEFERRED** (no
+  API implication, low/self-inflicted impact, Win/Linux only; agreed proportional
+  fix if revisited = a module-level open-menu registry + dismiss-all from
+  `DataTable._on_header_click`, NOT the risky grab). Analysis on the issue.
+- **#328** — the E2E multi-file `@reloadable` reload test is the one OPEN piece,
+  **DEFERRED** (the maintainer will write it). On PROVISIONAL `bootstack.dev`.
 - **Gallery opt-in keyboard-focus ring** (future) + deferred Gallery perf (debounce
-  `<Configure>`, bounded thumbnail-PhotoImage LRU, cache `_fit_caption`). Scope to keyboard
-  focus, NOT hover. Memory `project_gallery_focus_ring`.
-- **`add_spacer()`→public `Spacer`** still deferred — entangled with `feat/unified-toolbars`
-  (internal `Toolbar` is pack-based). Memory `project_unified_toolbars`.
-
-### ✅ SHIPPED — Undecorated window controls + border + maximized-drag — MERGED #175
-
-Undecorated `App`/`Window`/`AppShell` auto-inject a draggable titlebar (min/max/close) +
-1px border via `ChromeHostMixin._ensure_default_titlebar()` (layers on `add_toolbar()`, not
-a dedicated band); `App` gained `undecorated=`, `Window` gained `window_controls=`; #165
-maximized-drag re-anchors under the cursor. Memory `project_undecorated_window_chrome`.
-
-### Toward the 0.1.0 stable release
-
-- **#149** — final public-surface audit + **CHANGELOG** for the stable cut.
-- **#150** — test-harness stabilization (the GUI suites need one `App` per process;
-  the `.pytest_cache` perms warning on this machine is benign).
-- **#155** — Topic-guide technical-writer review pass (the `/reference/*` pages get
-  the same no-kitchen-sink edit the how-to guides already had; memory
-  `project_user_guide_fleshout`). The maintainer is comfortable with the how-tos.
-
-### Other candidates
-
-- **Docs site fleshout — substantially DONE.** The how-to guides (`docs/tasks/*` —
-  getting-input/handling-actions/displaying-data/building-forms/composing-fields/
-  dialogs/layout/application-icons + the full `navigation/` set), `getting-started/
-  app-structures`, and the production pages (`cli`/`debugging`/`distribution`) are all
-  written and substantial. Remaining is only opportunistic: a review pass on
-  `installation`/`quickstart` and enrichment of any still-thin page. Memory
-  `project_docs_site_fleshout`.
-- ~~**Docstring-backtick sweep**~~ — **DONE (PR #182):** 754 RST
-  double-backticks → single across 43 `src/` files. Convention is Google + SINGLE
-  backticks. Memory `project_docstring_backticks`.
+  `<Configure>`, bounded thumbnail-PhotoImage LRU, cache `_fit_caption`). Scope to
+  keyboard focus, NOT hover. Memory `project_gallery_focus_ring`.
+- **`add_spacer()` → public `Spacer`** — deferred, entangled with
+  `feat/unified-toolbars` (the internal `Toolbar` is pack-based). Memory
+  `project_unified_toolbars`.
 - **Code-review follow-ups #4–#10** — cleanup/altitude items recorded in
-  `docs/_dev/widget-api-audit.md` (SelectButton stale value after `options=`; screenshot
-  Win64 HWND hardening; group/window/date duplication; Calendar batch-redraw).
+  `docs/_dev/widget-api-audit.md` (SelectButton stale value after `options=`;
+  screenshot Win64 HWND hardening; group/window/date duplication; Calendar
+  batch-redraw).
+- **Docs site fleshout — substantially DONE.** Remaining is only opportunistic: a
+  review pass on `installation`/`quickstart` and enrichment of any still-thin page.
+  Memory `project_docs_site_fleshout`.
 
-**Throwaway demos `development/shell_*_demo.py` stay UNTRACKED** (scratch, not
-framework code). Side note logged: a future `Tabs` `variant='secondary'` (top
-indicator) — `project_secondary_tab_variant`, a standalone item.
+---
 
-### History — done initiatives
+## Release flow
 
-- **Public-API typing sweep — DONE** (branch `feat/api-reference-widgets`, merged via
-  PR #109). All widget batches typed (Application → Overlays/Forms/Dialogs): real param
-  types, per-widget `variant` Literals sourced from `style/builders/`, typed `on_*`
-  payloads (impl signature, not `@overload`), thin docstrings, every public prop/method
-  documented. Conventions live in the "API Reference & Guide page pattern" section +
-  `docs/_dev/typing-review.md`. Memories `project_enum_option_typing`,
-  `project_typed_event_payloads`, `project_variant_type_revisit`. Also shipped here:
-  `Tree.find`/`find_all` (predicate or `col(...)` condition; memory `project_tree_find_filter`).
-- **API Reference restructure — Stage 4 homing — DONE (PR #109).** The IA was re-cut to a
-  semantic-category structure: one page per CONCEPT (Application · Widgets · Reactivity ·
-  Events · Data · Validation · Theming · Localization · Scheduling · Shortcuts · Storage ·
-  Errors), full-path stub titles, pandas-style card landing; every public name homed,
-  guides converted to table-only API sections. Brief `docs/_dev/api-reference-restructure.md`;
-  memory `project_api_reference_restructure`. **NEXT (follow-on): flesh out widget Guides
-  with examples — the API Reference is a last resort; Guides carry teaching.**
-- **Deferred file-streaming items** — background/progressive ingest, keyset pagination,
-  auto-index (memory `project_file_source_streaming`).
+`bump-my-version` IS available — `.venv/Scripts/bump-my-version.exe`, v1.3.0.
+`bump-my-version bump patch` → push `main` + the `v*` tag → `release.yml` (PyPI +
+GitHub Release) → `docs.yml` deploys. There is **no `development` branch**
+(CONTRIBUTING.md + the localization workflow target `main`).
+
+**CHANGELOG convention:** a fix commit writes `## [Unreleased]`; the `Release X`
+commit renames it AND adds the `[X]:` link definition. **`main` has a GROWING
+`## [Unreleased]` section** — the #381 mode guard (PR #382), PR #384, then
+#387/#388/#393 and #394/#395 (which added the first `### Changed` entry). The
+next cut must sweep all of them.
+
+**⚠ Release-flow gotcha:** `bump-my-version bump patch --allow-dirty` commits
+**ONLY `pyproject.toml`** — it will NOT sweep the CHANGELOG rename into the
+`Release X` commit, which ships a release whose notes still say `## [Unreleased]`
+and breaks `release.yml`'s section extraction. **Promote `## [Unreleased]` to the
+version in its OWN commit BEFORE running `bump-my-version`.** Confirmed working on
+0.1.8: `docs(changelog): promote Unreleased to 0.1.8` (`7c136b20`) ran *before*
+`Release 0.1.8` (`b2f37f0f`, which again touched only `pyproject.toml`).
+`release.yml` extracts ONLY the `## [x]` section, so bottom link-defs are excluded
+from the GitHub Release body.
+
+---
+
+## Working agreements
+
+**Hold commits until the user tests; per-commit approval.** Never commit feature
+work to `main` — create a dedicated `feat/*` branch first. A fix pushed to a branch
+AFTER its PR merged is **stranded** — verify it landed in `main`.
+
+**Standing principles** (apply in every review):
+
+- **Live properties only for legitimate runtime needs**
+  (`feedback_live_properties_runtime_need`) — e.g. `surface` is **build-time, not
+  live**.
+- **Prefer Tk native/virtual-event bindings**; don't undo a convention without
+  reason (`feedback_prefer_native_bindings_dont_undo_conventions`).
+- **Describe the clean public surface in docs — no implementation/toolkit detail**
+  (`feedback_no_toolkit_internals_in_docs`).
+- **Adversarially verify reviewer and agent claims** — agents over-flag. The
+  2026-06-22 trust audit disproved 2 of the "bugs" it was handed; the Topic-guide
+  review agents over-flagged 10 of 12 pages.
+- **Pause and ask when a fix outgrows its issue**
+  (`feedback_pause_and_ask_when_stuck`) — #355 burned hours heading toward a
+  `Select` value-model rewrite before the maintainer pointed at the ~15-line fix.
+- **Test PUBLIC paths, not internal side-hacks.**
+
+### Techniques that have repeatedly beaten static reading
+
+- **Run an empirical probe instead of reading tangled code.** Decisive on the
+  icon-DPI pipeline, the boolean-control ttk state rules, the menu window-move
+  dismiss, and the #394 field alignment (FlexFrame / GridFrame / raw pack are too
+  tangled to trust by eye). **Rebuild the probe rather than reading**, if one of
+  these areas comes up again.
+- **Tests must fail for the RIGHT reason.** A pre-fix `AttributeError` proves
+  nothing — it only shows the new method doesn't exist yet. Stub the collaborator
+  (e.g. a tiny fake `DateDialog` with `on_result`/`show`/`result`) so the failure
+  is *behavioral*. Tests that only assert "construction doesn't raise" are what let
+  #358 ship twice. Memory `feedback_tests_must_fail_for_the_right_reason`.
+- **Pair any alignment/geometry assertion with a precondition** proving the setup
+  really took effect, or it can pass vacuously. **Measure within one process** —
+  `winfo_rooty()` is NOT comparable across two runs (different window positions).
+  Memory `reference_geometry_probe_same_process`.
+- **⚠ `event_generate` on a virtual event is DROPPED for some widgets while the
+  window is unmapped — use the `shown_app` fixture, not `app`.** The `app`
+  fixture's root is **withdrawn** (`wm_state() == 'withdrawn'`, everything
+  `winfo_ismapped() == 0`). A `bs.Button` still dispatches `<<Click>>` there, but a
+  composite like `bs.Slider` receives **nothing** — not even a **raw Tcl** binding
+  bypassing Python entirely, which is what proves it is Tk dropping the event and
+  not a bootstack wiring problem. So a payload test can look like a broken fix
+  when the fix is fine. `shown_app` maps the window and it works
+  (`winfo_ismapped() == 1`). **Pre-existing** — it measures identically with any
+  event-system change stashed, so confirm that with `git stash` before blaming
+  your own diff. Cost real time during #392. Memory
+  `reference_virtual_event_needs_mapped_window`.
+- **Run the BASELINE before the fix**, so a before/after transition is *observed*
+  rather than assumed. That is what turned "the branch fixes only 2 of 6" from a
+  suspicion into a fact.
+- **A control experiment separates causation from correlation.** For #392 it was
+  not enough that cancelling `sub_a` silenced `sub_b`; stripping the orphaned
+  binding line by hand and watching `sub_b` come back is what proved the cause. Do
+  this before filing any "X breaks Y" claim.
+- **Bisect order-dependent failures; do not theorize.** A scripted prefix-bisect
+  found the culprit file in 6 runs; a geometry probe turned "state pollution" into
+  "reqheight 1242 > window 828, so the geometry manager unmapped it".
+- **Measure the surface before scoping a sweep.** An AST pass over public
+  `__init__` signatures + a construct-with-a-bogus-value probe turned "audit the
+  siblings" from guesswork into a table (215 kwargs, 17/24 silently accepting) —
+  which is what justified drawing #381's line at behavior modes.
+- **A platform-specific backend is often constructible off-platform.**
+  `_NativeContextMenu` (macOS) is a `tk.Menu` wrapper and instantiates fine on
+  Windows, so macOS-only code got real coverage — and that caught a
+  `TclError`-on-separator bug. Ask "can I build the other platform's object
+  directly?" before accepting "unverifiable from this box".
+- **Before fixing a silent no-op, find what is LEANING on it.** `Form.set()`
+  applied `None` to every absent field and only worked because the write was
+  discarded — repairing the sentinel alone would have turned every partial
+  `form.set()` into a destructive overwrite. A no-op that has shipped for a while
+  is load-bearing somewhere.
+- **Prefer re-entering an existing routine over re-emitting an event by hand.**
+  The #388 fix calls the entry's own `_check_if_changed()` rather than building a
+  `ChangeEvent`, getting the `_prev_changed_value` bookkeeping for free.
+- **⚠ Spying on an instance attribute is USELESS if the bound method was already
+  captured.** `self.on_destroy(self._cleanup_x)` captures at construction, so
+  `obj._cleanup_x = spy` set afterward never fires and reads as "cleanup never
+  ran". **Patch the CLASS attribute before constructing**, or assert on the
+  observable side effect.
+- **⚠ A bulk `pathlib` rewrite flips CRLF→LF** (repo is `core.autocrlf=true`) —
+  same class as the `sed -i` trap. Prefer the Edit tool; if scripting, write bytes.
+  Memory `reference_autocrlf_sed_gotcha`.
+
+---
+
+## Recently shipped — pointers only
+
+Full detail (root causes, decisions, gotchas) is in
+**`docs/_dev/handoff-archive.md`**, indexed by issue/PR number.
+
+| Release | Contents |
+|---|---|
+| unreleased → **0.2.0** | #332 internal `set_*_visible` → properties · #379/#385 menu-backend test portability · #381 `InvalidChoiceError` on bad behavior-mode kwargs · #387 `DateField` clear + `Form.set()` merge · #388 date-picker `<<Change>>` · #394/#395 field row alignment |
+| **0.1.8** | macOS sizing on Tcl/Tk 9 (Aqua 72→96 DPI baseline broke `detect_scale_factor()`) |
+| **0.1.7** | Tk 9 scroll-event contract (`<TouchpadScroll>`, ±120 deltas, X11 TIP 474) + attach theme repaint |
+| **0.1.6** | Seven form/field/validation fixes (#362–#368, #371) |
+| **0.1.5** | Boolean-control state reads + Checkbox tristate (#360) |
+| **0.1.4** | `Select.add_validation_rule` restored (#357) |
+| **0.1.3** | Form `editor_options` take public widget kwargs (#354) |
+| **0.1.2** | Dropdown/context menus dismiss on window move (#345) |
+| **0.1.1** | `pygments` declared as a runtime dependency (#344) |
+| **0.1.0** | STABLE. Ship gate (#335) + theme-repaint unification (#338) + accent contrast (#340). Public compose API FROZEN under SemVer. `bootstack.dev` stays PROVISIONAL (excluded from the freeze). |
+
+Pre-0.1.0 initiatives — also in the archive: hot reload (`bootstack dev`),
+builder-function scaffolds, docs-IA 3-pillar restructure, splash screen, icon-DPI
+sizing, navigation API reshape (AppShell + Workbench), layout redesign
+(screen-axis grid engine), undecorated window chrome, media widget suite, the
+field-family reviews, field validation redesign, and the API Reference restructure.
+
+---
 
 ## Carryover (deferred)
 
@@ -2147,13 +1083,33 @@ sig.subscribe(lambda v: ...)
 
 ### Layout
 
+⚠ **This file's layout examples were STALE and are only partly swept — verify
+against a real signature before copying any of them.** Measured 2026-07-30 via
+`inspect.signature`:
+
+- **`bs.HStack` / `bs.VStack` DO NOT EXIST** — the stacks are **`bs.Row`** and
+  **`bs.Column`**. Every `HStack`/`VStack` still left in this file (the screenshot
+  patterns around the "HStack centering" gotcha, the layout-widget gotchas, the
+  context-manager example) is wrong. **Not yet swept** — do it opportunistically,
+  checking each replacement, rather than in one blind find-and-replace.
+- **`fill=` / `expand=` on a flex child now RAISE**, they don't degrade:
+  `BootstackError: fill is not a valid layout option for a Row/Column/Grid child.
+  Use grow= / align_self= (and justify_self= in a Grid) instead`. Good error —
+  trust it over this file.
+- **Container defaults are `horizontal_items=` / `vertical_items=` /
+  `grow_items=` / `weights=`.** `fill_items=`, `expand_items=`, `anchor_items=`
+  and `sticky_items=` are all GONE from `Row`/`Column`/`Grid`.
+
 ```python
-bs.VStack(padding=20, gap=12, fill="both", expand=True)
-bs.HStack(gap=8, anchor_items="center", fill="x")
-bs.Grid(columns=["auto", 1], gap=8, sticky_items="ew", fill="x")
+bs.Column(padding=20, gap=12)
+bs.Row(gap=8, vertical_items="center")
+bs.Grid(columns=["auto", 1], gap=8)
 ```
 
-`fill_items=`, `expand_items=`, `anchor_items=` — container defaults, per-child kwargs override.
+Full current signatures — `Row`/`Column`: `parent`, `horizontal_items`,
+`vertical_items`, `grow_items`, `weights`, `gap`, `padding`, `surface`,
+`show_border`, `width`, `height`, `**kwargs`. `Grid` swaps `grow_items`/`weights`
+for `columns`, `rows`, `auto_flow`.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,18 +88,36 @@ on the maintainer's test pass, nothing else. Remaining after that: #389, #390.**
 Every themed milestone shifted OUT one
 minor —
 `0.2.x — Widget polish` (#2) · `0.3.0 — Guided flows` (#3) ·
-`0.4.0 — Power-user interactions` (#4) · `0.5.0 — Structured editing` (#5).
+`0.4.0 — Power-user interactions` (#4) · `0.5.0 — Structured editing` (#5) ·
+**`0.6.0 — Argument and value strictness` (#7, NEW 2026-07-30)**.
 Mapping + reasoning: memory `project_roadmap_milestones`.
+
+**✅ EVERY open issue is milestoned as of 2026-07-30 — keep it that way.** An
+unmilestoned backlog makes the milestone feature worthless (maintainer's call).
+`0.6.0` was created to home the changes that RAISE where the framework currently
+accepts (#383, #369): they cannot ride the `0.2.x` patch line, and it was placed
+*after* the themed minors deliberately so nothing had to be renumbered a second
+time. Check with:
+`gh issue list --state open --json number,milestone --jq '[.[]|select(.milestone==null)]'`
 
 ### ★ START HERE — the #392 branch is REVIEWED; maintainer test pass, then #390 / #389, then cut 0.2.0
 
-0. **`fix/392-subscription-cancel` is DONE and REVIEWED — it needs the
+0. **`fix/392-subscription-cancel` is DONE and REVIEWED TWICE — it needs the
    maintainer's hands-on test pass and a commit split, not more analysis.**
-   Reviewed 2026-07-30 (`/code-review` + a follow-up pass); all four findings are
-   dispositioned below. **906 passed**, exit 0, clean `-W` docs build. Everything
-   is **UNCOMMITTED**; nothing staged.
+   Reviewed 2026-07-30 (`/code-review` + a follow-up pass), then **re-reviewed
+   the same day, which found a CRITICAL hole the first pass missed — now fixed**
+   (change 4 below). **911 passed**, exit 0, clean `-W` docs build. Everything is
+   **UNCOMMITTED**; nothing staged.
 
-   **THREE logical changes on the branch — split into three commits:**
+   ⚠ **The second review's headline claim was itself half wrong, and checking it
+   mattered.** It reported the funcid collision as a NEW regression, "with the
+   diff stashed b/c run". Measured: the stashed baseline fails **identically**
+   (`{'a':0,'b':0,'c':0}` + the same bgerror) — pre-fix this is just #392. So the
+   accurate framing is *the branch failed to fix one case*, not *the branch broke
+   something*. That distinction decided whether it was a ship-blocker. **Verify
+   the baseline claim, not just the failure claim.**
+
+   **FOUR logical changes on the branch — split into four commits:**
    1. **The #392 fix itself** — `_runtime/events.py` `_patched_bind` emits stock's
       exact script shape. Root cause below.
    2. **Mid-dispatch cancel** — NEW `_patched_unbind` (`events.py:271`), wired
@@ -114,13 +132,58 @@ Mapping + reasoning: memory `project_roadmap_milestones`.
    3. **`return 'break'` neutralized on the public surface** —
       `adapt_handler` (`widgets/_core/base.py:16`) discards public handlers'
       return values. See (a).
+   4. **Unique handler names + root-scheduled cache cleanup** (`events.py`) —
+      the fix for the critical hole. Keep it its OWN commit so it can be
+      reverted independently of 1–3. Root cause below.
 
    Files: `CHANGELOG.md`, `src/bootstack/_runtime/events.py`,
    `src/bootstack/widgets/_core/base.py`,
-   `tests/widgets/public/test_subscription_cancel.py` (NEW, **14 tests**).
+   `tests/widgets/public/test_subscription_cancel.py` (NEW, **18 tests** = 13
+   from the first pass + 5 from the second; the earlier "14" here was wrong).
    Untracked by convention, do NOT commit: `development/verify_392_*.py` (2),
    `development/scan_392_break_handlers.py`,
-   `development/probe_392_unbind_gaps.py`.
+   `development/probe_392_unbind_gaps.py`,
+   `development/probe_392_funcid_recycling.py`,
+   `development/probe_392_datacache_afteridle.py`,
+   `development/probe_392_shortcut_rebind.py`.
+
+   **★ ROOT CAUSE OF CHANGE 4 (settled, measured — do not re-derive).** Tkinter's
+   `Misc._register` names a binding's Tcl command `repr(id(f)) + f.__name__`,
+   where `f` is a bound method created for that one registration. Nothing else
+   references it, so releasing the command frees the method and CPython hands the
+   **same address** to the next one — measured **498/499** consecutive
+   bind/cancel/bind cycles produced an *identical* funcid, and every wrapper here
+   shared the `__name__` `wrapper`. Harmless while removals delete immediately;
+   NOT harmless once change 2 defers the delete to the next idle point. A binding
+   created in that window inherits a name a deletion is already pending on, and
+   that deletion then removes a **live** handler — #392's exact symptom on a new
+   trigger, interpreter-wide (a cancel on widget A killed a later bind on widget
+   B). Fix: give each wrapper a serialized `__name__` (`_unique_name`), which
+   keeps ALL of stock's registration and `_tclCommands` bookkeeping. Applied to
+   **both** wrappers — the real-event `regular_wrapper` too, since real events
+   are removed by the same patched `unbind`. Also fixed alongside: the data-cache
+   cleanup used `widget.after_idle` (`events.py:224`, **pre-existing**, violating
+   the root-not-widget rule the branch's own comment states) → `_root()`.
+   Measured before → after: collisions 498/499 → **0/499**; cancel-then-resubscribe
+   `{'a':0,'b':0,'c':0}` + bgerror → **`{'a':0,'b':1,'c':1}` clean**;
+   destroy-in-handler bgerror → **clean**; the teardown
+   `TclError: can't delete Tcl command` is gone. Probes:
+   `development/probe_392_funcid_recycling.py` (census / repro / cross-widget /
+   idle-gap / unique-name control), `probe_392_datacache_afteridle.py`,
+   `probe_392_shortcut_rebind.py`.
+
+   ⚠ **The failure is NONDETERMINISTIC, which shaped the tests.** Whether a reused
+   name actually swallows a handler depends on when the allocator returns the
+   address, so a *behavioral* test can pass on a broken build by luck — on the
+   first pre-fix run only 1 of 3 new behavioral tests failed. The reliable guard
+   is **structural**: `test_a_cancelled_handlers_name_is_never_reused` asserts 50
+   cancel/rebind cycles yield 50 distinct `_bind_id`s (fails `1 == 50` pre-fix,
+   every time). It reads a private attribute on purpose — a deliberate exception
+   to "test public paths", because the public symptom is a coin flip. **General
+   lesson: when a bug's public symptom is allocator- or timing-dependent, assert
+   the invariant, not the symptom.** `test_a_real_event_survives_a_cancel_and_
+   resubscribe_too` **PASSES PRE-FIX ON PURPOSE** (annotated in place) — it is the
+   only coverage of the real-event wrapper.
 
    **Review findings and their disposition — all four settled, don't reopen
    without new evidence:**
@@ -129,12 +192,19 @@ Mapping + reasoning: memory `project_roadmap_milestones`.
    *computed* the string `'break'` would silently drop its siblings. `return
    'break'` is also a quintessential Tk wart, and this project's whole premise is
    that Tk is invisible — so adopting it (undocumented, but pinned by a test) was
-   the worst of both worlds. `adapt_handler` now returns `None`. **Internal
-   handlers are unaffected** — they bind through `self.bind(...)` and never pass
-   through `adapt_handler`, which is used at public `on()` boundaries only (the 12
-   retargeting wrappers + `base.py:214,223`). The AST scan still holds: of 26
-   `return 'break'` functions in `src/`, only `numberentry_part.py:127-128` bind to
-   a `<<...>>` sequence, and both are internal. **No CHANGELOG entry — the
+   the worst of both worlds. `adapt_handler` now returns `None`. Internal
+   handlers do NOT pass through it — they bind through `self.bind(...)`, and
+   `adapt_handler` is used at public `on()` boundaries only (the 12 retargeting
+   wrappers + `base.py:214,223`). The AST scan still holds: of 26 `return 'break'`
+   functions in `src/`, only `numberentry_part.py:127-128` bind to a `<<...>>`
+   sequence, and both are internal. ⚠ **CORRECTION (second review): "internal
+   handlers are unaffected" was WRONG.** Bypassing `adapt_handler` is exactly why
+   those two still return a live `'break'` into the stock script shape, so on a
+   non-interactive field they abort the rest of that dispatch — and
+   `NumberEntryPart.on_increment` (`:335`) binds the same sequence behind them, so
+   the seam is real. Inert today (no caller; `increment` is not in the public event
+   registry; colorchooser's `<<Increment>>` binds are on `ttk.Spinbox`, a different
+   widget). **Filed as #401**, not fixed here. **No CHANGELOG entry — the
    behavior was never documented or reachable before this branch, so from a user's
    view nothing changed** (explicit maintainer call). If suppressing later
    handlers is ever wanted, it needs a native design (`event.stop()`), not an
@@ -152,6 +222,14 @@ Mapping + reasoning: memory `project_roadmap_milestones`.
    `datedialog.py:436` · `query.py:308` · `colorchooser.py:573` (which also uses
    the opposite precedence). Latent — nothing in-repo calls these. `_patched_unbind`
    already downgraded it from silent-catastrophe to silent-no-op.
+   (e) **Second review, remaining items — all FILED, none fixed here.** #399
+   `_patched_unbind`'s not-found guard leaks the Tcl command + closure forever
+   (the guard is right; the leak is its cost — reached via #397's drift and via
+   wholesale-unbind-then-cancel). #400 the single `except tk.TclError: return`
+   spans three operations, so a mid-sequence failure either strands the command
+   or reports a removal that did not happen — and `Subscription.cancel()` sets
+   `_cancelled = True` regardless. #401 above. **All three milestoned `0.2.x`**,
+   same as #397/#398.
 
    **⚠ `_patched_unbind` also changed one thing framework-wide, on purpose:** when
    the funcid is **not found** in that widget's script it now deletes **nothing**
@@ -202,8 +280,8 @@ Mapping + reasoning: memory `project_roadmap_milestones`.
    never run on either box. Issue also records two adjacent pre-existing shapes:
    `textarea/sidebar.py:49` removes **every** `<<Change>>` handler on the shared
    text widget including a user's, and `visual_focus.py:199` the same for root
-   `<Tab>`. **#397 and #398 are both UNMILESTONED — needs the maintainer's call**
-   (`0.2.x — Widget polish` looks right for both; internal-only, no compat break).
+   `<Tab>`. **#397 and #398 are both milestoned `0.2.x — Widget polish`**
+   (internal-only, no compat break).
 
    **Root cause of #392 (settled, do not re-derive).** `_patched_bind` wrote its own Tcl
    script for **virtual events** (`<<...>>` = every bootstack event) as a bare
@@ -228,7 +306,7 @@ Mapping + reasoning: memory `project_roadmap_milestones`.
    | after | `a=1 b=1 c=1` | `a=1 b=0 c=1` | `a=0 b=0 c=1` |
 
    **Verification already done — reproduce only if you distrust it:** full suite
-   `py -3.12 tests/run_gui.py` **exit 0**, main leg **906 passed** (893 + the 13
+   `py -3.12 tests/run_gui.py` **exit 0**, main leg **911 passed** (893 + the 18
    new), 18 legs, zero failures. Clean `-W` docs build succeeded warning-free
    (CHANGELOG is in the docs via `docs/release-notes.rst` — a CHANGELOG edit
    ALWAYS needs a docs build).
@@ -377,9 +455,12 @@ leak-fix.
   raises both ways; `RadioGroup` accepts at construction, raises on assignment;
   `ToggleGroup` accepts both; and where accepted, `value` says `'MX'` while
   `selection` says `None`). Wants ONE family decision, not four patches.
-- **#369 and #383 are deliberately un-milestoned** — both would raise where the
-  framework currently accepts, so they cannot ride the `0.2.x` patch line and need
-  a minor of their own. #352 and #328 are also homeless.
+- **#369 and #383 are milestoned `0.6.0 — Argument and value strictness`** — both
+  would raise where the framework currently accepts, so they cannot ride the
+  `0.2.x` patch line and needed a minor of their own. `0.6.0` was created for
+  exactly this and placed AFTER the themed minors so nothing was renumbered
+  again. #352 → `0.5.0 — Structured editing`; #328 → `0.2.x` (follows the
+  hot-reload umbrella #322).
 - **#208** — DataTable: persist selection by record id across search/sort/page.
 - **#192** — color-swatch `Select` control (decision-gated; lock shape/naming with
   the maintainer first). A `Select`-style dropdown rendering color swatches inline,
@@ -539,6 +620,21 @@ AFTER its PR merged is **stranded** — verify it landed in `main`.
   goes the pending callback goes with it. Guard the callback against both `TclError`
   **and `AttributeError`** — `destroy()` sets `_tclCommands` to `None`, which
   `deletecommand` then cannot update. Cost a real defect in the #392 follow-up.
+- **⚠ Tkinter binding names are recycled — never let a deferred cleanup hold one.**
+  `Misc._register` names a command `repr(id(bound_method)) + func.__name__`, and
+  that bound method exists only for the registration, so releasing the command
+  frees the address for immediate reuse: **498/499** consecutive bind/cancel/bind
+  cycles returned the *identical* name. Anything that postpones a
+  `deletecommand` can therefore delete a *different, live* binding. If you defer
+  cleanup keyed on a tkinter callback name, make the name unique first (a serial
+  in `func.__name__` is enough and keeps stock's bookkeeping). Cost a critical
+  defect in #392's own fix. Memory `reference_tkinter_funcid_recycling`.
+- **⚠ When a symptom is allocator- or timing-dependent, assert the INVARIANT, not
+  the symptom.** The above fails only when the allocator happens to hand the
+  address back, so behavioral tests passed on a broken build — 1 of 3 caught it
+  on the first pre-fix run. A structural test (50 cancel/rebind cycles → 50
+  distinct ids) fails every time. Worth breaking "test public paths" for; say why
+  in the test.
 - **⚠ A bulk `pathlib` rewrite flips CRLF→LF** (repo is `core.autocrlf=true`) —
   same class as the `sed -i` trap. Prefer the Edit tool; if scripting, write bytes.
   Memory `reference_autocrlf_sed_gotcha`.

--- a/docs/_dev/handoff-archive.md
+++ b/docs/_dev/handoff-archive.md
@@ -1,0 +1,1178 @@
+# bootstack — Handoff archive
+
+Session history split out of `CLAUDE.md` (2026-07-30) to keep the working
+handoff small. Every entry below shipped and is merged to `main`; each carries
+the root-cause analysis, the decisions and their reasoning, and the gotchas that
+bit along the way — the things git history does not record.
+
+**Read the relevant entry before working in an area it covers.** It is indexed
+by issue and PR number, so `grep` for `#392` / `PR #385` / a widget name.
+`CLAUDE.md` keeps only what is still OPEN plus the standing rules.
+
+---
+
+## Recently completed (all merged to `main`)
+
+Pointers only — these shipped; rationale, detail, and gotchas live in the linked
+memories and git history.
+
+- **#394 → PR #395 (MERGED 2026-07-29) — a validation rule misaligned a row of
+  fields.** Reporter `bLynnb2762` on 0.1.8/Windows: adding `required` to two of
+  four fields in a row left the other two sitting **9px lower**. **It was TWO bugs
+  under one report** — that split is the whole finding, don't re-derive it.
+  - **(a) In a `Form`.** `_build_items` grids every cell `sticky='nsew'`, so all
+    cells were **already** stretched to the tallest field — the cells were never
+    the problem. Inside the `Field` composite the entry row was packed
+    **`expand=True`**, so it absorbed the slack and **centered itself in it**,
+    putting the extra height *between the label and its own input*. Fix = drop
+    that one `expand=True` (`field.py`) so slack collects below the stack. ⚠ The
+    reporter's own diagnosis (a `vertical_items` knob on `GroupItem`) was **wrong**
+    and so was the first read here — **the Form needed no new alignment knob.**
+  - **(b) In a row-mode container.** Different mechanism: the field frames keep
+    their **natural** heights (61 vs 80) and the cross-axis default (`center`)
+    dropped the shorter ones; (a) does nothing here. Fix (maintainer's call) =
+    field widgets contribute **`vertical='top'` as a SOFT default**. Precedence,
+    most specific first: child's explicit `vertical=` → container's explicit
+    `vertical_items=` → **child-declared default (only when the container's cross
+    axis is unset)** → framework `center`. **That gate is the whole trap:** a
+    widget default must never silently beat an argument the author wrote (cf.
+    #381). To express "unset", `Row`/`Column` moved to `*_items: ... | None = None`
+    resolved inside `FlexFrame` — **the `None`-means-unset convention `Card`/
+    `GroupBox`/`Expander`/the AppShell page already used**, so this aligned
+    `Row`/`Column` with four existing containers rather than inventing anything.
+    `None` resolves to exactly what was hard-coded (stacking axis → leading edge,
+    cross axis → center), so non-field layouts are unchanged. One
+    **`_resolve_cross()`** owns precedence at **BOTH** call sites — `_relayout`
+    **and** the O(1) `_grid_appended_plain` append path; covering only one would
+    make alignment depend on whether a relayout happened to run.
+  - **Scope widened by `/code-review`, which caught two gaps that left the fix
+    half-effective.** (1) **Every row-mode container except `Row`** pre-resolved
+    its own unset default to `'center'`, suppressing the field default — measured
+    `Card(layout="row")` `[248, 257, 248]`, the identical 9px. Since
+    `Card(layout="row")` around a form row is common this would have **shipped
+    visibly unfixed**; eight copies of that block collapsed into one
+    **`resolve_layout_items()`** (`_core/container.py`) — grid mode still gets
+    concrete values (the grid engine has no "unset"), column/row pass it through.
+    (2) **`bs.Select`** is the ONE `Field`-backed public widget outside
+    `FieldAddonMixin` (its `SelectBox` subclasses `Field`) and has had
+    `add_validation_rule` since #357, so it sat low beside real fields (562 vs
+    553) — it carries `_flex_vertical_default` directly.
+  - **⚠ TWO CORRECTIONS to earlier notes.** (i) The prior handoff claimed
+    **`bs.Grid` has the same bug** — **it does not.** `Grid` defaults **both** axes
+    to `stretch`, so its cells align once the entry stops centering in the slack
+    (measured). There was never a Grid decision to make. (ii) A review finding
+    claimed the docstrings contradict the signature by stating the effective
+    default while rendering `| None = None` — **that is the house style**
+    (`card.py:33` already reads that way), so it was left alone.
+  - **Known asymmetry, accepted:** `Row()` and `Row(vertical_items='center')` now
+    behave **differently** even though the docs call `center` the default — an
+    author who writes the default out explicitly gets centered fields. Deliberate
+    (the alternative is ignoring an explicit argument) but it is a trap, and it is
+    the strongest argument against the soft-default approach if it is ever
+    revisited. Also **CHANGELOG `### Changed`:** where a field shares a grid row
+    or a `'stretch'` cross axis with a **taller** widget the entry moved from
+    centered to under its label (measured 59px → 19px in a 142px cell) — an
+    improvement (the input no longer floats below its own caption) but a real
+    visual change. Doc screenshot scenes were checked: they pair fields with
+    *shorter* siblings, so none needed regenerating.
+  - Tests **`test_field_row_alignment.py`** (14) — #394 had none. **5 fail pre-fix
+    BEHAVIORALLY** (`entries misaligned across the row: {180, 189}`), not with an
+    `AttributeError`, and each geometry assertion carries a precondition proving
+    the rule really grew the field so it cannot pass vacuously. Suite **893 passed,
+    exit 0**; clean `-W` docs build. **The geometry probes were far more decisive
+    than reading the layout code**, which is tangled across FlexFrame / GridFrame /
+    raw pack — rebuild one rather than reading, if this area comes up again (the
+    scratch probes and the reporter-repro demo were deleted once #394 shipped;
+    they were for visual validation only). Two rules that mattered: a
+    within-process measurement is required — `winfo_rooty()` is **not** comparable
+    across two runs (different window positions), so compare siblings in one run or
+    measure the entry's offset *inside* the field frame; and pair any alignment
+    assertion with a precondition proving the rule really grew the field, or it can
+    pass vacuously. Memory `reference_geometry_probe_same_process`.
+  - **Process gotcha that bit here:** a bulk `pathlib` rewrite of 6 files
+    **flipped CRLF→LF** (repo is `core.autocrlf=true`) — same class as the `sed -i`
+    trap in `reference_autocrlf_sed_gotcha`. Caught from the `git diff` warning and
+    restored; prefer the Edit tool, and if scripting, write bytes.
+
+- **0.1.x session 2026-07-29 — discussion #386 triaged into four issues, two
+  fixed and merged, plus #385.** User `bLynnb2762` filed **discussion #386** as an
+  *idea* ("let me reset a `DateField` to `None`"); investigation found **two real
+  bugs underneath it**, both now on `main`, and split the rest into a feature and
+  a design question. **All Windows + Tk 8.6.**
+  - **#387 → PR #391 (MERGED).** `DateField.value = None` **and its own public
+    `clear()`** were silent no-ops — the date stayed on screen and in
+    `form.get()`. **Root cause: `TextEntryPart.value()` (`_parts/textentry_part.py`)
+    is a combined getter/setter using `None` as its "no argument" sentinel**, so
+    `value(None)` called the *getter*. The set branch already handled `None`
+    correctly — which is exactly why the `.value = ''` workaround worked, same code
+    path. Fix = a module-level **`_UNSET`** sentinel (also in `spinnerentry_part.py`,
+    which carries its own copy). Verified no caller passed `None` expecting a get.
+    Affected **every** field on `TextEntryPart`; it surfaced on `DateField` only
+    because that is the one whose `clear()` passes `None` (the others pass `""` and
+    worked by accident). `TimeField` was immune — `TimeEntry` subclasses `SelectBox`.
+    ⚠ **The landmine:** `Form.set()` looped **all** items applying
+    `_data.get(key)` = `None` for absent keys, harmless ONLY because that write was
+    discarded — so **fixing the sentinel alone would have turned every partial
+    `form.set()` into a destructive overwrite**, including the reporter's own code.
+    `set()` now writes only the keys given and **merges** into `_data` instead of
+    replacing (which also fixed a latent bug: partial updates used to *drop* the
+    unmentioned keys from `_data`). Deliberate: `configure(data=)` stays a
+    whole-record write, so absent keys now genuinely clear.
+  - **#388 → PR #393 (MERGED).** Choosing a date in the picker emitted **no
+    `<<Change>>`** — a bound `Signal` stayed stale, `on_change` never ran, `Form`
+    never registered the edit, while typing the same date and pressing Return
+    worked. `_show_date_picker` assigned `value` directly; that event comes only
+    from `_check_if_changed()` on FocusOut/Return. **Range mode was already correct**
+    (`_set_range` emits) — single mode was the outlier. Fix = both call sites route
+    through **`_apply_picked`**, which assigns then calls the entry's **existing**
+    `_check_if_changed()`. Reusing it (not hand-building a `ChangeEvent`) is what
+    makes it safe: it advances `_prev_changed_value`, so a later focus-out cannot
+    re-announce the same pick, and the double application (dialog callback + the
+    post-`show()` fallback) is inert on the second pass. Also corrected the
+    DateField docs, which claimed `on_change` fires on a `value=` assignment — it
+    does not, by design.
+  - **#389 FILED** — `Form.reset()` (construction-time values) and `Form.clear()`
+    (`None`). **Maintainer decision: they are DIFFERENT verbs** — reset = originals,
+    clear = none. Both justified: `reset()` is **not user-implementable** (after an
+    edit, `get()` no longer knows the original), `clear()` is the data-entry case.
+    Slider clears to `min_value` (it has no null state, and that is already the
+    de-facto seeding behavior). Needs an `__init__` snapshot because `set()`
+    destroys `_data`; both must clear validation state.
+  - **#390 FILED (design, needs a decision)** — see the signal-emptiness entry
+    under "Next up".
+  - **#385 MERGED** — validated on Windows first (869 passed, exit 0, with `main`
+    merged in). Its `test_menu_backend_probe.py` runs **16 tests, zero skips** here.
+  - **#383** got the `Slider.value = None` → raw `TypeError` case added to its sweep.
+
+- **0.1.8 PATCH SHIPPED — macOS sizing on Tcl/Tk 9 (PR #377 for #375;
+  2026-07-23).** `bootstack 0.1.8` is on **PyPI** + tagged **`v0.1.8`**. Tk 9
+  changed the resolution macOS reports (Aqua's **72 → 96 DPI** baseline), and
+  `detect_scale_factor()` (`winfo_fpixels('1i')/72`) read that as a high-density
+  display — so on any Tk 9-linked Python the whole UI rendered **~1/3 too
+  large**. Text, icons, padding, control sizes all restored; matches Tk 8.6
+  exactly. Win/Linux unaffected. Tests **`test_tk9_scaling_baseline.py`** (8) —
+  and note they **monkeypatch `platform.system()` + `tkinter.TkVersion`, so they
+  need no display and no Tk 9**, which is why #380 calls them the cheap CI win.
+  ⚠ **CHANGELOG/release gotcha bit this cut** — see the release-flow note under
+  "Next up".
+
+- **0.1.x session 2026-07-28 — three PRs merged/open, one issue filed.** Worked
+  the open-issue backlog. **All verified on Windows + Tk 8.6 only** (see the
+  environment note below).
+  - **#381 → PR #382 (MERGED).** A behavior-mode argument is read by comparing
+    against one literal, so `selection_mode="multiple"` silently turned
+    multi-select **off** — no error, no warning. New **`validate_choice`**
+    (`widgets/_core/choices.py`) + public **`InvalidChoiceError`**, applied to
+    `selection_mode` (DataTable/ListView/Tree/Gallery/Calendar/DateField),
+    DataTable `sorting_mode`/`paging_mode`, `mode` (ToggleGroup/PathField),
+    ScrollView `scroll_direction`/`scrollbar_visibility`, `scrollbars`
+    (TextArea/CodeEditor), sidebar-toggle `collapse`. `SELECTION_MODES =
+    get_args(SelectionMode)` so the check can't drift from the type.
+    **Two decisions worth remembering:** (1) the issue cited #367 as precedent
+    for raising on a bad `editor=` name — **that is wrong**, #367 made the
+    *fallback* safe and never raises; the real precedent is **`ValueError`**
+    (`ContextMenu(trigger=)`, RadioGroup), so `InvalidChoiceError` inherits
+    **both** `BootstackError` and `ValueError` and those older guards can migrate
+    later without breaking callers. (2) **Scope was measured, not guessed** — an
+    AST audit found **215** Literal-typed public `__init__` kwargs and a 24-case
+    probe found **17 silently accepting** garbage; a blanket sweep is wrong
+    because **`| str`-widened args (`accent`/`surface`) must NOT be guarded**
+    (`'primary[+1]'`, `'primary[500]'` aren't in the alias). Line drawn at
+    *behavior* modes. **Guards run BEFORE `_resolve_parent`** — it raises its own
+    "created outside any container" error, which buried the typo.
+  - **#332 → PR #384 (MERGED).** Not really a rename: `ShellLayout` held each
+    flag **twice** — read-only `statusbar_visible`/`rail_visible`/
+    `sidebar_visible`/`dock_visible` properties *and* a separate
+    `set_*_visible(bool)` family. Gave the existing properties setters, deleted
+    the methods. Properties (not `show_*`/`hide_*` verb pairs) because the
+    getters and every sibling region accessor already are, and callers assign
+    computed bools that verb pairs would turn back into if/else.
+    `AppShell.statusbar`'s reveal hook was a **lambda** (can't hold an
+    assignment) → named `_reveal_statusbar`. Internal only.
+  - **#379 → PR #385 (MERGED 2026-07-29, after a macOS run AND a Windows
+    re-validation).** Six macOS failures, none a
+    product bug. New **`menu_probe`** + **`menus_are_native`** fixtures in
+    `tests/conftest.py` so the four backend-assuming tests assert the same fact
+    on both `ContextMenu` backends instead of the Windows shape (a `skipif` would
+    have *preserved* the coverage hole — those are the only tests for menu
+    construction + overlay propagation). **Key technique: `_NativeContextMenu` is
+    constructible on Windows** (a `tk.Menu` is real everywhere; only the *choice*
+    of backend is platform-specific), so `test_menu_backend_probe.py` (16) drives
+    **both backend classes directly** and the macOS branch is exercised on
+    Win/Linux. That caught a real defect in the helper: **`entrycget(i,'state')`
+    raises `TclError` on a SEPARATOR** on the native backend while the themed one
+    returns `False`. Measured: both agree count=3 and index alignment for
+    `[command, separator, command]` — only the separator's state differed.
+    **PageStack order-dependence hypothesis (UNCONFIRMED):** `shown_app` did
+    `deiconify()` + **`update_idletasks()`, which does not process the map event
+    at all** (idle callbacks only), so `winfo_ismapped()` depended on what was
+    queued ahead; now pumps `update()` until mapped (bounded 100). **The PR body
+    carries step-by-step macOS tester instructions**, including what each failure
+    mode means if PageStack still fails.
+  - **#383 FILED** — the follow-up sweep: presentation kwargs still degrading
+    silently (`density`, `Tabs.orient`, `Slider.orient`, `Gauge.variant`) **plus**
+    args that raise but leak a **raw `TclError`/`AttributeError`**
+    (`Button.icon_position`, `Label.justify`, `Scrollbar.variant`,
+    `Expander.icon_position`, `ProgressBar.mode`). Suggests sweeping **by argument
+    name**, not by widget.
+
+- **0.1.7 PATCH SHIPPED — Tk 9 scroll-event contract + attach theme repaint
+  (PRs #373, #374; 2026-07-23).** `bootstack 0.1.7` is on **PyPI** + tagged
+  **`v0.1.7`** ("Tcl/Tk 9 scroll support"); verified by installing the published
+  wheel into a clean Tk 9 venv. **#372** ("Scroll not
+  working on MacOS", user `cleonello`): scrolling
+  worked on Python 3.13.9, not 3.14.6. **It is NOT a Python change** — `tkinter`
+  is unchanged between those versions apart from docstrings, `after(**kw)`, and
+  `trace_variable` deprecation warnings. It is **Tcl/Tk 8.6 → 9.0** (reporter had
+  9.0.3; the python.org installer still ships **8.6.17**, which is why 3.13
+  "worked"). **Root cause, measured not inferred:** on Tk 9 + Aqua a trackpad
+  fires **only `<TouchpadScroll>`** — a probe logged **293 TouchpadScroll, ZERO
+  MouseWheel** — and every scrolling widget bound only `<MouseWheel>`. Two more
+  breaks in the same contract: Tk 9 normalizes wheel deltas to **±120** on all
+  platforms (so Aqua's `-event.delta` scrolled 120 units/notch), and X11
+  **Button-4/5 are no longer delivered to scripts** (TIP 474). **Fix:** new
+  **`_runtime/wheel.py`** (`wheel_sequences` / `wheel_notches` / `precise_deltas` /
+  `scale_num` / `PixelAccumulator`) replacing the delta branch **duplicated across
+  9 files**; bindings unconditional, X11 buttons kept only as a Tk ≤8.6 fallback
+  gated on **Tk version, not `winsys`**. Widgets copy Tk's **two** conventions:
+  *pixel* scrolling (ScrollView/TextArea/ScrolledText/Tabs) vs *accumulated whole
+  rows* (ListView/Tree/Gallery), plus a 40px/step throttle on the Spinbox/
+  NumberField steppers. **DataTable needed nothing** — Tk 9 binds TouchpadScroll on
+  the ttk Treeview class itself (verified). Incidental fix: a ScrollView notch moved
+  **10 canvas units on X11** vs 1 elsewhere; now 1 everywhere. Tests
+  **`test_scroll_events.py`** (25; 3 fail pre-fix). Verified on **Tk 9.0.4 AND
+  8.6.17** + confirmed live on a real trackpad. Full suite on Tk 9: **751 passed**,
+  only the 6 known pre-existing failures. `trace_variable`/`trace_vdelete`/
+  `trace_vinfo` (removed in Tcl 9) are **not used** anywhere — scrolling was the
+  only Tk 9 gap. Memory `reference_tk9_scroll_events`.
+  **Repro env:** `brew install python-tk@3.14` → `/opt/homebrew/opt/python@3.14/bin/python3.14`
+  (3.14.6 + Tcl/Tk 9.0.4). **⚠ The touchpad tests SKIP on Tk 8.6** — on the default
+  `.venv` the file reports "15 passed, 10 skipped" and looks green while testing
+  nothing about the fix. **There is no test workflow at all** (`.github/workflows/`
+  has only `docs.yml` + `release.yml`), so this can regress invisibly — the top
+  open item from that session.
+  **UPSTREAM: `ttkbootstrap` has the identical defect** — same code lineage, same
+  `winsys` branch in `widgets/scrolled.py` (binding 436-440, delta 546-556) and
+  `dialogs/colordropper.py:157-160`. Measured on 2.0.0 + Tk 9.0.4: a trackpad
+  gesture does nothing and ONE wheel notch jumps an 80-row `ScrolledFrame` to the
+  end (`0.0 → 0.813`). Filed as **israel-dryer/ttkbootstrap#1290** with the fix
+  shape; the #373 diff maps closely onto `scrolled.py`. **Repro gotcha:** the wheel
+  tag is only added to bindtags on mouse-enter, so synthetic events do nothing until
+  `enable_scrolling()` is called — and the content-fits guard silently returns
+  early until the scrollregion is actually computed. Both produce a convincing
+  false "dead" reading.
+
+- **0.1.6 PATCH SHIPPED — seven form/field/validation fixes
+  (PRs #362–#368; released 2026-07-21).** On **PyPI** + tagged **`v0.1.6`**
+  (plus #371, a `Decimal`/`value_format` fix, folded into the cut). Kicked off by the user
+  `bLynnb2762` reporting on the CLOSED **#358** that tristate still failed; filed
+  fresh as **#361** (different root cause). **#362:** a checkbox built by a `Form`
+  ignored `tristate` — the form passed an explicit `value=False` over the widget's
+  indeterminate default; `editor_options` also COLLIDED with the kwargs the form
+  fills (`value`/`label`/`options`) → `TypeError` from an internal class. Two value
+  bugs alongside: `TextField`/`PasswordField`/`PathField` gated the initial value on
+  **truthiness** (so `value=0` rendered empty, and a form wrote the blank back over
+  the record), and the form **stringified** non-text data (a `Decimal`/`date` became
+  `str` in `form.data` at construction — a data-integrity regression *my own first
+  fix introduced*, caught by review). **#363:** the same collision existed in
+  `MenuButton(menu_options=)`, `ButtonGroup.add`/`add_all`,
+  `RadioGroup`/`ToggleGroup.add`, `Toolbar`/`StatusBar.add_widget` → all now route
+  through **`merge_kwargs`** (`widgets/_core/kwargs.py`); see the corrected Gotcha.
+  **#364:** a placeholder is rendered by INSERTING its text, and validation read the
+  raw entry, so **`required` passed on an untouched field** (a form with a required
+  placeholder field submitted empty); `field.text` also reported the hint while
+  `value` said empty. **#365:** deleted the 27 `tests/features/*` visual scripts
+  (never collected — `testpaths` covers only `tests/cli`, `tests/widgets/public`,
+  `tests/data`). **#367 (#366):** `email`/`pattern`/`stringLength` ran on EMPTY
+  values, so an **optional** field left blank blocked `Form.validate()` with no way
+  forward — now they pass on empty (matching `range`'s existing precedent); also
+  `required` was dropped for an unrecognized `editor=` name (a typo silently let an
+  empty field submit). **#368 (#355):** a `Select` REJECTED a value not in its
+  option list, so opening a `Form`/`DataTable` editor on a record whose option had
+  been retired **raised** — while a later programmatic write was silently dropped.
+  **Root cause:** `Select` stores display TEXT and decodes the value back through
+  the option list, so the `ValueError` was guarding *decodability*, not policy. Fix
+  = register the retired value under its own coerced text (`_register_retired_value`)
+  so the decode stays total (an `int` reads back an `int`); it is never added to
+  `_records`, so the popup is unchanged. Surfaced two more: a **searchable** Select
+  committed its top match when the popup was merely opened and dismissed, and
+  validation ran against the **label** (so a rule on a decoupled list rejected valid
+  selections). Added **`Select.validate()`** (every other field had one; its own
+  `add_validation_rule` docstring already promised it). **#369 filed** — the
+  selection family disagrees on off-list values (`SelectButton` raises both ways;
+  `RadioGroup` accepts at construction, raises on assignment; `ToggleGroup` accepts
+  both; and where accepted, `value` says `'MX'` while `selection` says `None`) —
+  wants ONE family decision, not four patches. **PROCESS (the session's real
+  lesson): adversarial review caught a defect in EVERY round**, including two
+  regressions I introduced — the `Decimal`→`str` coercion, and a
+  `_get_validation_value` override that broke **`bs.TimeField`** (`TimeEntry`
+  subclasses `SelectBox`, so typed out-of-range input validated clean). Tests that
+  only assert *construction doesn't raise* are what let #358 ship twice — and I
+  repeated it, writing a test that certified a **broken** documented example
+  (`menu_options={'offset': 4}` crashes on open; the docstring now says `(4, 0)`).
+  **CHANGELOG convention (I got this wrong on four branches):** a fix commit writes
+  `## [Unreleased]`; the `Release X` commit renames it AND adds the `[X]:` link
+  definition. Memory `feedback_pause_and_ask_when_stuck` — I over-complicated #355
+  for hours (heading toward a `Select` value-model rewrite) before the maintainer
+  pointed at the ~15-line map fix; **pause and ask when a fix outgrows its issue.**
+
+- **0.1.5 PATCH SHIPPED — boolean-control state reads + Checkbox tristate (PR #360;
+  2026-07-20).** `bootstack 0.1.5` is on **PyPI** + tagged **`v0.1.5`** ("boolean
+  control state fixes"). **Three bugs, one root cause (user `bLynnb2762`).** `Checkbox`,
+  `Switch`, `ToggleButton` share **`_BooleanControlBase`**, which read state by
+  comparing the backing Tk var's *coerced* value against the Python `checked_value`
+  (`self._internal.get() == self._checked_value`) — type-fragile, only correct when
+  the var type matched the value type. **(#358)** `Checkbox(tristate=True)` never went
+  indeterminate — `BooleanVar` can't hold a third value and the dash never rendered;
+  `.value` returned `False` not `None`. **(#359)** `ToggleButton(value=True).checked`
+  returned **`False`** (StringVar-backed → `'1' == True` is `False`). **Latent:** a
+  non-bool `checked_value`/`unchecked_value` (`"yes"`, ints) was silently coerced away
+  on Checkbox/Switch. **Fix = read the ttk `selected`/`alternate` STATE** (var-agnostic)
+  in `.value`/`.checked`/`_command`; a shared **`_apply_value`** maps the public value
+  onto on/off + the indeterminate flag. **Two gotchas the empirical probes caught:**
+  (1) **`configure(command=...)` RESETS ttk state** — so seeding must run AFTER it
+  (indeterminate `alternate` set earlier is wiped); (2) a **var write clears
+  `alternate`**, so indeterminate = set off-value THEN flag `state(('alternate',))`,
+  and the explicit `!alternate` clears elsewhere are redundant. **Var-type fix pushed
+  to the PRIMITIVE** (`checkbutton.py`), **consistent with RadioGroup/ToggleGroup**
+  (both do `StringVar(value=...)` explicitly — the precedent that made the tk import OK):
+  inject a `StringVar` **only when non-bool on/off values are given**, else keep the
+  `BooleanVar` so the **default control's auto-created `.signal` stays boolean** (the
+  code-review caught that always-StringVar leaked `'1'`/`'0'` strings through `.signal`,
+  where `"0"` is truthy — a real regression; conditional injection closes it). **Adversarial
+  `/code-review` (high) found 5, 2 real** — the `.signal`-type leak (fixed) + a redundant
+  `!alternate` (removed); the other 3 were non-issues (tristate+signal is documented;
+  `.value` fallback is more-correct; `_prev_value` staleness didn't reproduce). NB
+  **ToggleButton was ALREADY StringVar** (its `class_='Toolbutton'` dodges the
+  `TCheckbutton`→BooleanVar inference in `infer_default_value_for_widget`), so its
+  `.signal` was always string — no regression there. Tests **`test_boolean_controls.py`**
+  (the `.value`/`.checked`/tristate coverage these widgets NEVER had — which is why all
+  three shipped; 8 fail pre-fix). Docs: tristate scene added to the Full Example +
+  **regenerated `checkbox-tristate-*.png`** (old ones rendered indeterminate as
+  unchecked). **Process win: running empirical probes beat static reading repeatedly** —
+  the `configure(command)` reset, the var-write-clears-alternate rule, and the
+  ToggleButton-already-StringVar fact were all discovered by driving the widget, not
+  reading it.
+- **0.1.4 PATCH SHIPPED — `Select.add_validation_rule` restored (PR #357;
+  2026-07-20).** `bootstack 0.1.4` is on **PyPI** + tagged **`v0.1.4`** ("Select
+  validation fix"). Also re-worded the PyPI **`description`** (maintainer's pending
+  "built on Tk" tagline, folded into this cut). **Bug (user `bLynnb2762`, #356):** a
+  **0.1.3 regression** — `form.field(key).add_validation_rule(...)` on a `select`
+  editor raised `AttributeError: 'Select' object has no attribute
+  'add_validation_rule'`. **Root cause:** PR #354 (0.1.3) made `Form.field()` return
+  the **public wrapper** widget; the field-family wrappers carry `add_validation_rule`
+  via `field_mixin`, but `bs.Select` did **not** — and among the non-field editors its
+  internal `SelectBox` was the only one that had been inheriting it (from the `Field`
+  composite). So Select was the single casualty. **Fix (bounty PR #357 by external
+  contributor AnasBabari):** add `add_validation_rule` on `bs.Select`. **My review +
+  refactor:** the contributor's first pass hoisted `message`/`trigger` params with a
+  **`trigger="change"` default — but `'change'` is NOT a valid `RuleTriggerType`**
+  (`key`/`blur`/`always`/`manual`), so a rule added with no explicit trigger only ran
+  on manual `validate()`, never live. Refactored to **mirror the field-family
+  signature exactly** — `add_validation_rule(self, rule_type: RuleType, **kwargs)`
+  delegating straight through — which lets `ValidationRule`'s per-rule
+  `_default_trigger()` apply (required→`always`). Pushed onto the fork PR branch
+  (`maintainerCanModify`), squash-merged (contributor keeps authored credit + bounty).
+  Test added to `test_form_editor_options.py`. **CHANGELOG/close gotcha:** #356 used
+  `Fixes: <url>` (colon) which GitHub's auto-close does NOT parse → closed manually.
+- **0.1.3 PATCH SHIPPED — Form `editor_options` use public widget kwargs (PR #354,
+  #353; 2026-07-17, pre-session).** `bootstack 0.1.3` on **PyPI** + tagged **`v0.1.3`**.
+  Form built the **internal** impl widgets and forwarded `editor_options` raw, so users
+  had to pass Tk option names (`increment` not `step`) and `textarea` couldn't take
+  `show_border`. Rewrote `_build_field` to construct the **public wrapper** widgets via
+  `_construct_editor`, so `step`/`min_value`/`show_border`/`mask`/slider-bounds work as
+  documented; **`field()` now returns the public wrapper** (the change that regressed
+  Select validation — see 0.1.4). Also a homepage-tagline docs commit landed on `main`
+  the same day. **NB this predates the session** — recorded here because CLAUDE.md had
+  gone stale at 0.1.2.
+- **0.1.2 PATCH SHIPPED — dropdown/context menus dismiss on window move (PR #345;
+  2026-06-25).** `bootstack 0.1.2` is on **PyPI** + tagged **`v0.1.2`**. **Bug
+  (user-reported, Win10):** an open toolbar `add_menu` dropdown (and any Win/Linux
+  `ContextMenu`/`Select`/`MenuButton` popup) stayed pinned at its old screen
+  position when you dragged/resized/minimized the window — it "hung in the air."
+  The `_ToplevelContextMenu` (overrideredirect Toplevel backend) only dismissed on
+  **outside mouse clicks** bound on the owning window; dragging the native title
+  bar fires no click, only `<Configure>`/`<Unmap>` on the toplevel, which nothing
+  listened for. **Fix:** while shown, also bind the binding-root's
+  `<Configure>`/`<Unmap>` → new `_on_window_change` method dismisses (guarded to
+  `event.widget is the toplevel` so a child relayout doesn't close it); torn down
+  with the existing outside-click cleanup. Shared backend → fixes ALL Win/Linux
+  popups at once. Verified decorated AND undecorated (both move via `wm geometry`
+  → `<Configure>`); macOS `_NativeContextMenu` untouched (native menu self-dismisses).
+  **NB this is the window-MOVE bug — DISTINCT from #207** (the `'break'`-target
+  dismiss case, still OPEN; I confirmed a `'break'` toolbar widget already dismisses
+  here). Tests in `test_toolbar_menu.py` (window-change dismissal + binding
+  teardown). **Process:** empirical self-driving repro (move window, assert
+  `winfo_viewable()`) was decisive — static reading missed that no click fires on a
+  title-bar drag. Confirmed Py 3.12.10's `unbind(seq, funcid)` removes only that
+  funcid (not the unbind-wipes-all of older Tkinter), so binding `<Configure>` on
+  the app toplevel is safe. **CHANGELOG gotcha (fixed):** `## [0.1.1]` was a
+  bracketed link with NO `[0.1.1]:` definition (dead link); added `[0.1.1]:` +
+  `[0.1.2]:` defs. **Release-notes gotcha:** `release.yml` extracts ONLY the
+  `## [x]` section, so the bottom link-defs are excluded → `[0.1.2]` renders as
+  literal brackets in the GitHub Release body (see Next-up for the fix).
+- **0.1.1 PATCH SHIPPED — `pygments` declared as a runtime dependency (PR #344;
+  2026-06-24).** `bootstack 0.1.1` is on **PyPI** and tagged **`v0.1.1`** (GitHub
+  Release, notes from the CHANGELOG `## [0.1.1]` section). **Bug:** `CodeEditor`
+  hard-imports `pygments` (via `_try_install_highlighter`) for syntax highlighting,
+  but it was declared as a dependency **nowhere** in `pyproject.toml` — so a clean
+  `pip install bootstack` (no incidental pygments) crashed on any
+  `CodeEditor(language=...)`, including the bundled `bootstack` demo's editing page
+  (`ModuleNotFoundError: No module named 'pygments'`). Fix = add `pygments>=2.15`
+  to `[project].dependencies` (hard dep, per the maintainer — pure-Python, no
+  transitive deps, and highlighting is core to a top-level `bs.*` widget; matches
+  batteries-included). **Full dependency audit done while here — `pygments` was the
+  ONLY gap:** every optional extra (`viz`/matplotlib, `parquet`/pyarrow,
+  `excel`/xlsxwriter, `hdf5`/pandas+tables, `viz-seaborn`/seaborn) is lazy-imported
+  inside functions and gated by `_require(...)`/`_require_matplotlib` (so `import
+  bootstack` + core widget construction never crash); `PyInstaller` is a
+  packaging-time tool (`try/except` in the CLI); `tomli` is a dead fallback
+  (`tomllib` is stdlib on `requires-python >=3.12`); `cycler` is guarded + ships
+  with matplotlib. **Release process note (CORRECTED 2026-07-21):**
+  `bump-my-version` IS available — `.venv/Scripts/bump-my-version.exe`, v1.3.0 — so
+  the normal `bump-my-version bump patch` flow works. (The 0.1.1 session could not
+  reach it and replicated the config by hand: bump BOTH `version` (line 7) and
+  `[tool.bumpversion] current_version`, commit `Release X`, annotated tag `vX`.
+  That manual path is the fallback, not the norm.)
+- **0.1.0 STABLE SHIPPED — ship gate + theme-repaint unification + accent contrast
+  (2026-06-24).** `bootstack 0.1.0` is on **PyPI** (`pip install bootstack`, no
+  `--pre`) and tagged **`v0.1.0`** (stable GitHub Release, `prerelease=false`).
+  Verified on **Windows AND macOS**. **#149 ship gate (PR #335 — MERGED):**
+  public-surface audit + lock + CHANGELOG + Release Notes + Roadmap page; the
+  folded items shipped in **PR #334** (`text=<Signal>` → `TypeError` guard across
+  text-bearing widgets; `cli/run.py` double-cwd fix). `bootstack.__version__` is
+  already DYNAMIC (`importlib.metadata`), so the "stale 0.1.0a6" worry was moot.
+  **Pre-release framing removed (PR #342):** README/CONTRIBUTING warnings gone;
+  pyproject `Development Status` 3-Alpha→**4-Beta** (Beta over Production/Stable —
+  no production mileage yet; pandas precedent = bump to 5 once earned, not at 1.0)
+  + fixed the bogus `Environment :: X11 :: GTK` (it's **Tk**) → Win32/MacOS X/X11.
+  **GitHub Release notes now come FROM the CHANGELOG (PR #343):** `release.yml`
+  checks out the repo and extracts the `## [<version>]` section as the release
+  body (GitHub's auto "What's Changed" appended below; an alpha tag with no
+  section falls back to auto-only). **Theme-repaint unification (PR #338):**
+  replaced THREE overlapping mechanisms (STD-publisher + `_enable_theme_repaint`;
+  `register_tk_widget` WeakSet + `<Map>` registry — RETIRED the grows-forever
+  leak; per-widget hacks) with ONE rule — a tree widget defines
+  **`_bs_apply_theme(self)`**, driven by `Style.apply_theme_walk(root,
+  only_stale=)` (theme-change → walk VISIBLE from root; container-show → walk
+  STALE subtree IGNORING `winfo_viewable()`, unreliable across a canvas boundary);
+  show-triggers in PageStack (covers Tabs) + Expander (covers Accordion);
+  non-tree reactors (Image handle / window chrome / app `on_theme_change`) stay on
+  root `<<BsThemeChanged>>`. The meter canvas takes the surface TOKEN (not a frozen
+  hex) so the walk re-resolves it; `style_resolver` now lets an explicit `surface=`
+  win over inheritance (the gauge "bg doesn't recolor" root cause). Dev note
+  **`docs/_dev/theme-repaint-architecture.md`**. **Accent text-on-color fix (PR
+  #340):** `on_color` light-mode white gate 4.5→**3.0** (the large/bold WCAG bar
+  that button labels meet) so saturated colored accents read white in BOTH modes
+  (dracula-light purple primary was wrongly black) while bright cyan `info`/yellow
+  `warning` stay black; + a contrast FLOOR catching bucket-edge cases in either
+  mode (catppuccin-dark `warning` was white at ~2:1). Test `test_on_color_contrast.py`.
+  **macOS fixes (PR #339, local agent):** kept nav pages mapped (#336) + anchored
+  toasts to the visible frame above the Dock (#337). **Dead-test cleanup (PR
+  #341):** deleted stale `test_gauge_theme.py` (asserted #338-deleted mechanisms)
+  + fixed `test_icon_image_props.py`'s private-fixture/no-container setup. Milestone
+  **0.1.0 (stable) CLOSED** (11 issues); **#322** (provisional hot-reload umbrella,
+  E2E test still deferred to the maintainer) moved to **0.1.1**.
+- **Hot-reload follow-ups #325/#326/#327 + #328 docs (PR #333 — MERGED;
+  2026-06-24).** Four fixes on PROVISIONAL `bootstack.dev`, one PR. **#325:**
+  AppShell `_dev_reset_region` restores the status band to its forced state
+  (`set_statusbar_visible(False)` unless `show_statusbar=True`) so an empty band
+  doesn't linger after a no-segment reload — AND `show_statusbar=True` now genuinely
+  forces the band visible at construction (was materialize-only; stored
+  `self._show_statusbar_forced`); App/AppShell reset now CANCEL a scheduled
+  native-menu `after_idle` (new `ChromeHostMixin._cancel_native_menu_pending`) vs
+  nulling the handle (macOS double-fire). **#326:** the per-page fast path is gated
+  on EVERY changed file being a builder module (`_builder_module_files`) — a changed
+  non-builder/state module takes the full reload-then-reexec instead of a selective
+  `importlib.reload` that splits object identity without rebinding. **#327:** watch
+  root widens from the entry file's dir to the project `src/` tree
+  (`_project_watch_root` walks up to `bootstack.toml`; falls back to the file dir for
+  loose scripts); watcher snapshot stamps `(mtime, size)` to catch same-tick saves;
+  symlink/scope caveats documented. **#328 (docs only):** added a "Gating dev-only
+  code" section for `is_dev_mode()` — **the E2E multi-file `@reloadable` reload test
+  is the remaining #328 piece, DEFERRED** (the maintainer will do it). Tests: watcher
+  tuple + size-change; `_project_watch_root` widen/fallback; shell GUI legs green.
+  **Naming note (`set_*_visible` is INTERNAL):** `ShellLayout.set_statusbar_visible`
+  / `set_rail_visible` / `set_sidebar_visible` / `set_dock_visible` are an internal
+  family (public uses verbs `show_sidebar()`/`hide_sidebar()`/`toggle_sidebar()` +
+  `show_statusbar=`); **#332 filed** to rename the internal family to the idiom (low
+  priority). Memory `project_hot_reload` (followups thread).
+- **Docs-IA: fold Production into the User Guide + caption renames (#323/#324;
+  2026-06-24).** The docs navbar dropped from **4 pillars to 3** (**User Guide ·
+  Widgets · API Reference**). The former **Production** pillar folded into the User
+  Guide as a new **Developer tools** caption (`cli`/`hot-reload`/`debugging`/
+  `distribution`); **`App Configuration`** (`/production/app-settings`) moved to the
+  **Feature guides** caption (it's a subsystem guide, not tooling/shipping). **#324
+  decision = fold-into-User-Guide** (maintainer chose it over rename-in-place /
+  reorder). The **Topics** caption was renamed **Feature guides** (more descriptive of
+  the subsystem deep-dives; the locked constraint is only "not Concepts/Explanation").
+  **#323:** the `Composing Fields` how-to renamed → **`Customizing Fields`**
+  (`/tasks/composing-fields` → `/tasks/customizing-fields`) to kill the "Composing X"
+  clash with the new **Composing with Builders** how-to (it's about *specializing* a
+  field, not decomposition). Leaf pages STAY in `production/` (no URL churn — internal
+  dir name only); the one accepted churn is the #323 rename (no redirect mechanism →
+  dead old URL, fine per no-shims). `production/index.rst` DELETED. Inbound `:doc:`
+  refs + 6 widget See-also links repointed. Clean `-W` build, no orphans. Memory
+  `project_docs_ia_pillars`.
+- **Builder-function scaffolds + examples audit (PR #330 — MERGED; 2026-06-24).**
+  The staged builder-pattern work the roadmap flagged as "START HERE." **#321:**
+  every CLI page/view scaffold flipped from a class
+  (`__init__`/`_build`/`self.root`) to a **`build_<name>()` builder function**
+  (`cli/templates/__init__.py`). Layout moved onto the page region — AppShell pages
+  paint **directly** into the page (`padding`/`gap`/`horizontal_items` on
+  `nav.add_page(...)`; the page IS the column, no inner wrapper); basic **pack** view
+  paints into the padded App body, **grid** view opens a `bs.Grid` (a layout the
+  column body lacks — not redundant; needs `horizontal="stretch"` to fill);
+  **master-detail** `build_detail(record)` opens its **own** padded `Column` (the
+  detail region is a bare `ContentHost` fill area, no padding). Stateful handlers
+  became **closures over local field refs** (not `self.*` methods) — the documented
+  "builder default, class is the escape hatch" story. `add page`/`add view` emit
+  `build_<name>` (suffix-stripped: `DashboardPage`→`build_dashboard`) + matching
+  wiring hints (new `_build_func_name`/`_readable_title` helpers). **Naming
+  convention LOCKED:** *component* builders are bare (`user_card`), *page/region*
+  builders are `build_<name>` — a **Naming** note in the **Composing with Builders**
+  how-to ties scaffolds + how-to into one system. **#320 Part 2:** flagship
+  `docs/examples/appshell.py` factors its metric cards into a reusable
+  `metric_card()` builder; nav examples were already class-free (the reshape did it);
+  the `bootstack gallery` demo already uses `_build_*` builders (left as-is — its
+  inner `Column` is legit scroll-content padding for `scrollable=True` pages, NOT
+  class-view redundancy). **#320 Part 1 + the `_resolve_parent` guard shipped in
+  #329** (the guard at `base.py:97` raises a clear `BootstackError` when a builder is
+  called with no active container + no `parent=` — matches the how-to's "one rule").
+  Verified: all 6 scaffold variants build in isolated subprocesses, the printed
+  add-page wiring builds end-to-end, 186 cli/public-surface tests, clean `-W` docs
+  build. Memory `project_builder_scaffolds`.
+- **Hot reload — `bootstack dev` + feature-review fixes (PR #329 — MERGED;
+  2026-06-24).** The dev workflow (BUILT on `feat/hot-reload` in the prior
+  session) got a **4-reviewer adversarial audit + fixes**, then merged.
+  `bootstack dev app.py` re-execs the `with bs.App()` body in place on save
+  (window + module-level signals/sources/stores + active route survive; broken
+  edits show an in-window banner); `@reloadable` rebuilds just one page's region
+  (multi-file); a restart fallback covers function-wrapped apps (auto-selected;
+  `--restart` forces). New **PROVISIONAL** `bootstack.dev` (carved OUT of the
+  0.1.0 freeze): `reloadable` + `is_dev_mode`. **Blockers the review caught +
+  fixed:** 🔴 **win32 `os.execv` restart was BROKEN** — execv does NOT replace the
+  process in place on Windows (new PID + caller exits), so the supervisor died
+  after the FIRST reload (the prior session's "Verified Windows" missed it — it
+  only exercised in-process). Replaced execv with a **CLI `subprocess.run`
+  supervisor loop** on a sentinel exit code (`DEV_RESTART_EXIT_CODE`), made
+  **crash-resilient** (a broken edit waits-and-relaunches instead of ending the
+  session — surfaced by LIVE testing, not the static review). 🔴 **AppShell/
+  Workbench error banner was dead** (`_content_frame` is a method on shells, an
+  attr on App — reloader now resolves both). + `relative_to` guard on an
+  absolute/`..` entry. **Docs IA:** the builder-functions guide became the
+  **"Composing with Builders"** how-to (`docs/tasks/composing-with-builders.rst`
+  — goal-indexed, not a subsystem topic) + restart-mode "when to force
+  `--restart`" guidance + the demo video / README hero. Reviewers over-flagged
+  (the mount-accumulation suspicion was disproved — `reset_mounts` is wired).
+  Memories `reference_win32_execv_not_inplace`, `project_hot_reload`.
+  **Non-blocking follow-ups filed: #325** (reset-cleanup gaps), **#326**
+  (`_reload_modules` identity-split scoping), **#327** (watcher scope/polling),
+  **#328** (multi-file reload test + thin is_dev_mode docs). **Docs-IA spin-offs:
+  #323** (rename "Composing Fields" → "Customizing Fields") · **#324** (rethink the
+  "Production" pillar). Process note: **running it caught what reading it didn't.**
+- **Splash screen — cross-platform `windowtype` + `bs.Splash` (PRs #313, #318 —
+  MERGED; 2026-06-23).** Two-step feature, each its own branch→PR→`main`.
+  **#308 (PR #313):** `Toplevel(windowtype=...)` was honored only on macOS
+  (`MacWindowStyle`) and X11 (`-type`); **win32 never read it**. Added a win32
+  branch (`_runtime/toplevel.py`) translating the chromeless types
+  (`splash`/`tooltip`/`dock`) → `overrideredirect` and `utility` → `-toolwindow` —
+  **one switch, all three platforms** (maintainer chose the auto contract: the
+  caller need NOT also pass `overrideredirect=True`). macOS asymmetry preserved for
+  free (`overrideredirect()` already no-ops on Aqua). **#310 (PR #318):**
+  **`bs.Splash`** — a borderless intro screen (its own `Toplevel`,
+  `windowtype="splash"`) constructed inside the `App` context. **Registration, not
+  suppression:** construction resolves the ambient app and registers on it; the
+  internal `App.mainloop` gained ONE branch — if a splash is up, defer `show()`
+  until it dismisses (`_notify_app_ready`). **Shows at its own `__exit__`** (after
+  content authored, before the synchronous body build it precedes — so it genuinely
+  covers that cost) with `update()` to force paint; the `with` block scopes content
+  only, not lifetime. One dismiss knob `until=` (`'ready'`|`<float>`|`'manual'`) +
+  `skippable`/`dismiss()` on top + `min_duration` floor under all. Best-effort
+  `after()`-driven alpha fade (snaps where unsupported). Lean surface: `is_showing`,
+  `dismiss()`, `on_dismiss`→`SplashDismissEvent(reason)`; guards (no app / second
+  splash → `BootstackError`). Added `SplashDismissEvent`/`SplashDismissReason` to
+  `bootstack.events` + the events API ref; **re-homed the drifted `SashMoveEvent`/
+  `ScrollEvent`** there too. Docs: `widgets/splash.rst` + a `tasks/splash-screens.rst`
+  how-to (cover-startup, timed branding, welcome, **real progress via worker thread
+  + Signal**, and the **event-loop timing rule** — motion only shows while the loop
+  turns, so a `'ready'` splash over a synchronous build is a STILL image by design).
+  Tests `test_splash.py` (14). **Process catches (maintainer caught both):** a stray
+  "Tk" in the how-to broke the no-toolkit-in-docs rule; and `events.rst` had silently
+  drifted from `events.__all__` — fixed + added a coverage guard (PR #319,
+  `test_events_doc_coverage.py`). Memory `project_splash_widget`.
+- **Icon-DPI sizing + Tooltip subtree coverage (PRs #306, #307, #309 — MERGED;
+  2026-06-23).** Three small fixes off the 0.1.0 cleanup backlog, each its own
+  branch→PR→`main`. **#267 (PR #306):** the public `Image` handle (`get_icon` /
+  `image=`) and the MenuButton chevron rendered glyphs at their literal *logical*
+  size and so read soft at fractional/high DPI. Fix = new **`scale_icon_size(base)`**
+  (`_runtime/utility.py`, logical→physical, floored at base like
+  `scale_padding_floor`) applied in both `Image` render paths (`_load_pil`,
+  `_materialize`; reported `width`/`height` stay logical — public contract unchanged)
+  + the chevron routed through `b.scale()` to match combobox/spinbox. **Adversarial
+  verification overturned the issue's headline:** the Workbench rail was NOT soft (it
+  already scales 28→41 via `normalize_icon_spec`); the soft paths were only the public
+  handle + the chevron. **#305 (PR #309):** text+icon `Button`/`MenuButton` icons
+  *double-scaled* at high DPI — `icon_size()`'s text branch returned the font ascent
+  (already physical), then `normalize_icon_spec` re-scaled it. Fix = that branch now
+  returns logical (`round(ascent / ui_scale)`) so normalize is the single scaler.
+  **Validated row heights** at both densities × DPIs: this fixed a real ~10px
+  inflation of the COMPACT text+icon button at 150% (65→55, matching siblings).
+  **#260 (PR #307):** `Tooltip.refresh_bindings()` (public + internal, mirroring
+  `ScrollView`) re-covers a container target's subtree for children added *after*
+  attach (`propagate_target_bindings` only tags descendants present at attach time).
+  **#207 DEFERRED** (maintainer call): no API implication, low self-inflicted impact,
+  Win/Linux only; the risky grab fix breaks reopen-at-new-spot — agreed proportional
+  fix if revisited is an open-menu registry. Memory
+  `reference_icon_dpi_scaling_pipeline`. Process note: the empirical icon-size probe
+  (`development/probe_icon_sizes.py`, untracked) was decisive — static reading of the
+  4-mechanism scaling pipeline was too tangled to trust.
+- **Trust audit of the 2026-06-22 session + fixes (PRs #301, #302 — MERGED;
+  2026-06-22).** A prior agent (on another machine) shipped 14 PRs (#289, #291–#299
+  + releases `0.1.0a14`); the maintainer found repeated errors/hallucinations and
+  asked for a full review. Method: **5 parallel adversarial reviewers** (one per PR
+  cluster) + clean `-W` docs build + full GUI suite. Verdict: mostly sound but **not
+  trustworthy as-is**. Brief: **`docs/_dev/review-2026-06-22-trust-audit.md`**.
+  Fixed in **PR #301**: (1) 🔴 **#299 toolbar regression merged with a FAILING test**
+  — `_apply_bar_defaults` used "has `**kwargs`" as a proxy for "accepts
+  `density`/`surface`", crashing `add_widget(Checkbox/Switch/ToggleButton/Radio)` and
+  no-op for `TextField`/`Select`; fix = inject only **explicitly-declared** params;
+  (2) 🟠 **DataTable `iter_rows` clobbered the shared source** — the view-mutation CM
+  spanned a `yield`, leaking this view's filter/sort onto the shared source until GC;
+  fix = wrap each read, not the yield (+ regression test proven to fail pre-fix);
+  (3) 🟠 two **`lambda ok: btn.disabled = not ok`** docstrings (SyntaxError) →
+  named-handler; (4) the **`-W` docs build was broken** since PR #266
+  (`widget-sizing.rst` titles inside an include skipped a heading level) → `.. rubric::`;
+  (5) DataTable test hygiene (hallucinated `enable_search=` → `searchable=`; `_internal`
+  pokes → public); (6) `signals/README.md` rewritten (was pervasively stale —
+  `get()`/`unsubscribe()`/`bs.Entry`/`app.mainloop()`/the `master=` gotcha #292
+  overturned); (7) **CodeEditor #296/#297** (selection API, block indent/dedent) and
+  **ScrollView #298** (`on_scroll`/`scroll_position`/keyboard) shipped undocumented +
+  untested → docs + **20 new tests** + docstring fixes (incl. `scroll_position` no
+  longer claims `(1.0,1.0)` reachable); (8) **#262** — `Toolbar.add_button`/`add_label`
+  returned internal `_impl` primitives → now return public `bs.Button`/`bs.Label`
+  (live props); added **`surface=` to `bs.Button`** (construction-only — *build-time,
+  not a live property*; matches the surface a ghost/outline button sits on so it
+  blends; a toolbar sets `'chrome'` for the buttons it builds); preserved
+  draggable-titlebar label drag via internal `Toolbar._attach_drag`. **PR #302**:
+  documented `surface=` in `button.rst` (usage-only, no implementation detail).
+  **Verified clean (no over-flag corrections):** #292 Signal lazy-realization rewrite
+  is correct; #295 internal-access scrub, carousel #289, pyinstaller #291, new chart
+  example all check out. Two reviewer **over-flags disproved**: the #296 `read_only`
+  "fix" was a no-op rename, and `Toolbar._surface` is always defaulted by the base
+  Frame (no `AttributeError`). **Process gotchas (bit me):** piping a build/test
+  command to `tail` masks its exit code with `tail`'s 0 — *never pipe the command
+  whose status you need* (it hid both a failing test leg AND the broken docs build);
+  toolbar item spacing is now uniform `padx=2` (the pack-based bar has **no `gap`** —
+  a real gap migration is the unified-toolbars rework, `project_unified_toolbars`).
+  **Now-DONE issues (close them):** #246, #251, #252, #254, #255, #262, #263.
+- **Pre-release `0.1.0a12` shipped + demo rebuild + CONTRIBUTING + Topic-guide
+  review** (2026-06-21; all MERGED). Cut **`0.1.0a12`** to PyPI + GitHub Release
+  (`bump-my-version bump pre_n` → push `main` + tag → `release.yml` → `docs.yml`).
+  Landed in it: the **Topic-guide technical-writer review** (#155, PR **#268** —
+  verified all 12 `docs/reference/*` against the standard; the assessment agents
+  **over-flagged**, only **2 real fixes** came out: a typed-signal section in
+  `signals`, two missing imports in `typography`; the other 10 already met it —
+  *adversarially verify agent claims*); the **hero-first demo rebuild** (#269, PR
+  **#270** — `cli/demo.py` 995→564 lines, 18→12 hero pages, fixed the
+  `AppShell(nav_variant=)` launch crash, the "broken demo"); the **README** refresh
+  (centered screenshots, fixed the broken `shell.add_page` example, stale 8→real 10
+  theme list, +Workbench/Window/ThemeToggle, +`appicon`/`promote` CLI, demoted
+  `add i18n`, re-shot gallery + hero); and **`CONTRIBUTING.md`** (PR **#271** — dev
+  setup + feature-branch→`main` PR flow + localization-review section reusing #17's
+  language; **closed the localization issue fan-out** #17/#19–#37). Verified
+  pre-ship: CLI + all 6 templates scaffold/build/`add`/`doctor`/`icons`/`appicon`.
+- **Docs lead-in + screenshot-refresh pass — PR #266 (MERGED)** + the
+  **interactive-widget review initiative COMPLETE.** All interactive widgets are
+  now reviewed (Button #243/#244, ButtonGroup #245, TextArea #247/#248, CodeEditor,
+  ScrollView, SplitView, Tooltip, Toolbar, StatusBar — each its own merged PR). Then
+  **PR #266**: ~45 widget pages got a Usage **mental-model lead-in** (intro stays
+  definitional; teaching leads the Usage section; no bare Usage); the widget-sizing
+  include split **Row vs Column** (different cross-axis options — Column uses
+  `horizontal` for cross-align + `grow` fills vertical, Row the mirror); **dialogs
+  now capture like app windows** — routed the dialog target through the App/Window
+  DWM-extended-bounds + `inset=2` path so the native frame is cropped and a **single
+  CSS border + shadow** replaces it (`.bs-dialog-screenshot` shares the
+  `.bs-window-screenshot` rule; no native/CSS double border); two **broken dialog
+  scenes** (`message-dialogs`, `dialog`) fixed — they parented raw tk primitives
+  into the dialog's now-public-`Column` content area (rewritten with public widgets);
+  the **filter-dialog value list rebuilt on the managed `FlexFrame` content** the
+  public ScrollView uses (dropped the legacy raw `ttk.Frame`-in-canvas + a redundant
+  racing `<Configure>` width binding — fixed the clipped/deformed list); stale
+  screenshots regenerated (app/window/appshell/workbench/card/home-hero/navigation)
+  and the **workbench hero image** wired into its page. **Filed #267** — DPI-aware
+  icon sizing (icons render soft at fractional DPI: sizes hardcoded, **no `ui_scale`**
+  multiplier anywhere; rail worst at 28px; own branch). Investigation gotcha: the
+  workspaces nav shot's softness is the **icon DPI issue (#267)**, not capture width
+  — the Workbench renders the same 720px as the AppShell scenes, native capture, no
+  downscale (a `_capture_max_width`/size bump was tried and **reverted**).
+- **Widget-review initiative — Button · ButtonGroup · TextArea** (prior session;
+  all MERGED). Began the "finish reviewing the interactive widgets" sweep
+  (audit→fix→test→docs→follow-ups, one PR each). **Button** (#243; walk-backs
+  #244): activation-based `on_click` (class map → `<<Click>>` from a command
+  dispatcher → fires on mouse/keyboard/`click()`, honors disabled, Stream-composes)
+  + `text` setter routes through the bound var; **walked back** an over-eager
+  `disabled`/`text` getter change (only broke via an internal side-hack — test
+  public paths, not pokes). **ButtonGroup** (#245): no correctness bugs (disabled
+  propagation + `on_click` verified); docs (Events/Keyboard) + bare-`except` fix;
+  `accent/variant/density/orient` kept construction-only (not runtime needs).
+  **TextArea** (#247): read-only state desync (broke programmatic `value=`/`insert`),
+  placeholder flipping read-only off, and a **Tab focus-trap** all fixed; docs got
+  Validation+Keyboard sections. Native-bindings follow-up (#248): undo/redo now use
+  Tk's `<<Undo>>`/`<<Redo>>` virtual events (platform-correct keys; CodeEditor
+  benefits too). Swept the rest for hardcoded-key reinventions — none others (custom
+  shortcuts are intentional). Memories `project_button_review`,
+  `project_widget_review_initiative`, `feedback_live_properties_runtime_need`,
+  `feedback_prefer_native_bindings_dont_undo_conventions`. Also this session:
+  **#234 SpinnerField parity** (#241, increment/decrement methods only),
+  **#222 CLOSED won't-do** (live placeholder/mask).
+- **Typed-signal round-trip + high-DPI border fix** (this session; PRs **#238** +
+  **#239**, both MERGED). Two field follow-ups closed end-to-end:
+  - **#227 — `Signal` now round-trips object values** (PR **#238**). `Signal` chose
+    its Tk var from the initial value's type, so a `date`/`time`/object landed in a
+    StringVar and `sig()` read back the **string**. Fix = an **object mode** for
+    non-Tk-native values (anything not `bool`/`int`/`float`/`str`/`set`): the cached
+    Python object is the source of truth (`__call__` returns it), the StringVar is
+    just the write-trace bus (`set()` dedupes on the object, writes `str(value)` to
+    notify). **Native signals are byte-for-byte unchanged** (branch only activates for
+    objects → zero regression). Also fixed: `ValueSignalMixin._sync_value_set()`
+    (called from each field's `value` setter) pushes a **programmatic** `field.value=`
+    to the bound signal (was on_change-only). **`textsignal=` REMOVED from
+    `NumberField`/`DateField`/`TimeField`** (typed fields bind via `signal=`; guarded
+    with a `TypeError` since `**kwargs` would silently swallow it) — Date/Time docs
+    now feature typed `signal=` with a `.map()`-derived text signal for display. This
+    also resolved **#237** (the user report that kicked it off). Escape-hatch caveat:
+    `sig.var`/`sig.tk` returns the backing StringVar (string form); `sig()` is the
+    supported path. Memory `project_field_value_signal_dtype`.
+  - **#90 — high-DPI entry border washout** (PR **#239**). On high-DPI the resting
+    (unfocused) field border vanished (focus border fine; `hdpi=False` fixed it). The
+    visible border is a **`ttk_class="TField"` nine-patch whose slice scales with
+    DPI**, but the gap to the inner widget was a **hardcoded `padding=5`** — at high
+    DPI the slice outgrows the gap and the child **overpaints** the border. Fix =
+    **`scale_padding_floor(base)`** (`_runtime/utility.py` =
+    `max(base, round(base*ui_scale))`): **round** not truncate (1.5x kept clipping the
+    rounded corners with `int()`), **floor** at base (low DPI keeps tuned spacing).
+    Applied at both TField sites — the `Field` composite (all 7 field widgets) **and**
+    `TextArea`/`CodeEditor`. **Not** the image/LANCZOS path (probe proved the image
+    keeps full contrast; the cap idea was a dead end). **`show_border` widgets**
+    (context menus/toasts/snackbars/tooltips/Select popup) use a fixed ttk relief
+    border, **unaffected**. Repro without 4K hardware via `App(scaling=2.667)` (the
+    washout is driven by the scale *number*). Memory
+    `reference_hidpi_ninepatch_border_padding`.
+- **Field-family widget reviews + validation follow-ons** (this session; all
+  MERGED) — closed out the `TextField` review that spawned the validation rebuild,
+  then reviewed the whole **field family** one PR each (audit→fix→test→docs→
+  file-follow-ups). **Validation follow-ons first:** **#216** (PR **#219**) —
+  `NumberField(value=None)`/`value=""` crashed at construction (`float('')`; an
+  empty number field stores `''`, the guard only checked `is not None`) → normalize
+  empty→`None`, skip bounds. **#217 part 1** (PR **#220**) — reactive **`Form.valid`**
+  (`Signal[bool]` AND-ed over the member fields' `valid` signals via subscriptions)
+  + **`Form.errors`** (live `dict[str,str]` from the fields' `error` signals), on
+  internal+public `Form`; a submit button binds `form.valid`. **#217 part 2
+  (stream-based triggers) DEFERRED** — re-evaluated as pure internal churn (current
+  `_setup_validation_binds`/`after()` works, not Tk-coupled). **Docs cross-ref rule**
+  (PR **#221**) — added to `docs/_dev/widget-review-and-docs-standards.md`: a widget
+  section on a cross-cutting subject (validation/events/data/layout/…) must
+  `:doc:`-link the matching how-to/topic guide (the field-items *Validation* gap was
+  the trigger). **Then the 7 reviews:** TextField (#223), NumberField (#224),
+  PasswordField (#225 docs + **#229** read-only-reveal fix), DateField (#228),
+  TimeField (#230), PathField (#231), SpinnerField (#233). **Pattern:** NO wrapper
+  had correctness bugs (every audit-agent "critical" claim died under adversarial
+  verification — e.g. the "addon-state bypass" was false: `configure(state=)` routes
+  through `Field._delegate_state` which syncs addons; "`.text` needs a setter"
+  contradicts the locked read-only value/text contract). The yield was **docs** —
+  every page lacked the `/reference/validation` cross-link, the reactive
+  `field.valid`/`field.error` surface, and a fleshed See-also; each got a
+  mental-model lead, Date/Time/Path gained full Validation sections. **Two real code
+  changes (decided with maintainer):** PasswordField reveal toggle now `active_when_
+  readonly=True` (#229 — the flag postdates the widget; revealing only flips the mask
+  char, safe under read-only); **TimeField now starts EMPTY** (#230 — was
+  `datetime.now().time()` in `timeentry.py`, the only field not starting empty, which
+  silently **defeated `required=True`**; pre-release clean break). **Systemic bug
+  fixed across the family:** validation screenshot scenes called `field.validate("blur")`
+  but public `validate()` takes **no** arg (raised in the `after()` tick → error never
+  rendered); fixed to `field.validate()` + regenerated. **Open follow-ups (additive,
+  not bugs):** **#227** (`Signal` is StringVar-backed for objects → `Date/TimeField`
+  `signal=` reads back a *string*, and field→signal doesn't fire on programmatic
+  `.value=`; so Date/Time docs keep `textsignal=`; NumberField unaffected) · **#232**
+  (PathField dialog-config options as live properties) · **#234** (SpinnerField↔
+  NumberField parity: increment/decrement, live min/max/step). Memory
+  `project_field_family_review`. **Process gotcha:** a fix pushed to a branch AFTER
+  its PR merged is stranded — cherry-pick onto a fresh branch (bit us with #225→#229).
+- **Field validation redesign** (PR **#218**, MERGED) — started as a `TextField`
+  review (audit→fix→test→docs), surfaced that validation was **fundamentally
+  broken for typed fields**, and turned into a 4-phase rebuild. **Phase 1:**
+  validation now runs against the field's **typed value** via one resolver
+  (`TextEntryPart._get_validation_value` = `_parse_or_none(get())`;
+  `NumberEntryPart` override coerces to its numeric type) — all 7 field wrappers
+  route through it (was 4 passing the raw datum → `TypeError`, 2 passing text);
+  `add_validation_rule` guards the silent `ValidationRule`-object double-wrap with
+  a `TypeError`. **Phase 2:** type-aware rule taxonomy — text-rules
+  (`stringLength`/`pattern`/`email`) vs value-rules; new **`range`** rule
+  (number/date/time bounds with a message, vs silent `min_value`/`max_value`
+  clamping); an inapplicable rule is **rejected at attach time** with
+  `BootstackError`, keyed off a per-wrapper `_VALIDATION_KIND` class attr
+  (`number`/`date`/`time`; `text` default); redundant date/time
+  `add_validation_rule` overrides removed (they bypassed the guard). **Phase 3:**
+  reactive validity surface — the engine owns `_valid_signal`/`_error_signal`
+  (source of truth, set via `_set_validity` on every run); public **`field.valid`**
+  / **`field.error`** Signals (`bs.Label(textsignal=field.error)`); the Field
+  message label is now bound to the error signal (imperative `_show_error`/
+  `_clear_error` gone); `Form.validate()` routed through the entry's validator.
+  **Phase 4:** `docs/reference/validation.rst` rewritten (typed-value model,
+  `range`, type-aware behavior, reactive signals); api-ref `RuleType` += `range`.
+  Brief `docs/_dev/field-validation-system.md`; memory
+  `project_field_validation_redesign`. Tests `test_field_validation_typed.py`
+  (27). **Follow-ups BOTH DONE this session** (see the field-family entry above):
+  **#216** (PR #219) NumberField empty-construction crash · **#217 part 1** (PR #220)
+  reactive `Form.valid`/`Form.errors` (part 2 stream-triggers deferred). NB the
+  **string-only `add_validation_rule`** decision is locked (a `ValidationRule` object
+  carries no info the string form lacks).
+- **Slider/RangeSlider review** (PR **#212**, MERGED) — value clamps to range, disabled
+  honored on every key (incl. Home/End), Home/End emit `<<Commit>>`, tightening the range
+  re-clamps the value(s); widget pages gained Events + Keyboard sections + value/min-max
+  screenshots. (The `fix/slider-review` branch is merged — stale.) `step=` follow-up
+  (#213/#210) and the Tab focus-trap (#211) are under "Next up".
+- **Shell chrome divider + context-menu / DataTable interaction fixes** (this
+  session; PRs **#206** and **#209**, both MERGED to `main`) — two batches from
+  dogfooding the AppShell + DataTable demos:
+  - **#206 — persistent chrome→content border + softer inter-toolbar divider**
+    (`fix/shell-content-border`). The chrome→workspace boundary is now owned by
+    **`ShellLayout`** (a content-surfaced `_body_sep` at the soft
+    `DIVIDER_BORDER_STRENGTH=0.90`, always packed between the chrome stack and the
+    body, mirroring the bottom `_status_sep`) — authors no longer rely on
+    `add_toolbar(divider=True)` for it, and the stroke matches the rail/sidebar/
+    status dividers instead of reading heavy (the original complaint). The
+    per-toolbar `add_toolbar(divider=True)` hairline was **softened to 0.90 + kept
+    chrome-surfaced** (was the default heavy blend) so an inter-bar divider matches;
+    it's now reserved for separating stacked bars. `appshell.rst` notes the
+    auto-boundary. Plain `App`/`Window` keep `divider=` as their chrome separator
+    (no shell layout, no auto border).
+  - **#209 — context-menu dismissal + DataTable right-click/selection + FormDialog
+    action result** (`fix/contextmenu-outside-dismiss`). (a) **ContextMenu**: the
+    overrideredirect popup's outside-dismiss now watches **all mouse buttons**
+    (was `<Button-1>` only — a right-click to open another menu slipped past it);
+    a one-shot **`_suppress_next_outside`** guard set in `show()` kills the
+    reopen-race that widening introduced (right-click another row reopens, doesn't
+    self-dismiss); and **`hide()` now runs BEFORE an item's handler** (a modal
+    handler was blocking with the menu still visible). (b) **DataTable**:
+    right-click **no longer changes the selection** (it set `_context_iid`; the
+    row-menu commands target it via new **`_context_iids()`** = clicked row, or the
+    whole selection when the click is inside a multi-selection); a left-click on a
+    checkbox/group table now **dismisses an open menu through the `'break'`** path
+    (`_dismiss_context_menus()` at the top of `_on_header_click`, since the tree's
+    `'break'` stopped the toplevel outside handler); and **selection survives a
+    `_refresh_tree` rebuild** for still-visible rows (sort keeps all, search narrows
+    — was a full clear on every search/sort/page). (c) **FormDialog**: `show()` was
+    overwriting `result` with form data for any non-cancel close, discarding a
+    custom button's `result` — so the edit dialog's **Delete** (`{"result":
+    "delete"}`) returned data instead of `"delete"` and the row was updated, never
+    deleted; new **`_resolve_result()`** maps submit buttons→form data, action
+    buttons→their result, cancel→None. (d) **Docs**: fixed stale `event["text"]`
+    dict-subscript in ContextMenu/MenuButton examples+guides (`on_select` gets a
+    `MenuSelectEvent` dataclass → `event.text`). **Follow-up issues filed:**
+    **#207** (general grab-based dismiss so user-attached menus also dismiss when a
+    host widget returns `'break'`) · **#208** (persist DataTable selection by record
+    id across pages — the "keep visible matches" interim shipped here).
+- **Navigation API reshape — `AppShell` + `Workbench` (#200)** (this session; PR
+  **#202**, MERGED to `main`) — split the one polymorphic `AppShell` into two
+  honest classes along the **topology** axis: **`bs.AppShell`** = single-tier
+  *sidebar host*; new **`bs.Workbench`** = two-tier *workspace host*
+  (`add_workspace` + rail). Shared **`_SidebarHost`** mixin (on `AppShell` +
+  `Workspace`); a private **`_ShellBase`** carries window/chrome/lifecycle. The
+  **provider** axis is four parallel front doors — **`page_nav()`** (authored
+  pages), **`list_nav()`** / **`tree_nav()`** (data-bound master-detail),
+  **`custom_nav()`** (renamed from `panel()`); one per sidebar, only `page_nav`
+  authored (`add_page`/`add_header`/`add_divider`). Provider options live on the
+  provider: **`page_nav(variant='ghost'|'solid')`** (standalone-only; forced to the
+  wash under a rail) and the full `PageStack.add` **layout kwargs on `add_page`**
+  (a page IS a column — no inner wrapper). Footer = **`pin_to_footer=`** flag
+  (dropped `add_footer_page`/`add_footer_workspace`). Shell kwargs keep only app-wide
+  chrome (`nav_accent`, surfaces, `rail_*`). **Framework fix surfaced in review:
+  `ContentHost` now FILLS its child** — master-detail/custom content was shrinking
+  and centering (the apparent "extra padding"); detail panes left-aligned at
+  `padding=(16, 10)`. Internal `Shell`/`Workspace` keep `add_page`/`add_workspace`/
+  `panel`/`nav_selection` (public layer is the rename boundary). Built `Workbench`
+  doc page + screenshot scenes; AppShell page gained a "Sidebars at a glance" card
+  grid + ghost/solid + compact shots; Workbench compact is **not** a mode (rail is
+  the icon tier → sidebar is expanded/hidden, documented). **#189 nav_variant
+  (PR #199, MERGED) was folded in** — `nav_variant` ctor kwarg → `page_nav(variant=)`;
+  its `test_nav_selection.py` removed (superseded by `test_appshell_reshape.py`).
+  Tests: `test_appshell_reshape.py` (6) + `test_workbench.py` (2). Memory
+  `project_navigation_api_reshape`. **Follow-up: #201 — SHIPPED (sidebar
+  hamburger, see top of this list).**
+- **Sidebar hamburger toggle — `Toolbar.add_sidebar_toggle()` (#201)** (this
+  session; on `feat/nav-expandable-group`) — #201 was filed as an *expandable
+  sub-item nav group*, but the maintainer **reinterpreted it** as a built-in
+  **hamburger that collapses/expands the AppShell sidebar** (the accordion-style
+  sub-items stay parked per the nav-spec Revision-4 cut — compose `bs.Accordion`
+  in a `custom_nav`). The collapse machinery already existed (`toggle_sidebar()`/
+  `show_sidebar()`/`hide_sidebar()`/`sidebar_mode`, Ctrl-B); what was missing was
+  a control. Modeled on `ThemeToggle`/`add_theme_toggle()` but **NOT standalone**
+  (a sidebar toggle is meaningless outside one shell): an internal
+  `SidebarToggle(Button)` (`widgets/sidebar_toggle.py`, **not** in `bs.*`) built by
+  **`Toolbar.add_sidebar_toggle(**kwargs)`**, which wires it to the owning shell.
+  **AppShell-only** — the guard is `isinstance(host, AppShell)` (a `_SidebarHost`;
+  `Workbench` inherits `toggle_sidebar` from `_ShellBase` so a `hasattr` check is
+  too loose), raising `BootstackError` on `Workbench`/`App`/`Window`. Enabler:
+  `add_toolbar()` (ChromeHostMixin) now passes `_host=self` into the `Toolbar`;
+  `Toolbar.__init__` stores `self._host`. **Author places it wherever they want in
+  the bar — no auto-injection.** `collapse='compact'` is the **default** (the
+  desktop/Fluent convention: shrink to the icon rail, reusing the shell's
+  `_can_compact_active()` so it **falls back to hidden** for non-compactable
+  data-bound navs); `collapse='hidden'` always fully hides. **Mode-dependent
+  default icon** (`icon=None` resolves to `layout-sidebar` for compact, `list` for
+  hidden); single steady glyph unless the author passes a stateful pair
+  (`collapse_icon` shown while expanded, `expand_icon` while collapsed, each
+  falling back to `icon`). A ~6px toggle-vs-rail offset in compact is **left as-is
+  by decision** (only visible compacted; aligning would couple toolbar padding to
+  rail width). Tests `tests/widgets/public/test_sidebar_toggle.py` (8). Docs:
+  "Sidebar toggle" section in `docs/widgets/toolbar.rst` (full detail) + the
+  AppShell page's "Sidebar visibility" section (the user-facing control,
+  cross-linked). StatusBar deliberately **not** given the method (scope creep — a
+  hamburger belongs in a toolbar).
+- **Gallery/Carousel height-floor cleanup (#160)** (PR **#185**, MERGED) — added the
+  regression test + hardened two magic numbers into named constants; the floor itself
+  shipped in #161. Memory `project_picture_suite`.
+- **Tab overflow handling (#168)** (PR **#184**, MERGED) — clipped tabs scroll (wheel +
+  selected-tab auto-scroll) with a trailing chevron overflow menu; `max_tabs=`; always-on
+  (plain strip kept only for `tab_width='stretch'`). Three framework fixes: PackFrame
+  no-repack when `gap==0`, PageStack pre-size-on-swap, deferred `_scroll_into_view`.
+- **ContextMenu/Tooltip cover container children (#166)** (PR **#183**, MERGED) —
+  `propagate_target_bindings()` adds the container's path bindtag to every descendant so
+  the gesture fires anywhere inside. Memory `reference_bindtags_underused`.
+- **Theme-repaint cleanup (#177) + docstring-backtick sweep** (PRs **#181**/**#182**,
+  MERGED) — code-editor `StyleRegistry`/`SearchOverlay`/`IndentGuides` migrated onto
+  `<<BsThemeChanged>>`; dead `FloodGauge` deleted; 754 RST double→single backticks across
+  43 `src/` files. Memory `project_docstring_backticks`.
+- **Undecorated window chrome (#162/#165) + theme-repaint perf (#167)** (PRs #175/#176/
+  #178/#179/#180, MERGED) — undecorated App/Window/AppShell auto-inject titlebar+border;
+  canvas widgets re-resolve colors via the STD publisher (post-rebuild), gated on
+  visibility (gallery toggle ~2960ms→~580ms). Memories `project_undecorated_window_chrome`,
+  `reference_theme_repaint_mechanisms`.
+- **Pre-release `0.1.0a10` shipped + docs deploy fixed** (PRs #139/#140, MERGED) — Toast
+  split into `toast()`/`Notification`/`Snackbar`; gallery/demo widget coverage; released to
+  PyPI + GitHub Release; docs-deploy fixed (restored `docs/CNAME` + `html_extra_path`).
+  Memories `project_prerelease_readiness`, `project_toast_notification_split`.
+- **0.1.0 API-freeze pass — breaking changes drained + ThemeToggle + media floor** (PRs
+  #141–#161, MERGED) — workflow action bump (#141), ttkbootstrap naming purge (#142),
+  clipboard scope (#151), nav missing-key errors (#153), `Theme.from_existing` (#156),
+  `Signal.subscribe` cancelable handle (#157), VariantToken retirement (#158), `ThemeToggle`
+  (#159), media min-height floor (#161). Memories `project_clipboard_api_scope`,
+  `project_variant_type_revisit`, `project_picture_suite`.
+- **AppShell + navigation clean-slate rewrite** (PRs #133–#136, MERGED; later split into
+  AppShell + Workbench by #200/#202 — see top) — VS Code-style rail + swappable sidebar +
+  content; `bs.AppShell` swapped onto the new `Shell`, standalone `bs.SideNav` dropped.
+  Companions: theme/Bootstrap-alignment v2 (#137), thin-scrollbar exposure (#138),
+  nav-patterns docs (#136). Spec `docs/_dev/appshell-navigation-spec.md` (Revision 4).
+  Memories `project_appshell_sidenav_refactor`, `project_theme_bootstrap_alignment`,
+  `project_thin_scrollbar_initiative`, `project_nav_patterns_section`.
+- **Media widget suite — Picture / Gallery / Carousel / Avatar** (PRs #126–#132, MERGED) —
+  media-display widgets on the public `Image` handle: Picture (fit modes, animated GIF),
+  Gallery (record-native thumbnail grid), Carousel (one-at-a-time stepper), Avatar
+  (image-or-initials). Plus `on_select` rename (#130) + theme-aware demo videos (#131).
+  Memories `project_picture_suite`, `project_avatar_widget`, `project_doc_demo_videos`.
+- **Public Image/Icon API + AppIcon + field signals** (PR #125, MERGED) — `bootstack.images`
+  (`Image` handle, `get_icon`/`list_icons`, `AppIcon` → `.ico`/`.icns`/`.png`); `App`/`Window`
+  `icon=`; live `icon`/`image` setters; typed `signal=` on Number/Date/Time fields;
+  `bootstack.toml` scoped to build/scaffold; public file-dialog verbs; ships `bootstack appicon`.
+  Memories `project_image_icon_public_api`, `project_field_value_signal_dtype`.
+- **Menu bar + command bar** (PR #124, MERGED) — cross-platform `app.menubar` (themed strip on
+  Win/Linux, native `NSMenu` on macOS); `Toolbar`→`CommandBar`; legacy `bs.MenuBar` removed;
+  `app.menu`→`app.menubar`, `app.toolbar`→`app.commandbar`. Memory `project_menu_redesign`;
+  follow-up `project_macos_window_chrome`.
+- **Widget detach/attach** (PR #123, MERGED) — `detach()`/`attach()`/`is_attached` across
+  pack/grid/place; `on_attach`/`on_detach`; `attached=False` ctor; new `index=` pack knob.
+  Memory `project_widget_attach_detach`; backlog `project_inherited_base_api_docs`.
+- **Select grouping + popup height cap** (PR #122, MERGED) — `Select(group_by="field")` clusters
+  the popup under verbatim headers (names any bag field, presentational only); `max_visible_items=N`.
+  Memory `project_select_options_databag`.
+- **Universal `.selection` on ListView/DataTable/Tree** (PR #120, MERGED) — polymorphic by
+  `selection_mode` (dict/list, TreeNode handles); replaced `get_selected()`/`selected_rows`/
+  `selected_nodes` (clean break); `ListView.select_items`/`deselect_items`. Memory `project_option_databag`.
+- **Field value/text/label contract + option data bag** (PRs #113–#116, MERGED) — `label`=caption,
+  `text`=formatted display (public read-only), `value`=raw datum (never derived from text); shared
+  `Option = str | tuple | OptionDict` + `normalize_option` with a data bag; `.selection` accessor.
+  Memories `project_field_value_text_model`, `project_option_databag`.
+- **Widget API gap audit + documentation** (PR #111, MERGED) — audited ~49 widgets vs their
+  `_impl/` internals; added lifecycle (`destroy`/`on_destroy`), `WindowControlsMixin` on
+  App/AppShell/Window (AppShell is now a `PublicWidgetBase`), group management, live properties;
+  new **Application** widget category with full-window screenshots. Brief `docs/_dev/widget-api-audit.md`.
+- **Linked type aliases + widget-API consistency** (MERGED) — public aliases render as their
+  short NAME, linked to a `.. py:type::` entry (dropped `sphinx_autodoc_typehints`;
+  `autodoc_type_aliases` FQN map; `python_use_unqualified_type_names`; a `TypeAliasForwardRef`
+  patch). Memories `project_enum_option_typing`, `reference_typed_alias_linking`.
+- **Unified data bag** (PR #92) — non-scalar fields carried across Tree/DataTable/ListView
+  (SQLite `_bs_data` JSON column; `bs.SerializationError` on non-JSON). Memory `project_data_bag`.
+- **Large-file streaming** (PRs #93–#96) — chunked `load()`; pluggable reader/writer registries;
+  `FileDataSource` → SQLite working store; `export_formats`. Memory `project_file_source_streaming`.
+- **Tree public-API modernization** (PR #91) — recycle-view canvas Tree, `TreeNode` handles.
+  Memories `project_tree_row_model`, `reference_treeview_perrow_indicator_state`.
+- **Icon rendering + DataTable polish** — ink-metric icon renderer; `Table`→`DataTable` +
+  DataSource decoupling. Memories `project_icon_rendering`, `project_table_datasource_coupling`.
+- **Tree data-source backing** (PR #97) — `Tree(data_source=, parent_field=)` lazy hierarchy
+  from a flat adjacency-list source. Memory `project_tree_datasource_backing`.
+- **SqliteDataSource schema inference** (PR #98) — `load()` samples leading rows to infer column
+  types (fixes the TEXT-affinity-from-leading-NULL bug).
+- **Signal runtime cleanup** — `signal()` single getter; `is_signal()` duck-types. Memory
+  `reference_signal_duck_typing`.
+- **Preferences store `bs.Store`** — dict-like JSON file-backed prefs; shared `_core/paths.py`.
+  Memory `project_persistent_kv_store`.
+- **AppSettings flattening** (PR #101) — flat `App()`/`AppShell()` kwargs; `settings=`/`AppSettings`
+  gone. See the "FLAT kwargs" gotcha. Memory `project_app_settings_flattening`.
+- **Reference docs review pass** (PR #103) — enriched `docs/reference/*` + `localization.rst`;
+  `compare` rule; `Form.validate()` runs all rules.
+- **Top-level namespace curation + dialogs restructure** (PR #104) — `bootstack` slimmed to the
+  compose surface (~85 names); dialog classes → `bootstack.dialogs`. Memory `project_toplevel_api_surface`.
+- **Docs build warnings cleanup** (PR #106) — clean-build 40→0; keep it warning-free.
+- **API Reference restructure — Stages 1–3** (PR #107) — Diátaxis split: narrative (Widgets +
+  Guides) + by-module API Reference; templates/recipe in "## API Reference & Guide page pattern".
+  Memory `project_api_reference_restructure`. (Stage 4 homing DONE — see "History".)
+
+## Closed backlogs
+
+The pre-ship and per-initiative backlogs, kept for the decisions recorded in
+them. Anything still open was carried forward into `CLAUDE.md`.
+
+### ★ NEXT — Pre-ship polish backlog (#186–#195, filed 2026-06-18)
+
+Ten maintainer-requested items to resolve before shipping 0.1.0 — all filed as
+tracked issues (each issue links the relevant impl file + has detail).
+**Nine of ten SHIPPED:** #186/#190/#193/#194 (PR **#196**), #195 (PR **#197**),
+#188 (PR **#198**), **#189 (PR #199 → folded into the nav reshape PR #202)**, **#187
+(PR #203)**, **#191 (PR #204 — themed color tab + `ask_color(value=)` rename)** — all
+merged to `main`. **One remains** (its own `feat/*` branch → PR → `main`):
+
+- **#189 `solid` sidebar selection variant — DONE.** Shipped as **`nav_variant`**
+  on `AppShell` (PR #199, gated to the standalone nav), then **superseded by the
+  navigation reshape (#200, PR #202)**: the variant now lives on
+  **`page_nav(variant='ghost'|'solid')`**, standalone-only. See the reshape pointer
+  at the top of "Recently completed".
+- **#187 StatusBar.add_widget class-only? — DONE (PR #203, MERGED).** Decision:
+  **class-only** on BOTH `Toolbar` AND `StatusBar` (`add_widget(WidgetClass, **kwargs)`).
+  The two were ALREADY polymorphic in lockstep (not StatusBar-only), so class-only on
+  both keeps them consistent while dropping the redundant instance branch (couldn't
+  inherit bar density/surface; required a manual attach). No flexibility lost — a
+  self-built widget drops in via the container protocol (`parent=bar`, auto-attaches).
+  `StatusBar` gained the `_apply_bar_defaults` helper it lacked. **NB the public param
+  is annotated `widget_cls: Any` not `: type`** — the bare builtin `type` renders an
+  ambiguous `ref.python` cross-ref under `python_use_unqualified_type_names` (collides
+  with the many `.type` attrs); the precise `: type` stays only on the private
+  `_apply_bar_defaults` (not rendered). Also fixed a stale `StatusBar(fill="x",
+  side="bottom")` docstring (would raise under the grid engine) → `horizontal="stretch"`,
+  and enriched `docs/tasks/composing-fields.rst` with a **"Subclassing for a reusable
+  type"** section (`SearchField(bs.TextField)` via `insert_addon`, justified by exactly
+  this change — a container can only build your field if it's a class). Test
+  `tests/widgets/public/test_statusbar.py` (3).
+- **#192 Color-swatch Select control (feature, larger)** — a `Select`-style
+  dropdown rendering color swatches inline (complements `ask_color()`). New widget
+  or Select variant — lock shape/naming with the maintainer first.
+
+**SHIPPED detail (this session):** #195 (PR #197) — placeholder renders unmasked
+under an input mask; `TextEntryPart` captures the mask char, clears `show` while
+the placeholder shows, restores it for real input; PasswordEntry eye-toggle no-ops
+while placeholder showing. Test `test_field_placeholder_mask.py`. NB `TextField`'s
+public mask kwarg is **`mask=`** (not `show=`). #188 (PR #198) — accented Card
+border now **`b.border(surface)`** (a soft stroke derived from the card's own
+`{accent}[subtle]` tinted surface), NOT `{accent}_emphasis` (the issue's original
+suggestion — rejected as too strong on review). Test `test_card_border.py`.
+
+### Field-family review follow-ups
+
+The field family is fully reviewed (see the top "Recently completed" entries).
+**#227 (DONE, PR #238 — object-mode Signal) and #232 (DONE — PathField live dialog
+props) are merged; #237/#217 closed.** Two additive follow-ups remain OPEN — neither
+is a correctness bug:
+
+- **#222 — TextField live properties** (OPEN, ready to build). Expose `placeholder`
+  / `mask` (high value — runtime UX toggles) and `allow_blank` / `value_format`
+  (lower — the configure-delegate already works imperatively) as live get/set
+  properties. The underlying `TextEntryPart` already supports them
+  (`_placeholder_text`/`_show_char`/`_delegate_allow_blank`/`_delegate_value_format`).
+  Explicitly **NOT** a `.text` setter (read-only by the value/text contract — write
+  through `.value`). Clean, low-risk, no decision needed.
+- **#234 — SpinnerField↔NumberField parity** (OPEN, decision-gated) — live
+  `min_value`/`max_value`/`step` props, `increment()`/`decrement()` methods,
+  `on_increment`/`on_decrement` events. **May be won't-do** (SpinnerField is
+  intentionally simpler) — get the maintainer's call before any code.
+
+### Slider follow-ups — DONE
+
+Slider `step=` snapping (#210, PR #213) and the RangeSlider `<Tab>` focus-trap
+(#211, PR #215) both MERGED. Nothing open here.
+
+### ✅ SHIPPED — Layout redesign (screen-axis grid engine) — MERGED #170
+
+Replaced the Tk pack stack with a **screen-axis** vocabulary on the Tk grid manager:
+`horizontal`/`vertical`/`grow` (bare = self, `*_items` = children); edge-name values
+(`left`/`center`/`right`/`stretch`) + `space-between`/`-around`/`-evenly`; `HStack`/`VStack`
+→ `Row`/`Column`, `Separator`→`Divider`, new `Spacer`; **cross-axis default `center`**;
+legacy `fill`/`expand`/`anchor`/`sticky` now RAISE. Post-merge: #171 (GridFrame O(N) build),
+#169 (deploy docs on release only), #172 (README/docs-home refresh), #173 (CLI icons on the
+public layer + Gallery/MemoryDataSource fixes). Memories `project_layout_redesign`,
+`feedback_layout_conversion_rules`, `project_layout_crossaxis_default`, `project_divider_rename`,
+`project_dialog_content_builder_native`.
+
+**Live follow-ups (not blockers):**
+- **Gallery opt-in keyboard-focus ring** (future) + deferred Gallery perf (debounce
+  `<Configure>`, bounded thumbnail-PhotoImage LRU, cache `_fit_caption`). Scope to keyboard
+  focus, NOT hover. Memory `project_gallery_focus_ring`.
+- **`add_spacer()`→public `Spacer`** still deferred — entangled with `feat/unified-toolbars`
+  (internal `Toolbar` is pack-based). Memory `project_unified_toolbars`.
+
+### ✅ SHIPPED — Undecorated window controls + border + maximized-drag — MERGED #175
+
+Undecorated `App`/`Window`/`AppShell` auto-inject a draggable titlebar (min/max/close) +
+1px border via `ChromeHostMixin._ensure_default_titlebar()` (layers on `add_toolbar()`, not
+a dedicated band); `App` gained `undecorated=`, `Window` gained `window_controls=`; #165
+maximized-drag re-anchors under the cursor. Memory `project_undecorated_window_chrome`.
+
+### Toward the 0.1.0 stable release
+
+- **#149** — final public-surface audit + **CHANGELOG** for the stable cut.
+- **#150** — test-harness stabilization (the GUI suites need one `App` per process;
+  the `.pytest_cache` perms warning on this machine is benign).
+- **#155** — Topic-guide technical-writer review pass (the `/reference/*` pages get
+  the same no-kitchen-sink edit the how-to guides already had; memory
+  `project_user_guide_fleshout`). The maintainer is comfortable with the how-tos.
+
+### Other candidates
+
+- **Docs site fleshout — substantially DONE.** The how-to guides (`docs/tasks/*` —
+  getting-input/handling-actions/displaying-data/building-forms/composing-fields/
+  dialogs/layout/application-icons + the full `navigation/` set), `getting-started/
+  app-structures`, and the production pages (`cli`/`debugging`/`distribution`) are all
+  written and substantial. Remaining is only opportunistic: a review pass on
+  `installation`/`quickstart` and enrichment of any still-thin page. Memory
+  `project_docs_site_fleshout`.
+- ~~**Docstring-backtick sweep**~~ — **DONE (PR #182):** 754 RST
+  double-backticks → single across 43 `src/` files. Convention is Google + SINGLE
+  backticks. Memory `project_docstring_backticks`.
+- **Code-review follow-ups #4–#10** — cleanup/altitude items recorded in
+  `docs/_dev/widget-api-audit.md` (SelectButton stale value after `options=`; screenshot
+  Win64 HWND hardening; group/window/date duplication; Calendar batch-redraw).
+
+**Throwaway demos `development/shell_*_demo.py` stay UNTRACKED** (scratch, not
+framework code). Side note logged: a future `Tabs` `variant='secondary'` (top
+indicator) — `project_secondary_tab_variant`, a standalone item.
+
+### History — done initiatives
+
+- **Public-API typing sweep — DONE** (branch `feat/api-reference-widgets`, merged via
+  PR #109). All widget batches typed (Application → Overlays/Forms/Dialogs): real param
+  types, per-widget `variant` Literals sourced from `style/builders/`, typed `on_*`
+  payloads (impl signature, not `@overload`), thin docstrings, every public prop/method
+  documented. Conventions live in the "API Reference & Guide page pattern" section +
+  `docs/_dev/typing-review.md`. Memories `project_enum_option_typing`,
+  `project_typed_event_payloads`, `project_variant_type_revisit`. Also shipped here:
+  `Tree.find`/`find_all` (predicate or `col(...)` condition; memory `project_tree_find_filter`).
+- **API Reference restructure — Stage 4 homing — DONE (PR #109).** The IA was re-cut to a
+  semantic-category structure: one page per CONCEPT (Application · Widgets · Reactivity ·
+  Events · Data · Validation · Theming · Localization · Scheduling · Shortcuts · Storage ·
+  Errors), full-path stub titles, pandas-style card landing; every public name homed,
+  guides converted to table-only API sections. Brief `docs/_dev/api-reference-restructure.md`;
+  memory `project_api_reference_restructure`. **NEXT (follow-on): flesh out widget Guides
+  with examples — the API Reference is a last resort; Guides carry teaching.**
+- **Deferred file-streaming items** — background/progressive ingest, keyset pagination,
+  auto-index (memory `project_file_source_streaming`).
+

--- a/src/bootstack/_runtime/events.py
+++ b/src/bootstack/_runtime/events.py
@@ -46,6 +46,7 @@ _MAX_CACHE_SIZE = 100  # Prevent unbounded growth
 # Store original tkinter methods before patching
 _original_event_generate: Callable = tk.Misc.event_generate
 _original_bind: Callable = tk.Misc.bind
+_original_unbind: Callable = tk.Misc.unbind
 
 
 def _patched_event_generate(
@@ -274,6 +275,83 @@ def _patched_bind(
     return _original_bind(self, sequence, func, add)
 
 
+def _patched_unbind(
+    self: tk.Misc,
+    sequence: str,
+    funcid: Optional[str] = None
+) -> None:
+    """Enhanced unbind that cannot disturb the other handlers for an event.
+
+    Stock tkinter removes one handler in two steps: rewrite the binding script
+    without that handler's line, then delete the Tcl command behind it. The
+    rewrite is correct, but the deletion is immediate — and all handlers for an
+    event share ONE script, so if the removal happens *while that script is
+    running* (a handler cancelling another handler's subscription), execution
+    later reaches the deleted command and the whole script aborts. Every handler
+    after the cancelled one is skipped for that dispatch, and the error surfaces
+    nowhere Python can see it.
+
+    This version neutralizes the command in place instead, then deletes it once
+    the current dispatch has finished. An already-running script then evaluates
+    a harmless no-op where the cancelled handler used to be and carries on to
+    the handlers after it.
+
+    Args:
+        self: The widget instance (automatically provided)
+        sequence: Event sequence the handler was bound to
+        funcid: Identifier returned by `bind`. When omitted, every handler for
+            the sequence is removed and the original implementation is used.
+    """
+    if funcid is None:
+        # Removing everything replaces the whole script, so there is no
+        # surviving line that could reference a deleted command.
+        return _original_unbind(self, sequence)
+
+    what = ('bind', self._w, sequence)
+    try:
+        script = self.tk.call(what)
+        lines = str(script).split('\n')
+        # Must match what `_patched_bind` emits (and stock `Misc._bind`).
+        prefix = 'if {"[%s ' % funcid
+        keep = [line for line in lines if not line.startswith(prefix)]
+        if len(keep) == len(lines):
+            # This funcid is not bound to this widget and sequence, so it is
+            # not ours to delete — the live binding may be somewhere else, and
+            # deleting its command would orphan it. Leave everything alone.
+            return
+        remaining = '\n'.join(keep)
+        self.tk.call(*what, remaining if remaining.strip() else '')
+        # Replace the command rather than deleting it, so an in-flight copy of
+        # the concatenated script has something harmless to call.
+        self.tk.createcommand(funcid, lambda *args: '')
+    except tk.TclError:
+        return
+
+    def _delete_command() -> None:
+        try:
+            self.deletecommand(funcid)
+        except (tk.TclError, AttributeError):
+            # Already swept, most likely because the widget was destroyed
+            # before the interpreter went idle. `AttributeError` is that same
+            # case seen from the other side: destroy() clears the widget's
+            # command bookkeeping, which `deletecommand` then cannot update.
+            pass
+
+    try:
+        # Deliberately scheduled on the root, not on `self`. Deferred work owned
+        # by a widget is torn down with it, and destroying a widget between the
+        # cancellation and the next idle point would leave the pending callback
+        # referring to a command that destroy() had already deleted — a silent
+        # error of exactly the kind this function exists to avoid. The root
+        # outlives every widget, and when the root itself goes the pending
+        # callback goes with it, which is equally fine: there is nothing left to
+        # clean up.
+        self._root().after_idle(_delete_command)
+    except (tk.TclError, AttributeError):
+        # No event loop left to defer onto; nothing can be mid-dispatch either.
+        _delete_command()
+
+
 def cleanup_event_cache() -> None:
     """Manually clear the entire event data cache.
 
@@ -364,9 +442,10 @@ def get_cache_size() -> int:
 def install_enhanced_events() -> None:
     """Install the enhanced event system by patching tkinter methods.
 
-    This function applies monkey patches to tkinter's Misc class,
-    replacing event_generate and bind with enhanced versions that
-    support passing custom data through virtual events.
+    This function applies monkey patches to tkinter's Misc class, replacing
+    event_generate and bind with enhanced versions that support passing custom
+    data through virtual events, and unbind with a version that cannot disturb
+    the other handlers for an event while one is being removed.
 
     The patches are applied globally and affect all tkinter widgets
     in the application. This function is called automatically when
@@ -386,6 +465,7 @@ def install_enhanced_events() -> None:
     """
     tk.Misc.event_generate = _patched_event_generate
     tk.Misc.bind = _patched_bind
+    tk.Misc.unbind = _patched_unbind
 
 
 def uninstall_enhanced_events() -> None:
@@ -409,6 +489,7 @@ def uninstall_enhanced_events() -> None:
     """
     tk.Misc.event_generate = _original_event_generate
     tk.Misc.bind = _original_bind
+    tk.Misc.unbind = _original_unbind
     cleanup_event_cache()
 
 

--- a/src/bootstack/_runtime/events.py
+++ b/src/bootstack/_runtime/events.py
@@ -32,6 +32,7 @@ Note:
     applied globally and affect all tkinter widgets in the application.
 """
 
+import itertools
 import tkinter as tk
 import uuid
 import weakref
@@ -42,6 +43,31 @@ from typing import Any, Callable, Optional, Union
 # Global storage for event data with LRU cache behavior
 _event_data_cache: OrderedDict[str, Any] = OrderedDict()
 _MAX_CACHE_SIZE = 100  # Prevent unbounded growth
+
+# Serial number used to give every registered handler a unique name. See
+# `_unique_name` for why the stock naming scheme is not safe here.
+_binding_seq = itertools.count()
+
+
+def _unique_name(prefix: str) -> str:
+    """Return a handler name that can never collide with a previous one.
+
+    Tkinter names the Tcl command behind a binding `repr(id(f)) + f.__name__`,
+    where `f` is a bound method created for that registration alone. Nothing
+    else refers to it, so releasing the command frees the method and CPython is
+    free to hand the very same address to the next one — measured at 498 out of
+    499 consecutive bind/cancel/bind cycles. Every wrapper registered here has
+    the same `__name__`, so the whole name would repeat with it.
+
+    That is harmless while removals delete the command immediately, but
+    `_patched_unbind` defers the deletion to the next idle point. A repeated
+    name means a binding created in the meantime inherits the name a deletion is
+    already pending on, and that deletion then takes out a live handler — the
+    #392 failure again, on a new trigger. A serial number in the name keeps the
+    two apart no matter what the allocator does.
+    """
+    return '%s%d' % (prefix, next(_binding_seq))
+
 
 # Store original tkinter methods before patching
 _original_event_generate: Callable = tk.Misc.event_generate
@@ -220,15 +246,30 @@ def _patched_bind(
                 # Attach custom data (don't pop yet - multiple handlers may need it)
                 if data_guid and data_guid in _event_data_cache:
                     event.data = _event_data_cache[data_guid]
-                    # Schedule cleanup after all handlers have run
-                    widget.after_idle(lambda: _event_data_cache.pop(data_guid, None))
+                    # Schedule cleanup after all handlers have run. On the root,
+                    # not on `widget`: deferred work owned by a widget is torn
+                    # down with it, so a handler that destroys its own widget
+                    # would leave this callback pointing at a command destroy()
+                    # had already swept — a silent background error. The root
+                    # outlives every widget. (Same rule as `_patched_unbind`.)
+                    try:
+                        widget._root().after_idle(
+                            lambda: _event_data_cache.pop(data_guid, None)
+                        )
+                    except (tk.TclError, AttributeError):
+                        # No event loop left to defer onto; the LRU cap reclaims
+                        # the entry instead.
+                        pass
                 else:
                     # Data might have been evicted from cache already
                     event.data = None
 
                 return func(event)
 
-            # Register wrapper function with tkinter
+            # Register wrapper function with tkinter. The name tkinter builds
+            # ends with the function's `__name__`, so making that unique is
+            # enough to keep a deferred deletion off a later binding.
+            wrapper.__name__ = _unique_name('bsvirtual')
             name = self._register(wrapper)
 
             # Build the binding script. Its exact shape is load-bearing, and
@@ -269,6 +310,9 @@ def _patched_bind(
                     event.data = None
                 return func(event)
 
+            # Real events are removed by the same patched `unbind`, so they need
+            # the same protection from a recycled name. See `_unique_name`.
+            regular_wrapper.__name__ = _unique_name('bsregular')
             return _original_bind(self, sequence, regular_wrapper, add)
 
     # No function or sequence provided, pass through to original

--- a/src/bootstack/_runtime/events.py
+++ b/src/bootstack/_runtime/events.py
@@ -230,12 +230,34 @@ def _patched_bind(
             # Register wrapper function with tkinter
             name = self._register(wrapper)
 
-            # Build command with all substitutions including %d for data GUID
+            # Build the binding script. Its exact shape is load-bearing, and
+            # this must stay byte-for-byte what stock `Misc._bind` emits:
+            #
+            #   * Removing a single handler works by matching the line prefix
+            #     `if {"[<funcid> ` — note the TRAILING SPACE, which means the
+            #     substitution list below must never be empty. A script in any
+            #     other shape is invisible to the matcher, so the handler
+            #     survives while its command is deleted, leaving an orphan that
+            #     aborts every handler after it. All handlers for an event share
+            #     ONE concatenated script, so that took out every handler
+            #     registered after the cancelled one (#392).
+            #   * The `if {...} == "break"` test is what lets a handler return
+            #     'break' to stop the remaining handlers for that event.
+            #
+            # (The trailing newline only separates this line from the next
+            # handler's; Tk inserts its own separator when appending a `+`
+            # script. It is kept to match stock exactly.)
+            #
+            # The substitution list carries %d (our data token) ahead of the
+            # standard values; its order must match `wrapper`'s parameters.
             # Substitution codes: https://tcl.tk/man/tcl8.6/TkCmd/bind.htm
-            cmd = f'{name} %d %# %b %h %w %k %s %t %x %y %X %Y %A %K %N %T %E %D'
+            subst = '%d %# %b %h %w %k %s %t %x %y %X %Y %A %K %N %T %E %D'
+            cmd = '%sif {"[%s %s]" == "break"} break\n' % (
+                '+' if add else '', name, subst
+            )
 
             # Bind to widget
-            self.tk.call('bind', self._w, sequence, cmd if not add else '+' + cmd)
+            self.tk.call('bind', self._w, sequence, cmd)
 
             return name
         else:

--- a/src/bootstack/widgets/_core/base.py
+++ b/src/bootstack/widgets/_core/base.py
@@ -13,20 +13,30 @@ if TYPE_CHECKING:
     from bootstack.streams import Stream
 
 
-def adapt_handler(handler: Callable[[Any], Any]) -> Callable[[Any], Any]:
+def adapt_handler(handler: Callable[[Any], Any]) -> Callable[[Any], None]:
     """Wrap a public handler so it receives a bootstack event, not a raw one.
 
     Data-carrying events (emitted with `data=<payload>`) deliver the payload
     object directly — the handler argument *is* the payload. Native/context
     events carry no payload, so the raw toolkit event is curated into a clean
     :class:`~bootstack.events.Event` first.
+
+    A handler's return value is deliberately discarded. The underlying toolkit
+    treats one particular return value as "stop the remaining handlers for this
+    event", which would make any handler that happens to return that value drop
+    its siblings — silently, and with nothing in the public API to explain it.
+    Suppressing later handlers is a capability worth designing on purpose rather
+    than inheriting, so nothing is promised here. Handlers bound internally do
+    not pass through this wrapper and are unaffected.
     """
 
-    def _wrapped(raw: Any) -> Any:
+    def _wrapped(raw: Any) -> None:
         payload = getattr(raw, "data", None)
         if payload is not None:
-            return handler(payload)
-        return handler(Event._from_tk(raw))
+            handler(payload)
+        else:
+            handler(Event._from_tk(raw))
+        return None
 
     return _wrapped
 

--- a/tests/widgets/public/test_subscription_cancel.py
+++ b/tests/widgets/public/test_subscription_cancel.py
@@ -15,7 +15,9 @@ handler registered after the cancelled one.
 Only virtual events (`<<...>>` — every bootstack event) took the custom path;
 real events like `<Configure>` go through stock `bind` and were never affected.
 
-Emitting stock Tkinter's script shape fixes cancellation.
+Emitting stock Tkinter's script shape fixes cancellation. It also makes handler
+return values significant, which is NOT wanted on the public surface — see
+`test_a_handler_return_value_cannot_suppress_the_others`.
 
 Matching the script shape is only half of it. Stock `unbind` also deletes the Tcl
 command behind a handler the moment it is asked to, and the copy of the script Tk
@@ -279,3 +281,56 @@ def test_cancelling_then_destroying_the_widget_is_quiet(app):
         assert seen == []
     finally:
         root.deletecommand("bgerror")
+
+
+# --- A handler's return value must stay inert ---------------------------
+
+def test_a_handler_return_value_cannot_suppress_the_others(app):
+    # Matching the toolkit's script shape made handler return values
+    # significant, where they had been discarded before. One particular string
+    # means "stop the remaining handlers", so a handler that merely computed it
+    # by accident would silently drop its siblings.
+    #
+    # `adapt_handler` discards public handlers' return values so that cannot
+    # happen. Suppressing later handlers is a feature to design deliberately,
+    # not to inherit from the toolkit — see the docstring there.
+    button = bs.Button("go")
+    calls = {"a": 0, "b": 0}
+
+    def returns_break(event):
+        calls["a"] += 1
+        return "break"
+
+    button.on_click(returns_break)
+    button.on_click(lambda e: calls.__setitem__("b", calls["b"] + 1))
+    app._tk_root.update_idletasks()
+
+    _fire(app, button)
+
+    assert calls == {"a": 1, "b": 1}
+
+
+def test_a_return_value_is_inert_on_the_payload_path_too(shown_app):
+    # `adapt_handler` has two arms — payload events and curated native events.
+    # The test above covers the native arm; this one covers the payload arm.
+    #
+    # A widget whose `on()` and `emit()` agree on their target is required here:
+    # on the field wrappers they do not, so `field.emit(...)` never reaches a
+    # handler registered by `field.on_change(...)` and this would pass
+    # vacuously (#396). `shown_app`, not `app`, because a generated event is not
+    # delivered to this composite while its window is unmapped.
+    slider = bs.Slider(value=5, min_value=0, max_value=10)
+    calls = {"a": 0, "b": 0}
+
+    def returns_break(event):
+        calls["a"] += 1
+        return "break"
+
+    slider.on_change(returns_break)
+    slider.on_change(lambda e: calls.__setitem__("b", calls["b"] + 1))
+    shown_app._tk_root.update()
+
+    slider.emit("change", data=bs.events.SliderEvent(value=7.0))
+    shown_app._tk_root.update()
+
+    assert calls == {"a": 1, "b": 1}

--- a/tests/widgets/public/test_subscription_cancel.py
+++ b/tests/widgets/public/test_subscription_cancel.py
@@ -283,6 +283,145 @@ def test_cancelling_then_destroying_the_widget_is_quiet(app):
         root.deletecommand("bgerror")
 
 
+# --- Subscribing again in the same turn as a cancellation ---------------
+#
+# Deferring the cleanup means a handler's name outlives the handler itself for a
+# moment. Tkinter builds that name from the address of a bound method created for
+# that registration alone, and cancelling releases the last reference to it — so
+# the next registration is handed the very same address, and with it the same
+# name. The pending deletion would then remove a binding made after it, silently.
+# `_unique_name` is what keeps the two apart.
+
+
+def test_a_cancelled_handlers_name_is_never_reused(app):
+    # The deterministic guard for the three tests below. Whether a reused name
+    # actually swallows a handler depends on when the allocator hands the same
+    # address back, which varies with whatever else the process is doing — so
+    # the behavioral tests can pass on a broken build by luck. This one cannot:
+    # it asserts the invariant that makes the failure impossible in the first
+    # place. Measured on the stock naming scheme, 498 of 499 consecutive cycles
+    # reused the name.
+    button = bs.Button("go")
+    names = []
+    for _ in range(50):
+        sub = button.on_click(lambda e: None)
+        names.append(sub._bind_id)
+        sub.cancel()
+    app._tk_root.update_idletasks()
+
+    assert len(set(names)) == len(names), "a handler name was reused after cancel"
+
+
+def test_subscribing_again_right_after_a_cancel_keeps_the_new_handlers(app):
+    # Swapping a handler — cancel, then register the replacement — is the whole
+    # point of holding a subscription, and it happens well inside one turn of
+    # the event loop. There must be no idle point between the two here: that gap
+    # is exactly what this is guarding against needing.
+    #
+    # This is the user-visible contract, but it is a best-effort detector: it
+    # only fails on a broken build when the allocator happens to hand back the
+    # cancelled handler's address. `test_a_cancelled_handlers_name_is_never_reused`
+    # is the guard that always fails.
+    root = app._tk_root
+    button = bs.Button("go")
+    calls = {"a": 0, "b": 0, "c": 0}
+
+    sub_a = button.on_click(lambda e: calls.__setitem__("a", calls["a"] + 1))
+    root.update_idletasks()
+    _fire(app, button)
+    assert calls == {"a": 1, "b": 0, "c": 0}, "precondition: the first handler is live"
+
+    calls.update(a=0)
+    sub_a.cancel()
+    button.on_click(lambda e: calls.__setitem__("b", calls["b"] + 1))
+    button.on_click(lambda e: calls.__setitem__("c", calls["c"] + 1))
+    root.update_idletasks()  # the deferred cleanup lands here
+
+    _fire(app, button)
+
+    assert calls == {"a": 0, "b": 1, "c": 1}
+
+
+def test_subscribing_again_right_after_a_cancel_is_quiet(app):
+    # The companion failure has no return value to inspect: reusing a name the
+    # pending cleanup still refers to leaves a binding pointing at a deleted
+    # command, which Tk reports on its background-error channel and nowhere
+    # Python can see. Read that channel directly.
+    root = app._tk_root
+    seen: list = []
+    root.tk.createcommand("bgerror", lambda *a: seen.append(a[0] if a else ""))
+    try:
+        button = bs.Button("go")
+        sub = button.on_click(lambda e: None)
+        root.update_idletasks()
+
+        sub.cancel()
+        button.on_click(lambda e: None)
+        root.update_idletasks()
+        _fire(app, button)
+
+        assert seen == []
+    finally:
+        root.deletecommand("bgerror")
+
+
+def test_a_real_event_survives_a_cancel_and_resubscribe_too(app):
+    # Real events (`hover` is `<Enter>`) take the stock binding path, but they
+    # are removed by the same patched `unbind`, so they need the same protection.
+    # The virtual-event tests above bind a different wrapper and would not cover
+    # this one.
+    #
+    # PASSES PRE-FIX ON PURPOSE — measured: the address reuse that breaks the
+    # virtual path did not happen to land here. Not a dud; it is the only
+    # coverage of the real-event wrapper, and it fails if that path regresses
+    # outright.
+    root = app._tk_root
+    button = bs.Button("go")
+    calls = {"a": 0, "b": 0}
+
+    sub_a = button.on("hover", lambda e: calls.__setitem__("a", calls["a"] + 1))
+    root.update_idletasks()
+    button.emit("hover")
+    root.update()
+    assert calls == {"a": 1, "b": 0}, "precondition: the first handler is live"
+
+    calls.update(a=0)
+    sub_a.cancel()
+    button.on("hover", lambda e: calls.__setitem__("b", calls["b"] + 1))
+    root.update_idletasks()
+
+    button.emit("hover")
+    root.update()
+
+    assert calls == {"a": 0, "b": 1}
+
+
+def test_a_handler_that_destroys_its_own_widget_is_quiet(app):
+    # A payload event caches its data and clears the entry once every handler
+    # has run. That cleanup is deferred, so it must be owned by something that
+    # outlives the widget — a handler destroying its own widget (a dialog
+    # dismissing itself, a page tearing down) is ordinary, and getting it wrong
+    # leaves a pending callback on a command destroy() already swept.
+    #
+    # Invisible to Python, like the teardown case above: read the background
+    # channel.
+    root = app._tk_root
+    seen: list = []
+    root.tk.createcommand("bgerror", lambda *a: seen.append(a[0] if a else ""))
+    try:
+        button = bs.Button("go")
+        button.on_click(lambda e: button.destroy())
+        root.update_idletasks()
+
+        button.emit("click", data={"payload": 1})
+        root.update()
+        root.update_idletasks()
+
+        assert seen == []
+    finally:
+        root.deletecommand("bgerror")
+
+
 # --- A handler's return value must stay inert ---------------------------
 
 def test_a_handler_return_value_cannot_suppress_the_others(app):

--- a/tests/widgets/public/test_subscription_cancel.py
+++ b/tests/widgets/public/test_subscription_cancel.py
@@ -1,0 +1,128 @@
+"""Regression tests for `Subscription.cancel()` (#392).
+
+Cancelling one subscription used to silence *every other handler* on the same
+event, with no Python-level error to show for it.
+
+The runtime patches `bind` so virtual events can carry a data payload, and it
+wrote its own Tcl binding script in a bare `<funcid> %d %# ...` shape. Tkinter's
+`unbind(sequence, funcid)` removes a single handler by matching the line prefix
+`if {"[<funcid> ` that its own `bind` emits — so nothing matched, the binding
+survived, and yet the Tcl command behind it was still deleted. The orphan then
+errored on every dispatch; because bootstack binds with `add='+'` all handlers
+for an event live in ONE concatenated script, so that error aborted every
+handler registered after the cancelled one.
+
+Only virtual events (`<<...>>` — every bootstack event) took the custom path;
+real events like `<Configure>` go through stock `bind` and were never affected.
+
+Emitting stock Tkinter's script shape fixes cancellation.
+"""
+from __future__ import annotations
+
+import bootstack as bs
+
+
+def _fire(app, widget) -> None:
+    widget.emit("click")
+    app._tk_root.update()
+
+
+# --- The reported bug: cancelling one handler killed the others ---------
+
+def test_cancelling_one_subscription_leaves_the_others_working(app):
+    # Reported repro: two `on_click` subscriptions, cancel the first, and
+    # neither fired afterward.
+    button = bs.Button("go")
+    calls = {"a": 0, "b": 0}
+    sub_a = button.on_click(lambda e: calls.__setitem__("a", calls["a"] + 1))
+    button.on_click(lambda e: calls.__setitem__("b", calls["b"] + 1))
+    app._tk_root.update_idletasks()
+
+    _fire(app, button)
+    assert calls == {"a": 1, "b": 1}, "precondition: both handlers are live"
+
+    sub_a.cancel()
+    calls.update(a=0, b=0)
+    _fire(app, button)
+
+    assert calls == {"a": 0, "b": 1}
+
+
+def test_cancelling_a_middle_subscription_spares_both_neighbors(app):
+    # The abort took out everything *after* the cancelled handler, so a
+    # two-handler test can't tell "later handlers die" from "all die".
+    button = bs.Button("go")
+    calls = {"a": 0, "b": 0, "c": 0}
+    button.on_click(lambda e: calls.__setitem__("a", calls["a"] + 1))
+    sub_b = button.on_click(lambda e: calls.__setitem__("b", calls["b"] + 1))
+    button.on_click(lambda e: calls.__setitem__("c", calls["c"] + 1))
+    app._tk_root.update_idletasks()
+
+    _fire(app, button)
+    assert calls == {"a": 1, "b": 1, "c": 1}, "precondition: all three are live"
+
+    sub_b.cancel()
+    calls.update(a=0, b=0, c=0)
+    _fire(app, button)
+
+    assert calls == {"a": 1, "b": 0, "c": 1}
+
+
+def test_cancelling_every_subscription_leaves_nothing_bound(app):
+    button = bs.Button("go")
+    calls = {"a": 0, "b": 0}
+    sub_a = button.on_click(lambda e: calls.__setitem__("a", calls["a"] + 1))
+    sub_b = button.on_click(lambda e: calls.__setitem__("b", calls["b"] + 1))
+    app._tk_root.update_idletasks()
+
+    _fire(app, button)
+    assert calls == {"a": 1, "b": 1}, "precondition: both handlers are live"
+
+    sub_a.cancel()
+    sub_b.cancel()
+    calls.update(a=0, b=0)
+    _fire(app, button)
+
+    assert calls == {"a": 0, "b": 0}
+
+
+def test_cancel_is_idempotent(app):
+    button = bs.Button("go")
+    calls = {"a": 0, "b": 0}
+    sub_a = button.on_click(lambda e: calls.__setitem__("a", calls["a"] + 1))
+    button.on_click(lambda e: calls.__setitem__("b", calls["b"] + 1))
+    app._tk_root.update_idletasks()
+
+    sub_a.cancel()
+    sub_a.cancel()
+
+    _fire(app, button)
+    assert calls == {"a": 0, "b": 1}
+
+
+# --- The data payload must survive the new script shape ----------------
+
+def test_a_surviving_handler_still_receives_its_payload(shown_app):
+    # The whole reason for the custom script was the %d data token; a
+    # cancellation fix that dropped the payload would be no fix at all.
+    #
+    # `shown_app`, not `app`: a generated event isn't delivered to this
+    # composite while its window is unmapped, and the `app` fixture's root is
+    # withdrawn. (Pre-existing and unrelated — it measures the same either
+    # side of this fix.)
+    slider = bs.Slider(value=5, min_value=0, max_value=10)
+    seen: list = []
+    sub_first = slider.on_change(lambda e: None)
+    slider.on_change(lambda e: seen.append(e.value))
+    shown_app._tk_root.update()
+
+    slider.emit("change", data=bs.events.SliderEvent(value=7.0))
+    shown_app._tk_root.update()
+    assert seen == [7.0], "precondition: the payload arrives while both are live"
+
+    sub_first.cancel()
+    seen.clear()
+    slider.emit("change", data=bs.events.SliderEvent(value=9.0))
+    shown_app._tk_root.update()
+
+    assert seen == [9.0]

--- a/tests/widgets/public/test_subscription_cancel.py
+++ b/tests/widgets/public/test_subscription_cancel.py
@@ -16,6 +16,13 @@ Only virtual events (`<<...>>` — every bootstack event) took the custom path;
 real events like `<Configure>` go through stock `bind` and were never affected.
 
 Emitting stock Tkinter's script shape fixes cancellation.
+
+Matching the script shape is only half of it. Stock `unbind` also deletes the Tcl
+command behind a handler the moment it is asked to, and the copy of the script Tk
+is currently running is not the one the removal rewrites — so cancelling *from
+inside a handler for the same event* hit the deleted command further down and
+aborted the remainder of that dispatch, just as silently. `unbind` is patched to
+neutralize the command in place and delete it once the dispatch has finished.
 """
 from __future__ import annotations
 
@@ -126,3 +133,149 @@ def test_a_surviving_handler_still_receives_its_payload(shown_app):
     shown_app._tk_root.update()
 
     assert seen == [9.0]
+
+
+# --- Cancelling from inside a handler for the same event ----------------
+#
+# All handlers for an event share one script, and the copy Tk is running is not
+# the one a cancellation rewrites. Removing a handler mid-dispatch therefore has
+# to leave something callable behind where it used to be, or the rest of that
+# dispatch is skipped with nothing raised to show for it.
+
+def test_cancelling_a_later_handler_from_inside_one_spares_the_rest(app):
+    button = bs.Button("go")
+    calls = {"a": 0, "b": 0, "c": 0}
+
+    def cancel_b(event):
+        calls["a"] += 1
+        sub_b.cancel()
+
+    button.on_click(cancel_b)
+    sub_b = button.on_click(lambda e: calls.__setitem__("b", calls["b"] + 1))
+    button.on_click(lambda e: calls.__setitem__("c", calls["c"] + 1))
+    app._tk_root.update_idletasks()
+
+    _fire(app, button)
+
+    # `b` is cancelled before it is reached, so it must not run; `c` is behind
+    # it in the same script and must still run.
+    assert calls == {"a": 1, "b": 0, "c": 1}
+
+
+def test_cancelling_the_last_handler_from_inside_one_spares_the_middle(app):
+    # Guards the mirror error: a fix that let the whole dispatch continue by
+    # skipping the *rest* of the script would pass the test above.
+    #
+    # PASSES PRE-FIX ON PURPOSE — with nothing bound after the cancelled
+    # handler there was nothing left for the aborted dispatch to swallow. Not a
+    # dud; it fails if a fix ever over-reaches in the other direction.
+    button = bs.Button("go")
+    calls = {"a": 0, "b": 0, "c": 0}
+
+    def cancel_c(event):
+        calls["a"] += 1
+        sub_c.cancel()
+
+    button.on_click(cancel_c)
+    button.on_click(lambda e: calls.__setitem__("b", calls["b"] + 1))
+    sub_c = button.on_click(lambda e: calls.__setitem__("c", calls["c"] + 1))
+    app._tk_root.update_idletasks()
+
+    _fire(app, button)
+
+    assert calls == {"a": 1, "b": 1, "c": 0}
+
+
+def test_a_handler_can_cancel_its_own_subscription(app):
+    # The unsubscribe-on-first-result shape. The handler is mid-flight when its
+    # own binding goes away, so this is the case most likely to misbehave.
+    #
+    # PASSES PRE-FIX ON PURPOSE — a handler's own line has already been
+    # evaluated by the time it runs, so this case was never broken. It is here
+    # to catch a cancellation fix that breaks it.
+    button = bs.Button("go")
+    calls = {"a": 0, "b": 0}
+
+    def once(event):
+        calls["a"] += 1
+        sub_a.cancel()
+
+    sub_a = button.on_click(once)
+    button.on_click(lambda e: calls.__setitem__("b", calls["b"] + 1))
+    app._tk_root.update_idletasks()
+
+    _fire(app, button)
+    assert calls == {"a": 1, "b": 1}, "the handler behind it still runs"
+
+    calls.update(a=0, b=0)
+    _fire(app, button)
+    assert calls == {"a": 0, "b": 1}, "and it really is unsubscribed"
+
+
+def test_cancelling_mid_dispatch_does_not_leak_the_binding(app):
+    # The deferred cleanup must actually happen, not just be postponed forever.
+    #
+    # PASSES PRE-FIX ON PURPOSE — the old code deleted the command immediately
+    # (which is exactly what caused the abort). This guards the cost of deferring
+    # it: postponed must not mean skipped.
+    button = bs.Button("go")
+    calls = {"a": 0}
+
+    def cancel_self(event):
+        calls["a"] += 1
+        sub_a.cancel()
+
+    sub_a = button.on_click(cancel_self)
+    app._tk_root.update_idletasks()
+
+    _fire(app, button)
+    app._tk_root.update_idletasks()
+    app._tk_root.update()
+
+    bind_id = sub_a._bind_id
+    registered = app._tk_root.tk.call("info", "commands", bind_id)
+    assert not registered, f"{bind_id} outlived the dispatch that cancelled it"
+
+
+def test_unbinding_a_foreign_funcid_leaves_the_real_binding_alone(app):
+    # A funcid unbound from the wrong widget used to delete the command behind
+    # the still-live binding, orphaning it. Removing nothing must delete nothing.
+    button = bs.Button("go")
+    other = bs.Button("other")
+    calls = {"a": 0}
+    sub_a = button.on_click(lambda e: calls.__setitem__("a", calls["a"] + 1))
+    app._tk_root.update_idletasks()
+
+    other._internal.unbind(sub_a._sequence, sub_a._bind_id)
+    app._tk_root.update_idletasks()
+    app._tk_root.update()
+
+    _fire(app, button)
+    assert calls == {"a": 1}
+
+
+def test_cancelling_then_destroying_the_widget_is_quiet(app):
+    # Cleaning up the removed handler is deferred to the next idle point, so it
+    # must be owned by something that outlives the widget being cleaned up.
+    # Cancel-then-destroy is an ordinary teardown order, and getting this wrong
+    # leaves a pending callback pointing at an already-swept command.
+    #
+    # The failure is invisible to Python — it surfaces only as a background
+    # error inside the interpreter — so this reads that channel directly. There
+    # is no public surface that reports it.
+    root = app._tk_root
+    seen: list = []
+    root.tk.createcommand("bgerror", lambda *a: seen.append(a[0] if a else ""))
+    try:
+        button = bs.Button("go")
+        sub = button.on_click(lambda e: None)
+        root.update_idletasks()
+
+        sub.cancel()
+        button.destroy()
+        root.update_idletasks()
+        root.update()
+
+        assert seen == []
+    finally:
+        root.deletecommand("bgerror")


### PR DESCRIPTION
Closes #392.

Cancelling one subscription stopped every *other* handler listening to that same event on that widget, with nothing raised to show for it. Two `on_click` handlers, cancel the first, and neither ran again.

## The four changes

Each is its own commit and each carries the tests for its own behavior, so the suite is green at every commit — not only at the tip.

**1. Emit the toolkit's binding script shape** (`7ea9dbdb`)

`_patched_bind` wrote its own Tcl script for virtual events — every bootstack event — in a bare `<funcid> %d %# ...` shape. Stock `Misc._unbind` removes one handler by matching the line prefix `if {"[<funcid> ` that stock `_bind` emits, so nothing ever matched: the binding survived while `deletecommand` still ran. The orphaned command then errored on every dispatch, and because bindings are added with `+` they form ONE concatenated script — so that error aborted every handler registered after the cancelled one. Real events took `_original_bind` and were never affected.

**2. Keep the other handlers alive when one is cancelled mid-dispatch** (`a1613451`)

Stock `unbind` deletes the command immediately, and the copy of the script Tk is *running* is not the one a removal rewrites — so cancelling from inside a handler for the same event hit the deleted command further down and aborted the remainder of that dispatch. This was inherited stock behavior, reproduced on raw `tkinter`, not a regression from change 1. `unbind` is patched to neutralize the command in place and delete it at the next idle point.

Two deliberate behavior notes: when the funcid is not found in that widget's script the patch deletes **nothing** (stock deletes it anyway, orphaning whatever is still bound to it — audited all ~95 `unbind` call sites in `src/`, no internal caller depends on the old behavior and two are improved by the guard); and the deferred cleanup is scheduled on the **root**, not the widget, because deferred work owned by a widget is torn down with it.

**3. A handler's return value stays inert** (`4777f6d2`)

Change 1 made return values significant where they had been discarded — one particular string means "stop the remaining handlers", so a public handler that merely *computed* it would silently drop its siblings. `adapt_handler` now discards public handlers' return values. Internal handlers bind through `self.bind(...)` and never pass through it. No CHANGELOG entry: the behavior was neither documented nor reachable before this branch.

**4. Unique binding names** (`23839ff5`)

Found by a second review pass. Deferring the deletion (change 2) is only safe if names are never reused — and tkinter's are. `Misc._register` names the command `repr(id(f)) + f.__name__` where `f` is a bound method created for that registration alone, so neutralizing the command frees the method and CPython hands back the same address: **498 of 499** consecutive bind/cancel/bind cycles produced an identical funcid.

The consequence was #392's own symptom on a new trigger — cancel a subscription, register a replacement before the next idle point, and the pending deletion removed the **new** binding, silently, taking every handler after it. Blast radius was interpreter-wide. Each wrapper now gets a serialized `__name__`, which breaks the collision while keeping all of stock's bookkeeping. Applied to the real-event wrapper too.

Also fixed here, same defect class and pre-existing: the event-data cache cleanup used `widget.after_idle`, so a handler destroying its own widget left a pending callback on an already-swept command.

## Measured

| | before | after |
|---|---|---|
| funcid collisions | 498/499 | **0/499** |
| cancel → resubscribe | `{a:0,b:0,c:0}` + background error | **`{a:0,b:1,c:1}`, clean** |
| cross-widget blast radius | `{x:0}` + background error | **`{x:1}`, clean** |
| destroy-in-handler | `invalid command name` | **clean** |

The teardown `TclError: can't delete Tcl command` is gone too.

## Verification

Full suite **exit 0, 911 passed**, 18 legs, zero failures. Clean `-W` docs build, warning-free. Both re-run after the commit split, not only before it.

Every new test was checked against a simulated pre-fix build. Four pass pre-fix **on purpose** and are annotated in place — they guard the opposite error or the regression path.

One test deliberately breaks the "test public paths" rule: the funcid symptom is allocator-dependent, so a behavioral test can pass on a broken build by luck (on the first pre-fix run only 1 of 3 caught it). `test_a_cancelled_handlers_name_is_never_reused` asserts the invariant instead — 50 cancel/rebind cycles yield 50 distinct ids — and fails `1 == 50` every time. The reasoning is in the test.

## Follow-ups filed, not fixed here

#399 (the not-found guard leaks the command), #400 (one `except TclError` spans three operations), #401 (`numberentry_part`'s internal `'break'`, inert today but the seam is real). All milestoned `0.2.x`.

## Note on the commit range

This PR contains **7** commits, not 5. `c89489ca` and `ee7290f3` are pre-existing handoff-doc commits that were never pushed to `origin/main` — including the one that puts `docs/_dev/handoff-archive.md` in the repo. They are unrelated to #392; they ride along because `origin/main` is behind local `main`. Push `main` first if you would rather they land separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)