### PR TITLE
fix(shell): require a modifier for the sidebar toggle shortcut (#403)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and from 0.1.0 onward the project adheres to
 
 <!-- release-notes-start -->
 
+## [Unreleased]
+
+### Fixed
+
+- **Typing a lowercase `b` no longer collapses an `AppShell` sidebar.** The sidebar toggle is documented as Ctrl-B (Cmd-B on macOS), but off macOS it also fired on a bare `b` typed into any field — including a `TextField`, `PasswordField`, `TextArea` or `CodeEditor` — on a machine with NumLock switched on. Windows reports NumLock using the same modifier bit that the shortcut's macOS half was registered under, so an unmodified keystroke matched it. The macOS shortcut is now registered only on macOS. An uppercase `B` was never affected, which is what made the behavior look intermittent. (#403)
+
 ## [0.2.0] — form and field correctness
 
 This is the first minor release since `0.1.0`, and it carries one change that is not backward compatible: an argument naming a behavior mode now raises on a value outside its documented set, where it used to degrade quietly. See **Changed**.

--- a/src/bootstack/widgets/_impl/composites/shell/shell.py
+++ b/src/bootstack/widgets/_impl/composites/shell/shell.py
@@ -100,9 +100,13 @@ class Shell(ShellLayout):
         self._build_nav_region()
 
         # Ctrl/Cmd-B toggles sidebar visibility (the hamburger action).
+        # Bind Command only on macOS: elsewhere Tk resolves "Command" to Mod1,
+        # which is the NumLock bit on Windows and Alt on X11, so an unguarded
+        # <Command-b> fires on a bare "b" whenever NumLock is on (#403).
         if self._collapsible:
             self.bind("<Control-b>", self._on_toggle_shortcut, add="+")
-            self.bind("<Command-b>", self._on_toggle_shortcut, add="+")
+            if self.winsys == "aqua":
+                self.bind("<Command-b>", self._on_toggle_shortcut, add="+")
 
     def _build_nav_region(self) -> None:
         """Build the sidebar/content decks and rail switcher, and wire the model.

--- a/tests/widgets/public/test_appshell_shortcuts.py
+++ b/tests/widgets/public/test_appshell_shortcuts.py
@@ -1,0 +1,76 @@
+"""The AppShell sidebar-toggle shortcut — modifier key required (#403).
+
+The shortcut is Ctrl-B (Cmd-B on macOS). It must NOT fire on a bare `b` typed
+into a field: Tk resolves the `Command` modifier word to `Mod1` on Windows and
+X11, and Windows reports `Mod1` for NumLock, so a `<Command-b>` binding left
+unguarded off macOS matched every unmodified `b` on a machine with NumLock on.
+
+The NumLock bit is supplied explicitly (`state=8`) rather than being taken from
+the host, so the test reproduces the reported failure on any machine.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import bootstack as bs
+
+pytestmark = pytest.mark.isolated
+
+# Tk's Mod1 bit — set by NumLock on Windows, by Alt on X11.
+_MOD1 = 8
+
+
+@pytest.fixture(scope="module")
+def shell():
+    s = bs.AppShell(title="Shortcuts", size=(800, 540))
+    s.__enter__()
+    with s.page_nav() as nav:
+        with nav.add_page("entry", text="Data Entry", icon="clipboard2-data"):
+            field = bs.TextField(label="Text Field")
+    s.navigate("entry")
+    s._internal.update()
+    s._entry_widget = field.tk
+    try:
+        yield s
+    finally:
+        try:
+            s._internal.destroy()
+        except Exception:
+            pass
+
+
+@pytest.fixture()
+def expanded(shell):
+    """Start each test from an expanded sidebar."""
+    shell.sidebar_mode = "expanded"
+    shell._internal.update()
+    return shell
+
+
+def test_modifier_shortcut_toggles_the_sidebar(expanded):
+    # Precondition: the shortcut is wired at all, so a "did not toggle"
+    # assertion below cannot pass vacuously on a shell that binds nothing.
+    entry = expanded._entry_widget
+    entry.focus_force()
+    entry.event_generate("<Control-KeyPress-b>")
+    expanded._internal.update()
+    assert expanded.sidebar_mode != "expanded"
+
+
+def test_bare_b_does_not_toggle_the_sidebar(expanded):
+    # A plain "b" — no modifier, but carrying the NumLock bit that Windows
+    # reports as Mod1. Typing must reach the field and leave the sidebar alone.
+    entry = expanded._entry_widget
+    entry.focus_force()
+    entry.event_generate("<KeyPress-b>", state=_MOD1)
+    expanded._internal.update()
+    assert expanded.sidebar_mode == "expanded"
+
+
+def test_bare_b_without_numlock_does_not_toggle_the_sidebar(expanded):
+    entry = expanded._entry_widget
+    entry.focus_force()
+    entry.event_generate("<KeyPress-b>")
+    expanded._internal.update()
+    assert expanded.sidebar_mode == "expanded"


### PR DESCRIPTION
Closes #403.

The `AppShell` sidebar toggle is documented as Ctrl-B (Cmd-B on macOS), but off macOS it also fired on a bare lowercase `b` typed into any field — `TextField`, `PasswordField`, `TextArea`, `CodeEditor` — on a machine with NumLock switched on.

Tk rewrites the `Command` modifier word to `Mod1` on Windows and X11, and Windows sets the `Mod1` bit for NumLock (X11 sets it for Alt). The shell bound `<Command-b>` unconditionally, so with NumLock on, an unmodified keystroke matched it. Uppercase `B` is a different keysym and never matched, which is what made the behavior look intermittent and kept it out of the test suite. Measured with a real keystroke on Windows: `REAL 'b' with numlock=ON -> ('Mod1-b', state=8)`, `numlock=OFF -> ('any', 'b', state=0)`.

The fix guards the Command binding behind `winsys == "aqua"`, matching how the framework already guards `<Command-w>` (`_runtime/app.py`) and `<Command-f>`/`<Command-h>` (`textarea/search_overlay.py`). `<Control-b>` is untouched on every platform, so macOS keeps both bindings exactly as it has them today and nothing documented is removed. Linux is fixed too — Alt+B silently toggled the sidebar there for the same reason.

New `tests/widgets/public/test_appshell_shortcuts.py`, three tests: Ctrl-B toggles (the precondition, so the negative assertions cannot pass on a shell that binds nothing at all), a bare `b` carrying the NumLock bit does not toggle, and a bare `b` without it does not toggle. The bit is supplied explicitly via `event_generate(..., state=8)` rather than taken from the host, so the test reproduces the failure on any machine. Verified against the pre-fix baseline: the NumLock test fails behaviorally (`assert 'compact' == 'expanded'`), not with an AttributeError. The file lands in `tests/widgets/public/` — the `tests/widgets/` root is collected by nothing (#380).

Full suite green on Windows: `py -3.12 tests/run_gui.py`, exit 0, all legs passed.

Separate and pre-existing, not addressed here: on macOS `Control-B` in a text field both moves the cursor back a character and toggles the sidebar, because the handler's `"break"` comes after the Entry class binding has already run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
