### PR TITLE
test(shell): make the #403 regression tests actually run and assert

### DIFF
--- a/tests/run_gui.py
+++ b/tests/run_gui.py
@@ -29,6 +29,7 @@ REPO = Path(__file__).resolve().parent.parent
 ISOLATED = [
     "tests/widgets/public/test_undecorated_titlebar.py",
     "tests/widgets/public/test_appshell_reshape.py",
+    "tests/widgets/public/test_appshell_shortcuts.py",
     "tests/widgets/public/test_workbench.py",
     "tests/widgets/public/test_sidebar_toggle.py",
     "tests/widgets/public/test_tabs_overflow.py",

--- a/tests/widgets/public/test_appshell_shortcuts.py
+++ b/tests/widgets/public/test_appshell_shortcuts.py
@@ -23,14 +23,21 @@ _MOD1 = 8
 
 @pytest.fixture(scope="module")
 def shell():
-    s = bs.AppShell(title="Shortcuts", size=(800, 540))
-    s.__enter__()
-    with s.page_nav() as nav:
-        with nav.add_page("entry", text="Data Entry", icon="clipboard2-data"):
-            field = bs.TextField(label="Text Field")
-    s.navigate("entry")
+    # Built through the context manager so the parent-context stack is left
+    # balanced (`__enter__` without `__exit__` strands the shell on it).
+    with bs.AppShell(title="Shortcuts", size=(800, 540)) as s:
+        with s.page_nav() as nav:
+            with nav.add_page("entry", text="Data Entry", icon="clipboard2-data"):
+                field = bs.TextField(label="Text Field")
+        s.navigate("entry")
+    # The window must be MAPPED or focus_force lands on the root and the
+    # synthesized keystrokes never reach the entry, which would make the
+    # "typing still works" half of these tests pass vacuously. `run()` is what
+    # normally reveals the shell, and the suite never calls it.
+    s._internal.deiconify()
     s._internal.update()
-    s._entry_widget = field.tk
+    s._field = field
+    s._entry_widget = field._internal.entry_widget
     try:
         yield s
     finally:
@@ -42,8 +49,10 @@ def shell():
 
 @pytest.fixture()
 def expanded(shell):
-    """Start each test from an expanded sidebar."""
+    """Start each test from an expanded sidebar and an empty field."""
     shell.sidebar_mode = "expanded"
+    shell._field.value = ""
+    shell._entry_widget.focus_force()
     shell._internal.update()
     return shell
 
@@ -51,9 +60,7 @@ def expanded(shell):
 def test_modifier_shortcut_toggles_the_sidebar(expanded):
     # Precondition: the shortcut is wired at all, so a "did not toggle"
     # assertion below cannot pass vacuously on a shell that binds nothing.
-    entry = expanded._entry_widget
-    entry.focus_force()
-    entry.event_generate("<Control-KeyPress-b>")
+    expanded._entry_widget.event_generate("<Control-KeyPress-b>")
     expanded._internal.update()
     assert expanded.sidebar_mode != "expanded"
 
@@ -61,16 +68,34 @@ def test_modifier_shortcut_toggles_the_sidebar(expanded):
 def test_bare_b_does_not_toggle_the_sidebar(expanded):
     # A plain "b" — no modifier, but carrying the NumLock bit that Windows
     # reports as Mod1. Typing must reach the field and leave the sidebar alone.
-    entry = expanded._entry_widget
-    entry.focus_force()
-    entry.event_generate("<KeyPress-b>", state=_MOD1)
+    expanded._entry_widget.event_generate("<KeyPress-b>", state=_MOD1)
     expanded._internal.update()
     assert expanded.sidebar_mode == "expanded"
+    assert expanded._field.text == "b"
 
 
 def test_bare_b_without_numlock_does_not_toggle_the_sidebar(expanded):
-    entry = expanded._entry_widget
-    entry.focus_force()
-    entry.event_generate("<KeyPress-b>")
+    expanded._entry_widget.event_generate("<KeyPress-b>")
     expanded._internal.update()
     assert expanded.sidebar_mode == "expanded"
+    assert expanded._field.text == "b"
+
+
+def test_command_binding_exists_only_on_macos(shell):
+    # The suite runs on Windows and Linux, where every test above exercises the
+    # non-aqua branch only — so a typo in the guard would drop the macOS
+    # shortcut with nothing failing. Assert the binding table directly.
+    # `windowingsystem` is read from Tk rather than from the shell's cached
+    # `winsys`, so the check does not lean on the same value the guard used.
+    #
+    # Match on the KEY, not on the literal sequence: off macOS Tk normalizes the
+    # `Command` modifier word to `Mod1`, so the unguarded binding shows up as
+    # `<Mod1-Key-b>` and a `"<Command-Key-b>" not in ...` assertion would pass
+    # vacuously on the very platform this test runs on (measured, not assumed).
+    b_bindings = {seq for seq in shell._internal.bind() if seq.endswith("-Key-b>")}
+    assert "<Control-Key-b>" in b_bindings
+    extra = b_bindings - {"<Control-Key-b>"}
+    if shell._internal.tk.call("tk", "windowingsystem") == "aqua":
+        assert len(extra) == 1, "Cmd-B must be bound on macOS"
+    else:
+        assert extra == set(), f"unguarded modifier binding off macOS: {extra}"


### PR DESCRIPTION
Follow-up to #404. The #403 fix is correct and stays as merged — this PR only repairs its test coverage, which a review of the merged diff found to be running nowhere and under-asserting where it did run.

## The tests ran in no leg of the suite

`tests/widgets/public/test_appshell_shortcuts.py` sets `pytestmark = pytest.mark.isolated` but was never added to the `ISOLATED` list in `tests/run_gui.py`. Leg 1 passes `-m "not isolated"` and deselects it; leg 2 iterates a hardcoded list that did not contain it. So `python tests/run_gui.py` — the documented way to run the suite — executed **zero** of the three tests, and #403 had no standing coverage. Registering the path fixes that and also keeps a plain `pytest` run from building a second Tk root inside the shared-root process.

## Three ways the tests under-asserted

**The keystrokes never reached the field.** The shell was left withdrawn, so `focus_force` landed on the root and `field.text` was `''` after the generate — the "typing must reach the field" half of `test_bare_b_does_not_toggle_the_sidebar` was only a comment, never an assertion. The fixture now deiconifies and the events target the inner entry, so both halves are real. The sidebar half was genuinely exercised all along (the toplevel tag is in the composite's bindtags), so the tests were not vacuous — but a regression where the shortcut swallowed the keystroke would not have been caught.

**The aqua branch had no coverage in either direction.** Every test exercises the non-macOS path, and the suite runs on Windows and Linux, so a typo in the `winsys == "aqua"` guard would silently drop the macOS shortcut with nothing failing. `test_command_binding_exists_only_on_macos` asserts the binding table directly.

That test matches on the **key**, not on the literal sequence, and the reason is worth recording: Tk rewrites the `Command` modifier word to `Mod1` off macOS, so an unguarded binding reads back from `bind()` as `<Mod1-Key-b>`. The obvious assertion — `assert "<Command-Key-b>" not in widget.bind()` — therefore passes **vacuously** on the very platform the suite runs on. Measured by binding `<Command-b>` by hand and reading the table back.

**The fixture stranded the shell on the parent-context stack** by calling `__enter__` without `__exit__`. It is now built through the context manager. `deiconify()` stays explicit, because `run()` is what normally reveals a shell and the suite never calls it.

## Verification

Control experiment: with the guard deliberately broken (`if True:` in place of the `winsys` check, reverted afterward), `test_bare_b_does_not_toggle_the_sidebar` and `test_command_binding_exists_only_on_macos` both fail, for the right reason — `AssertionError: unguarded modifier binding off macOS: {'<Mod1-Key-b>'}`. On the fixed guard, 4 passed.

Full suite on Windows (`py -3.12 tests/run_gui.py`): **992 passed, 18 skipped**, exit 0, all legs green, with the module now appearing as its own leg.

## Not in this PR

The same NumLock trap is still reachable through the public `Shortcuts` API — `_BINDING_MODIFIERS` guards `'mod'` and `'alt'` with `if IS_MAC` but leaves `'command'` and `'option'` unconditional, while `_WIN_NAMES` maps both to `Ctrl`/`Alt`. Measured: `Shortcut(pattern='Command+S').binding == '<Command-s>'` while `.display == 'Ctrl+S'`. Filed as #405 with both resolutions written up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
