### PR TITLE
docs(events): drop the phantom custom-event section and correct the guard description (#409)

### DIFF
--- a/docs/reference/events.rst
+++ b/docs/reference/events.rst
@@ -483,11 +483,16 @@ Pass the event's matching payload from :mod:`bootstack.events`, the same object 
 
    field.emit("change", data=ChangeEvent(value=new_value))
 
-``emit()`` takes the same names as ``on()``, and both are limited to the events a
-widget actually publishes. An unrecognized name raises
-:class:`~bootstack.errors.UnknownEventError` listing the ones that widget knows, so
-a misspelling fails at the call instead of leaving behind a handler that quietly
-never runs.
+``emit()`` takes the same names as ``on()``. An unrecognized name raises
+:class:`~bootstack.errors.UnknownEventError`, so a misspelling fails at the call
+instead of leaving behind a handler that quietly never runs.
+
+Reserve ``emit()`` for the data-carrying events — ``change``, ``select``, ``input``
+and the rest. Names that stand for a real interaction (``click``, ``focus``,
+``blur``, ``submit``) are a different matter: emitting one asks the toolkit to
+deliver an actual input event, which carries no payload and drives the widget
+rather than notifying about it, so a handler bound through ``on()`` may not see it
+at all. To make one of those happen, use the widget's own properties and methods.
 
 See also
 --------

--- a/docs/reference/events.rst
+++ b/docs/reference/events.rst
@@ -469,28 +469,25 @@ Around ordinary synchronous code the event loop never pumps, so the handler
 would never fire before the block exits — use ``with`` only when something
 inside it processes events.
 
-Emitting your own events
+Emitting events yourself
 ------------------------
 
-Use ``emit()`` to fire an event yourself, optionally with a payload — this is how
-a composite widget surfaces its own high-level activity to listeners. Any name
-that isn't a built-in event is treated as a **custom event**, and its handlers
-receive whatever you pass as ``data``. A plain dict is the natural choice:
+Use ``emit()`` to fire an event as though the widget had produced it — this is how
+a composite surfaces activity from one of its parts to handlers bound on the whole.
+Pass the event's matching payload from :mod:`bootstack.events`, the same object an
+``on_<event>()`` handler would receive:
 
 .. code-block:: python
 
-   # A handler bound by name...
-   widget.on("row_imported", lambda e: print(e["row"], e["source"]))
+   from bootstack.events import ChangeEvent
 
-   # ...fires when you emit that event with a payload.
-   widget.emit("row_imported", data={"row": 42, "source": "clipboard"})
+   field.emit("change", data=ChangeEvent(value=new_value))
 
-For a built-in event, pass its matching payload from :mod:`bootstack.events`
-instead — the same object an ``on_<event>()`` handler would receive:
-
-.. code-block:: python
-
-   widget.emit("change", data=bs.events.ChangeEvent(value=new_value))
+``emit()`` takes the same names as ``on()``, and both are limited to the events a
+widget actually publishes. An unrecognized name raises
+:class:`~bootstack.errors.UnknownEventError` listing the ones that widget knows, so
+a misspelling fails at the call instead of leaving behind a handler that quietly
+never runs.
 
 See also
 --------

--- a/src/bootstack/widgets/_core/base.py
+++ b/src/bootstack/widgets/_core/base.py
@@ -282,7 +282,9 @@ class PublicWidgetBase:
         Example:
             .. code-block:: python
 
-               widget.emit("change", data=bs.events.ChangeEvent(value=new_value))
+               from bootstack.events import ChangeEvent
+
+               field.emit("change", data=ChangeEvent(value=new_value))
         """
         sequence = resolve_event(self, str(event))
 


### PR DESCRIPTION
Closes #409.

## What the issue was, and the correction that matters more than the fix

`docs/reference/events.rst` claimed that *"any name that isn't a built-in event is treated as a custom event"* and showed a worked `on("row_imported")` / `emit("row_imported")` example. Both calls raise `UnknownEventError` — `resolve_event()` has no fallback branch for an unregistered bare name.

The issue framed this as documenting *"a feature that was never built."* That framing is wrong, and it is worth correcting because it changes what the right fix is. Custom events work today, two ways, both verified by probe: a **literal virtual sequence** on any stock widget (`on("<<RowImported>>")` / `emit(..., data={...})` delivers the payload dict intact), and a **bare name on a class that has called `register_widget_events()`**. What is absent is only the bare-name-on-a-*stock*-widget spelling the docs happened to use.

That narrows the fix from a gap to a tradeoff. The fallback is roughly one line — `return f"<<{name}>>"` — but it is the same line that makes `on("chnage", ...)` raise today, so adding it would trade a framework-wide typo guard for a handler that binds fine and silently never fires. That is a direct reversal of the strictness direction that earned the `0.6.0` milestone (#369, #383). Rewriting the section was the call instead.

## Two commits

**`78e06636`** removes the phantom section and rewrites the `emit()` example. Placeholder moves from `widget` to `field`, because `change` is a per-class event rather than a global one, so `emit("change")` genuinely does not work on an arbitrary widget — the old example was wrong in a second, quieter way.

**`ac132ac3`** corrects the replacement paragraph, which made two claims about the strictness guard that do not hold:

- *"Both are limited to the events a widget actually publishes"* is false in both directions. Every name in `GLOBAL_EVENT_MAP` resolves on every widget whether or not it publishes it — `Label` accepts `on("submit")` though it never emits one — and `resolve_event()` passes any literal `<...>` sequence through unchanged. It is a known-name check, not a publishes check.
- *"Listing the ones that widget knows"* is false as well. `all_known` is a process-wide union of `GLOBAL_EVENT_MAP` and every entry in `_CLASS_EVENT_MAPS`, so a `Button` typo is reported alongside `cursor_move`, `export` and `item_drag_start` — events registered by unrelated classes. This was the sentence carrying the justification for keeping the guard over the fallback, so it is the one that most needed to be accurate.

It also adds the caveat the section was missing: `emit()` consults `_event_target()` only for `<<Virtual>>` sequences and fires native-mapped names on `_internal`, so `emit("submit")` on a retargeting composite reaches nothing a listener bound through `on()` can see. `PublicWidgetBase.emit`'s own docstring already documented this; the guide did not, which left the guide less accurate than the source it documents.

Finally, the `emit()` docstring example moves to `from bootstack.events import ChangeEvent`, finishing the correction the first commit made in the guide. That spelling was written on 2026-06-08 during the Stage 4 docs sweep, roughly nineteen hours *after* `637b2407` scoped framework primitives into submodules — copied from an `events.rst` the refactor had already made stale. `bs.events` still resolves transitively, which is why nothing caught it: `tests/test_public_surface.py` gates the curated top-level name set, not the reachability of submodules as attributes.

## Left open deliberately

The rewritten section is **silent on custom events**, so a composite author reading it has no sanctioned path — the working literal-sequence spelling stays undocumented on purpose, since featuring it would put toolkit-shaped sequences in the docs. That silence is the one real cost of shipping this as-is, and it is filed as **#412**: promote `register_widget_events()` (or a thin wrapper) to public API, which would give composite authors a documented bare-name path *while keeping the typo guard*. Narrowing `all_known` to the widget's own MRO maps rides along with it, so this branch stays docs-only.

No CHANGELOG entry: docs-only, no package behavior change, so a reader scanning "was I affected?" gets nothing actionable. `## [Unreleased]` stays absent until the next code fix.

## Verified

Clean `sphinx -W` build from a removed `_build`, zero warnings. `development/probe_409_custom_events.py` green — 7 checks, exit 0, including the typo-guard control that proves this is a tradeoff and not a pure bug. The `UnknownEventError` xref resolves to its autodoc home in `api-reference/errors.rst`. No `bs.events` spellings remain in `src/` or `docs/`. `git diff main...HEAD -- CLAUDE.md` is empty — the branch does not touch the handoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
