### PR TITLE
fix(textarea): import bootstack without idlelib (#430)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and from 0.1.0 onward the project adheres to
 
 <!-- release-notes-start -->
 
+## [Unreleased]
+
+### Fixed
+
+- **`import bootstack` no longer requires `idlelib`, so it works on Linux builds of Python that ship without IDLE.** `idlelib` is part of the standard library, but Debian and Ubuntu package IDLE separately — the way they package Tkinter separately — and it is not installed by default. bootstack imported `WidgetRedirector` from it at module scope, in code the top-level package reaches unconditionally, so on those systems `import bootstack` raised `ModuleNotFoundError: No module named 'idlelib'` and nothing in the framework could be used at all. Since `idlelib` is standard library it is not on PyPI and could not be declared as a dependency, so there was no way to fix this by installing something. That one class is now part of bootstack, alongside the other pieces of the code editor already adapted from IDLE, and nothing in the framework imports `idlelib` any more. Windows and macOS were never affected: the python.org installers bundle IDLE. (#430)
+
 ## [0.2.2] — DataTable group headers and row events
 
 ### Changed

--- a/NOTICE
+++ b/NOTICE
@@ -8,3 +8,23 @@ licensed under the MIT License.
 
 The original ttkbootstrap license and copyright notice are preserved above
 in compliance with the MIT License terms.
+
+This project also contains code derived from IDLE, part of the CPython
+standard library (https://github.com/python/cpython),
+Copyright (c) 2001-2023 Python Software Foundation; All Rights Reserved,
+licensed under the Python Software Foundation License Agreement, Version 2.
+
+  src/bootstack/widgets/_impl/composites/textarea/redirector.py
+
+is a port of idlelib/redirector.py, carrying its WidgetRedirector and
+OriginalCommand classes and their dispatch logic. Summary of the changes made,
+as the Python Software Foundation License Agreement asks for: the
+OriginalCommand interface was narrowed to three private attributes,
+WidgetRedirector.__repr__ was dropped, the operation name is coerced to a
+string before lookup, the widget reference is retained after close() rather
+than deleted, and type hints and rewritten documentation were added.
+
+Other modules in the same package implement designs described in IDLE — the
+Delegator and Percolator chain, UndoDelegator, the editor sidebar, and
+parenmatch's flash-and-restore highlighting — but share no substantial code
+with it and are original implementations.

--- a/development/probe_430_idlelib_free_import.py
+++ b/development/probe_430_idlelib_free_import.py
@@ -1,7 +1,11 @@
-"""Does the ported WidgetRedirector actually work, on a Python with no idlelib?
+"""Does the ported WidgetRedirector work, and is the import free of idlelib?
 
-Run inside the clean venv holding the PyPI build, whose filter.py has been
-repointed at the port. Three things to establish, in order:
+Written to run unchanged on Windows, macOS, and Linux. Only arm 1 depends on
+the machine: it can be *proved* only where `idlelib` is absent, so everywhere
+else it reports SKIP and the run continues. Arms 2-4 test the port's behavior,
+which has nothing to do with whether idlelib happens to be installed — gating
+them behind arm 1 left them runnable only on the one box that cannot finish the
+GUI suite (#432), which is the opposite of what a probe is for.
 
   1. `import bootstack` succeeds at all, which is the bug being fixed.
   2. The redirector intercepts BOTH a Python-side call and one made through the
@@ -12,17 +16,20 @@ repointed at the port. Three things to establish, in order:
 
 Arm 2 carries its own control: an unregistered operation must pass through
 untouched, or "it was intercepted" would prove nothing.
+
+Run: py -3.12 development/probe_430_idlelib_free_import.py    (Windows)
+     python development/probe_430_idlelib_free_import.py      (macOS, Linux)
 """
-import sys
+import platform
 import tkinter as tk
 
 import bootstack as bs
+print(f"  0. platform                   : {platform.system()}, Tk {tk.TkVersion}")
 print(f"  1. import bootstack           : OK, version {bs.__version__}")
 print(f"     idlelib importable?        : ", end="")
 try:
     import idlelib  # noqa: F401
-    print("YES — this box cannot prove anything, install without it")
-    sys.exit(1)
+    print("YES — arm 1 SKIPPED, only a box without idlelib can prove it")
 except ImportError:
     print("no (so the port is what made arm 1 pass)")
 

--- a/development/probe_430_idlelib_free_import.py
+++ b/development/probe_430_idlelib_free_import.py
@@ -1,0 +1,95 @@
+"""Does the ported WidgetRedirector actually work, on a Python with no idlelib?
+
+Run inside the clean venv holding the PyPI build, whose filter.py has been
+repointed at the port. Three things to establish, in order:
+
+  1. `import bootstack` succeeds at all, which is the bug being fixed.
+  2. The redirector intercepts BOTH a Python-side call and one made through the
+     Tcl command directly. The second is what a keystroke looks like, and it is
+     the entire reason this class exists rather than a <Key> binding.
+  3. close() puts the widget back, so a real CodeEditor can be built and torn
+     down without leaving the Text broken.
+
+Arm 2 carries its own control: an unregistered operation must pass through
+untouched, or "it was intercepted" would prove nothing.
+"""
+import sys
+import tkinter as tk
+
+import bootstack as bs
+print(f"  1. import bootstack           : OK, version {bs.__version__}")
+print(f"     idlelib importable?        : ", end="")
+try:
+    import idlelib  # noqa: F401
+    print("YES — this box cannot prove anything, install without it")
+    sys.exit(1)
+except ImportError:
+    print("no (so the port is what made arm 1 pass)")
+
+from bootstack.widgets._impl.composites.textarea.redirector import (
+    WidgetRedirector,
+)
+
+# The App is created first and owns the root: a CodeEditor needs one, and a
+# second Tk root would be a different interpreter entirely.
+with bs.App(title="port check", size=(500, 400)) as app:
+    editor = bs.CodeEditor(language="python")
+
+root = app.tk
+root.update()
+
+text = tk.Text(root)
+text.pack()
+root.update()
+
+seen = []
+redirector = WidgetRedirector(text)
+original_insert = redirector.register(
+    "insert", lambda *args: (seen.append(args), original_insert(*args))[1]
+)
+
+# --- arm 2a: a call written in Python ---------------------------------------
+text.insert("end", "from python\n")
+python_side = len(seen)
+
+# --- arm 2b: a call through the Tcl command, which is what a keystroke does --
+text.tk.call(text._w, "insert", "end", "from tcl\n")
+tcl_side = len(seen) - python_side
+
+# --- arm 2 control: an operation nobody registered must pass through ---------
+text.tk.call(text._w, "mark", "set", "insert", "1.0")
+after_control = len(seen)
+
+content = text.get("1.0", "end-1c")
+print(f"  2. intercepted a Python call  : {python_side == 1} ({python_side})")
+print(f"     intercepted a Tcl call     : {tcl_side == 1} ({tcl_side})")
+print(f"     control, unregistered op   : {after_control == 2} "
+      f"(untouched, still {after_control})")
+print(f"     text actually reached widget: {content.splitlines()!r}")
+
+# --- arm 3: close() restores the widget -------------------------------------
+redirector.close()
+before = len(seen)
+text.insert("end", "after close\n")
+print(f"  3. close() stops interception : {len(seen) == before}")
+print(f"     widget still usable        : "
+      f"{text.get('1.0', 'end-1c').splitlines()[-1]!r}")
+
+text.destroy()
+
+# --- arm 4: the real thing, built and destroyed -----------------------------
+editor_ok = "n/a"
+try:
+    # A CodeEditor builds a FilterChain, which is the only caller of the port
+    # in the framework — so this exercises register/dispatch through the real
+    # code path rather than a hand-built one.
+    editor.value = "def hello():\n    return 1\n"
+    editor.insert("# appended\n")
+    root.update()
+    round_trip = editor.value.strip().splitlines()
+    editor_ok = f"OK, round-tripped {round_trip!r}"
+except Exception as exc:  # noqa: BLE001 - reporting, not handling
+    editor_ok = f"FAILED {type(exc).__name__}: {exc}"
+print(f"  4. a real CodeEditor          : {editor_ok}")
+
+root.destroy()

--- a/src/bootstack/widgets/_impl/composites/textarea/filter.py
+++ b/src/bootstack/widgets/_impl/composites/textarea/filter.py
@@ -12,7 +12,9 @@ which are clean Python callables, not raw Tcl strings.
 from __future__ import annotations
 
 import tkinter as tk
-from idlelib.redirector import WidgetRedirector
+from bootstack.widgets._impl.composites.textarea.redirector import (
+    WidgetRedirector,
+)
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:

--- a/src/bootstack/widgets/_impl/composites/textarea/redirector.py
+++ b/src/bootstack/widgets/_impl/composites/textarea/redirector.py
@@ -1,0 +1,138 @@
+"""Tk command interception for the edit filter chain.
+
+Port of IDLE's `idlelib/redirector.py`. The rest of this package already ports
+that design rather than importing it — `filter.py` adapts Delegator and
+Percolator, `undo.py` adapts UndoDelegator, `sidebar.py` and
+`extensions/line_numbers.py` port the sidebar — and this was the one piece left
+as a live import. `idlelib` is standard library, but not every Python build
+ships it, so that import made the whole framework unimportable on those builds
+rather than degrading the code editor.
+
+A Tk widget is backed by a Tcl command named after the widget's path, and every
+operation on the widget goes through it — including the ones Tk's own key
+bindings perform, which never reach Python at all. Renaming that command and
+putting a dispatcher in its place is what lets the filter chain see an insert
+that came from a keystroke, which is the whole reason this exists.
+"""
+from __future__ import annotations
+
+import tkinter as tk
+from typing import Any, Callable
+
+
+class WidgetRedirector:
+    """Intercepts operations on a Tk widget, including the toolkit's own.
+
+    Renames the widget's Tcl command out of the way and installs a dispatcher
+    under the original name. Registered operations are routed to a Python
+    callable; everything else passes straight through to the renamed command.
+
+    Only one redirector can exist for a given widget — the rename fails once
+    the name it renames to is taken.
+
+    Args:
+        widget: The widget whose operations are to be intercepted.
+    """
+
+    def __init__(self, widget: tk.Misc) -> None:
+        self._operations: dict[str, Callable[..., Any]] = {}
+        self.widget = widget
+        self.tk = widget.tk
+        path = widget._w
+        self.orig = path + "_orig"
+        self.tk.call("rename", path, self.orig)
+        self.tk.createcommand(path, self.dispatch)
+
+    def register(
+        self, operation: str, function: Callable[..., Any]
+    ) -> OriginalCommand:
+        """Route `operation` to `function`, returning a way to call the original.
+
+        The function is also set on the widget, so a call written in Python —
+        `text.insert(...)` — is intercepted the same way a keystroke is.
+        Registering a second function for the same operation replaces the first
+        in both places.
+
+        Args:
+            operation: Name of the widget operation, such as `insert`.
+            function: What to call in its place. It receives the operation's
+                arguments, and is handed the returned callable to pass the call
+                on with.
+        """
+        self._operations[operation] = function
+        setattr(self.widget, operation, function)
+        return OriginalCommand(self, operation)
+
+    def unregister(self, operation: str) -> Callable[..., Any] | None:
+        """Stop routing `operation`, returning whatever was handling it.
+
+        Returns None if the operation was not registered. Dropping the widget
+        attribute that `register` set unmasks the widget's own method again.
+
+        Args:
+            operation: Name of the widget operation to stop intercepting.
+        """
+        function = self._operations.pop(operation, None)
+        if function is None:
+            return None
+        try:
+            delattr(self.widget, operation)
+        except AttributeError:
+            pass
+        return function
+
+    def dispatch(self, operation, *args):
+        """Handle one call to the widget, invoked from Tcl.
+
+        A registered operation goes to its function and does not continue on to
+        the widget — the function decides whether to pass the call along, using
+        the callable it was given at registration. Everything else goes
+        straight through.
+
+        Args:
+            operation: The operation being performed. Tcl may hand this over as
+                its own object type rather than a string.
+            args: The operation's arguments, exactly as Tcl passed them.
+        """
+        operation = str(operation)
+        function = self._operations.get(operation)
+        try:
+            if function is not None:
+                return function(*args)
+            return self.tk.call((self.orig, operation) + args)
+        except tk.TclError:
+            # What the toolkit itself does with a failed widget command. The
+            # caller here is Tcl, which has nowhere useful to put an exception.
+            return ""
+
+    def close(self) -> None:
+        """Undo the interception and restore the widget's own Tcl command."""
+        for operation in list(self._operations):
+            self.unregister(operation)
+        path = self.widget._w
+        self.tk.deletecommand(path)
+        self.tk.call("rename", self.orig, path)
+
+
+class OriginalCommand:
+    """The widget operation a redirector displaced, as a plain callable.
+
+    Returned by `WidgetRedirector.register` so a registered function can pass
+    the call on to the widget after inspecting or changing it. Calling this
+    reaches the widget directly and does not re-enter the chain.
+
+    Args:
+        redirector: The redirector that displaced the operation.
+        operation: Name of the displaced operation.
+    """
+
+    def __init__(self, redirector: WidgetRedirector, operation: str) -> None:
+        self._operation = operation
+        self._call = redirector.tk.call
+        self._target = (redirector.orig, operation)
+
+    def __call__(self, *args):
+        return self._call(self._target + args)
+
+    def __repr__(self) -> str:
+        return f"OriginalCommand({self._operation!r})"

--- a/tests/widgets/public/test_import_without_idlelib.py
+++ b/tests/widgets/public/test_import_without_idlelib.py
@@ -1,0 +1,67 @@
+"""`import bootstack` must not depend on optional parts of the standard library.
+
+`idlelib` is standard library, but not every Python build ships it — Debian and
+Ubuntu package IDLE separately, the same way they package `python3-tk`
+separately, so `import idlelib` fails on a stock system Python there. An import
+of it at module scope anywhere reachable from `bootstack/__init__` therefore
+takes down the entire framework rather than degrading one widget, which is what
+shipped in 0.2.2 (#430).
+
+Neither maintainer box can reproduce that: the python.org installers for
+Windows and macOS bundle IDLE, so `import idlelib` always succeeds there. This
+guards the invariant directly instead of relying on the platform to expose it.
+
+Lives under `tests/widgets/public/` because `testpaths` is `tests/cli`,
+`tests/widgets/public`, `tests/data` — a file outside those three is collected
+by nothing at all. It is not a widget test.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+
+# Setting a name to None in `sys.modules` makes importing it raise, which stands
+# in for a Python build that does not ship it. The import runs in a subprocess
+# because `bootstack` is already imported long before any test runs.
+_BLOCKED_IMPORT = (
+    "import sys\n"
+    "sys.modules['idlelib'] = None\n"
+    "sys.modules['idlelib.redirector'] = None\n"
+    "import bootstack\n"
+)
+
+
+def test_bootstack_imports_on_a_python_without_idlelib():
+    """The framework imports with `idlelib` unavailable.
+
+    Controlled rather than assumed: run against the code this replaced, the
+    same subprocess exits 1 with `ModuleNotFoundError: import of
+    idlelib.redirector halted; None in sys.modules`. So the check fails for the
+    right reason and is not merely asserting that importing works.
+    """
+    result = subprocess.run(
+        [sys.executable, "-c", _BLOCKED_IMPORT],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_the_blocking_trick_actually_blocks():
+    """Control for the test above, which would pass vacuously if it did not.
+
+    If `sys.modules[name] = None` stopped making imports fail — a detail of the
+    import system, not of this project — the test above would report success
+    while proving nothing at all.
+    """
+    result = subprocess.run(
+        [sys.executable, "-c", _BLOCKED_IMPORT.replace(
+            "import bootstack", "import idlelib.redirector"
+        )],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert "idlelib" in result.stderr


### PR DESCRIPTION
`import bootstack` raised `ModuleNotFoundError: No module named 'idlelib'` on Python builds that ship without IDLE — Debian and Ubuntu package it separately, so a stock system Python there could not import the framework at all, not just `CodeEditor`. Because `idlelib` is standard library it is not on PyPI and could not be declared as a dependency, so there was no packaging fix. `WidgetRedirector` is ported instead of imported.

Verified on Windows, which the original Linux work could not cover: full suite green (976 passed / 13 skipped widgets+CLI, 123 / 6 data, exit 0), collection 1168 → 1170 for exactly the two new tests, and the regression test controlled by reverting the import — it fails with the expected `ModuleNotFoundError`. All four probe arms pass, including interception through the Tcl command with its own control.

`NOTICE` now attributes `redirector.py` under the PSF License Agreement, scoped to the one file that measurably carries IDLE's code.

Closes #430.

🤖 Generated with [Claude Code](https://claude.com/claude-code)