### PR TITLE
feat(capture): save a widget, window, or app view as an image file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ docsenv
 errors
 development/archived
 development/issues
+# Output written by the capture probe/demo — artifacts, not source.
+development/screencap_out
 testenv
 pyvenv
 identifier.sqlite

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and from 0.1.0 onward the project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- **Every widget can now save a picture of itself.** `capture(path)` writes the area a widget occupies on screen to an image file and returns the path it wrote — call it on the app for the whole window, or on any single widget for just that part of it. The file extension picks the format, so `.png`, `.jpg`, and `.pdf` all work, and missing folders in the path are created for you. Pair it with `ask_save_file()` to let the user choose where the picture goes. The window is raised before the picture is taken, and an always-on-top setting the window already had is left exactly as it was found. Capturing a hidden or detached widget raises an error rather than silently saving whatever happened to be behind it. (#427)
+
 ### Changed
 
 - **A dialog button's command can now refuse its own press by returning `False`.** The dialog then records no result and stays open, where previously the return value was ignored and the press completed regardless — recording the button's result and closing the window even when the command had decided to do nothing. This is how a button rejects the input it was given: validate in the command, return `False` to keep the dialog open, return anything else to let it close. If you have a button command that returns `False` for some other reason, it will now suppress that button rather than being ignored; return `None` to keep the previous behavior. `FormDialog` already treated `False` this way for the commands you give it, so this brings the underlying `Dialog` in line with it — and `Form`'s own button row, the other place these specifications are used, honors it too, where it previously recorded a result for a press its command had just declined. A form stays on screen after a press, so a refused press there also clears any result an earlier press recorded: `form.result` is the most recent press that completed, never an older one made against data you have since edited. (#437)

--- a/development/demo_427_capture.py
+++ b/development/demo_427_capture.py
@@ -1,0 +1,108 @@
+"""Interactive demo for `widget.capture()` (#427) and the #429 fix.
+
+Shows the result INSIDE the window: every capture is written to a file and then
+loaded back into the panel on the right, so what you see is the pixels that
+landed on disk rather than a claim that they did.
+
+What to try, in order:
+
+  1. `Capture the card`   — one widget, not the whole window. The picture that
+     comes back is just the card, at the card's size.
+  2. `Capture the window` — the whole application.
+  3. `Export…`            — the documented pattern: a save dialog, then a
+     capture of whatever you chose. THEN TRY DOUBLE-CLICKING IT. Before #429
+     the second click re-entered the handler mid-capture and stacked a second
+     save dialog on top of the first; now it waits its turn, so you get one
+     dialog, and the second click runs after the capture has finished.
+  4. `Capture a hidden widget` — the refusal path. A capture reads the screen,
+     so a widget that is not on it cannot be photographed, and saying so beats
+     silently saving whatever was behind it.
+
+Run:  py -3.12 development/demo_427_capture.py
+"""
+
+from pathlib import Path
+
+import bootstack as bs
+from bootstack.errors import BootstackError
+
+OUT = Path(__file__).parent / "capture_demo_out"
+OUT.mkdir(parents=True, exist_ok=True)
+
+with bs.App(title="capture() demo — #427", size=(900, 560), padding=16,
+            gap=12) as app:
+
+    bs.Label("widget.capture()", font="heading-lg")
+    bs.Label(
+        "Every capture below is written to a file, then loaded back into the "
+        "panel on the right.",
+        font="caption", wrap_width=840,
+    )
+
+    with bs.Row(gap=16, vertical_items="start"):
+
+        with bs.Column(gap=12):
+
+            # The subject of arm 1 — a widget worth photographing on its own.
+            with bs.Card(padding=16, gap=8) as card:
+                bs.Label("Quarterly summary", font="heading-md")
+                bs.Label("Revenue    $128,400", font="code")
+                bs.Label("Expenses    $71,200", font="code")
+                bs.Label("Net         $57,200", font="code")
+                bs.ProgressBar(value=68, accent="success")
+
+            # Never shown, so it can never be captured — arm 4.
+            hidden = bs.Label("you cannot photograph me")
+            hidden.detach()
+
+            # Wrapped, and given the column's width: the refusal message is a
+            # full sentence, and unwrapped it stretches the window wider than
+            # the screen — at which point the grab runs off the desktop edge
+            # and pads the difference with black.
+            status = bs.Label("Nothing captured yet.", font="caption",
+                              wrap_width=420, justify="left", anchor="w")
+
+            with bs.Row(gap=8):
+                bs.Button("Capture the card", accent="primary",
+                          on_click=lambda: shoot(card, "card"))
+                bs.Button("Capture the window",
+                          on_click=lambda: shoot(app, "window"))
+
+            with bs.Row(gap=8):
+                bs.Button("Export…", accent="secondary", on_click=lambda: export())
+                bs.Button("Capture a hidden widget", variant="outline",
+                          on_click=lambda: shoot(hidden, "hidden"))
+
+        with bs.Column(gap=8):
+            bs.Label("What was written to disk", font="heading-md")
+            preview = bs.Picture(width=390, height=300, fit="contain")
+            preview_path = bs.Label("—", font="caption", wrap_width=390,
+                                    justify="left", anchor="w")
+
+    def show(written):
+        """Load the file back in, so the panel proves the capture happened."""
+        preview.image = str(written)
+        preview_path.text = str(written)
+        status.text = f"Wrote {written.name}"
+
+    def shoot(target, name):
+        try:
+            show(target.capture(OUT / f"{name}.png"))
+        except BootstackError as exc:
+            # The refusal path is part of the feature, not a demo failure.
+            status.text = f"Refused: {exc}"
+            preview_path.text = "—"
+
+    def export():
+        chosen = bs.ask_save_file(
+            title="Save the capture",
+            initial_file="dashboard.png",
+            file_types=[("PNG image", "*.png"), ("JPEG image", "*.jpg")],
+            initial_dir=str(OUT),
+        )
+        if not chosen:
+            status.text = "Export cancelled."
+            return
+        show(app.capture(chosen))
+
+app.run()

--- a/development/demo_429_busy_during_settle.py
+++ b/development/demo_429_busy_during_settle.py
@@ -25,19 +25,30 @@ WHAT TO DO
      there is a wide window to click into.
   3. Read the log in the window.
 
-WHAT YOU SHOULD SEE
+WHAT YOU SHOULD SEE — AND IT DEPENDS ON THE PLATFORM
 
   captures started: 1        <- every extra click was swallowed
   max nesting:      1        <- the handler never re-entered itself
 
-WHAT A FAILURE LOOKS LIKE
+  Expected where the toolkit honors `tk busy`: X11 and Win32 map the busy
+  window, so the click lands on it and is discarded.
 
-  captures started: 3        <- the clicks got through
-  max nesting:      2        <- and one landed INSIDE the running capture
+WHAT macOS DOES, AND IT IS NOT A REGRESSION
 
-Nesting above 1 is the defect in #429: for a real application that second
-click opens a second save dialog on top of the first, and starts an
-overlapping capture nobody asked for.
+  captures started: 3
+  max nesting:      2        <- a click landed INSIDE the running capture
+
+  ⚠ MEASURED AND EXPECTED ON AQUA. `tk busy hold` there reports success and
+  never maps the window it created — `tk busy status` returns 1 while the busy
+  window sits at `winfo_ismapped() == 0`, and Tk's own hit test at the button
+  still resolves to the button. Reproduced in plain tkinter on Tk 8.6.17, so
+  it is the toolkit, not the framework. Run arm 0 of
+  `probe_429_busy_during_settle.py` to see what THIS box does before reading
+  a re-entry here as a defect.
+
+Nesting above 1 on a platform whose arm 0 says the hold IS real is the defect
+in #429: for a real application that second click opens a second save dialog
+on top of the first, and starts an overlapping capture nobody asked for.
 
 The demo captures to a temporary directory and deletes nothing, so the images
 are there if you want to confirm the picture is of the window rather than of a
@@ -100,24 +111,66 @@ def main() -> int:
             finally:
                 depth -= 1
 
+        def hold_is_real() -> bool:
+            """Does `tk busy` actually block input on THIS box?
+
+            `tk busy status` is not the answer — macOS returns 1 for a busy
+            window it never maps. What settles it is whether that window is
+            mapped and whether Tk's hit test at the button resolves to it.
+            """
+            top = app._internal.winfo_toplevel()
+            inner = export_button._internal
+            x, y = inner.winfo_rootx() + 5, inner.winfo_rooty() + 5
+            try:
+                top.tk.call("tk", "busy", "hold", top._w)
+                app.tk.update()
+                mapped = any(
+                    str(top.tk.call("winfo", "ismapped", str(w))) == "1"
+                    for w in top.tk.splitlist(
+                        top.tk.call("winfo", "children", top._w))
+                    if "Busy" in str(w)
+                )
+                hit = str(top.tk.call("winfo", "containing", x, y))
+                return mapped and hit != str(inner)
+            except Exception:                     # noqa: BLE001 - demo surface
+                return False
+            finally:
+                try:
+                    top.tk.call("tk", "busy", "forget", top._w)
+                    app.tk.update()
+                except Exception:                 # noqa: BLE001
+                    pass
+
         def report() -> None:
+            real = hold_is_real()
             note("")
             note("---- verdict " + "-" * 30)
             note(f"captures started: {started}")
             note(f"captures finished: {finished}")
             note(f"max nesting:      {max_depth}")
+            note(f"tk busy honored here: {'yes' if real else 'NO'}")
             if started == 0:
                 note("NOTHING CLICKED — click Export, then click it again fast.")
+            elif max_depth > 1 and real:
+                note("FAIL — this platform honors the hold and a click still")
+                note("re-entered the handler mid-capture.")
             elif max_depth > 1:
-                note("FAIL — a click re-entered the handler mid-capture.")
+                note("EXPECTED — this platform does not honor `tk busy`, so")
+                note("the click was never going to be blocked. Not a")
+                note("regression; it is the known limit (macOS/aqua).")
             elif started > 1:
                 note("Clicks were spaced out. Click FASTER to test the guard:")
                 note("the extra clicks have to land during the pause.")
-            else:
+            elif real:
                 note("PASS — the extra clicks were swallowed.")
+            else:
+                note("INCONCLUSIVE — only one capture ran, and this platform")
+                note("would not have blocked a click anyway. Click faster.")
 
         with bs.Row(gap=8):
-            bs.Button("Export", accent="primary", on_click=on_export)
+            # Named: hold_is_real() hit-tests against this exact button.
+            export_button = bs.Button("Export", accent="primary",
+                                      on_click=on_export)
             bs.Button("Show verdict", on_click=report)
             bs.Button("Quit", on_click=app.close)
 

--- a/development/demo_429_busy_during_settle.py
+++ b/development/demo_429_busy_during_settle.py
@@ -1,0 +1,135 @@
+"""Manual demo: does `tk busy` swallow a REAL click during settle? (#429)
+
+⚠ THIS ONE NEEDS A HUMAN. It is the only arm of #429 that cannot be automated,
+and the reason is worth stating so nobody replaces it with a probe:
+
+    `tk busy` intercepts input by putting a window over the target, so it only
+    ever sees events the window system routed by pointer position.
+    `event_generate` aimed at a widget delivers straight to that widget's
+    bindings and never consults the busy window at all. A synthesized click
+    therefore re-enters the handler whether busy is held or not — measured,
+    with `tk busy status` reading 1 at the time. Any automated version of this
+    check is a false negative waiting to happen.
+
+`tests/widgets/public/test_capture.py` covers the halves that CAN be asserted:
+that settling repaints the area a closed window uncovered, and that the window
+is held busy while it dispatches. What is left for a person is whether that
+hold actually stops a click.
+
+WHAT TO DO
+
+  1. Run it.
+  2. Click "Export" ONCE, then immediately click it again two or three more
+     times, as fast as you can — an impatient user who thinks nothing
+     happened. The capture takes about a second and a half, deliberately, so
+     there is a wide window to click into.
+  3. Read the log in the window.
+
+WHAT YOU SHOULD SEE
+
+  captures started: 1        <- every extra click was swallowed
+  max nesting:      1        <- the handler never re-entered itself
+
+WHAT A FAILURE LOOKS LIKE
+
+  captures started: 3        <- the clicks got through
+  max nesting:      2        <- and one landed INSIDE the running capture
+
+Nesting above 1 is the defect in #429: for a real application that second
+click opens a second save dialog on top of the first, and starts an
+overlapping capture nobody asked for.
+
+The demo captures to a temporary directory and deletes nothing, so the images
+are there if you want to confirm the picture is of the window rather than of a
+dialog left over the top of it.
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+
+import bootstack as bs
+
+OUT = Path(tempfile.gettempdir()) / "bootstack-demo-429-busy"
+OUT.mkdir(parents=True, exist_ok=True)
+
+# Long enough that a person can comfortably click into the settle window.
+SETTLE = 1.5
+
+
+def main() -> int:
+    started = 0
+    finished = 0
+    depth = 0
+    max_depth = 0
+
+    with bs.App(title="#429 — click Export repeatedly", size=(520, 360),
+                padding=16, gap=8) as app:
+        bs.Label("Click Export once, then keep clicking",
+                 font="heading-md")
+        bs.Label(
+            f"The capture pauses for {SETTLE}s on purpose. Extra clicks during "
+            f"that pause should be swallowed.",
+            font="caption",
+        )
+        log = bs.TextArea(height=12, read_only=True)
+        lines: list[str] = []
+
+        def note(message: str) -> None:
+            # The tail is rewritten rather than appended to: there is no public
+            # way to scroll a TextArea, so a plain append would push the newest
+            # line out of sight exactly when it matters.
+            lines.append(message)
+            log.value = "\n".join(lines[-12:])
+
+        def on_export() -> None:
+            nonlocal started, finished, depth, max_depth
+            started += 1
+            depth += 1
+            max_depth = max(max_depth, depth)
+            mine = started
+            note(f"[{mine}] capture started   (nesting now {depth})")
+            try:
+                app.capture(OUT / f"shot-{mine}.png", settle=SETTLE)
+                finished += 1
+                note(f"[{mine}] capture finished")
+            except Exception as exc:              # noqa: BLE001 - demo surface
+                note(f"[{mine}] capture FAILED: {type(exc).__name__}: {exc}")
+            finally:
+                depth -= 1
+
+        def report() -> None:
+            note("")
+            note("---- verdict " + "-" * 30)
+            note(f"captures started: {started}")
+            note(f"captures finished: {finished}")
+            note(f"max nesting:      {max_depth}")
+            if started == 0:
+                note("NOTHING CLICKED — click Export, then click it again fast.")
+            elif max_depth > 1:
+                note("FAIL — a click re-entered the handler mid-capture.")
+            elif started > 1:
+                note("Clicks were spaced out. Click FASTER to test the guard:")
+                note("the extra clicks have to land during the pause.")
+            else:
+                note("PASS — the extra clicks were swallowed.")
+
+        with bs.Row(gap=8):
+            bs.Button("Export", accent="primary", on_click=on_export)
+            bs.Button("Show verdict", on_click=report)
+            bs.Button("Quit", on_click=app.close)
+
+        note(f"platform={sys.platform}  settle={SETTLE}s")
+        note(f"images -> {OUT}")
+        note("")
+
+    app.run()
+    print(f"captures started={started} finished={finished} max_nesting={max_depth}")
+    print(f"images in {OUT}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/development/handoff-429-settle.md
+++ b/development/handoff-429-settle.md
@@ -1,0 +1,178 @@
+# Branch handoff — #429, the settle guard (`feat/widget-capture-427`)
+
+Written 2026-08-10, on the branch, because `CLAUDE.md` **must not be edited on a
+feature branch** — its handoff state lives on `main` only, and a branch that
+edits it silently reverts main's copy at merge (the trap that nearly bit #410).
+Everything below is what `CLAUDE.md` will need to say once this merges; the
+last section lists the exact lines to change.
+
+⚠ **`CLAUDE.md` is STALE about this branch on both counts.** It says
+"**24 commits, head `ac9a87a3`**" and "**#429 is open against its own code** —
+settle that, then PR it", which reads as though nothing had been done. Read
+this file instead.
+
+Measured 2026-08-10: **31 commits ahead of `origin/main`, head `d7dfd5a1`**.
+⚠ Do not arrive at that by adding this session's 4 commits to the recorded 24 —
+that gives 27, and it is wrong. The branch was rebased onto `main` after `0.2.3`
+and the old figure was counted against a different base. `git rev-list --count
+origin/main..HEAD` settles it in one command, which is the rule this file's
+parent already states.
+
+## Where #429 stands
+
+**Half fixed, half documented as a known limitation. Not open in the sense
+CLAUDE.md implies.**
+
+#429 was filed as *a click during `settle()` re-enters the handler and starts an
+overlapping capture*. The first fix (`e616f5dc`) stopped `settle()` dispatching
+at all. **That fix caused a worse defect and has been reversed.**
+
+### The defect the first fix caused — REAL, and fixed
+
+On macOS the area a closing window uncovers is repainted only while the event
+loop is turning. A settle that dispatches nothing photographs whatever was
+there before.
+
+Measured through the **public** method, following the pattern its own docstring
+teaches — a real modal dialog (`grab_set()` + `wait_window()`) dismissed through
+its own close path, then `capture()`:
+
+| settle | result |
+|---|---|
+| sleep-only (`e616f5dc`) | **51400 of 60800 px wrong** — the saved file is a picture of the dismissed dialog |
+| dispatching | 0 px |
+
+⚠ **It needs no dialog at all.** `capture()` raises the window as documented
+behavior, so *any* other window sitting over the application is uncovered by the
+capture itself. With one window overlapping and left open, the saved file is a
+picture of that window: **53314 px against a 145 px reference**. This is the
+ordinary state of a desktop app, which is what makes it a real bug rather than
+an edge case.
+
+`settle()` dispatches again. Regression coverage is
+`test_settling_repaints_the_area_a_closed_window_uncovered`, which fails against
+unfixed source at 64000/64000 px.
+
+### The input half — NOT fixed on macOS, and that is a decision
+
+`tk busy hold` blocks input while the loop turns. **It does nothing on macOS.**
+
+```
+tk 8.6.17, windowingsystem aqua
+tk busy status -> 1          (reports success)
+._Busy         -> winfo_ismapped() == 0    (never mapped)
+winfo containing at the button's position -> the button
+```
+
+Reproduced in **plain tkinter with no bootstack involved**, and identically
+whether the hold is placed on the toplevel, on the content frame, or followed by
+an explicit `raise`. So it is the toolkit, not the framework, and not a wrong
+invocation. Confirmed end to end by hand: a real click re-enters the handler.
+
+**Maintainer decision (2026-08-10): keep the hold anyway.** X11 and Win32 map
+the busy window and are expected to honor it, and it costs nothing where it does
+not work. What changed instead is that nothing claims it works everywhere — the
+`settle()` docstring records the measurement, the how-to carries a note plus the
+workaround (disable the button around the export), and the test that asserts the
+hold is requested and released says in its docstring that this is **not**
+evidence input is blocked.
+
+⚠ **Do not "fix" this by making `settle()` stop dispatching again.** That is
+where this started, and it trades a UX annoyance for wrong output. The relative
+cost is the whole point: the repaint defect produces a picture of the wrong
+thing; the input defect produces a stacked save dialog on an impatient
+double-click.
+
+## What the Windows/Linux leg must answer
+
+**Arm 0 of `probe_429_busy_during_settle.py` is the headline result**, not arm 3.
+It reports whether the busy window is actually mapped and whether Tk's hit test
+at a button resolves to it. If arm 0 says **no** on Windows too, the hold is dead
+weight on every platform and should be stripped before the PR — that is a
+one-line probe run rather than another manual click round.
+
+```
+py -3.12 development/probe_429_busy_during_settle.py      <- arm 0 decides the hold's fate
+py -3.12 development/probe_429_settle_without_input.py
+py -3.12 development/verify_427_capture.py
+py -3.12 tests/run_gui.py
+py -3.12 development/demo_429_busy_during_settle.py       <- manual, needs clicks
+```
+
+Also worth reading off the settle probe: if its **sleep-only arm comes back
+clean on Windows**, the defect is macOS-specific and `e616f5dc` only broke one
+platform. If it comes back stale, the branch has been broken on Windows since
+2026-08-10 too.
+
+## Things measured here that should not be re-derived
+
+- **A synthesized click cannot test `tk busy`, by construction.**
+  `event_generate` aimed at a widget delivers straight to that widget's bindings
+  and never consults the busy window — it re-enters with `tk busy status`
+  reading 1. Every automated attempt at the input question is a false negative.
+  That is why `demo_429_busy_during_settle.py` needs a human.
+- **`tk busy status` is not evidence the hold works.** It returns 1 on a
+  platform that never maps the window. Check `winfo_ismapped()` and the hit
+  test, which is what arm 0 does.
+- **An invisibility measurement cannot prove a busy overlay is harmless.**
+  "Busy is invisible in the photograph, 0 px" was recorded as evidence the
+  approach worked; it was invisible because it was never mapped. Wherever arm 0
+  says no, arm 3 is trivially true and means nothing.
+- **The guard is on input, not on scheduled work.** A capture started from a
+  timer still re-enters, because `tk busy` blocks what the window system routes
+  by pointer position. `probe_429_capture_reentrancy.py` arm 1 records this as
+  the known limit rather than a failure.
+- **All three #429 probes used to drive their arms through `_capture.settle`**,
+  so when the sleep-only version shipped their controls silently became the
+  test — identical code in both arms, byte-identical images, and verdicts that
+  said nothing. Strategies are pinned per-file now; only arms explicitly labeled
+  `shipped` read the live implementation.
+- **A destroyed target reaches `settle()`.** It flushes pending drawing first,
+  so idle work queued before the capture can destroy the widget; the toplevel
+  lookup is guarded for that, not just the `tk busy` calls.
+
+## Suite state on this branch
+
+Measured 2026-08-10 on macOS (Tk 8.6, `.venv/bin/python`), at **`d7dfd5a1`**:
+
+| leg | result |
+|---|---|
+| widgets+CLI, shared root | 969 passed / 20 skipped |
+| data | 125 passed / 4 skipped |
+| `test_capture.py` (isolated) | 23 passed |
+
+Clean `-W` docs build.
+
+Two pre-existing reds, neither from this work:
+
+- `test_appshell_shortcuts.py::test_bare_b_does_not_toggle_the_sidebar` fails at
+  baseline with every change stashed. Not filed as far as this session knows.
+- The capture leg showed environmental flakiness under `run_gui.py` on one of
+  two full runs — 11 failures, all "cannot identify image file", passing clean
+  on the re-run. Standalone it passes every time.
+
+## The four commits
+
+| SHA | What |
+|---|---|
+| `e4fd4af7` | the fix — dispatching settle + `tk busy` hold, `capture.py` / `base.py` / `test_capture.py` |
+| `9aada08d` | how-to: correct what the pause guarantees |
+| `a7d8941a` | re-point the three probes, add the manual demo |
+| `d7dfd5a1` | say the input guard does nothing on macOS; add probe arm 0 |
+
+## What `CLAUDE.md` needs when this merges
+
+Do this **on `main`**, not here:
+
+- `24 commits, head ac9a87a3` → **31 commits, head `d7dfd5a1`** (line ~164),
+  counted with `git rev-list --count origin/main..HEAD` on 2026-08-10.
+- The IN FLIGHT block and START HERE both say **#429 must be settled before the
+  PR**. Replace with: the repaint half is fixed, the input half is a documented
+  macOS limitation by maintainer decision, and what remains is the Windows leg
+  (arm 0) then the PR.
+- The unmilestoned-issues list counts **#429** among seven. It stays open —
+  the input half is genuinely unresolved on macOS — but it is no longer
+  "a defect in `capture()`'s own code" that blocks the PR.
+- ⚠ The `944 / 14 at ef7e6421` figure is already flagged as stale in that file.
+  Replace with the table above, **with its commit and date**, per the standing
+  rule.

--- a/development/handoff-429-settle.md
+++ b/development/handoff-429-settle.md
@@ -83,6 +83,103 @@ cost is the whole point: the repaint defect produces a picture of the wrong
 thing; the input defect produces a stacked save dialog on an impatient
 double-click.
 
+## ✅ THE WINDOWS LEG HAS RUN — 2026-08-11, at `1654c60e`
+
+**Both questions it was asked are answered, and both answers favor what shipped.**
+Windows box: Python 3.12.10, Tk 8.6, Pillow 12.0.0, Windows 11 (10.0.26200), two
+2560x1440 displays with the **primary at (0,0) and a second at (-2560, 0)** — so
+the negative-origin case is genuinely exercised here rather than skipped.
+
+### 1. The hold is REAL on Windows — arm 0 says YES
+
+```
+[0] is the hold real on this platform: YES - busy window mapped and the hit
+    test at the button resolves to ''; input should be blocked here
+[1] busy held while settling dispatched: PASS - 0 before, 1 during, 0 after
+[3] noise floor across a restack: 0 px (380x160)
+[3] busy visible in the photograph?: PASS - 0 px vs a 0 px floor; invisible
+```
+
+**So the hold is NOT dead weight and must not be stripped.** That was the exact
+decision this leg existed to settle: had Windows also reported "never mapped",
+the guard would have been doing nothing on any platform. It maps the busy window
+and routes the hit test away from the button, which is what the maintainer's
+2026-08-10 decision assumed and did not yet have evidence for.
+
+⚠ **Arm 3 is only meaningful HERE.** On macOS "invisible in the photograph" is
+trivially true because the window is never mapped. Windows maps it and the
+capture is still identical — 0 px against a 0 px floor — so on the one platform
+where the question is real, the guard costs the photograph nothing.
+
+### 2. The repaint defect is macOS-SPECIFIC
+
+```
+noise floor: 50 px between two ref shots
+control: dispatching settle after a window closed   PASS - 14 px (clean)
+test:    sleep-only settle after a window closed    FAIL - 14 px; this arm
+         reproduces the defect and it stopped reproducing, so the comparison is dead
+shipped: _capture.settle after a window closed      PASS - 14 px (clean)
+tk busy held during the shot                        PASS - 14 px (clean)
+```
+
+⚠ **That `FAIL` is the EXPECTED reading on this box, not a regression.** The arm
+exists to reproduce the defect, and it cannot here — which is precisely the
+outcome this file predicted ("if its sleep-only arm comes back clean on Windows,
+the defect is macOS-specific and `e616f5dc` only broke one platform"). The DWM
+keeps a backing store, so a Windows window looks right without processing Expose.
+**`e616f5dc` was never broken on Windows; it was broken on macOS only.**
+
+### 3. Everything else on this box
+
+- `verify_427_capture.py` — **14 passed, 0 failed, 0 skipped**, including
+  `negative-origin display captures real pixels` (control blank at 1, `capture()`
+  at 187) and both topmost-restoration arms.
+- `py -3.12 tests/run_gui.py` — **exit 0, all legs passed**. 20 legs,
+  **1129 passed / 21 skipped** summed. Shared root **932 / 14** (75 deselected),
+  data **125 / 4**, `test_capture.py` **23 passed**.
+- **Neither macOS red reproduced.** `test_bare_b_does_not_toggle_the_sidebar`
+  passes here — it is the Aqua modifier-bit assumption (#431/#434), so Windows is
+  the platform it was written for. And the capture leg showed **no** "cannot
+  identify image file" flakiness across a full run.
+
+### ⚠ The probe could not finish on the box it was written to inform
+
+`probe_429_busy_during_settle.py` **crashed with `UnicodeEncodeError` before
+printing arm 3's verdict** — a single `⚠` inside an f-string that reaches
+`print()`, against this box's **cp1252** console. Everything had already been
+computed; the run died in the reporting loop, so the headline arm printed and the
+last one was lost.
+
+**This is the third instance of the same trap** — #430's check mark, this
+branch's own `b005509b`, now this — and the sharpest, because the probe existed
+*specifically* to answer a Windows question and was the one thing that could not
+complete on Windows. Fixed by dropping the character. **Probe output must be
+pure ASCII; docstrings and comments are fine, since only `print()` goes through
+the console codec.**
+
+### 4. ✅ The manual demo PASSES on Windows — the guard works end to end
+
+`development/demo_429_busy_during_settle.py`, run by the maintainer 2026-08-11:
+**a rapid second click during the capture does not stack a second save dialog.**
+
+That is the half no automated arm can reach. A synthesized click is delivered
+straight to the widget's bindings and never consults the busy window — arm 2
+measures exactly that, re-entering to depth 2 *with* the hold up — so a human is
+the only instrument for it. Arm 0 said the window system *should* block the
+click; this is the confirmation that it does.
+
+**So #429 is now: repaint half fixed and covered by a regression test, input half
+WORKING on Windows and a documented limitation on macOS.** Nothing about it
+blocks the PR.
+
+### What is left
+
+⚠ **A REBASE before the PR.** The branch is **26 behind / 32 ahead**
+of `origin/main` as of 2026-08-11, because #442 (#428/#437/#438) merged
+underneath it. The suite figures above are against the pre-#442 base, which is
+why the shared leg reads **932 / 14** rather than main's current **962 / 14** —
+those are the same tests, not a regression.
+
 ## What the Windows/Linux leg must answer
 
 **Arm 0 of `probe_429_busy_during_settle.py` is the headline result**, not arm 3.

--- a/development/probe_427_macos_offscreen.py
+++ b/development/probe_427_macos_offscreen.py
@@ -1,0 +1,147 @@
+"""Why all eight capture tests fail on macOS (#427).
+
+The shared-root suite stacks widgets past the bottom of a 1470x956 display,
+so every capture test asks for a region at y ~= 2810-2990 — entirely off the
+screen. What happens next is the finding: `screencapture -R` writes no valid
+PNG for an off-screen region, Pillow raises `UnidentifiedImageError`, and
+because that is a subclass of `OSError` the capture module reads it as
+"ImageGrab is unavailable on this platform" and falls through to the Linux
+subprocess chain. None of those tools exist on a Mac, so the user is told to
+install `grim` — on a machine whose built-in `screencapture` works perfectly.
+
+Every arm carries a control, so a machine that cannot reproduce the trap says
+so rather than quietly agreeing.
+
+Run: python development/probe_427_macos_offscreen.py
+"""
+
+import sys
+import tkinter
+from pathlib import Path
+
+from PIL import Image, ImageGrab, UnidentifiedImageError
+from screeninfo import get_monitors
+
+import bootstack as bs
+from bootstack import errors as bs_errors
+from bootstack._core import capture as cap
+
+OUT = Path(__file__).parent / "screencap_out"
+OUT.mkdir(parents=True, exist_ok=True)
+results = []
+
+
+def line(label, detail):
+    results.append((label, detail))
+    print(f"  {label:<46} {detail}")
+
+
+def run():
+    monitor = get_monitors()[0]
+    print(f"\n  display: {monitor.width}x{monitor.height} logical\n")
+
+    # --- mechanism: is UnidentifiedImageError swallowed as OSError? ---------
+    line("UnidentifiedImageError is an OSError",
+         issubclass(UnidentifiedImageError, OSError))
+    line("...so the missing-backend except catches it",
+         "yes — which is why the region has to be diagnosed separately")
+    line("capture module can read the display layout",
+         cap._covered_by_a_display((0, 0, 10, 10)) is not None)
+
+    # --- ARM 1 (control): an on-screen widget captures fine -----------------
+    root = app.tk
+    root.geometry("+80+80")
+    root.update()
+    cap.settle(root, 0.2)
+    try:
+        on_screen = card.capture(OUT / "probe-onscreen.png")
+        with Image.open(on_screen) as img:
+            line("CONTROL on-screen capture", f"OK {img.size}")
+        control_ok = True
+    except Exception as exc:  # noqa: BLE001 - reporting, not handling
+        line("CONTROL on-screen capture", f"{type(exc).__name__}: {exc}")
+        control_ok = False
+
+    if not control_ok:
+        line("VERDICT", "control failed — the rest proves nothing")
+        report()
+        return
+
+    # --- ARM 2: the exact region the suite asks for ------------------------
+    offscreen_bbox = (97, 2810, 170, 2830)
+    try:
+        ImageGrab.grab(bbox=offscreen_bbox, all_screens=True)
+        line("raw ImageGrab on the suite's bbox", "returned an image (no trap)")
+    except Exception as exc:  # noqa: BLE001
+        line("raw ImageGrab on the suite's bbox", f"{type(exc).__name__}")
+
+    try:
+        cap.capture_region(offscreen_bbox, OUT / "probe-offscreen.png")
+        line("capture_region on that bbox", "succeeded (no trap here)")
+    except bs_errors.BootstackError as exc:
+        first = str(exc).split("—")[0].strip().rstrip(".")
+        line("capture_region on that bbox", f"BootstackError: {first}")
+        line("  ^ message mentions Linux-only tools",
+             "grim" in str(exc) or "XCB" in str(exc))
+    except Exception as exc:  # noqa: BLE001
+        line("capture_region on that bbox", f"{type(exc).__name__}: {exc}")
+
+    # --- ARM 3: a real window dragged below the screen ---------------------
+    # The user-reachable version of the same thing: no test harness involved.
+    root.geometry(f"+120+{monitor.height + 200}")
+    root.update()
+    cap.settle(root, 0.3)
+    line("window moved to y", root.winfo_rooty())
+    try:
+        app.capture(OUT / "probe-window-offscreen.png")
+        line("capture() on an off-screen window", "succeeded")
+    except bs_errors.BootstackError as exc:
+        first = str(exc).split("—")[0].strip().rstrip(".")
+        line("capture() on an off-screen window", f"BootstackError: {first}")
+    except Exception as exc:  # noqa: BLE001
+        line("capture() on an off-screen window", f"{type(exc).__name__}: {exc}")
+
+    # --- ARM 4: half off the bottom edge -----------------------------------
+    root.geometry(f"+140+{monitor.height - 120}")
+    root.update()
+    cap.settle(root, 0.3)
+    try:
+        partial = app.capture(OUT / "probe-window-partial.png")
+        with Image.open(partial) as img:
+            line("capture() on a half-off-screen window", f"OK {img.size}")
+    except Exception as exc:  # noqa: BLE001
+        line("capture() on a half-off-screen window",
+             f"{type(exc).__name__}: {str(exc).split('—')[0].strip()}")
+
+    # --- ARM 5: is screencapture itself fine? ------------------------------
+    # Proves the platform tool works and only the region was the problem.
+    import shutil
+    line("screencapture on PATH", bool(shutil.which("screencapture")))
+    line("no Linux backend installed",
+         not any(shutil.which(n) for n, _ in cap._SUBPROCESS_BACKENDS))
+
+    root.geometry("+80+80")
+    root.update()
+    report()
+
+
+def report():
+    print(f"\n  {len(results)} measurements\n")
+    app.close()
+
+
+if sys.platform != "darwin":
+    print("This probe measures the macOS path; run it on a Mac.")
+    raise SystemExit(0)
+
+print(f"\n  tk {tkinter.TkVersion}  pillow {Image.__version__}")
+
+with bs.App(title="Off-screen capture probe", padding=16, gap=10,
+            size=(480, 300)) as app:
+    bs.Label("Off-screen capture probe", font="heading-lg")
+    with bs.Card(padding=12, gap=6) as card:
+        bs.Label("Card content", accent="primary")
+        bs.Button("Colored", accent="primary")
+
+app.schedule.delay(600, run)
+app.run()

--- a/development/probe_427_review_fixes.py
+++ b/development/probe_427_review_fixes.py
@@ -1,0 +1,69 @@
+"""Controls for the #427 review fixes — proves each guard had something to catch.
+
+A guard that is never exercised is indistinguishable from a guard that is not
+needed, so each check here reproduces the PRE-FIX behavior directly rather than
+trusting the description of it. Run with `py -3.12`.
+"""
+from __future__ import annotations
+
+import tkinter
+from tkinter import ttk
+
+from PIL import Image
+
+print("1. PIL crops past the edge by PADDING WITH BLACK, silently")
+desktop = Image.new("RGB", (1920, 1080), "white")
+outside = desktop.crop((1930, 10, 2200, 300))  # the pre-fix line, verbatim
+colors = outside.getcolors()
+print(f"   crop((1930, 10, 2200, 300)) -> size={outside.size} colors={colors}")
+assert colors == [(outside.size[0] * outside.size[1], (0, 0, 0))], colors
+print("   CONFIRMED: an all-black image, no exception. Nothing to debug.\n")
+
+print("2. The pre-fix save() gate (mode == 'RGBA') misses a palette image")
+palette = Image.new("P", (4, 4))
+pre_fix_would_convert = palette.mode == "RGBA"
+print(f"   mode={palette.mode!r} -> pre-fix converts? {pre_fix_would_convert}")
+assert not pre_fix_would_convert
+try:
+    palette.save("_probe_427.jpg")
+except OSError as exc:
+    print(f"   CONFIRMED: unconverted .jpg save raises -> {exc}\n")
+else:  # pragma: no cover - would mean Pillow started accepting mode P
+    raise SystemExit("   Pillow accepted mode P as JPEG; finding is stale")
+finally:
+    import os
+
+    if os.path.exists("_probe_427.jpg"):
+        os.remove("_probe_427.jpg")
+
+print("3. A negative inset EXPANDS the rectangle past the widget")
+x, y, width, height, inset = 100, 100, 60, 20, -8
+left, top = x + inset, y + inset
+right, bottom = x + width - inset, y + height - inset
+print(f"   widget=({x}, {y}) {width}x{height}, inset={inset}")
+print(f"   -> ({left}, {top}) to ({right}, {bottom})")
+assert right - left == width - 2 * inset == 76
+print("   CONFIRMED: 60x20 widget yields a 76x36 grab, and the pre-fix")
+print("   `right <= left` guard cannot see it — the box only got bigger.\n")
+
+print("4. winfo_ismapped() on a destroyed widget — raw TclError, or clean 0?")
+root = tkinter.Tk()
+root.geometry("200x100+50+50")
+root.deiconify()
+root.update()
+label = ttk.Label(root, text="probe")
+label.pack()
+root.update()
+print(f"   alive: ismapped={label.winfo_ismapped()} exists={label.winfo_exists()}")
+label.destroy()
+root.update()
+print(f"   destroyed: exists={label.winfo_exists()}")
+try:
+    mapped = label.winfo_ismapped()
+except tkinter.TclError as exc:
+    print(f"   CONFIRMED: ismapped() RAISES -> {type(exc).__name__}: {exc}")
+    print("   Pre-fix, that escaped capture() as a raw toolkit error.")
+else:  # pragma: no cover - would mean the finding was wrong
+    print(f"   ismapped() returned {mapped} without raising.")
+    print("   The pre-fix path gave a clean BootstackError; finding overstated.")
+root.destroy()

--- a/development/probe_427_review_verify.py
+++ b/development/probe_427_review_verify.py
@@ -1,0 +1,139 @@
+"""Independent verification of the #427 review's findings 1 and 2.
+
+Both are claims about guards in `PublicWidgetBase.capture()`, and both would be
+real defects if true, so neither is taken on trust. Every arm carries a control
+so an arm that cannot reproduce its trap says so rather than quietly agreeing.
+
+FINDING 1: a widget scrolled out of view inside a `ScrollView` stays mapped, so
+the `winfo_ismapped()` guard passes and the grab reads a rectangle that is not
+the widget — silently.
+
+FINDING 2: `winfo_exists()` returns 0 for a destroyed child but RAISES for a
+destroyed root, so the destroyed-target guard leaks a raw `TclError` when the
+capture target is the App itself.
+
+Run: python development/probe_427_review_verify.py
+"""
+
+import tkinter
+from pathlib import Path
+
+from PIL import Image
+
+import bootstack as bs
+from bootstack.errors import BootstackError
+
+OUT = Path(__file__).parent / "screencap_out"
+OUT.mkdir(parents=True, exist_ok=True)
+
+
+def line(label, detail):
+    print(f"  {label:<52} {detail}")
+
+
+def distinct(path):
+    with Image.open(path) as img:
+        colors = img.convert("RGB").getcolors(maxcolors=1_000_000)
+    return len(colors) if colors else 999_999
+
+
+def finding_2_destroyed_root():
+    """winfo_exists() on a destroyed ROOT vs a destroyed CHILD."""
+    print("\n--- FINDING 2: destroyed target ---")
+
+    # Control: a destroyed CHILD reports 0 and does not raise.
+    root = tkinter.Tk()
+    root.geometry("200x100+100+100")
+    child = tkinter.Label(root, text="x")
+    child.pack()
+    root.update_idletasks()
+    child.destroy()
+    try:
+        line("CONTROL destroyed child winfo_exists()", child.winfo_exists())
+    except tkinter.TclError as exc:
+        line("CONTROL destroyed child winfo_exists()", f"raised {exc}")
+    root.destroy()
+
+    # The claim: a destroyed ROOT raises instead of reporting 0.
+    root2 = tkinter.Tk()
+    root2.geometry("200x100+100+100")
+    root2.update_idletasks()
+    root2.destroy()
+    try:
+        line("destroyed ROOT winfo_exists()", root2.winfo_exists())
+        line("VERDICT finding 2", "NOT reproduced — it returned a value")
+    except tkinter.TclError as exc:
+        line("destroyed ROOT winfo_exists()", f"RAISED TclError: {exc}")
+        line("VERDICT finding 2", "REPRODUCED")
+
+
+def finding_1_scrolled_out(app, rows, view):
+    """A row scrolled out of the viewport: still mapped? grab still succeeds?"""
+    print("\n--- FINDING 1: clipped by a scroll viewport ---")
+
+    top = app.tk
+    tw, th = top.winfo_width(), top.winfo_height()
+    ty, tx = top.winfo_rooty(), top.winfo_rootx()
+    line("window rect (x, y, w, h)", f"({tx}, {ty}, {tw}, {th})")
+
+    # Control arm: the FIRST row is inside the viewport and captures normally.
+    first = rows[0]
+    shot = first.capture(OUT / "review-row-visible.png", settle=0)
+    line("CONTROL visible row rooty", first.tk.winfo_rooty())
+    line("CONTROL visible row colors", distinct(shot))
+
+    # Scroll just far enough that row 0 leaves the viewport while its rect is
+    # still ON the display. Scrolling to the bottom pushes it ~1100px above the
+    # window, off the top of the screen, where the off-display guard catches it
+    # — that is geometry luck, not a guard doing its job, and it hides the
+    # defect being measured here.
+    view.yview_moveto(0.12)
+    top.update_idletasks()
+    top.update()
+
+    ry = first.tk.winfo_rooty()
+    mapped = first.tk.winfo_ismapped()
+    viewable = first.tk.winfo_viewable()
+    line("scrolled-out row winfo_ismapped()", mapped)
+    line("scrolled-out row winfo_viewable()", viewable)
+    line("scrolled-out row rooty", ry)
+    line("...window spans y", f"{ty} to {ty + th}")
+    outside = ry < ty or ry > ty + th
+    line("row rect lies OUTSIDE the window", outside)
+
+    if not outside:
+        line("VERDICT finding 1", "could not push the row out — arm inconclusive")
+        return
+
+    try:
+        bad = first.capture(OUT / "review-row-scrolled-out.png", settle=0)
+        colors = distinct(bad)
+        line("capture() on the scrolled-out row", f"SUCCEEDED, {colors} colors")
+        line("VERDICT finding 1",
+             "REPRODUCED — wrong pixels, no error" if colors <= 2
+             else f"succeeded with {colors} colors (captured SOMETHING else)")
+    except BootstackError as exc:
+        line("capture() on the scrolled-out row",
+             f"BootstackError: {str(exc).split('—')[0].strip()[:60]}")
+        line("VERDICT finding 1", "guarded here (may be geometry luck)")
+
+
+def run():
+    finding_1_scrolled_out(app, rows, view)
+    finding_2_destroyed_root()
+    print()
+    app.close()
+
+
+rows = []
+
+with bs.App(title="Review verify", padding=8, gap=6, size=(420, 240)) as app:
+    bs.Label("Scroll probe", font="heading-md")
+    with bs.ScrollView(scroll_direction="vertical", height=150) as view:
+        for i in range(40):
+            with bs.Card(padding=6) as row:
+                bs.Label(f"row {i}", accent="primary" if i == 0 else "default")
+            rows.append(row)
+
+app.schedule.delay(700, run)
+app.run()

--- a/development/probe_429_busy_during_settle.py
+++ b/development/probe_429_busy_during_settle.py
@@ -1,4 +1,4 @@
-"""Probe: can `tk busy` swallow input during settle() without spoiling the shot?
+"""Probe: is the `tk busy` guard held during settle, and does it spoil the shot?
 
 #429's real cost is an end-user one — an impatient second click during
 `capture(settle=)` re-enters the handler and stacks a second save dialog. Any
@@ -6,163 +6,199 @@ fix that lives in `capture()` itself is too late, because the developer's
 handler opens that dialog BEFORE it calls capture. The only place the framework
 can fix it for the end user is to stop the click being dispatched at all.
 
-`tk busy hold` is the candidate. It has to clear two bars, and failing either
-one rules it out:
+`tk busy hold` is what ships. Settling has to dispatch — the area a closed
+window uncovers is not repainted otherwise, which is the defect
+`probe_429_settle_without_input.py` records — so the guard has to block input
+while the loop turns rather than by refusing to turn it.
 
-  1. It must swallow a click that arrives during the settle window.
-  2. It must be INVISIBLE to the capture. A busy window sits over the target,
-     and the whole point of this feature is photographing that target.
+⚠ WHAT THIS PROBE CANNOT DO, AND WHY IT NO LONGER TRIES. It used to claim it
+measured whether busy SWALLOWS A CLICK. It cannot. `tk busy` intercepts input
+by putting a window over the target, so it only ever sees events the window
+system routed by pointer position, while `event_generate` aimed at a widget
+delivers straight to that widget's bindings and never consults the busy window.
+A synthesized click re-enters whether busy is held or not — arm 2 below
+demonstrates exactly that, with `tk busy status` reading 1 at the time. The
+earlier version read its own false negative as evidence and reported "busy did
+not block it". The swallowing half is a manual check:
+`development/demo_429_busy_during_settle.py`.
 
-Arm 3 is the control for arm 2: two captures of the same unchanged window with
-busy OFF, to establish how much two shots of identical content differ on their
-own. Without it, "the busy shot differs by N pixels" means nothing.
+⚠ AND ITS CONTROL USED TO DRIFT. Arms were driven through `_capture.settle`,
+so when the sleep-only version shipped the control silently became the test and
+arm 2 reported "no re-entry without busy either; arm 1 proves nothing" — true,
+but about the wrong thing. Strategies are pinned in this file now.
 
-Run:  py -3.12 development/probe_429_busy_during_settle.py
+Arms:
+
+  1. Is the window held busy WHILE settling dispatches? Structural, and the
+     one thing here that is worth automating — it is also asserted by
+     `tests/widgets/public/test_capture.py`.
+  2. Does a synthesized click re-enter anyway? It does. Kept as the standing
+     demonstration that this technique cannot answer the input question.
+  3. Is the busy window visible in the photograph? Compared against a floor
+     measured across a window RESTACK, not across two identical back-to-back
+     grabs — the old floor was two static shots, far too tight a yardstick for
+     a comparison that restacks a window, and it turned text antialiasing into
+     a reported failure.
+
+Run:  python development/probe_429_busy_during_settle.py
 """
 
 from __future__ import annotations
 
 import sys
 import tempfile
+import time
 from pathlib import Path
 
 from PIL import Image, ImageChops
 
 import bootstack as bs
+from bootstack._core import capture as _capture
 
 OUT = Path(tempfile.gettempdir()) / "bootstack-probe-429-busy"
 OUT.mkdir(parents=True, exist_ok=True)
 
 SETTLE = 0.3
+results: list[tuple[str, str]] = []
 
 
-def busy_supported(widget) -> bool:
-    """Whether `tk busy` exists, asked without destroying anything.
+def settle_dispatch_no_busy(tk_widget, seconds: float) -> None:
+    """Dispatch throughout, with NO busy guard — pinned, never imported.
 
-    Checked on a live app rather than a throwaway one: tearing a root down
-    takes the named fonts with it, and every later app in the process then
-    fails to build a button.
+    This is the pre-#429 shape, and it is what arm 3 compares against: the
+    same dispatching behavior the shipped settle has, minus the one thing
+    under test.
     """
-    try:
-        widget.winfo_toplevel().tk.call(
-            "tk", "busy", "status", widget.winfo_toplevel()._w
-        )
-        return True
-    except Exception:  # noqa: BLE001 - probing for the command's existence
-        return False
+    root = tk_widget._root()
+    root.update_idletasks()
+    root.update()
+    deadline = time.monotonic() + max(seconds, 0.0)
+    while time.monotonic() < deadline:
+        time.sleep(0.01)
+        root.update()
 
 
 def differing_pixels(a: Path, b: Path) -> tuple[int, str]:
-    """Count pixels that differ between two captures."""
     with Image.open(a) as ia, Image.open(b) as ib:
         ia, ib = ia.convert("RGB"), ib.convert("RGB")
         if ia.size != ib.size:
             return -1, f"different sizes {ia.size} vs {ib.size}"
         diff = ImageChops.difference(ia, ib)
-        count = sum(1 for px in diff.getdata() if px != (0, 0, 0))
-        return count, f"{ia.size[0]}x{ia.size[1]}"
+        return (sum(1 for px in diff.getdata() if px != (0, 0, 0)),
+                f"{ia.size[0]}x{ia.size[1]}")
 
 
-def run_arm(name: str, *, use_busy: bool, click: bool) -> tuple[int, Path]:
-    """Return (max handler nesting depth, captured path)."""
-    depth = 0
-    max_depth = 0
-    calls = 0
-    written: list[Path] = []
-    notes: list[str] = []
-
-    with bs.App(title=f"#429 busy {name}", size=(380, 160), padding=12) as app:
-        bs.Label("Capture target", font="heading-md")
-        button = bs.Button("Export", on_click=lambda: on_export())
-
-        def on_export() -> None:
-            nonlocal depth, max_depth, calls
-            calls += 1
-            depth += 1
-            max_depth = max(max_depth, depth)
-            target = app._internal
-            held = False
-            if calls == 1:
-                notes.append(f"tk busy available: {busy_supported(target)}")
-            try:
-                if use_busy:
-                    try:
-                        top = target.winfo_toplevel()
-                        top.tk.call("tk", "busy", "hold", top._w, "-cursor",
-                                    "watch")
-                        held = True
-                    except Exception as exc:  # noqa: BLE001
-                        notes.append(f"busy hold failed: {exc}")
-                written.append(app.capture(OUT / f"{name}-{calls}.png",
-                                           settle=SETTLE))
-            except Exception as exc:  # noqa: BLE001 - the probe reports
-                notes.append(f"{type(exc).__name__}: {exc}")
-            finally:
-                if held:
-                    try:
-                        top.tk.call("tk", "busy", "forget", top._w)
-                    except Exception as exc:  # noqa: BLE001
-                        notes.append(f"busy forget failed: {exc}")
-                depth -= 1
-
-        def fire_second() -> None:
-            inner = button._internal
-            inner.event_generate("<Button-1>", x=5, y=5)
-            inner.event_generate("<ButtonRelease-1>", x=5, y=5)
-
-        def start() -> None:
-            if click:
-                app.tk.after(100, fire_second)
-            on_export()
-
-        app.tk.after(400, start)
-        app.tk.after(int(SETTLE * 1000) + 2500, app.close)
-
-    app.run()
-
-    for note in notes:
-        print(f"  note: {note}")
-    print(f"  calls={calls}  max_depth={max_depth}")
-    return max_depth, (written[0] if written else Path())
+def shoot(app, name: str, settle_fn) -> Path:
+    """capture() with the settle step swapped out, and a restack first."""
+    target = app._internal
+    with _capture.raised(target):
+        settle_fn(target, SETTLE)
+        return _capture.capture_region(
+            _capture.widget_region(target, 0), OUT / f"{name}.png"
+        )
 
 
 def main() -> int:
     print(f"platform={sys.platform}  settle={SETTLE}s  out={OUT}")
-    failures = 0
+    depth = 0
+    max_depth = 0
+    busy_seen: list[str] = []
 
-    print("\n[1] busy ON, click during settle - does it swallow the click?")
-    depth, busy_shot = run_arm("busy", use_busy=True, click=True)
-    if depth == 1:
-        print("  PASS - the click did not re-enter the handler")
-    else:
-        print(f"  FAIL - re-entered at depth {depth}; busy did not block it")
-        failures += 1
+    with bs.App(title="#429 busy", size=(380, 160), padding=12) as app:
+        bs.Label("Capture target", font="heading-md")
+        button = bs.Button("Export", on_click=lambda: on_export())
+        top = app._internal.winfo_toplevel()
 
-    print("\n[2] busy OFF, click during settle - the control for arm 1")
-    depth, plain_shot = run_arm("plain", use_busy=False, click=True)
-    if depth > 1:
-        print("  PASS - re-enters without busy, so arm 1 measures the guard")
-    else:
-        print("  FAIL - no re-entry without busy either; arm 1 proves nothing")
-        failures += 1
+        def busy_status() -> str:
+            try:
+                return str(top.tk.call("tk", "busy", "status", top._w))
+            except Exception as exc:            # noqa: BLE001 - probe reports
+                return f"unavailable ({exc})"
 
-    print("\n[3] is the busy window visible in the photograph?")
-    _, baseline_a = run_arm("baseline-a", use_busy=False, click=False)
-    _, baseline_b = run_arm("baseline-b", use_busy=False, click=False)
-    noise, size_a = differing_pixels(baseline_a, baseline_b)
-    print(f"  control: two busy-OFF captures differ by {noise} px ({size_a})")
-    signal, size_b = differing_pixels(baseline_a, busy_shot)
-    print(f"  test:    busy-ON vs busy-OFF differ by {signal} px ({size_b})")
-    if signal < 0 or noise < 0:
-        print("  INCONCLUSIVE - captures are different sizes; compare by hand")
-    elif signal <= max(noise, 0) :
-        print("  PASS - busy is invisible to the capture (within its own noise)")
-    else:
-        print(f"  FAIL - busy changes the photograph by {signal - noise} px "
-              f"beyond noise; inspect {busy_shot}")
-        failures += 1
+        def on_export() -> None:
+            nonlocal depth, max_depth
+            depth += 1
+            max_depth = max(max_depth, depth)
+            try:
+                app.capture(OUT / f"export-{max_depth}-{depth}.png",
+                            settle=SETTLE)
+            finally:
+                depth -= 1
 
-    print(f"\n{'FAILURES: ' + str(failures) if failures else 'all arms as expected'}")
+        def click_the_button() -> None:
+            inner = button._internal
+            inner.event_generate("<Button-1>", x=5, y=5)
+            inner.event_generate("<ButtonRelease-1>", x=5, y=5)
+
+        def sequence() -> None:
+            nonlocal depth, max_depth
+
+            # [1] Is busy held while settling dispatches? Read from inside the
+            # settle window by a timer, which only runs because it dispatches.
+            before = busy_status()
+            app.tk.after(60, lambda: busy_seen.append(busy_status()))
+            app.capture(OUT / "structural.png", settle=SETTLE)
+            after = busy_status()
+            if busy_seen == ["1"] and before == "0" and after == "0":
+                results.append(("[1] busy held while settling dispatched",
+                                "PASS - 0 before, 1 during, 0 after"))
+            elif not busy_seen:
+                results.append(("[1] busy held while settling dispatched",
+                                "FAIL - the timer never fired, so settling "
+                                "dispatched nothing at all"))
+            else:
+                results.append(("[1] busy held while settling dispatched",
+                                f"FAIL - before={before} during={busy_seen} "
+                                f"after={after}"))
+
+            # [2] The blind spot, kept deliberately.
+            depth = max_depth = 0
+            app.tk.after(80, click_the_button)
+            on_export()
+            if max_depth > 1:
+                results.append((
+                    "[2] synthesized click during settle",
+                    f"AS EXPECTED - re-entered to depth {max_depth} WITH busy "
+                    f"held; event_generate bypasses the busy window, so this "
+                    f"technique cannot test the guard. Use the manual demo."))
+            else:
+                results.append((
+                    "[2] synthesized click during settle",
+                    "UNEXPECTED - did not re-enter. That is not evidence busy "
+                    "worked; check the click fired at all before believing it."))
+
+            # [3] Is the busy window visible? Floor measured across a restack.
+            a = shoot(app, "floor-a", settle_dispatch_no_busy)
+            b = shoot(app, "floor-b", settle_dispatch_no_busy)
+            floor, size = differing_pixels(a, b)
+            results.append(("[3] noise floor across a restack",
+                            f"{floor} px ({size})"))
+            shipped = shoot(app, "shipped", _capture.settle)
+            signal, _ = differing_pixels(a, shipped)
+            if signal < 0 or floor < 0:
+                results.append(("[3] busy visible in the photograph?",
+                                "INCONCLUSIVE - sizes differ, compare by hand"))
+            elif signal <= floor:
+                results.append(("[3] busy visible in the photograph?",
+                                f"PASS - {signal} px vs a {floor} px floor; "
+                                f"invisible"))
+            else:
+                results.append(("[3] busy visible in the photograph?",
+                                f"FAIL - {signal} px vs a {floor} px floor; "
+                                f"inspect {shipped}"))
+
+            app.close()
+
+        app.tk.after(600, sequence)
+        app.tk.after(30000, app.close)
+
+    app.run()
+
+    print()
+    for label, verdict in results:
+        print(f"  {label}: {verdict}")
+    failures = [v for _, v in results if v.startswith("FAIL")]
+    print(f"\n{'FAILURES: ' + str(len(failures)) if failures else 'all arms as expected'}")
     print(f"images in {OUT}")
     return 1 if failures else 0
 

--- a/development/probe_429_busy_during_settle.py
+++ b/development/probe_429_busy_during_settle.py
@@ -29,9 +29,15 @@ but about the wrong thing. Strategies are pinned in this file now.
 
 Arms:
 
-  1. Is the window held busy WHILE settling dispatches? Structural, and the
-     one thing here that is worth automating — it is also asserted by
-     `tests/widgets/public/test_capture.py`.
+  0. IS THE HOLD REAL ON THIS PLATFORM? `tk busy status` is not the answer —
+     macOS returns 1 for a busy window it never maps. The answer is whether
+     that window is MAPPED and whether Tk's own hit test at a button inside
+     the target resolves to it or to the button. This arm is the automatable
+     substitute for the manual click check, and it is the arm that would have
+     caught the macOS hole immediately. Measured on Tk 8.6.17/aqua:
+     status=1, mapped=0, hit=the button.
+  1. Is the window held busy WHILE settling dispatches? Structural, and it is
+     also asserted by `tests/widgets/public/test_capture.py`.
   2. Does a synthesized click re-enter anyway? It does. Kept as the standing
      demonstration that this technique cannot answer the input question.
   3. Is the busy window visible in the photograph? Compared against a floor
@@ -133,6 +139,33 @@ def main() -> int:
         def sequence() -> None:
             nonlocal depth, max_depth
 
+            # [0] Does the hold DO anything here? status is not evidence.
+            inner = button._internal
+            px, py = inner.winfo_rootx() + 5, inner.winfo_rooty() + 5
+            top.tk.call("tk", "busy", "hold", top._w)
+            app.tk.update()
+            busy_windows = [str(w) for w in
+                            top.tk.splitlist(top.tk.call("winfo", "children",
+                                                         top._w))
+                            if "Busy" in str(w)]
+            mapped = [w for w in busy_windows
+                      if str(top.tk.call("winfo", "ismapped", w)) == "1"]
+            hit = str(top.tk.call("winfo", "containing", px, py))
+            top.tk.call("tk", "busy", "forget", top._w)
+            app.tk.update()
+            if mapped and hit not in (str(inner), str(inner._w)):
+                results.append((
+                    "[0] is the hold real on this platform",
+                    f"YES - busy window mapped and the hit test at the button "
+                    f"resolves to {hit!r}; input should be blocked here"))
+            else:
+                results.append((
+                    "[0] is the hold real on this platform",
+                    f"NO - busy windows {busy_windows or 'none'}, mapped "
+                    f"{mapped or 'none'}, hit test at the button resolves to "
+                    f"{hit!r}. The hold is accepted and does nothing, so a "
+                    f"real click re-enters. Known on macOS/aqua."))
+
             # [1] Is busy held while settling dispatches? Read from inside the
             # settle window by a timer, which only runs because it dispatches.
             before = busy_status()
@@ -179,9 +212,12 @@ def main() -> int:
                 results.append(("[3] busy visible in the photograph?",
                                 "INCONCLUSIVE - sizes differ, compare by hand"))
             elif signal <= floor:
-                results.append(("[3] busy visible in the photograph?",
-                                f"PASS - {signal} px vs a {floor} px floor; "
-                                f"invisible"))
+                results.append((
+                    "[3] busy visible in the photograph?",
+                    f"PASS - {signal} px vs a {floor} px floor; invisible. "
+                    f"⚠ READ THIS WITH ARM 0: where the hold is not real the "
+                    f"window is never mapped, so invisibility is trivially "
+                    f"true and says nothing about a platform that maps it."))
             else:
                 results.append(("[3] busy visible in the photograph?",
                                 f"FAIL - {signal} px vs a {floor} px floor; "

--- a/development/probe_429_busy_during_settle.py
+++ b/development/probe_429_busy_during_settle.py
@@ -1,0 +1,171 @@
+"""Probe: can `tk busy` swallow input during settle() without spoiling the shot?
+
+#429's real cost is an end-user one — an impatient second click during
+`capture(settle=)` re-enters the handler and stacks a second save dialog. Any
+fix that lives in `capture()` itself is too late, because the developer's
+handler opens that dialog BEFORE it calls capture. The only place the framework
+can fix it for the end user is to stop the click being dispatched at all.
+
+`tk busy hold` is the candidate. It has to clear two bars, and failing either
+one rules it out:
+
+  1. It must swallow a click that arrives during the settle window.
+  2. It must be INVISIBLE to the capture. A busy window sits over the target,
+     and the whole point of this feature is photographing that target.
+
+Arm 3 is the control for arm 2: two captures of the same unchanged window with
+busy OFF, to establish how much two shots of identical content differ on their
+own. Without it, "the busy shot differs by N pixels" means nothing.
+
+Run:  py -3.12 development/probe_429_busy_during_settle.py
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+
+from PIL import Image, ImageChops
+
+import bootstack as bs
+
+OUT = Path(tempfile.gettempdir()) / "bootstack-probe-429-busy"
+OUT.mkdir(parents=True, exist_ok=True)
+
+SETTLE = 0.3
+
+
+def busy_supported(widget) -> bool:
+    """Whether `tk busy` exists, asked without destroying anything.
+
+    Checked on a live app rather than a throwaway one: tearing a root down
+    takes the named fonts with it, and every later app in the process then
+    fails to build a button.
+    """
+    try:
+        widget.winfo_toplevel().tk.call(
+            "tk", "busy", "status", widget.winfo_toplevel()._w
+        )
+        return True
+    except Exception:  # noqa: BLE001 - probing for the command's existence
+        return False
+
+
+def differing_pixels(a: Path, b: Path) -> tuple[int, str]:
+    """Count pixels that differ between two captures."""
+    with Image.open(a) as ia, Image.open(b) as ib:
+        ia, ib = ia.convert("RGB"), ib.convert("RGB")
+        if ia.size != ib.size:
+            return -1, f"different sizes {ia.size} vs {ib.size}"
+        diff = ImageChops.difference(ia, ib)
+        count = sum(1 for px in diff.getdata() if px != (0, 0, 0))
+        return count, f"{ia.size[0]}x{ia.size[1]}"
+
+
+def run_arm(name: str, *, use_busy: bool, click: bool) -> tuple[int, Path]:
+    """Return (max handler nesting depth, captured path)."""
+    depth = 0
+    max_depth = 0
+    calls = 0
+    written: list[Path] = []
+    notes: list[str] = []
+
+    with bs.App(title=f"#429 busy {name}", size=(380, 160), padding=12) as app:
+        bs.Label("Capture target", font="heading-md")
+        button = bs.Button("Export", on_click=lambda: on_export())
+
+        def on_export() -> None:
+            nonlocal depth, max_depth, calls
+            calls += 1
+            depth += 1
+            max_depth = max(max_depth, depth)
+            target = app._internal
+            held = False
+            if calls == 1:
+                notes.append(f"tk busy available: {busy_supported(target)}")
+            try:
+                if use_busy:
+                    try:
+                        top = target.winfo_toplevel()
+                        top.tk.call("tk", "busy", "hold", top._w, "-cursor",
+                                    "watch")
+                        held = True
+                    except Exception as exc:  # noqa: BLE001
+                        notes.append(f"busy hold failed: {exc}")
+                written.append(app.capture(OUT / f"{name}-{calls}.png",
+                                           settle=SETTLE))
+            except Exception as exc:  # noqa: BLE001 - the probe reports
+                notes.append(f"{type(exc).__name__}: {exc}")
+            finally:
+                if held:
+                    try:
+                        top.tk.call("tk", "busy", "forget", top._w)
+                    except Exception as exc:  # noqa: BLE001
+                        notes.append(f"busy forget failed: {exc}")
+                depth -= 1
+
+        def fire_second() -> None:
+            inner = button._internal
+            inner.event_generate("<Button-1>", x=5, y=5)
+            inner.event_generate("<ButtonRelease-1>", x=5, y=5)
+
+        def start() -> None:
+            if click:
+                app.tk.after(100, fire_second)
+            on_export()
+
+        app.tk.after(400, start)
+        app.tk.after(int(SETTLE * 1000) + 2500, app.close)
+
+    app.run()
+
+    for note in notes:
+        print(f"  note: {note}")
+    print(f"  calls={calls}  max_depth={max_depth}")
+    return max_depth, (written[0] if written else Path())
+
+
+def main() -> int:
+    print(f"platform={sys.platform}  settle={SETTLE}s  out={OUT}")
+    failures = 0
+
+    print("\n[1] busy ON, click during settle - does it swallow the click?")
+    depth, busy_shot = run_arm("busy", use_busy=True, click=True)
+    if depth == 1:
+        print("  PASS - the click did not re-enter the handler")
+    else:
+        print(f"  FAIL - re-entered at depth {depth}; busy did not block it")
+        failures += 1
+
+    print("\n[2] busy OFF, click during settle - the control for arm 1")
+    depth, plain_shot = run_arm("plain", use_busy=False, click=True)
+    if depth > 1:
+        print("  PASS - re-enters without busy, so arm 1 measures the guard")
+    else:
+        print("  FAIL - no re-entry without busy either; arm 1 proves nothing")
+        failures += 1
+
+    print("\n[3] is the busy window visible in the photograph?")
+    _, baseline_a = run_arm("baseline-a", use_busy=False, click=False)
+    _, baseline_b = run_arm("baseline-b", use_busy=False, click=False)
+    noise, size_a = differing_pixels(baseline_a, baseline_b)
+    print(f"  control: two busy-OFF captures differ by {noise} px ({size_a})")
+    signal, size_b = differing_pixels(baseline_a, busy_shot)
+    print(f"  test:    busy-ON vs busy-OFF differ by {signal} px ({size_b})")
+    if signal < 0 or noise < 0:
+        print("  INCONCLUSIVE - captures are different sizes; compare by hand")
+    elif signal <= max(noise, 0) :
+        print("  PASS - busy is invisible to the capture (within its own noise)")
+    else:
+        print(f"  FAIL - busy changes the photograph by {signal - noise} px "
+              f"beyond noise; inspect {busy_shot}")
+        failures += 1
+
+    print(f"\n{'FAILURES: ' + str(failures) if failures else 'all arms as expected'}")
+    print(f"images in {OUT}")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/development/probe_429_busy_during_settle.py
+++ b/development/probe_429_busy_during_settle.py
@@ -215,7 +215,7 @@ def main() -> int:
                 results.append((
                     "[3] busy visible in the photograph?",
                     f"PASS - {signal} px vs a {floor} px floor; invisible. "
-                    f"⚠ READ THIS WITH ARM 0: where the hold is not real the "
+                    f"READ THIS WITH ARM 0: where the hold is not real the "
                     f"window is never mapped, so invisibility is trivially "
                     f"true and says nothing about a platform that maps it."))
             else:

--- a/development/probe_429_capture_reentrancy.py
+++ b/development/probe_429_capture_reentrancy.py
@@ -1,0 +1,134 @@
+"""Probe: does a click during `capture(settle=)` re-enter the handler? (#429)
+
+`settle()` turns the event loop so the desktop can repaint, which means
+anything queued runs there too — including another click on the button that
+started the capture. #427's review found this by reading; nothing had ever
+reproduced it.
+
+The invariant measured here is NESTING DEPTH, not call count. A handler called
+twice in a row is ordinary; a handler entered a second time while the first
+call is still inside `capture()` is the defect. Depth is what tells them apart,
+and it is what a fix has to move.
+
+MEASURED, and the reason `settle()` no longer turns the event loop:
+
+  before the fix   arm 1 depth 2, arm 3 depth 2   (re-entered mid-capture)
+  after the fix    every arm depth 1, calls 2     (serialized, nothing lost)
+
+`calls=2` after the fix is the half worth keeping in view — the second click is
+not swallowed, it just waits its turn, so the person clicking still gets what
+they asked for and never sees a stacked dialog.
+
+Three arms, each printing PASS/FAIL against the FIXED behavior:
+
+  1. guard   — a queued call lands during a 0.3s settle. Expect depth 1;
+     depth 2 means the re-entrancy is back.
+  2. control — the same queued call lands after the capture returns. Expect
+     depth 1 and calls 2. This arm is what proves arm 1 measures nesting
+     rather than "the handler only ran once", and it read depth 1 both before
+     and after the fix.
+  3. click   — arm 1 driven by a synthesized button release, confirming real
+     input takes the same path as a queued callback.
+
+Run it on any box with a display:  py -3.12 development/probe_429_capture_reentrancy.py
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+
+import bootstack as bs
+
+OUT = Path(tempfile.gettempdir()) / "bootstack-probe-429"
+OUT.mkdir(parents=True, exist_ok=True)
+
+SETTLE = 0.3
+
+
+def run_arm(name: str, *, queue_delay_ms: int, use_click: bool) -> int:
+    """Return the maximum handler nesting depth observed."""
+    depth = 0
+    max_depth = 0
+    calls = 0
+    errors: list[str] = []
+
+    with bs.App(title=f"#429 {name}", size=(360, 140), padding=12) as app:
+        button = bs.Button("Export", on_click=lambda: on_export())
+
+        def on_export() -> None:
+            nonlocal depth, max_depth, calls
+            calls += 1
+            depth += 1
+            max_depth = max(max_depth, depth)
+            try:
+                app.capture(OUT / f"{name}-{calls}.png", settle=SETTLE)
+            except Exception as exc:  # noqa: BLE001 - the probe reports, never raises
+                errors.append(f"{type(exc).__name__}: {exc}")
+            finally:
+                depth -= 1
+
+        def fire_second() -> None:
+            if use_click:
+                # A real release over the widget is what runs a ttk command.
+                inner = button._internal
+                inner.event_generate("<Button-1>", x=5, y=5)
+                inner.event_generate("<ButtonRelease-1>", x=5, y=5)
+            else:
+                on_export()
+
+        def start() -> None:
+            # Queue the second invocation, then start the first capture. The
+            # delay decides whether it lands inside the settle window or after
+            # it, which is the only difference between arms 1 and 2.
+            app.tk.after(queue_delay_ms, fire_second)
+            on_export()
+
+        app.tk.after(400, start)
+        app.tk.after(int(SETTLE * 1000) + 2500, app.close)
+
+    app.run()
+
+    verdict = "re-entered" if max_depth > 1 else "not re-entered"
+    print(f"  calls={calls}  max_depth={max_depth}  ({verdict})")
+    for err in errors:
+        print(f"  error: {err}")
+    return max_depth
+
+
+def main() -> int:
+    print(f"platform={sys.platform}  settle={SETTLE}s  out={OUT}")
+    failures = 0
+
+    print("\n[1] guard — second call queued INSIDE the settle window")
+    depth = run_arm("repro", queue_delay_ms=100, use_click=False)
+    if depth == 1:
+        print("  PASS - settling did not dispatch it; no re-entry (was depth 2)")
+    else:
+        print("  FAIL - #429 is back: the handler re-entered during settle()")
+        failures += 1
+
+    print("\n[2] control — same call queued AFTER the capture returns")
+    depth = run_arm("control", queue_delay_ms=int(SETTLE * 1000) + 900,
+                    use_click=False)
+    if depth == 1:
+        print("  PASS - two sequential calls, no nesting (arm 1 measures nesting)")
+    else:
+        print(f"  FAIL - control nested at depth {depth}; arm 1 proves nothing")
+        failures += 1
+
+    print("\n[3] click — a synthesized button release inside the settle window")
+    depth = run_arm("click", queue_delay_ms=100, use_click=True)
+    if depth == 1:
+        print("  PASS - real input waits its turn too (was depth 2)")
+    else:
+        print("  FAIL - a real click still re-enters mid-capture")
+        failures += 1
+
+    print(f"\n{'FAILURES: ' + str(failures) if failures else 'all arms as expected'}")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/development/probe_429_capture_reentrancy.py
+++ b/development/probe_429_capture_reentrancy.py
@@ -10,25 +10,42 @@ twice in a row is ordinary; a handler entered a second time while the first
 call is still inside `capture()` is the defect. Depth is what tells them apart,
 and it is what a fix has to move.
 
-MEASURED, and the reason `settle()` no longer turns the event loop:
+⚠ THIS PROBE'S EXPECTATIONS WERE WRITTEN AGAINST A FIX THAT WAS REVERSED, AND
+NEITHER OF ITS RE-ENTRY ARMS TESTS WHAT NOW GUARDS THE CAPTURE. Settling was
+briefly changed to dispatch nothing at all, and both arms below were tuned to
+that. It could not stay: on macOS the area a closed dialog uncovers is never
+repainted without dispatch, so the capture photographed the dismissed dialog —
+51400 of 60800 pixels wrong, through the public method. Settling dispatches
+again, and blocks INPUT with `tk busy` for the duration instead. See
+`probe_429_settle_without_input.py`.
 
-  before the fix   arm 1 depth 2, arm 3 depth 2   (re-entered mid-capture)
-  after the fix    every arm depth 1, calls 2     (serialized, nothing lost)
+What that means for each arm here, all of it measured:
 
-`calls=2` after the fix is the half worth keeping in view — the second click is
-not swallowed, it just waits its turn, so the person clicking still gets what
-they asked for and never sees a stacked dialog.
+  arm 1 drives the handler from a TIMER, and `tk busy` blocks input, not
+  scheduled work — so it re-enters, at depth 2, by design rather than by
+  defect. It is kept because that is the honest limitation of the guard: a
+  capture started from a timer can overlap one already running.
 
-Three arms, each printing PASS/FAIL against the FIXED behavior:
+  arm 3 synthesizes a click, which cannot test the guard at all —
+  `event_generate` aimed at a widget delivers straight to its bindings and
+  never consults the busy window, so it re-enters whether busy is held or not,
+  with `tk busy status` reading 1 at the time.
 
-  1. guard   — a queued call lands during a 0.3s settle. Expect depth 1;
-     depth 2 means the re-entrancy is back.
-  2. control — the same queued call lands after the capture returns. Expect
+The one question this probe was built for — does a REAL second click re-enter —
+is now a manual check: `development/demo_429_busy_during_settle.py`.
+
+The invariant measured is NESTING DEPTH, not call count. A handler called twice
+in a row is ordinary; a handler entered a second time while the first call is
+still inside `capture()` is the defect. Depth is what tells them apart.
+
+Three arms:
+
+  1. scheduled — a queued call lands during a 0.3s settle. Depth 2 EXPECTED:
+     the guard is on input, and a timer is not input.
+  2. control   — the same queued call lands after the capture returns. Expect
      depth 1 and calls 2. This arm is what proves arm 1 measures nesting
-     rather than "the handler only ran once", and it read depth 1 both before
-     and after the fix.
-  3. click   — arm 1 driven by a synthesized button release, confirming real
-     input takes the same path as a queued callback.
+     rather than "the handler only ran once".
+  3. synthetic click — depth 2 EXPECTED, and it says nothing about the guard.
 
 Run it on any box with a display:  py -3.12 development/probe_429_capture_reentrancy.py
 """
@@ -101,12 +118,15 @@ def main() -> int:
     print(f"platform={sys.platform}  settle={SETTLE}s  out={OUT}")
     failures = 0
 
-    print("\n[1] guard — second call queued INSIDE the settle window")
+    print("\n[1] scheduled — second call queued INSIDE the settle window")
     depth = run_arm("repro", queue_delay_ms=100, use_click=False)
-    if depth == 1:
-        print("  PASS - settling did not dispatch it; no re-entry (was depth 2)")
+    if depth > 1:
+        print("  AS EXPECTED - a timer re-enters; the guard is on input, and "
+              "scheduled work is not input. This is the guard's known limit.")
     else:
-        print("  FAIL - #429 is back: the handler re-entered during settle()")
+        print("  UNEXPECTED - a timer did not re-enter. Either settling "
+              "stopped dispatching (which breaks the repaint — see "
+              "probe_429_settle_without_input.py) or the timer never fired.")
         failures += 1
 
     print("\n[2] control — same call queued AFTER the capture returns")
@@ -118,12 +138,16 @@ def main() -> int:
         print(f"  FAIL - control nested at depth {depth}; arm 1 proves nothing")
         failures += 1
 
-    print("\n[3] click — a synthesized button release inside the settle window")
+    print("\n[3] synthetic click — a button release inside the settle window")
     depth = run_arm("click", queue_delay_ms=100, use_click=True)
-    if depth == 1:
-        print("  PASS - real input waits its turn too (was depth 2)")
+    if depth > 1:
+        print("  AS EXPECTED - and it proves nothing about the guard: a "
+              "synthesized click bypasses the busy window entirely. Whether a "
+              "REAL click is swallowed is manual — "
+              "development/demo_429_busy_during_settle.py")
     else:
-        print("  FAIL - a real click still re-enters mid-capture")
+        print("  UNEXPECTED - check the click fired at all before reading "
+              "this as the guard working; it cannot be what stopped it.")
         failures += 1
 
     print(f"\n{'FAILURES: ' + str(failures) if failures else 'all arms as expected'}")

--- a/development/probe_429_settle_without_input.py
+++ b/development/probe_429_settle_without_input.py
@@ -1,16 +1,26 @@
 """Probe: can settle() wait WITHOUT dispatching input, and still repaint? (#429)
 
-`settle()` runs `root.update()` in its wait loop. That is what lets a queued
-click re-enter the handler (#429) — and it is also what the current docstring
-promises ("the interface stays responsive while this waits"). The promise is
-the bug.
+⚠ ANSWERED — NO, and this probe is kept as the record of how that was
+established. On macOS the area a closed window uncovers is repainted only
+while the event loop is turning. A sleep-only settle photographs the dialog
+that was just dismissed: measured at 51400 of 60800 pixels wrong through the
+public `capture()`, following the pattern its own docstring teaches. What
+ships now dispatches, and blocks input with `tk busy` instead.
 
-The alternative is to flush our own drawing and then simply sleep. No input is
-dispatched, so an impatient second click waits its turn instead of stacking a
-second save dialog on the end user. The question is whether the capture is
-still CORRECT: the area a just-closed dialog uncovered has to be repainted
-before the pixels are read, and repaint may need event processing we would no
-longer be doing.
+The original question was the reverse. `settle()` ran `root.update()` in its
+wait loop, which is what let a queued click re-enter the handler (#429), so
+the alternative was to flush our own drawing and simply sleep — no dispatch,
+so an impatient second click waits its turn rather than stacking a second save
+dialog. The open half was whether the capture stayed CORRECT, since repaint
+might need the very event processing that removes. It does.
+
+⚠ THE PROBE ITSELF IS THE OTHER LESSON. Its control used to call
+`_capture.settle`, so when the sleep-only version shipped the control BECAME
+the test — two arms running identical code, byte-identical images, and a
+"control" that could no longer disagree with what it was controlling for. It
+reported three FAILs that said nothing about the question. Every strategy is
+now pinned in this file; only the explicitly-labeled `shipped` arm reads the
+live implementation.
 
 ⚠ EVERY COMPARED CAPTURE COMES FROM ONE APP INSTANCE. An earlier version of
 this probe took each arm from its own `bs.App` and read a 59,988-pixel
@@ -25,16 +35,19 @@ Arms, all captured from the same window and compared against a reference shot
 of it with nothing ever placed over it:
 
   ref     — the yardstick.
-  update  — a window is closed just before the shot; settle uses update().
-            The CONTROL: today's behavior must come back clean, or the
-            scenario is broken and the sleep-only arm proves nothing.
-  sleep   — the same, with a sleep-only settle. Clean means repaint does not
-            need us to pump the loop.
+  update  — a window is closed just before the shot; settle dispatches
+            throughout. The CONTROL: it must come back clean, or the scenario
+            is broken and the sleep-only arm proves nothing.
+  sleep   — the same, with a sleep-only settle. Expected to come back STALE:
+            that is the defect, reproduced.
+  shipped — the same again, through whatever `_capture.settle` currently is.
+            Must match the `update` arm.
   busy    — `tk busy hold` in force during the shot, to settle whether the
-            busy window is photographed.
+            busy window is photographed. It is not.
 
-Then the point of the whole exercise: a click arriving during a sleep-only
-settle, which must NOT re-enter the handler.
+Then a click arriving during a sleep-only settle — which shows only that such
+a settle dispatches nothing. It cannot test the `tk busy` guard; see the note
+at that arm.
 
 Run:  py -3.12 development/probe_429_settle_without_input.py
 """
@@ -61,16 +74,42 @@ SETTLE = 0.3
 results: list[tuple[str, str]] = []
 
 
+# ⚠ EVERY STRATEGY BELOW IS DEFINED HERE, NOT IMPORTED FROM `_capture`.
+# This probe originally took its control from `_capture.settle` itself. When
+# the sleep-only change shipped, the control silently BECAME the test: both
+# arms ran identical code, produced byte-identical images, and the probe went
+# on reporting a "control" that could no longer fail differently from what it
+# was controlling for. Pin the comparison, or it drifts with the source.
+def settle_update_loop(tk_widget, seconds: float) -> None:
+    """The pre-#429 settle: dispatch throughout the wait."""
+    root = tk_widget._root()
+    root.update_idletasks()
+    root.update()
+    deadline = time.monotonic() + max(seconds, 0.0)
+    while time.monotonic() < deadline:
+        time.sleep(0.01)
+        root.update()
+
+
 def settle_sleep_only(tk_widget, seconds: float) -> None:
-    """Flush our own drawing, then wait without dispatching anything."""
+    """The first pass at #429: flush our drawing, then wait dispatching nothing.
+
+    ⚠ Kept as an arm rather than deleted, because it is the shape that caused
+    the defect: on macOS the area a closed window uncovers is never repainted
+    without dispatch, so the capture photographs the dismissed dialog.
+    """
     root = tk_widget._root()
     root.update_idletasks()
     time.sleep(max(seconds, 0.0))
     root.update_idletasks()
 
 
-def shoot(app, name: str, settle_fn=_capture.settle) -> Path:
-    """capture() with the settle step swapped out."""
+def shoot(app, name: str, settle_fn=settle_update_loop) -> Path:
+    """capture() with the settle step swapped out.
+
+    The default is the PINNED pre-#429 strategy, never `_capture.settle` — see
+    the note above the strategies.
+    """
     target = app._internal
     with _capture.raised(target):
         settle_fn(target, SETTLE)
@@ -103,13 +142,26 @@ def cover_then_close(app, hold_ms: int = 250) -> None:
     top.destroy()
 
 
-def judge(label: str, diff: int, floor: int) -> None:
+def judge(label: str, diff: int, floor: int, expect: str = "clean") -> None:
+    """Record an arm against what it is SUPPOSED to show.
+
+    One arm is expected to come back stale — it reproduces the defect — so a
+    bare pass/fail would leave this probe reporting a failure forever and
+    reading as broken. `expect` is what makes a reproduced defect a PASS and,
+    just as importantly, makes a defect that stopped reproducing a FAIL.
+    """
+    clean = diff <= floor
     if diff < 0:
         results.append((label, "INCONCLUSIVE - sizes differ"))
-    elif diff <= floor:
-        results.append((label, f"PASS - {diff} px vs a {floor} px floor"))
+    elif clean == (expect == "clean"):
+        state = "clean" if clean else "stale, as it should be"
+        results.append((label, f"PASS - {diff} px vs a {floor} px floor ({state})"))
+    elif expect == "stale":
+        results.append((label, (
+            f"FAIL - {diff} px vs a {floor} px floor; this arm reproduces the "
+            f"defect and it stopped reproducing, so the comparison is dead")))
     else:
-        results.append((label, f"FAIL - {diff} px vs a {floor} px floor"))
+        results.append((label, f"FAIL - {diff} px vs a {floor} px floor (stale)"))
 
 
 def main() -> int:
@@ -142,12 +194,19 @@ def main() -> int:
             results.append(("noise floor", f"{floor} px between two ref shots"))
 
             cover_then_close(app)
-            judge("control: update() settle after a window closed",
+            judge("control: dispatching settle after a window closed",
                   differing_pixels(ref, shoot(app, "update")), floor)
 
             cover_then_close(app)
             judge("test: sleep-only settle after a window closed",
                   differing_pixels(ref, shoot(app, "sleep", settle_sleep_only)),
+                  floor, expect="stale")
+
+            # What actually ships today, measured rather than assumed. Read
+            # against the two arms above: it has to match the dispatching one.
+            cover_then_close(app)
+            judge("shipped: _capture.settle after a window closed",
+                  differing_pixels(ref, shoot(app, "shipped", _capture.settle)),
                   floor)
 
             top = app._internal.winfo_toplevel()
@@ -160,7 +219,13 @@ def main() -> int:
             except tkinter.TclError as exc:
                 results.append(("tk busy", f"unavailable - {exc}"))
 
-            # The point of the change: a click during a sleep-only settle.
+            # ⚠ THIS ARM CANNOT TEST `tk busy`, and is kept only to show that
+            # a sleep-only settle dispatches nothing. `event_generate` aimed
+            # at a widget delivers straight to its bindings and never consults
+            # the busy window, so it re-enters whether busy is held or not —
+            # measured, with `tk busy status` reading 1 at the time. Whether a
+            # REAL click is swallowed is a manual check:
+            # development/demo_429_busy_during_settle.py
             app.tk.after(100, fire_second)
             on_click_capture()
 

--- a/development/probe_429_settle_without_input.py
+++ b/development/probe_429_settle_without_input.py
@@ -1,0 +1,188 @@
+"""Probe: can settle() wait WITHOUT dispatching input, and still repaint? (#429)
+
+`settle()` runs `root.update()` in its wait loop. That is what lets a queued
+click re-enter the handler (#429) — and it is also what the current docstring
+promises ("the interface stays responsive while this waits"). The promise is
+the bug.
+
+The alternative is to flush our own drawing and then simply sleep. No input is
+dispatched, so an impatient second click waits its turn instead of stacking a
+second save dialog on the end user. The question is whether the capture is
+still CORRECT: the area a just-closed dialog uncovered has to be repainted
+before the pixels are read, and repaint may need event processing we would no
+longer be doing.
+
+⚠ EVERY COMPARED CAPTURE COMES FROM ONE APP INSTANCE. An earlier version of
+this probe took each arm from its own `bs.App` and read a 59,988-pixel
+difference as a dirty capture. It was the theme: the FIRST app in a process
+renders its content white, and every later app in the same process falls back
+to default grey, so ~99% of pixels differ for reasons having nothing to do
+with what is being measured. Two same-population shots agreed to 14 px, which
+made the bogus control look sound. Same family as the repo's
+"measure within one process" rule, one notch stricter.
+
+Arms, all captured from the same window and compared against a reference shot
+of it with nothing ever placed over it:
+
+  ref     — the yardstick.
+  update  — a window is closed just before the shot; settle uses update().
+            The CONTROL: today's behavior must come back clean, or the
+            scenario is broken and the sleep-only arm proves nothing.
+  sleep   — the same, with a sleep-only settle. Clean means repaint does not
+            need us to pump the loop.
+  busy    — `tk busy hold` in force during the shot, to settle whether the
+            busy window is photographed.
+
+Then the point of the whole exercise: a click arriving during a sleep-only
+settle, which must NOT re-enter the handler.
+
+Run:  py -3.12 development/probe_429_settle_without_input.py
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import time
+import tkinter
+from pathlib import Path
+
+from PIL import Image, ImageChops
+
+import bootstack as bs
+from bootstack._core import capture as _capture
+
+OUT = Path(tempfile.gettempdir()) / "bootstack-probe-429-settle"
+OUT.mkdir(parents=True, exist_ok=True)
+
+SETTLE = 0.3
+# Two captures of an unchanged window are not bit-identical; this is the floor
+# arm `ref2` measures rather than assumes.
+results: list[tuple[str, str]] = []
+
+
+def settle_sleep_only(tk_widget, seconds: float) -> None:
+    """Flush our own drawing, then wait without dispatching anything."""
+    root = tk_widget._root()
+    root.update_idletasks()
+    time.sleep(max(seconds, 0.0))
+    root.update_idletasks()
+
+
+def shoot(app, name: str, settle_fn=_capture.settle) -> Path:
+    """capture() with the settle step swapped out."""
+    target = app._internal
+    with _capture.raised(target):
+        settle_fn(target, SETTLE)
+        return _capture.capture_region(
+            _capture.widget_region(target, 0), OUT / f"{name}.png"
+        )
+
+
+def differing_pixels(a: Path, b: Path) -> int:
+    with Image.open(a) as ia, Image.open(b) as ib:
+        ia, ib = ia.convert("RGB"), ib.convert("RGB")
+        if ia.size != ib.size:
+            return -1
+        diff = ImageChops.difference(ia, ib)
+        return sum(1 for px in diff.getdata() if px != (0, 0, 0))
+
+
+def cover_then_close(app, hold_ms: int = 250) -> None:
+    """Put a window over the app and close it, the way a save dialog does."""
+    top = tkinter.Toplevel(app._internal)
+    top.overrideredirect(True)
+    top.configure(background="#ff00ff")
+    x, y = app._internal.winfo_rootx(), app._internal.winfo_rooty()
+    w, h = app._internal.winfo_width(), app._internal.winfo_height()
+    top.geometry(f"{w}x{h}+{x}+{y}")
+    top.lift()
+    top.attributes("-topmost", True)
+    app.tk.update()
+    time.sleep(hold_ms / 1000)
+    top.destroy()
+
+
+def judge(label: str, diff: int, floor: int) -> None:
+    if diff < 0:
+        results.append((label, "INCONCLUSIVE - sizes differ"))
+    elif diff <= floor:
+        results.append((label, f"PASS - {diff} px vs a {floor} px floor"))
+    else:
+        results.append((label, f"FAIL - {diff} px vs a {floor} px floor"))
+
+
+def main() -> int:
+    print(f"platform={sys.platform}  settle={SETTLE}s  out={OUT}")
+    depth = 0
+    max_depth = 0
+
+    with bs.App(title="#429 settle", size=(380, 160), padding=12) as app:
+        bs.Label("Capture target", font="heading-md")
+        button = bs.Button("Export", on_click=lambda: on_click_capture())
+
+        def on_click_capture() -> None:
+            nonlocal depth, max_depth
+            depth += 1
+            max_depth = max(max_depth, depth)
+            try:
+                shoot(app, f"reentry-{max_depth}-{depth}", settle_sleep_only)
+            finally:
+                depth -= 1
+
+        def fire_second() -> None:
+            inner = button._internal
+            inner.event_generate("<Button-1>", x=5, y=5)
+            inner.event_generate("<ButtonRelease-1>", x=5, y=5)
+
+        def sequence() -> None:
+            ref = shoot(app, "ref")
+            ref2 = shoot(app, "ref2")
+            floor = max(differing_pixels(ref, ref2), 50)
+            results.append(("noise floor", f"{floor} px between two ref shots"))
+
+            cover_then_close(app)
+            judge("control: update() settle after a window closed",
+                  differing_pixels(ref, shoot(app, "update")), floor)
+
+            cover_then_close(app)
+            judge("test: sleep-only settle after a window closed",
+                  differing_pixels(ref, shoot(app, "sleep", settle_sleep_only)),
+                  floor)
+
+            top = app._internal.winfo_toplevel()
+            try:
+                top.tk.call("tk", "busy", "hold", top._w, "-cursor", "watch")
+                busy_shot = shoot(app, "busy")
+                top.tk.call("tk", "busy", "forget", top._w)
+                judge("tk busy held during the shot",
+                      differing_pixels(ref, busy_shot), floor)
+            except tkinter.TclError as exc:
+                results.append(("tk busy", f"unavailable - {exc}"))
+
+            # The point of the change: a click during a sleep-only settle.
+            app.tk.after(100, fire_second)
+            on_click_capture()
+
+        app.tk.after(600, sequence)
+        app.tk.after(9000, app.close)
+
+    app.run()
+
+    print()
+    for label, verdict in results:
+        print(f"  {label}: {verdict}")
+    reentry_ok = max_depth == 1
+    print(f"  click during a sleep-only settle: max_depth={max_depth} "
+          f"{'PASS - did not re-enter' if reentry_ok else 'FAIL - re-entered'}")
+
+    failures = [v for _, v in results if v.startswith("FAIL")]
+    if not reentry_ok:
+        failures.append("reentry")
+    print(f"\n{'FAILURES: ' + str(len(failures)) if failures else 'all arms as expected'}")
+    print(f"images in {OUT}")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/development/review-brief-427-capture.md
+++ b/development/review-brief-427-capture.md
@@ -1,0 +1,130 @@
+# Review brief — `widget.capture()` (#427)
+
+Branch `feat/widget-capture-427`, off `main`. Written for the review session so
+the reviewer does not re-derive what has already been measured, and knows where
+the genuine soft spots are.
+
+Origin: discussion #425, an external user wanting to share a dashboard view
+without using the snipping tool. Comment posted on the discussion 2026-08-07.
+
+## What it adds
+
+One public method, no new top-level names:
+
+```python
+widget.capture(path, *, inset=0, settle=0.1) -> Path
+```
+
+On `PublicWidgetBase`, so it reaches every widget plus `App`, `AppShell`, and
+`Window`. Backed by a new internal module `src/bootstack/_core/capture.py`.
+
+## Decisions already settled — please do not re-litigate
+
+Each of these was decided deliberately with the maintainer; the reasoning is on
+#427 and in the session that produced this branch.
+
+- **Path in, path out — no Pillow type in the public signature.** Returning an
+  image object would couple the public API to Pillow and pre-empt the deferred
+  public image handle. A no-argument `capture()` returning that handle stays
+  available later as a pure addition.
+- **No printing.** The Windows shell `print` verb cannot honor a printer name or
+  a copy count, so those parameters would be documented and silently ignored on
+  a whole platform. Measured on this box: `.pdf` resolves to `MSEdgePDF`, which
+  registers no print verb at all.
+- **Monitor enumeration stays internal.** `_runtime/window_utilities.py` already
+  enumerates monitors for window positioning; publishing a second `Monitor` type
+  would give the framework two answers to the same question. Unifying them is
+  its own branch.
+- **No capture event.** `capture()` is synchronous and returns the path, so an
+  event would have no producer the caller did not invoke. Revisit only if
+  capture ever becomes async or gains a framework-triggered entry point.
+- **The window is raised before the grab, unconditionally.** Not a parameter.
+  Capturing whatever happens to be on top is never what a caller wants.
+
+## Verified, with measurements
+
+Full GUI suite on this branch, `py -3.12 tests/run_gui.py`, exit 0:
+**940 passed / 14 skipped** on the widgets+CLI leg (the recorded `main` baseline
+is 930/14 — the difference is exactly the 10 new tests), **125 passed / 4
+skipped** on data, all isolated legs green.
+
+Docs: clean `-W --keep-going` build after `rm -rf docs/_build`, `build
+succeeded`, exit 0.
+
+## Controls that were run — this is the part worth trusting
+
+A passing test proves nothing until it has been shown to fail. Three controls:
+
+1. **The topmost-clobber defect reintroduced** (restore unconditionally rather
+   than only when this code changed it): `test_capture_leaves_a_deliberately_topmost_window_pinned`
+   fails with `assert 0`, while its opposite-direction arm still passes. So the
+   failure is behavioral, not a broken harness.
+2. **The `winfo_ismapped()` guard removed**: `test_detached_widget_cannot_be_captured`
+   fails with `DID NOT RAISE`. Without the guard, capturing a detached widget
+   silently succeeds and saves whatever was behind it.
+3. **The negative-origin monitor trap**, on the `x=-2560` display attached to
+   this machine: a naive `ImageGrab.grab(bbox, all_screens=False)` returns
+   **1 distinct color** (pure black, no exception), while `capture()` returns
+   **169**. The `all_screens` handling is load-bearing, not defensive.
+
+An earlier version of the probe **passed all ten of its checks while capturing a
+browser window** — it verified the rectangle and never the content. That is why
+the probe now toggles the theme between two captures and requires the pixels to
+change: it is causal proof the grab is reading this application. Measured delta
+211.6 where identical would be 0.0.
+
+## NOT verified — the open gap
+
+**Windows only.** Nothing here has run on macOS or Linux. Run
+`development/verify_427_capture.py` on each; it prints the platform, Tk version,
+Pillow version, monitor layout, and which capture backend is active, and skips
+arms that do not apply rather than failing them.
+
+On macOS specifically: a missing **Screen Recording permission** makes the system
+return a picture of the desktop with no windows in it and raise nothing. The
+theme-toggle arm detects exactly that, and the probe prints a hint naming the
+permission when it trips.
+
+## Look hard at these
+
+Self-flagged; each is a place I am not confident.
+
+1. **The Linux subprocess fallback crops with the wrong origin, probably.**
+   `_grab_via_subprocess` shells out to a full-screen tool and then does
+   `image.crop(bbox)`, where `bbox` is in *virtual-desktop* coordinates. The
+   grabbed image's origin is whatever the tool treats as (0, 0), which on a
+   multi-monitor setup — and certainly with a negative-origin display — is not
+   the virtual-desktop origin. Single-monitor Linux should be fine; multi-monitor
+   is likely wrong. I could not test it. This is the most likely real defect on
+   the branch.
+2. **`settle()` pumps the event loop, so a capture is re-entrant.** It calls
+   `root.update()` in a loop, and `update()` from inside a click handler
+   processes further events — including a second click on the same Export
+   button, which would start a second capture inside the first. Whether that
+   matters in practice, and whether it wants a guard, is a real question.
+3. **`winfo_ismapped()` does not catch an *obscured* widget**, only a hidden or
+   detached one. That is by design and documented, but confirm the how-to page's
+   wording matches the actual guarantee.
+4. **Capturing the app grabs the client area, not the window frame.**
+   `winfo_rootx/rooty` exclude the native title bar on Windows. macOS geometry
+   conventions differ and need measuring on that box.
+5. **`settle=0.1` means every capture blocks for a tenth of a second.** Chosen so
+   a capture taken right after a save dialog closes does not photograph the
+   dialog's leftover pixels. Reasonable default or not?
+6. **The tests deliberately assert no image content.** What the pixels show
+   depends on what else is on the machine's screen, which no assertion controls;
+   content correctness is the probe's job. The test module says so at the top —
+   worth a look to confirm that division is the right one rather than a gap.
+
+## How to run everything
+
+```
+py -3.12 -m pytest tests/widgets/public/test_capture.py -q
+py -3.12 tests/run_gui.py
+py -3.12 development/verify_427_capture.py
+rm -rf docs/_build && py -3.12 -m sphinx -b html docs docs/_build/html -W --keep-going
+```
+
+`development/screencap.py` and `screencap_demo.py` are the original prototype the
+issue references, kept for provenance. They are **not** what shipped — the
+prototype's printing half was dropped and its topmost handling was a defect.

--- a/development/screencap.py
+++ b/development/screencap.py
@@ -1,0 +1,303 @@
+"""Cross-platform screen capture and OS printing helpers.
+
+A standalone, dependency-light utility for capturing the screen, a window,
+or a single widget, and for handing a file to the operating system's
+printer. Written for discussion #425; not part of the public API.
+
+Capture uses Pillow's `ImageGrab`, with a subprocess fallback for Linux
+desktops where `ImageGrab` is unavailable (Wayland, or a Pillow built
+without XCB). Printing shells out to the platform's native print path.
+
+Multi-monitor is handled: coordinates are virtual-desktop coordinates, so
+a monitor placed left of or above the primary one has negative origins.
+Monitors are enumerated with `screeninfo`, the same library the framework's
+own window-positioning code uses.
+
+Requires: pillow, screeninfo
+
+Run `screencap_demo.py` for a live example.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import NamedTuple
+
+from PIL import Image, ImageGrab
+
+try:
+    from screeninfo import get_monitors
+    HAS_SCREENINFO = True
+except ImportError:  # mirrors the framework's own optional-import guard
+    HAS_SCREENINFO = False
+
+WINDOWS = sys.platform == "win32"
+MACOS = sys.platform == "darwin"
+
+
+class Monitor(NamedTuple):
+    """One display, in virtual-desktop coordinates."""
+
+    x: int
+    y: int
+    width: int
+    height: int
+    name: str
+    is_primary: bool
+
+    @property
+    def bbox(self):
+        """The monitor as a `(left, top, right, bottom)` capture region."""
+        return (self.x, self.y, self.x + self.width, self.y + self.height)
+
+
+def list_monitors():
+    """Return every attached monitor, primary first.
+
+    Coordinates are virtual-desktop coordinates: a monitor to the left of,
+    or above, the primary one has a negative `x` or `y`.
+    """
+    if not HAS_SCREENINFO:
+        return []
+    try:
+        found = get_monitors()
+    except Exception:
+        # screeninfo raises on some headless/exotic setups; treat as unknown.
+        return []
+
+    monitors = [
+        Monitor(m.x, m.y, m.width, m.height,
+                m.name or f"display-{i}", bool(getattr(m, "is_primary", False)))
+        for i, m in enumerate(found)
+    ]
+    monitors.sort(key=lambda m: not m.is_primary)
+    return monitors
+
+
+def monitor_at(x, y):
+    """Return the monitor containing a point, or `None` if it is off-screen."""
+    for monitor in list_monitors():
+        if monitor.x <= x < monitor.x + monitor.width and \
+                monitor.y <= y < monitor.y + monitor.height:
+            return monitor
+    return None
+
+
+def monitor_for_widget(widget):
+    """Return the monitor a widget's center sits on, or `None`."""
+    tk_widget = getattr(widget, "tk", widget)
+    x = tk_widget.winfo_rootx() + tk_widget.winfo_width() // 2
+    y = tk_widget.winfo_rooty() + tk_widget.winfo_height() // 2
+    return monitor_at(x, y)
+
+
+# --------------------------------------------------------------------------
+# Capture
+# --------------------------------------------------------------------------
+
+def capture_screen(path=None, *, bbox=None, all_screens=None):
+    """Capture the screen and return a Pillow image.
+
+    Args:
+        path: Optional file to save the capture to. The extension picks
+            the format (`.png` is the safe default for UI captures).
+        bbox: Optional `(left, top, right, bottom)` region in virtual-desktop
+            coordinates, which may be negative on a multi-monitor setup.
+            Captures the primary monitor when omitted.
+        all_screens: Span every monitor. Defaults to `True` whenever `bbox`
+            is given, because a region is addressed in virtual-desktop
+            coordinates and those are only reachable when the whole desktop
+            is in the grab. Windows only; ignored elsewhere.
+    """
+    if all_screens is None:
+        # Without this, a bbox on a monitor left of or above the primary one
+        # is cropped from a primary-only grab and comes back as a silently
+        # BLACK image — no exception, no clue. Measured on a two-monitor
+        # setup with the secondary at x=-2560.
+        all_screens = bbox is not None
+
+    try:
+        image = ImageGrab.grab(bbox=bbox, all_screens=all_screens)
+    except (OSError, NotImplementedError):
+        # Linux without XCB, or a Wayland session.
+        image = _grab_via_subprocess(bbox)
+
+    if image.mode == "RGBA":
+        image = image.convert("RGB")
+    if path:
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        image.save(path)
+    return image
+
+
+def capture_widget(widget, path=None, *, inset=0, delay=0.15):
+    """Capture the screen region occupied by a widget or window.
+
+    The capture is a screen grab of the widget's rectangle, so the widget
+    must be visible and unobstructed. Pass an app, a window, or any widget.
+
+    Args:
+        widget: A bootstack widget, window, or app.
+        path: Optional file to save the capture to.
+        inset: Pixels to trim from each edge. Use `2` to drop the native
+            window-border artifact when capturing a whole window.
+        delay: Seconds to wait after raising the window, so the compositor
+            has finished drawing before the pixels are read. This blocks
+            briefly, which is fine from a button handler. To defer a capture
+            without blocking, use `widget.schedule.delay(ms, fn)` and call
+            `capture_screen` from the callback, as `screencap_demo.py` does.
+    """
+    # `.tk` is the documented escape hatch. It is used here because reading a
+    # widget's screen rectangle, and forcing a repaint before the grab, have no
+    # public equivalent — the toolkit owns both. Confined to this function.
+    tk_widget = getattr(widget, "tk", widget)
+
+    top = tk_widget.winfo_toplevel()
+    top.lift()
+    top.attributes("-topmost", True)
+    top.update_idletasks()
+    top.update()
+    time.sleep(delay)
+
+    x, y = tk_widget.winfo_rootx(), tk_widget.winfo_rooty()
+    w, h = tk_widget.winfo_width(), tk_widget.winfo_height()
+    bbox = (x + inset, y + inset, x + w - inset, y + h - inset)
+
+    try:
+        return capture_screen(path, bbox=bbox)
+    finally:
+        top.attributes("-topmost", False)
+
+
+def capture_monitor(monitor=0, path=None):
+    """Capture one whole monitor.
+
+    Args:
+        monitor: A `Monitor` from `list_monitors()`, or an index into it
+            (`0` is the primary display).
+        path: Optional file to save the capture to.
+    """
+    if not isinstance(monitor, Monitor):
+        monitors = list_monitors()
+        if not monitors:
+            raise RuntimeError(
+                "Could not enumerate monitors — is `screeninfo` installed?"
+            )
+        try:
+            monitor = monitors[monitor]
+        except IndexError:
+            raise IndexError(
+                f"No monitor at index {monitor}; {len(monitors)} attached."
+            ) from None
+    return capture_screen(path, bbox=monitor.bbox)
+
+
+def _grab_via_subprocess(bbox=None):
+    """Fall back to a desktop screenshot tool (Linux/Wayland)."""
+    tools = [
+        ("grim", ["grim", "{out}"]),                      # wlroots / Sway
+        ("gnome-screenshot", ["gnome-screenshot", "-f", "{out}"]),
+        ("spectacle", ["spectacle", "-b", "-n", "-o", "{out}"]),  # KDE
+        ("import", ["import", "-window", "root", "{out}"]),       # ImageMagick
+    ]
+    for name, argv in tools:
+        if not shutil.which(name):
+            continue
+        out = Path(tempfile.gettempdir()) / f"_capture_{os.getpid()}.png"
+        try:
+            subprocess.run(
+                [a.format(out=out) for a in argv],
+                check=True,
+                capture_output=True,
+                timeout=30,
+            )
+            image = Image.open(out)
+            image.load()
+            out.unlink(missing_ok=True)
+            return image.crop(bbox) if bbox else image
+        except (subprocess.SubprocessError, OSError):
+            continue
+
+    raise RuntimeError(
+        "No screen capture backend available. Install a Pillow build with "
+        "XCB support, or one of: grim, gnome-screenshot, spectacle, import."
+    )
+
+
+# --------------------------------------------------------------------------
+# Printing
+# --------------------------------------------------------------------------
+
+def list_printers():
+    """Return the names of installed printers."""
+    if WINDOWS:
+        result = subprocess.run(
+            ["powershell", "-NoProfile", "-Command",
+             "Get-Printer | Select-Object -ExpandProperty Name"],
+            capture_output=True, text=True, timeout=30,
+        )
+    else:
+        if not shutil.which("lpstat"):
+            return []
+        result = subprocess.run(
+            ["lpstat", "-e"], capture_output=True, text=True, timeout=30
+        )
+    if result.returncode != 0:
+        return []
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def print_file(path, *, printer=None, copies=1):
+    """Send a file to a printer using the operating system's print path.
+
+    On Windows this invokes the shell's registered `print` verb for the
+    file type, which for images opens the Windows photo-printing wizard.
+    On macOS and Linux it submits the file to CUPS via `lp`.
+
+    Args:
+        path: File to print.
+        printer: Printer name. Uses the system default when omitted.
+            Ignored on Windows, which routes through the shell verb.
+        copies: Number of copies. Ignored on Windows.
+    """
+    path = Path(path).resolve()
+    if not path.is_file():
+        raise FileNotFoundError(path)
+
+    if WINDOWS:
+        # `print` is a shell verb registered per file type. Images resolve to
+        # the Photo Printing Wizard; other types depend on the installed
+        # handler, and some (PDF, plain text) may have none at all. The call
+        # is asynchronous and typically shows a dialog.
+        try:
+            os.startfile(str(path), "print")
+        except OSError as exc:
+            raise RuntimeError(
+                f"No print handler is registered for '{path.suffix}' files."
+            ) from exc
+        return
+
+    if not shutil.which("lp"):
+        raise RuntimeError("Printing requires CUPS (`lp` was not found).")
+
+    argv = ["lp"]
+    if printer:
+        argv += ["-d", printer]
+    if copies > 1:
+        argv += ["-n", str(copies)]
+    argv.append(str(path))
+    subprocess.run(argv, check=True, capture_output=True, timeout=60)
+
+
+def print_image(image, *, printer=None, copies=1):
+    """Print a Pillow image by writing it to a temporary file first."""
+    tmp = Path(tempfile.gettempdir()) / f"_print_{os.getpid()}.png"
+    image.save(tmp)
+    print_file(tmp, printer=printer, copies=copies)

--- a/development/screencap.py
+++ b/development/screencap.py
@@ -1,17 +1,33 @@
-"""Cross-platform screen capture and OS printing helpers.
+"""Cross-platform screen capture helpers.
 
 A standalone, dependency-light utility for capturing the screen, a window,
-or a single widget, and for handing a file to the operating system's
-printer. Written for discussion #425; not part of the public API.
+or a single widget. Written for discussion #425; not part of the public API.
 
 Capture uses Pillow's `ImageGrab`, with a subprocess fallback for Linux
 desktops where `ImageGrab` is unavailable (Wayland, or a Pillow built
-without XCB). Printing shells out to the platform's native print path.
+without XCB).
 
 Multi-monitor is handled: coordinates are virtual-desktop coordinates, so
 a monitor placed left of or above the primary one has negative origins.
 Monitors are enumerated with `screeninfo`, the same library the framework's
 own window-positioning code uses.
+
+⚠ This prototype also carried OS printing helpers — `list_printers()`,
+`print_file()` and `print_image()`. They have been REMOVED, and re-adding
+them needs issue #427 read first, because printing is out of scope there
+deliberately and with measurements. The Windows shell `print` verb cannot
+honor a printer name or a copy count, so `printer=` and `copies=` were
+documented parameters that a whole platform silently ignored — the
+degrading-kwarg class #381 fixed and #383 is still sweeping up. And `.pdf`,
+the format the reporter actually asked about, resolves to a handler that
+registers no print verb at all, so it failed outright. Exporting a file and
+letting the user print it from an application that prints well is the
+honest version of the feature, and it is what shipped.
+
+⚠ What SHIPPED is `bootstack._core.capture`, not this file — bounds-checked
+crops, negative-origin displays, an always-on-top setting restored as found,
+and an input guard while the desktop settles. This prototype's own topmost
+handling was a defect. It is kept only because #427 references it by path.
 
 Requires: pillow, screeninfo
 
@@ -229,75 +245,3 @@ def _grab_via_subprocess(bbox=None):
         "No screen capture backend available. Install a Pillow build with "
         "XCB support, or one of: grim, gnome-screenshot, spectacle, import."
     )
-
-
-# --------------------------------------------------------------------------
-# Printing
-# --------------------------------------------------------------------------
-
-def list_printers():
-    """Return the names of installed printers."""
-    if WINDOWS:
-        result = subprocess.run(
-            ["powershell", "-NoProfile", "-Command",
-             "Get-Printer | Select-Object -ExpandProperty Name"],
-            capture_output=True, text=True, timeout=30,
-        )
-    else:
-        if not shutil.which("lpstat"):
-            return []
-        result = subprocess.run(
-            ["lpstat", "-e"], capture_output=True, text=True, timeout=30
-        )
-    if result.returncode != 0:
-        return []
-    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
-
-
-def print_file(path, *, printer=None, copies=1):
-    """Send a file to a printer using the operating system's print path.
-
-    On Windows this invokes the shell's registered `print` verb for the
-    file type, which for images opens the Windows photo-printing wizard.
-    On macOS and Linux it submits the file to CUPS via `lp`.
-
-    Args:
-        path: File to print.
-        printer: Printer name. Uses the system default when omitted.
-            Ignored on Windows, which routes through the shell verb.
-        copies: Number of copies. Ignored on Windows.
-    """
-    path = Path(path).resolve()
-    if not path.is_file():
-        raise FileNotFoundError(path)
-
-    if WINDOWS:
-        # `print` is a shell verb registered per file type. Images resolve to
-        # the Photo Printing Wizard; other types depend on the installed
-        # handler, and some (PDF, plain text) may have none at all. The call
-        # is asynchronous and typically shows a dialog.
-        try:
-            os.startfile(str(path), "print")
-        except OSError as exc:
-            raise RuntimeError(
-                f"No print handler is registered for '{path.suffix}' files."
-            ) from exc
-        return
-
-    if not shutil.which("lp"):
-        raise RuntimeError("Printing requires CUPS (`lp` was not found).")
-
-    argv = ["lp"]
-    if printer:
-        argv += ["-d", printer]
-    if copies > 1:
-        argv += ["-n", str(copies)]
-    argv.append(str(path))
-    subprocess.run(argv, check=True, capture_output=True, timeout=60)
-
-
-def print_image(image, *, printer=None, copies=1):
-    """Print a Pillow image by writing it to a temporary file first."""
-    tmp = Path(tempfile.gettempdir()) / f"_print_{os.getpid()}.png"
-    image.save(tmp)
-    print_file(tmp, printer=printer, copies=copies)

--- a/development/screencap_demo.py
+++ b/development/screencap_demo.py
@@ -17,7 +17,7 @@ from pathlib import Path
 import bootstack as bs
 
 from screencap import (capture_monitor, capture_screen, capture_widget,
-                       list_monitors, list_printers, monitor_for_widget)
+                       list_monitors, monitor_for_widget)
 
 OUT = Path(__file__).parent / "screencap_out"
 
@@ -106,6 +106,5 @@ with bs.App(title="Screen capture demo", padding=16, gap=12, size=(760, 620)) as
 for _m in list_monitors():
     print(f"monitor {_m.name}: x={_m.x} y={_m.y} {_m.width}x{_m.height} "
           f"primary={_m.is_primary}")
-print("printers:", list_printers())
 print("output folder:", OUT)
 app.run()

--- a/development/screencap_demo.py
+++ b/development/screencap_demo.py
@@ -1,0 +1,111 @@
+"""Live demo for `screencap.py` — capture the screen or this window, and
+show the result immediately.
+
+Each capture is written to `development/screencap_out/` and then displayed
+in the preview area below the buttons, so you can see what was grabbed
+without leaving the app.
+
+Deferred work goes through `widget.schedule` (`delay`/`every`), the public
+scheduling API — its jobs are cancelled automatically when the widget is
+destroyed.
+
+Run: py -3.12 development/screencap_demo.py
+"""
+
+from pathlib import Path
+
+import bootstack as bs
+
+from screencap import (capture_monitor, capture_screen, capture_widget,
+                       list_monitors, list_printers, monitor_for_widget)
+
+OUT = Path(__file__).parent / "screencap_out"
+
+
+def on_all_monitors():
+    """Grab every monitor as one image spanning the whole virtual desktop."""
+    path = OUT / "all-monitors.png"
+    image = capture_screen(path, all_screens=True)
+    _show(path, f"All monitors — {image.width}x{image.height}")
+
+
+def on_this_monitor():
+    """Grab only the monitor this window is currently on."""
+    monitor = monitor_for_widget(app)
+    if monitor is None:
+        status.text = "Could not work out which monitor this window is on."
+        return
+    path = OUT / "this-monitor.png"
+    image = capture_monitor(monitor, path)
+    _show(path, f"{monitor.name} at ({monitor.x}, {monitor.y}) — "
+                f"{image.width}x{image.height}")
+
+
+def on_delayed():
+    """Count down, then grab the screen — time to bring another window up.
+
+    `schedule.every` returns a job; cancelling it stops the repeat.
+    """
+    remaining = [3]
+    status.text = "Capturing in 3 s — switch to another window now."
+
+    def tick():
+        remaining[0] -= 1
+        if remaining[0] > 0:
+            status.text = f"Capturing in {remaining[0]} s…"
+            return
+        job.cancel()
+        path = OUT / "delayed.png"
+        image = capture_screen(path, all_screens=True)
+        _show(path, f"Delayed capture — {image.width}x{image.height}")
+
+    job = app.schedule.every(1000, tick)
+
+
+def on_window():
+    """Grab this window's content area, trimming the border artifact."""
+    path = OUT / "app.png"
+    image = capture_widget(app, path, inset=2)
+    _show(path, f"This window — {image.width}x{image.height}")
+
+
+def on_widget():
+    """Grab just the button row, to show that any widget works."""
+    path = OUT / "body.png"
+    image = capture_widget(buttons, path)
+    _show(path, f"Button row only — {image.width}x{image.height}")
+
+
+def _show(path, caption):
+    # Reassigning `image` re-reads the file, so repeat captures refresh.
+    preview.image = str(path)
+    status.text = f"{caption}\n{path}"
+    print(caption, "->", path)
+
+
+with bs.App(title="Screen capture demo", padding=16, gap=12, size=(760, 620)) as app:
+    bs.Label("Screen capture", font="heading-lg")
+    bs.Label("Each button writes a PNG and previews it below.", font="caption")
+
+    with bs.Row(gap=8) as buttons:
+        bs.Button("All monitors", accent="primary", on_click=on_all_monitors)
+        bs.Button("This monitor", on_click=on_this_monitor)
+        bs.Button("In 3 s", on_click=on_delayed)
+        bs.Button("This window", on_click=on_window)
+        bs.Button("Button row", on_click=on_widget)
+
+    status = bs.Label("No capture yet.", font="caption")
+    # grow=1 claims the leftover vertical space; horizontal="stretch" fills the
+    # cross axis. Without the stretch a Picture collapses to its natural width,
+    # which for an empty one is a single pixel.
+    preview = bs.Picture(
+        fit="contain", corner_radius=4, surface="card",
+        grow=1, horizontal="stretch",
+    )
+
+for _m in list_monitors():
+    print(f"monitor {_m.name}: x={_m.x} y={_m.y} {_m.width}x{_m.height} "
+          f"primary={_m.is_primary}")
+print("printers:", list_printers())
+print("output folder:", OUT)
+app.run()

--- a/development/verify_427_capture.py
+++ b/development/verify_427_capture.py
@@ -22,6 +22,7 @@ Run: py -3.12 development/verify_427_capture.py     (Windows)
 
 import platform
 import sys
+import time
 import tkinter
 from pathlib import Path
 
@@ -66,6 +67,32 @@ def mean_difference(path_a, path_b):
         diff = ImageChops.difference(first, second).convert("L")
         pixels = first.size[0] * first.size[1]
         return sum(v * c for v, c in enumerate(diff.histogram())) / pixels
+
+
+def pinned(root, timeout=0.5):
+    """Ask for always-on-top, reporting whether the request actually took.
+
+    A window manager that honors it answers asynchronously, and that answer
+    arrives as a window event rather than an idle callback — so this polls
+    instead of reading once. Reading too early reports "not supported" on a
+    machine that supports it perfectly well.
+
+    A refused request still leaves one recorded, so it is put back before
+    reporting failure: otherwise the next reader gets the record rather than
+    the window manager's answer.
+    """
+    root.attributes("-topmost", True)
+    deadline = time.monotonic() + timeout
+    while True:
+        root.update()
+        if root.attributes("-topmost"):
+            return True
+        if time.monotonic() >= deadline:
+            break
+        time.sleep(0.01)
+    root.attributes("-topmost", False)
+    root.update_idletasks()
+    return False
 
 
 def banner():
@@ -162,29 +189,25 @@ def run_checks():
         # off — no error. Both arms below would then report on the window
         # manager rather than on the capture: the pinned arm fails and its
         # opposite passes for free.
-        root.attributes("-topmost", True)
-        root.update_idletasks()
-        if not root.attributes("-topmost"):
-            # Put the refused request back, so it cannot be read as a granted
-            # one by anything that looks later.
-            root.attributes("-topmost", False)
-            root.update_idletasks()
+        if not pinned(root):
             skip("always-on-top is restored",
                  "this window manager ignores -topmost, so neither direction "
                  "can be told apart")
         else:
+            # `update()` rather than `update_idletasks()` throughout: the
+            # window manager's answer is a window event, not an idle callback.
             root.attributes("-topmost", False)
-            root.update_idletasks()
+            root.update()
             app.capture(OUT / "verify-topmost-off.png")
             check("a non-topmost window is left non-topmost",
                   not root.attributes("-topmost"))
 
-            root.attributes("-topmost", True)
-            root.update_idletasks()
+            pinned(root)
             app.capture(OUT / "verify-topmost-on.png")
             check("a deliberately pinned window stays pinned",
                   bool(root.attributes("-topmost")))
             root.attributes("-topmost", False)
+            root.update()
     except tkinter.TclError as exc:
         skip("always-on-top is restored",
              f"window manager does not support -topmost: {exc}")

--- a/development/verify_427_capture.py
+++ b/development/verify_427_capture.py
@@ -174,8 +174,6 @@ def run_checks():
              f"window manager does not support -topmost: {exc}")
 
     negative_monitor_arm()
-    report()
-    app.close()
 
 
 def negative_monitor_arm():
@@ -251,5 +249,24 @@ with bs.App(title="Capture verification", padding=16, gap=10,
     bs.Label("Colored content above proves the grab is not blank.",
              font="caption")
 
-app.schedule.delay(600, run_checks)
+def main():
+    """Run the checks, and report whatever was measured no matter what.
+
+    Most arms assert rather than catch, and this runs inside a Tk callback, so
+    an unexpected raise would otherwise vanish into the toolkit's error handler
+    — leaving no summary and a window that never closes. A Linux box with no
+    capture backend hits that on the very first arm, which is precisely the
+    platform this script still has to be run on.
+    """
+    try:
+        run_checks()
+    except Exception as exc:  # noqa: BLE001 - reporting harness, not handling
+        check("verification ran to completion", False,
+              f"{type(exc).__name__}: {exc}")
+    finally:
+        report()
+        app.close()
+
+
+app.schedule.delay(600, main)
 app.run()

--- a/development/verify_427_capture.py
+++ b/development/verify_427_capture.py
@@ -1,0 +1,255 @@
+"""Cross-platform verification for `widget.capture()` (#427).
+
+Run this on every platform before the feature ships. It is written to be run
+on Windows, macOS, and Linux unchanged: arms that do not apply to the machine
+report SKIP rather than failing, and arms whose behavior is platform-dependent
+report what they measured instead of asserting a Windows answer everywhere.
+
+The arm that matters most is `capture tracks a theme toggle`. Geometry checks
+cannot tell this application apart from whatever window happens to occupy the
+same rectangle — an earlier version of this probe passed every geometry check
+while capturing a browser. Toggling the theme changes this window's pixels and
+nothing else's, so two captures that differ is causal proof the grab is reading
+this application.
+
+That same arm is how a macOS box reports a missing Screen Recording permission:
+without it the system hands back a picture of the desktop with no windows in it
+and raises nothing, so the two captures come back identical.
+
+Run: py -3.12 development/verify_427_capture.py     (Windows)
+     python development/verify_427_capture.py       (macOS, Linux)
+"""
+
+import platform
+import sys
+import tkinter
+from pathlib import Path
+
+from PIL import Image, ImageChops, ImageGrab
+from screeninfo import get_monitors
+
+import bootstack as bs
+from bootstack import errors as bs_errors
+
+OUT = Path(__file__).parent / "screencap_out"
+results = []
+
+
+def check(name, condition, detail=""):
+    results.append((name, "PASS" if condition else "FAIL", detail))
+
+
+def skip(name, why):
+    results.append((name, "SKIP", why))
+
+
+def note(name, detail):
+    results.append((name, "NOTE", detail))
+
+
+def distinct_colors(source):
+    img = source if isinstance(source, Image.Image) else Image.open(source)
+    try:
+        colors = img.convert("RGB").getcolors(maxcolors=1_000_000)
+    finally:
+        if img is not source:
+            img.close()
+    return len(colors) if colors else 999_999
+
+
+def mean_difference(path_a, path_b):
+    """Average per-pixel difference between two saved captures."""
+    with Image.open(path_a) as a, Image.open(path_b) as b:
+        first, second = a.convert("RGB"), b.convert("RGB")
+        if first.size != second.size:
+            return 255.0
+        diff = ImageChops.difference(first, second).convert("L")
+        pixels = first.size[0] * first.size[1]
+        return sum(v * c for v, c in enumerate(diff.histogram())) / pixels
+
+
+def banner():
+    print()
+    print(f"  platform : {sys.platform} ({platform.platform()})")
+    print(f"  python   : {sys.version.split()[0]}")
+    print(f"  tk       : {tkinter.TkVersion}")
+    print(f"  pillow   : {getattr(Image, '__version__', 'unknown')}")
+    for m in get_monitors():
+        primary = getattr(m, "is_primary", None)
+        print(f"  monitor  : {m.name} at ({m.x}, {m.y}) "
+              f"{m.width}x{m.height} primary={primary}")
+    # Which backend Pillow will use. A Linux session without XCB, or Wayland,
+    # falls through to a desktop screenshot tool instead.
+    try:
+        ImageGrab.grab(bbox=(0, 0, 4, 4))
+        print("  backend  : Pillow ImageGrab")
+    except (OSError, NotImplementedError) as exc:
+        print(f"  backend  : subprocess fallback (ImageGrab unavailable: {exc})")
+    print()
+
+
+def run_checks():
+    # --- basics -------------------------------------------------------------
+    png = app.capture(OUT / "verify-app.png", inset=2)
+    check("returns the path it wrote", png == OUT / "verify-app.png")
+    check("file exists and is non-empty", png.is_file() and png.stat().st_size > 0)
+
+    with Image.open(png) as img:
+        size = img.size
+    expected = (app.tk.winfo_width() - 4, app.tk.winfo_height() - 4)
+    check("size matches the widget rect minus inset", size == expected,
+          f"got {size}, expected {expected}")
+
+    colors = distinct_colors(png)
+    check("NOT a blank image", colors > 1, f"{colors} distinct colors")
+
+    # --- THE control: is this actually OUR window? --------------------------
+    bs.toggle_theme()
+    app.tk.update_idletasks()
+    toggled = app.capture(OUT / "verify-app-toggled.png", inset=2)
+    delta = mean_difference(png, toggled)
+    tracks = delta > 10
+    check("capture tracks a theme toggle (it IS our window)", tracks,
+          f"mean pixel delta {delta:.1f} (identical would be 0.0)")
+    if not tracks and sys.platform == "darwin":
+        note("macOS hint",
+             "identical captures usually mean Screen Recording permission is "
+             "not granted to the terminal or interpreter running this")
+    bs.toggle_theme()
+    app.tk.update_idletasks()
+
+    # --- a single widget ----------------------------------------------------
+    widget_png = card.capture(OUT / "verify-widget.png")
+    with Image.open(widget_png) as img:
+        widget_size = img.size
+    check("a single widget captures its own smaller rect",
+          widget_size[0] < size[0] and widget_size[1] < size[1],
+          f"widget {widget_size} vs app {size}")
+    check("widget capture is NOT blank", distinct_colors(widget_png) > 1)
+
+    # --- formats ------------------------------------------------------------
+    for suffix in (".jpg", ".pdf"):
+        try:
+            written = app.capture(OUT / f"verify-app{suffix}")
+            check(f"saves {suffix}", written.is_file() and written.stat().st_size > 0)
+        except Exception as exc:  # noqa: BLE001 - reporting, not handling
+            check(f"saves {suffix}", False, f"{type(exc).__name__}: {exc}")
+
+    # --- guards -------------------------------------------------------------
+    card.detach()
+    app.tk.update_idletasks()
+    try:
+        card.capture(OUT / "verify-should-not-exist.png")
+        check("detached widget raises", False, "no exception raised")
+    except bs_errors.BootstackError:
+        check("detached widget raises BootstackError", True)
+    except Exception as exc:  # noqa: BLE001
+        check("detached widget raises BootstackError", False,
+              f"raised {type(exc).__name__} instead")
+    card.attach()
+
+    try:
+        label.capture(OUT / "verify-should-not-exist.png", inset=9999)
+        check("absurd inset raises", False, "no exception raised")
+    except bs_errors.BootstackError:
+        check("absurd inset raises BootstackError", True)
+
+    # --- always-on-top is restored, both directions -------------------------
+    root = app.tk
+    try:
+        root.attributes("-topmost", False)
+        root.update_idletasks()
+        app.capture(OUT / "verify-topmost-off.png")
+        check("a non-topmost window is left non-topmost",
+              not root.attributes("-topmost"))
+
+        root.attributes("-topmost", True)
+        root.update_idletasks()
+        app.capture(OUT / "verify-topmost-on.png")
+        check("a deliberately pinned window stays pinned",
+              bool(root.attributes("-topmost")))
+        root.attributes("-topmost", False)
+    except tkinter.TclError as exc:
+        skip("always-on-top is restored",
+             f"window manager does not support -topmost: {exc}")
+
+    negative_monitor_arm()
+    report()
+    app.close()
+
+
+def negative_monitor_arm():
+    """The silent trap: a region at negative coordinates grabbed as pure black.
+
+    A window on a display placed left of or above the primary one sits at
+    negative virtual-desktop coordinates. Grabbing that rectangle without
+    spanning the whole desktop returns a uniformly black image and raises
+    nothing. Control arm first, so a machine that cannot reproduce the trap
+    says so instead of quietly "passing".
+    """
+    negative = [m for m in get_monitors() if m.x < 0 or m.y < 0]
+    if not negative:
+        skip("negative-origin monitor", "no monitor at a negative origin here")
+        return
+
+    target = negative[0]
+    original = app.tk.geometry()
+    app.tk.geometry(f"+{target.x + 400}+{target.y + 200}")
+    app.tk.update()
+    app.tk.update_idletasks()
+
+    root = app.tk
+    x, y = root.winfo_rootx(), root.winfo_rooty()
+    bbox = (x, y, x + root.winfo_width(), y + root.winfo_height())
+
+    try:
+        control = ImageGrab.grab(bbox=bbox, all_screens=False)
+        control_colors = distinct_colors(control)
+        control.close()
+    except (OSError, NotImplementedError, TypeError) as exc:
+        control_colors = None
+        note("negative-origin control", f"could not run the control: {exc}")
+
+    ours = distinct_colors(app.capture(OUT / "verify-negative-monitor.png"))
+
+    if control_colors is None:
+        note("negative-origin monitor", f"capture() gave {ours} distinct colors")
+    elif control_colors > 2:
+        note("negative-origin monitor",
+             f"this machine does NOT reproduce the trap (control had "
+             f"{control_colors} colors) — comparison proves nothing")
+    else:
+        check("negative-origin display captures real pixels", ours > 2,
+              f"control blank at {control_colors}, capture() at {ours}")
+
+    app.tk.geometry(original)
+    app.tk.update_idletasks()
+
+
+def report():
+    print()
+    width = max(len(name) for name, _, _ in results)
+    for name, status, detail in results:
+        print(f"  {status}  {name:<{width}}  {detail}")
+    failed = [n for n, s, _ in results if s == "FAIL"]
+    passed = sum(1 for _, s, _ in results if s == "PASS")
+    print(f"\n  {passed} passed, {len(failed)} failed, "
+          f"{sum(1 for _, s, _ in results if s == 'SKIP')} skipped")
+    if failed:
+        print("  FAILED:", ", ".join(failed))
+    print()
+
+
+banner()
+
+with bs.App(title="Capture verification", padding=16, gap=10,
+            size=(560, 360)) as app:
+    bs.Label("Capture verification", font="heading-lg")
+    with bs.Card(padding=12, gap=6) as card:
+        label = bs.Label("This card is captured on its own.", accent="primary")
+        bs.Button("Colored content", accent="primary")
+    bs.Label("Colored content above proves the grab is not blank.",
+             font="caption")
+
+app.schedule.delay(600, run_checks)
+app.run()

--- a/development/verify_427_capture.py
+++ b/development/verify_427_capture.py
@@ -157,18 +157,34 @@ def run_checks():
     # --- always-on-top is restored, both directions -------------------------
     root = app.tk
     try:
-        root.attributes("-topmost", False)
-        root.update_idletasks()
-        app.capture(OUT / "verify-topmost-off.png")
-        check("a non-topmost window is left non-topmost",
-              not root.attributes("-topmost"))
-
+        # Precondition. Always-on-top is a request to the window manager, and a
+        # session without one accepts the setting, ignores it, and reads back
+        # off — no error. Both arms below would then report on the window
+        # manager rather than on the capture: the pinned arm fails and its
+        # opposite passes for free.
         root.attributes("-topmost", True)
         root.update_idletasks()
-        app.capture(OUT / "verify-topmost-on.png")
-        check("a deliberately pinned window stays pinned",
-              bool(root.attributes("-topmost")))
-        root.attributes("-topmost", False)
+        if not root.attributes("-topmost"):
+            # Put the refused request back, so it cannot be read as a granted
+            # one by anything that looks later.
+            root.attributes("-topmost", False)
+            root.update_idletasks()
+            skip("always-on-top is restored",
+                 "this window manager ignores -topmost, so neither direction "
+                 "can be told apart")
+        else:
+            root.attributes("-topmost", False)
+            root.update_idletasks()
+            app.capture(OUT / "verify-topmost-off.png")
+            check("a non-topmost window is left non-topmost",
+                  not root.attributes("-topmost"))
+
+            root.attributes("-topmost", True)
+            root.update_idletasks()
+            app.capture(OUT / "verify-topmost-on.png")
+            check("a deliberately pinned window stays pinned",
+                  bool(root.attributes("-topmost")))
+            root.attributes("-topmost", False)
     except tkinter.TclError as exc:
         skip("always-on-top is restored",
              f"window manager does not support -topmost: {exc}")

--- a/docs/tasks/capturing-screenshots.rst
+++ b/docs/tasks/capturing-screenshots.rst
@@ -1,0 +1,127 @@
+Capturing Screenshots
+=====================
+
+Every widget can save a picture of itself. Call ``capture()`` on the app to get
+the whole window, or on a single widget to get just that part of it — useful for
+letting someone share a dashboard, a report, or one chart with a colleague who
+does not have the application.
+
+.. code-block:: python
+
+   import bootstack as bs
+
+   with bs.App(title="Dashboard") as app:
+       bs.Label("Quarterly numbers", font="heading-lg")
+       bs.Button("Save a picture", on_click=lambda: app.capture("dashboard.png"))
+   app.run()
+
+The one thing to understand up front: a capture reads pixels from the display.
+It photographs what is actually on screen rather than re-rendering the interface
+offscreen, so the widget has to be visible. The window is brought to the front
+automatically before the picture is taken.
+
+Letting the user choose the file
+--------------------------------
+
+In practice you rarely want a hard-coded filename. Pair the capture with
+:func:`~bootstack.dialogs.ask_save_file` and the user picks both the location
+and the format:
+
+.. code-block:: python
+
+   from bootstack.dialogs import ask_save_file
+
+   def on_export():
+       chosen = ask_save_file(
+           initial_file="dashboard.png",
+           file_types=[("PNG image", "*.png"),
+                       ("JPEG image", "*.jpg"),
+                       ("PDF document", "*.pdf")],
+       )
+       if chosen:
+           app.capture(chosen)
+
+   bs.Button("Export…", accent="primary", on_click=on_export)
+
+That is the whole feature for most applications — a button, a save dialog, and
+one call.
+
+Capturing part of the window
+----------------------------
+
+Call ``capture()`` on any widget to photograph only that widget. Give the piece
+you want to export a name and capture it directly:
+
+.. code-block:: python
+
+   with bs.Card(padding=12) as summary:
+       bs.Label("Revenue", font="heading-md")
+       bs.Label("$1.2M")
+
+   bs.Button("Share this card", on_click=lambda: summary.capture("revenue.png"))
+
+Capturing a whole window often catches a one-pixel border artifact from the
+native window frame. Trim it with ``inset``, which shaves that many pixels off
+every edge:
+
+.. code-block:: python
+
+   app.capture("window.png", inset=2)
+
+Choosing the format
+-------------------
+
+The file extension selects the format — there is no separate argument for it.
+``.png`` is the right default for interface captures because it stores the
+pixels exactly. ``.jpg`` produces a smaller file at some cost in sharpness,
+which is noticeable on text and thin lines. ``.pdf`` writes the capture as a
+single-page document, which is convenient when the picture is going to be
+printed or attached to a report.
+
+.. code-block:: python
+
+   app.capture("report.pdf")
+
+Missing folders in the path are created for you, and the method returns the path
+it wrote, so it composes with whatever comes next:
+
+.. code-block:: python
+
+   written = app.capture("exports/2026/q1.png")
+   bs.toast(f"Saved to {written}")
+
+What a capture cannot do
+------------------------
+
+Because a capture photographs the screen, a few things follow that are worth
+knowing before you build on it:
+
+- **The widget must be on screen.** Capturing a hidden or detached widget raises
+  an error rather than silently saving whatever happened to be behind it.
+- **Anything covering the widget is captured with it.** The window is raised
+  first, which handles the ordinary case, but a window pinned always-on-top by
+  another application still lands in the picture.
+- **The capture is what the screen shows.** A long list scrolled halfway down is
+  captured halfway down; there is no way to photograph content scrolled out of
+  view.
+
+If the application already had its window pinned always-on-top, that setting is
+left exactly as it was found.
+
+Printing
+--------
+
+There is deliberately no print method. Handing a file to the operating system's
+printer works very differently on each platform, and on Windows the only
+available route cannot be told which printer to use or how many copies to run —
+so the arguments would be there but ignored. Saving the capture and letting the
+user print it from an application built for printing is more dependable. A
+``.pdf`` capture is usually the most convenient thing to hand them.
+
+See also
+--------
+
+- :doc:`/tasks/dialogs` — the save dialog used above, and the rest of the dialog
+  verbs.
+- :doc:`/reference/images` — displaying images inside the interface, including
+  showing a capture back to the user.

--- a/docs/tasks/capturing-screenshots.rst
+++ b/docs/tasks/capturing-screenshots.rst
@@ -1,6 +1,8 @@
 Capturing Screenshots
 =====================
 
+.. versionadded:: 0.3.0
+
 Every widget can save a picture of itself. Call ``capture()`` on the app to get
 the whole window, or on a single widget to get just that part of it — useful for
 letting someone share a dashboard, a report, or one chart with a colleague who
@@ -43,6 +45,13 @@ format:
 
 That is the whole feature for most applications — a button, a save dialog, and
 one call.
+
+A capture pauses briefly before reading the screen, so the desktop can finish
+repainting the area a closing dialog just uncovered — a tenth of a second by
+default, adjustable with ``settle``. The pause is deliberate: nothing else runs
+during it, so an impatient second click on the export button waits its turn
+instead of re-entering the handler and opening a second save dialog on top of
+the first. You do not need to guard the button against double-clicks yourself.
 
 Capturing part of the window
 ----------------------------

--- a/docs/tasks/capturing-screenshots.rst
+++ b/docs/tasks/capturing-screenshots.rst
@@ -118,15 +118,15 @@ knowing before you build on it:
   application. While developing, the permission follows whatever launched the
   script, so it is the terminal or editor that needs it rather than the script
   itself.
-- **On Linux, a Wayland session may need a screenshot helper installed.** An X11
-  session captures directly and needs nothing. Wayland does not let an
-  application read the screen for itself, so the capture goes through the
-  desktop's own screenshot tool — ``grim`` on Sway and other wlroots desktops,
-  ``spectacle`` on KDE, ``gnome-screenshot`` where it is still present. Some
-  desktops ship none of them, and there the capture raises an error naming what
-  to install rather than saving anything. Worth checking early if your users are
-  on Linux, because it is the one platform where capture can be unavailable
-  outright.
+- **On Linux, a capture may need a screenshot helper installed.** Most X11
+  sessions capture directly and need nothing. Wayland does not let an
+  application read the screen for itself, and some X11 setups cannot either, so
+  the capture falls back to the desktop's own screenshot tool — ``grim`` on Sway
+  and other wlroots desktops, ``spectacle`` on KDE, ``gnome-screenshot`` where it
+  is still present, or ImageMagick's ``import``. A machine with none of them
+  installed raises an error naming those four rather than saving anything. Worth
+  checking early if your users are on Linux, because it is the one platform where
+  capturing can be unavailable outright.
 
 If the application already had its window pinned always-on-top, that setting is
 left exactly as it was found.

--- a/docs/tasks/capturing-screenshots.rst
+++ b/docs/tasks/capturing-screenshots.rst
@@ -24,15 +24,13 @@ Letting the user choose the file
 --------------------------------
 
 In practice you rarely want a hard-coded filename. Pair the capture with
-:func:`~bootstack.dialogs.ask_save_file` and the user picks both the location
-and the format:
+:func:`~bootstack.ask_save_file` and the user picks both the location and the
+format:
 
 .. code-block:: python
 
-   from bootstack.dialogs import ask_save_file
-
    def on_export():
-       chosen = ask_save_file(
+       chosen = bs.ask_save_file(
            initial_file="dashboard.png",
            file_types=[("PNG image", "*.png"),
                        ("JPEG image", "*.jpg"),
@@ -104,6 +102,15 @@ knowing before you build on it:
 - **The capture is what the screen shows.** A long list scrolled halfway down is
   captured halfway down; there is no way to photograph content scrolled out of
   view.
+- **On macOS, the application needs permission to record the screen.** Without it
+  the system quietly hands back a picture of the desktop instead of the window —
+  no error, just the wrong image. macOS asks the first time an application
+  captures anything and never asks again if that prompt was declined; grant it
+  under System Settings → Privacy and Security → Screen and System Audio
+  Recording (called Screen Recording before macOS 15) and restart the
+  application. While developing, the permission follows whatever launched the
+  script, so it is the terminal or editor that needs it rather than the script
+  itself.
 
 If the application already had its window pinned always-on-top, that setting is
 left exactly as it was found.

--- a/docs/tasks/capturing-screenshots.rst
+++ b/docs/tasks/capturing-screenshots.rst
@@ -52,10 +52,27 @@ default, adjustable with ``settle``. Without that pause the picture can come
 back showing the dialog that was just dismissed rather than the window
 underneath it.
 
-The window stops accepting input for the moment the pause lasts, so an
+The window also stops accepting input for the moment the pause lasts, so an
 impatient second click on the export button is discarded instead of
 re-entering the handler and opening a second save dialog on top of the first.
-You do not need to guard the button against double-clicks yourself.
+
+.. note::
+
+   That input guard is not honored on macOS. A second click during the pause
+   does reach the button there, so a handler that opens a save dialog can be
+   entered twice. If a double-click on your export button would cause trouble,
+   disable it for the duration:
+
+   .. code-block:: python
+
+      def on_export():
+          button.disabled = True
+          try:
+              chosen = bs.ask_save_file(initial_file="dashboard.png")
+              if chosen:
+                  app.capture(chosen)
+          finally:
+              button.disabled = False
 
 Capturing part of the window
 ----------------------------

--- a/docs/tasks/capturing-screenshots.rst
+++ b/docs/tasks/capturing-screenshots.rst
@@ -48,10 +48,14 @@ one call.
 
 A capture pauses briefly before reading the screen, so the desktop can finish
 repainting the area a closing dialog just uncovered — a tenth of a second by
-default, adjustable with ``settle``. The pause is deliberate: nothing else runs
-during it, so an impatient second click on the export button waits its turn
-instead of re-entering the handler and opening a second save dialog on top of
-the first. You do not need to guard the button against double-clicks yourself.
+default, adjustable with ``settle``. Without that pause the picture can come
+back showing the dialog that was just dismissed rather than the window
+underneath it.
+
+The window stops accepting input for the moment the pause lasts, so an
+impatient second click on the export button is discarded instead of
+re-entering the handler and opening a second save dialog on top of the first.
+You do not need to guard the button against double-clicks yourself.
 
 Capturing part of the window
 ----------------------------

--- a/docs/tasks/capturing-screenshots.rst
+++ b/docs/tasks/capturing-screenshots.rst
@@ -118,6 +118,15 @@ knowing before you build on it:
   application. While developing, the permission follows whatever launched the
   script, so it is the terminal or editor that needs it rather than the script
   itself.
+- **On Linux, a Wayland session may need a screenshot helper installed.** An X11
+  session captures directly and needs nothing. Wayland does not let an
+  application read the screen for itself, so the capture goes through the
+  desktop's own screenshot tool — ``grim`` on Sway and other wlroots desktops,
+  ``spectacle`` on KDE, ``gnome-screenshot`` where it is still present. Some
+  desktops ship none of them, and there the capture raises an error naming what
+  to install rather than saving anything. Worth checking early if your users are
+  on Linux, because it is the one platform where capture can be unavailable
+  outright.
 
 If the application already had its window pinned always-on-top, that setting is
 left exactly as it was found.

--- a/docs/tasks/capturing-screenshots.rst
+++ b/docs/tasks/capturing-screenshots.rst
@@ -101,7 +101,14 @@ knowing before you build on it:
   another application still lands in the picture.
 - **The capture is what the screen shows.** A long list scrolled halfway down is
   captured halfway down; there is no way to photograph content scrolled out of
-  view.
+  view. Capturing a widget that has been scrolled right out of its viewport
+  raises an error rather than photographing whatever now sits in its place — a
+  row still counts as capturable while any part of it is in view.
+- **On a Retina Mac the picture is saved at the window's own size.** A 560×360
+  window produces a 560×360 image rather than the finer pixel grid the display
+  actually draws it on, so text is slightly softer than in a screenshot taken
+  with the system's own tool. Captures come out the same size on every machine,
+  which is usually what you want when they are headed for a report.
 - **On macOS, the application needs permission to record the screen.** Without it
   the system quietly hands back a picture of the desktop instead of the window —
   no error, just the wrong image. macOS asks the first time an application

--- a/docs/user-guide/index.rst
+++ b/docs/user-guide/index.rst
@@ -116,6 +116,12 @@ How-to guides
 
       Intro screens that cover startup — timed branding, welcome, real progress.
 
+   .. grid-item-card:: :octicon:`device-camera;1.5em;sd-mr-1` Capturing Screenshots
+      :link: /tasks/capturing-screenshots
+      :link-type: doc
+
+      Save a window or a single widget as a PNG, JPEG, or PDF the user can share.
+
 Feature guides
 --------------
 
@@ -262,6 +268,7 @@ Developer tools
    /tasks/navigation/index
    /tasks/application-icons
    /tasks/splash-screens
+   /tasks/capturing-screenshots
 
 .. toctree::
    :caption: Feature guides

--- a/src/bootstack/_core/capture.py
+++ b/src/bootstack/_core/capture.py
@@ -81,6 +81,52 @@ def widget_region(tk_widget, inset: int = 0) -> tuple[int, int, int, int]:
     return (left, top, right, bottom)
 
 
+def still_exists(tk_widget) -> bool:
+    """Whether a widget is still alive, without leaking a toolkit error.
+
+    `winfo_exists()` reports 0 for a destroyed child but RAISES for a destroyed
+    root — the toolkit has no interpreter left to ask by then. Both mean the
+    same thing to a caller, so both answer False here.
+    """
+    try:
+        return bool(tk_widget.winfo_exists())
+    except tkinter.TclError:
+        return False
+
+
+def clipped_out_of_view(tk_widget) -> bool:
+    """Whether a widget's rectangle has left its own window entirely.
+
+    A widget scrolled out of a viewport stays MAPPED — the toolkit reports
+    `winfo_ismapped()` and `winfo_viewable()` as 1 for a row that is nowhere
+    near the visible area — while `winfo_rooty()` keeps reporting where the row
+    would be if the window were tall enough to show it. Measured: a row in a
+    scrolled list reported y=273 for a window spanning 390 to 630.
+
+    Capturing that rectangle photographs whatever else is on screen there and
+    saves it without complaint, which is the one outcome this module exists to
+    prevent. Only a rectangle that has left the window completely is refused;
+    a row half out of view still captures, matching the rule that a capture
+    shows what the screen shows.
+    """
+    top = tk_widget.winfo_toplevel()
+    if tk_widget is top:
+        return False
+
+    left, top_y = tk_widget.winfo_rootx(), tk_widget.winfo_rooty()
+    right = left + tk_widget.winfo_width()
+    bottom = top_y + tk_widget.winfo_height()
+
+    win_left, win_top = top.winfo_rootx(), top.winfo_rooty()
+    win_right = win_left + top.winfo_width()
+    win_bottom = win_top + top.winfo_height()
+
+    return not (
+        left < win_right and right > win_left
+        and top_y < win_bottom and bottom > win_top
+    )
+
+
 @contextlib.contextmanager
 def raised(tk_widget):
     """Hold a widget's window at the front for the duration of a capture.

--- a/src/bootstack/_core/capture.py
+++ b/src/bootstack/_core/capture.py
@@ -47,10 +47,14 @@ _PLAIN_COLOR_MODES = ("RGB", "L")
 
 # Tried in order, first one installed wins.
 _SUBPROCESS_BACKENDS = (
-    ("grim", ["grim", "{out}"]),                              # wlroots, Sway
+    ("grim", ["grim", "{out}"]),                                    # wlroots, Sway
     ("gnome-screenshot", ["gnome-screenshot", "-f", "{out}"]),
-    ("spectacle", ["spectacle", "-b", "-n", "-o", "{out}"]),  # KDE
-    ("import", ["import", "-window", "root", "{out}"]),       # ImageMagick
+    # `-f` asks for the full screen. Without it spectacle repeats whatever
+    # capture mode it was last used with, which is remembered in its own
+    # config — so the same call photographs the desktop on one machine and a
+    # single window on the next.
+    ("spectacle", ["spectacle", "-b", "-n", "-f", "-o", "{out}"]),  # KDE
+    ("import", ["import", "-window", "root", "{out}"]),             # ImageMagick
 )
 
 # Platforms whose region handling inside `ImageGrab` can be relied on. Windows

--- a/src/bootstack/_core/capture.py
+++ b/src/bootstack/_core/capture.py
@@ -16,6 +16,7 @@ import contextlib
 import os
 import shutil
 import subprocess
+import sys
 import tempfile
 import time
 import tkinter
@@ -24,6 +25,17 @@ from pathlib import Path
 from PIL import Image, ImageGrab
 
 from bootstack.errors import BootstackError
+
+try:
+    from screeninfo import get_monitors
+    HAS_SCREENINFO = True
+except ImportError:
+    HAS_SCREENINFO = False
+
+# Platforms whose capture backend ships with the operating system. There is
+# nothing to install and nothing to fall back to, so a failure here is a real
+# failure rather than a missing-backend one.
+_BUILTIN_BACKEND_PLATFORMS = ("win32", "darwin")
 
 # Formats that store plain color and nothing else. A capture bound for one of
 # these is converted first, because saving an image that carries transparency
@@ -145,9 +157,63 @@ def grab(bbox: tuple[int, int, int, int] | None = None) -> Image.Image:
         # exception raised and nothing to debug. Pillow honors the flag on
         # Windows and ignores it elsewhere.
         return ImageGrab.grab(bbox=bbox, all_screens=bbox is not None)
-    except (OSError, NotImplementedError):
+    except (OSError, NotImplementedError) as exc:
+        # Diagnosis happens only AFTER a failed grab, never before one, so
+        # nothing here can reject a capture that would have worked.
+        #
+        # The catch is deliberately wide because the failures it has to cover
+        # are: no ImageGrab on this build at all, and a grab that ran and came
+        # back with nothing usable. Those need opposite answers, and the
+        # exception type cannot tell them apart — Pillow reports a region no
+        # display covers as `UnidentifiedImageError`, which IS an `OSError`.
+        if bbox is not None and _covered_by_a_display(bbox) is False:
+            raise BootstackError(
+                f"The area being captured — ({bbox[0]}, {bbox[1]}) to "
+                f"({bbox[2]}, {bbox[3]}) — is not on any display, so there are "
+                f"no pixels to read. A window moved off the edge of the screen, "
+                f"or a widget scrolled out of view, is the usual cause."
+            ) from exc
+
+        if sys.platform in _BUILTIN_BACKEND_PLATFORMS:
+            # Falling through to the subprocess chain here would end in advice
+            # to install Linux screenshot tools on a machine that already has a
+            # working backend — wrong on its face and no help in fixing this.
+            raise BootstackError(
+                f"The screen capture failed — {exc}. The window may have been "
+                f"hidden or moved while the picture was being taken."
+            ) from exc
+
         # Wayland, or a Pillow built without XCB.
         return _grab_via_subprocess(bbox)
+
+
+def _covered_by_a_display(bbox: tuple[int, int, int, int]) -> bool | None:
+    """Whether any monitor covers part of `bbox`.
+
+    Returns None when the question cannot be answered — no `screeninfo`, or it
+    could not read the display layout — so a caller can tell "definitely not on
+    a display" apart from "could not tell", and only act on the former.
+
+    Partial overlap counts as covered. A window hanging off the bottom edge of
+    the screen captures perfectly well; only a region no monitor touches at all
+    has nothing to read.
+    """
+    if not HAS_SCREENINFO:
+        return None
+
+    left, top, right, bottom = bbox
+    try:
+        monitors = get_monitors()
+    except Exception:  # noqa: BLE001 - a diagnostic must not raise its own error
+        return None
+    if not monitors:
+        return None
+
+    return any(
+        left < m.x + m.width and right > m.x
+        and top < m.y + m.height and bottom > m.y
+        for m in monitors
+    )
 
 
 def save(image: Image.Image, path) -> Path:

--- a/src/bootstack/_core/capture.py
+++ b/src/bootstack/_core/capture.py
@@ -57,16 +57,22 @@ _SUBPROCESS_BACKENDS = (
     ("import", ["import", "-window", "root", "{out}"]),             # ImageMagick
 )
 
-# Platforms whose region handling inside `ImageGrab` can be relied on. Windows
-# reports the origin of the grab and crops the region against it; macOS hands
-# the region to `screencapture` and rescales what comes back, which is what
-# keeps the result aligned on a Retina display. Cropping those here instead
-# would throw both of those away.
+# Platforms where cutting the region has to stay `ImageGrab`'s job, because it
+# needs detail this module does not have. Windows crops against the origin its
+# own grab reports, which cannot be reconstructed from a rectangle alone; macOS
+# asks `screencapture` for the region and rescales the answer, which is what
+# keeps the result aligned on a Retina display. Cutting the region here would
+# discard both.
 #
-# Everywhere else — Linux — `ImageGrab` crops without checking that the
-# picture it grabbed actually covers the region, which pads the difference
-# with black and raises nothing. That is the failure `_crop_desktop` refuses,
-# so on those platforms the region is cut here rather than by the library.
+# This says which code owns the crop, not that the crop is checked — neither of
+# those is. Windows pads a region reaching past the grabbed desktop with black,
+# and macOS stretches a region the system clamped. Extending the bounds check to
+# them is a separate change, and one no box available here can verify.
+#
+# Everywhere else — Linux — `ImageGrab` grabs the whole desktop and crops it
+# with no check that it covers the region, padding the difference with black
+# and raising nothing. That is the failure `_crop_desktop` refuses, so there
+# the region is cut here rather than by the library.
 _LIBRARY_HANDLES_REGION = sys.platform in ("win32", "darwin")
 
 

--- a/src/bootstack/_core/capture.py
+++ b/src/bootstack/_core/capture.py
@@ -1,0 +1,194 @@
+"""Screen-region capture backing the public `widget.capture()`.
+
+A capture reads pixels from the display, so the region has to be visible:
+the widget must be on screen, and anything drawn over it is captured along
+with it. There is no offscreen rendering path — the toolkit does not offer
+one — which is why the public method requires a visible widget.
+
+Capture uses Pillow's `ImageGrab`, falling back to a desktop screenshot tool
+on Linux sessions where `ImageGrab` is unavailable (Wayland, or a Pillow
+built without XCB support).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+import tkinter
+from pathlib import Path
+
+from PIL import Image, ImageGrab
+
+from bootstack.errors import BootstackError
+
+# Formats with no alpha channel. A capture bound for one of these is
+# flattened first, because saving RGBA as JPEG fails outright.
+_NO_ALPHA_FORMATS = {".jpg", ".jpeg", ".pdf", ".bmp"}
+
+# Tried in order, first one installed wins.
+_SUBPROCESS_BACKENDS = (
+    ("grim", ["grim", "{out}"]),                              # wlroots, Sway
+    ("gnome-screenshot", ["gnome-screenshot", "-f", "{out}"]),
+    ("spectacle", ["spectacle", "-b", "-n", "-o", "{out}"]),  # KDE
+    ("import", ["import", "-window", "root", "{out}"]),       # ImageMagick
+)
+
+
+def widget_region(tk_widget, inset: int = 0) -> tuple[int, int, int, int]:
+    """Return a widget's on-screen rectangle as `(left, top, right, bottom)`.
+
+    Coordinates span the whole virtual desktop, so a widget on a monitor
+    placed to the left of, or above, the primary one has a negative origin.
+
+    Args:
+        tk_widget: The toolkit widget to measure.
+        inset: Pixels to trim from every edge.
+    """
+    x, y = tk_widget.winfo_rootx(), tk_widget.winfo_rooty()
+    width, height = tk_widget.winfo_width(), tk_widget.winfo_height()
+    left, top = x + inset, y + inset
+    right, bottom = x + width - inset, y + height - inset
+    if right <= left or bottom <= top:
+        raise BootstackError(
+            f"inset={inset} trims away the whole capture — the widget is only "
+            f"{width}x{height} pixels."
+        )
+    return (left, top, right, bottom)
+
+
+@contextlib.contextmanager
+def raised(tk_widget):
+    """Hold a widget's window at the front for the duration of a capture.
+
+    A capture reads whatever is on the display, so a window sitting over the
+    target is captured instead of it — silently, and with a plausible-looking
+    image to show for it. Raising the window first is what makes the result
+    mean what the caller asked for.
+
+    The previous always-on-top setting is restored on the way out, and left
+    alone entirely if it was already set, so a window the application
+    deliberately pinned on top does not get un-pinned by taking a picture.
+    """
+    top = tk_widget.winfo_toplevel()
+    try:
+        top.lift()
+    except tkinter.TclError:
+        pass
+
+    # None means "left alone" — either the setting could not be read, or the
+    # window manager does not support it. Some Linux window managers do not,
+    # and a capture must not fail just because it cannot pin a window.
+    was_topmost = None
+    try:
+        was_topmost = bool(top.attributes("-topmost"))
+        if not was_topmost:
+            top.attributes("-topmost", True)
+    except tkinter.TclError:
+        was_topmost = None
+
+    try:
+        yield
+    finally:
+        # Restore only what this function actually changed.
+        if was_topmost is False:
+            try:
+                top.attributes("-topmost", False)
+            except tkinter.TclError:
+                pass
+
+
+def settle(tk_widget, seconds: float) -> None:
+    """Let pending redraws finish before the pixels are read.
+
+    Flushes the framework's own drawing, then yields for `seconds` so the
+    desktop can repaint the area behind any window that has just closed — a
+    save dialog, most commonly. The event loop keeps running throughout, so
+    the interface does not freeze while this waits.
+
+    Args:
+        tk_widget: Any widget; its root window drives the event loop.
+        seconds: How long to yield for. Zero flushes without waiting.
+    """
+    root = tk_widget._root()
+    root.update_idletasks()
+    root.update()
+    deadline = time.monotonic() + max(seconds, 0.0)
+    while time.monotonic() < deadline:
+        time.sleep(0.01)
+        root.update()
+
+
+def capture_region(bbox: tuple[int, int, int, int], path) -> Path:
+    """Grab one screen region and write it to `path`, returning the path."""
+    return save(grab(bbox), path)
+
+
+def grab(bbox: tuple[int, int, int, int] | None = None) -> Image.Image:
+    """Grab a screen region, or the whole primary display when `bbox` is None."""
+    try:
+        # `all_screens` widens the grab to the whole virtual desktop. Without
+        # it, a region on a monitor left of or above the primary one is cropped
+        # out of a primary-only grab and comes back silently BLACK — no
+        # exception raised and nothing to debug. Pillow honors the flag on
+        # Windows and ignores it elsewhere.
+        return ImageGrab.grab(bbox=bbox, all_screens=bbox is not None)
+    except (OSError, NotImplementedError):
+        # Wayland, or a Pillow built without XCB.
+        return _grab_via_subprocess(bbox)
+
+
+def save(image: Image.Image, path) -> Path:
+    """Write an image to `path`, taking the format from its extension."""
+    path = Path(path)
+    if image.mode == "RGBA" and path.suffix.lower() in _NO_ALPHA_FORMATS:
+        image = image.convert("RGB")
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        image.save(path)
+    except (OSError, ValueError, KeyError) as exc:
+        raise BootstackError(
+            f"Could not save the capture to '{path}' — {exc}. The file "
+            f"extension selects the format; '.png', '.jpg', and '.pdf' are "
+            f"the usual choices."
+        ) from exc
+    return path
+
+
+def _grab_via_subprocess(
+    bbox: tuple[int, int, int, int] | None = None,
+) -> Image.Image:
+    """Capture through a desktop screenshot tool, for Linux without ImageGrab."""
+    for name, argv in _SUBPROCESS_BACKENDS:
+        if not shutil.which(name):
+            continue
+        # A unique name per call — a fixed one collides when two captures
+        # overlap, and the loser silently reads the other's pixels.
+        handle, tmp_name = tempfile.mkstemp(
+            prefix="bootstack-capture-", suffix=".png"
+        )
+        os.close(handle)
+        tmp = Path(tmp_name)
+        try:
+            subprocess.run(
+                [arg.format(out=tmp) for arg in argv],
+                check=True,
+                capture_output=True,
+                timeout=30,
+            )
+            with Image.open(tmp) as opened:
+                opened.load()
+                image = opened.copy()
+        except (subprocess.SubprocessError, OSError):
+            continue
+        finally:
+            tmp.unlink(missing_ok=True)
+        return image.crop(bbox) if bbox else image
+
+    raise BootstackError(
+        "No screen capture backend is available. Install a Pillow build with "
+        "XCB support, or one of: grim, gnome-screenshot, spectacle, import."
+    )

--- a/src/bootstack/_core/capture.py
+++ b/src/bootstack/_core/capture.py
@@ -73,7 +73,8 @@ _SUBPROCESS_BACKENDS = (
 # with no check that it covers the region, padding the difference with black
 # and raising nothing. That is the failure `_crop_desktop` refuses, so there
 # the region is cut here rather than by the library.
-_LIBRARY_HANDLES_REGION = sys.platform in ("win32", "darwin")
+_LIBRARY_REGION_PLATFORMS = ("win32", "darwin")
+_LIBRARY_HANDLES_REGION = sys.platform in _LIBRARY_REGION_PLATFORMS
 
 
 def widget_region(tk_widget, inset: int = 0) -> tuple[int, int, int, int]:

--- a/src/bootstack/_core/capture.py
+++ b/src/bootstack/_core/capture.py
@@ -214,9 +214,22 @@ def settle(tk_widget, seconds: float) -> None:
     re-enter the caller's handler, opening a second save dialog on top of the
     first and starting an overlapping capture, none of which the person
     clicking asked for. `tk busy` routes that click to a blocking window
-    instead, and is invisible in the photograph. Where it is unavailable the
-    wait still dispatches — a correct picture matters more than the stray
-    click, which is the trade the toolkit leaves us.
+    instead.
+
+    ⚠ THE HOLD IS BEST-EFFORT, AND ON macOS IT DOES NOTHING. Aqua reports the
+    hold as successful and never maps the window it created: `tk busy status`
+    returns 1 while the busy window sits at `winfo_ismapped() == 0`, and Tk's
+    own hit test at the button's position still resolves to the button. So a
+    real click re-enters the handler there — confirmed by hand, since a
+    synthesized click cannot test this. Measured on Tk 8.6.17 in plain
+    tkinter, so it is the toolkit rather than anything above it. X11 and Win32
+    map the window and are expected to honor it;
+    `development/probe_429_busy_during_settle.py` reports which a given box
+    does.
+
+    The wait dispatches either way. A correct picture is worth more than a
+    stray click: without dispatching, the capture reads pixels that are simply
+    wrong, and that is the failure this function exists to prevent.
 
     Args:
         tk_widget: Any widget; its root window is the one flushed.
@@ -242,6 +255,9 @@ def _input_blocked(tk_widget):
 
     Yields either way: a window that cannot be held busy is still captured,
     just without the protection from a stray click.
+
+    ⚠ Yielding `True` means the hold was ACCEPTED, not that input is actually
+    blocked — macOS accepts it and does not map the busy window. See `settle`.
 
     ⚠ The target may already be DEAD by the time this runs — settling flushes
     pending drawing first, and idle work queued before the capture can destroy

--- a/src/bootstack/_core/capture.py
+++ b/src/bootstack/_core/capture.py
@@ -194,22 +194,29 @@ def raised(tk_widget):
 def settle(tk_widget, seconds: float) -> None:
     """Let pending redraws finish before the pixels are read.
 
-    Flushes the framework's own drawing, then yields for `seconds` so the
-    desktop can repaint the area behind any window that has just closed — a
-    save dialog, most commonly. The event loop keeps running throughout, so
-    the interface does not freeze while this waits.
+    Flushes the framework's own drawing, then waits `seconds` so the desktop
+    can repaint the area behind any window that has just closed — a save
+    dialog, most commonly.
+
+    The wait deliberately does NOT dispatch events. Turning the event loop
+    here would run everything queued, including a second click on the button
+    that started the capture: that click re-enters the caller's handler, which
+    opens a second save dialog on top of the first and starts an overlapping
+    capture, none of which the person clicking asked for. Waiting quietly
+    costs a brief pause — a tenth of a second by default — and makes the
+    second click wait its turn instead. Flushing pending drawing is idle work,
+    so it still happens.
 
     Args:
-        tk_widget: Any widget; its root window drives the event loop.
-        seconds: How long to yield for. Zero flushes without waiting.
+        tk_widget: Any widget; its root window is the one flushed.
+        seconds: How long to wait for. Zero flushes without waiting.
     """
     root = tk_widget._root()
     root.update_idletasks()
-    root.update()
-    deadline = time.monotonic() + max(seconds, 0.0)
-    while time.monotonic() < deadline:
-        time.sleep(0.01)
-        root.update()
+    time.sleep(max(seconds, 0.0))
+    # Again after the wait: anything the pause allowed to arrive gets drawn
+    # before the pixels are read.
+    root.update_idletasks()
 
 
 def capture_region(bbox: tuple[int, int, int, int], path) -> Path:

--- a/src/bootstack/_core/capture.py
+++ b/src/bootstack/_core/capture.py
@@ -53,6 +53,18 @@ _SUBPROCESS_BACKENDS = (
     ("import", ["import", "-window", "root", "{out}"]),       # ImageMagick
 )
 
+# Platforms whose region handling inside `ImageGrab` can be relied on. Windows
+# reports the origin of the grab and crops the region against it; macOS hands
+# the region to `screencapture` and rescales what comes back, which is what
+# keeps the result aligned on a Retina display. Cropping those here instead
+# would throw both of those away.
+#
+# Everywhere else — Linux — `ImageGrab` crops without checking that the
+# picture it grabbed actually covers the region, which pads the difference
+# with black and raises nothing. That is the failure `_crop_desktop` refuses,
+# so on those platforms the region is cut here rather than by the library.
+_LIBRARY_HANDLES_REGION = sys.platform in ("win32", "darwin")
+
 
 def widget_region(tk_widget, inset: int = 0) -> tuple[int, int, int, int]:
     """Return a widget's on-screen rectangle as `(left, top, right, bottom)`.
@@ -197,12 +209,16 @@ def capture_region(bbox: tuple[int, int, int, int], path) -> Path:
 def grab(bbox: tuple[int, int, int, int] | None = None) -> Image.Image:
     """Grab a screen region, or the whole primary display when `bbox` is None."""
     try:
-        # `all_screens` widens the grab to the whole virtual desktop. Without
-        # it, a region on a monitor left of or above the primary one is cropped
-        # out of a primary-only grab and comes back silently BLACK — no
-        # exception raised and nothing to debug. Pillow honors the flag on
-        # Windows and ignores it elsewhere.
-        return ImageGrab.grab(bbox=bbox, all_screens=bbox is not None)
+        if _LIBRARY_HANDLES_REGION:
+            # `all_screens` widens the grab to the whole virtual desktop.
+            # Without it, a region on a monitor left of or above the primary
+            # one is cropped out of a primary-only grab and comes back
+            # silently BLACK — no exception raised and nothing to debug.
+            return ImageGrab.grab(bbox=bbox, all_screens=bbox is not None)
+        # Grab the whole desktop and cut the region out below, under the
+        # bounds check. This platform grabs everything and crops either way,
+        # so what changes is where the crop happens, not how much is read.
+        image = ImageGrab.grab()
     except (OSError, NotImplementedError) as exc:
         # Diagnosis happens only AFTER a failed grab, never before one, so
         # nothing here can reject a capture that would have worked.
@@ -231,6 +247,9 @@ def grab(bbox: tuple[int, int, int, int] | None = None) -> Image.Image:
 
         # Wayland, or a Pillow built without XCB.
         return _grab_via_subprocess(bbox)
+    # Outside the `except` on purpose: a region the grab missed is a capture
+    # failure to report, not a reason to try another backend.
+    return _crop_desktop(image, bbox) if bbox else image
 
 
 def _covered_by_a_display(bbox: tuple[int, int, int, int]) -> bool | None:
@@ -326,18 +345,18 @@ def _crop_desktop(
 ) -> Image.Image:
     """Cut a region out of a whole-desktop grab, refusing a region it misses.
 
-    The screenshot tools photograph the desktop and return an image measured
-    from their own origin, while the region is measured across the whole
-    virtual desktop. Those agree on an ordinary single-monitor session and can
-    disagree otherwise — most often when the window sits on a monitor the tool
-    did not photograph. Cropping past the edge of an image pads the result with
-    black rather than failing, so the caller would get a plausible-looking
-    all-black picture and no way to tell why. Raising is the better answer.
+    A whole-desktop grab returns an image measured from whatever its source
+    treats as the origin, while the region is measured across the whole virtual
+    desktop. Those agree on an ordinary single-monitor session and can disagree
+    otherwise — most often when the window sits on a monitor the grab did not
+    cover. Cropping past the edge of an image pads the result with black rather
+    than failing, so the caller would get a plausible-looking all-black picture
+    and no way to tell why. Raising is the better answer.
     """
     left, top, right, bottom = bbox
     if left < 0 or top < 0 or right > image.width or bottom > image.height:
         raise BootstackError(
-            f"The screen capture tool returned a {image.width}x{image.height} "
+            f"The screen capture returned a {image.width}x{image.height} "
             f"picture, which does not cover the area being captured — "
             f"({left}, {top}) to ({right}, {bottom}). This usually means the "
             f"window is on a monitor the tool did not photograph; moving it to "

--- a/src/bootstack/_core/capture.py
+++ b/src/bootstack/_core/capture.py
@@ -37,6 +37,10 @@ except ImportError:
 # failure rather than a missing-backend one.
 _BUILTIN_BACKEND_PLATFORMS = ("win32", "darwin")
 
+# How long to pause between event-loop turns while settling. Short enough to
+# stay responsive to the repaint we are waiting for, long enough not to spin.
+_SETTLE_TICK = 0.01
+
 # Formats that store plain color and nothing else. A capture bound for one of
 # these is converted first, because saving an image that carries transparency
 # — or a color palette — as JPEG fails outright.
@@ -194,18 +198,25 @@ def raised(tk_widget):
 def settle(tk_widget, seconds: float) -> None:
     """Let pending redraws finish before the pixels are read.
 
-    Flushes the framework's own drawing, then waits `seconds` so the desktop
-    can repaint the area behind any window that has just closed — a save
-    dialog, most commonly.
+    Waits `seconds` while the event loop turns, so the desktop can repaint
+    the area behind any window that has just closed — a save dialog, most
+    commonly.
 
-    The wait deliberately does NOT dispatch events. Turning the event loop
-    here would run everything queued, including a second click on the button
-    that started the capture: that click re-enters the caller's handler, which
-    opens a second save dialog on top of the first and starts an overlapping
-    capture, none of which the person clicking asked for. Waiting quietly
-    costs a brief pause — a tenth of a second by default — and makes the
-    second click wait its turn instead. Flushing pending drawing is idle work,
-    so it still happens.
+    The wait has to dispatch events. Flushing our own drawing is not enough:
+    the area a closing window uncovers is repainted by the desktop, and on
+    macOS that repaint does not happen at all unless the loop is turning. A
+    capture taken without it photographs the dialog that was just dismissed
+    rather than the widget underneath.
+
+    Dispatching brings its own problem, which is why the window is held busy
+    for the duration. Turning the loop runs everything queued, including a
+    second click on the button that started the capture: that click would
+    re-enter the caller's handler, opening a second save dialog on top of the
+    first and starting an overlapping capture, none of which the person
+    clicking asked for. `tk busy` routes that click to a blocking window
+    instead, and is invisible in the photograph. Where it is unavailable the
+    wait still dispatches — a correct picture matters more than the stray
+    click, which is the trade the toolkit leaves us.
 
     Args:
         tk_widget: Any widget; its root window is the one flushed.
@@ -213,10 +224,48 @@ def settle(tk_widget, seconds: float) -> None:
     """
     root = tk_widget._root()
     root.update_idletasks()
-    time.sleep(max(seconds, 0.0))
-    # Again after the wait: anything the pause allowed to arrive gets drawn
-    # before the pixels are read.
+    with _input_blocked(tk_widget):
+        deadline = time.perf_counter() + max(seconds, 0.0)
+        while time.perf_counter() < deadline:
+            root.update()
+            # Yield the processor rather than spinning on update() alone.
+            time.sleep(_SETTLE_TICK)
+        # Once more after the wait, so anything the pause allowed to arrive
+        # is drawn before the pixels are read.
+        root.update()
     root.update_idletasks()
+
+
+@contextlib.contextmanager
+def _input_blocked(tk_widget):
+    """Route input away from a window while the event loop is being turned.
+
+    Yields either way: a window that cannot be held busy is still captured,
+    just without the protection from a stray click.
+
+    ⚠ The target may already be DEAD by the time this runs — settling flushes
+    pending drawing first, and idle work queued before the capture can destroy
+    it. Asking a destroyed widget for its toplevel raises a raw `TclError`,
+    which would escape a method documented to raise `BootstackError` and
+    pre-empt the guard that reports the closure properly. So the lookup is
+    guarded too, not just the `tk busy` calls.
+    """
+    top = None
+    held = False
+    try:
+        top = tk_widget.winfo_toplevel()
+        top.tk.call("tk", "busy", "hold", top._w)
+        held = True
+    except tkinter.TclError:
+        held = False
+    try:
+        yield held
+    finally:
+        if held and top is not None:
+            try:
+                top.tk.call("tk", "busy", "forget", top._w)
+            except tkinter.TclError:
+                pass
 
 
 def capture_region(bbox: tuple[int, int, int, int], path) -> Path:

--- a/src/bootstack/_core/capture.py
+++ b/src/bootstack/_core/capture.py
@@ -368,8 +368,9 @@ def _crop_desktop(
         raise BootstackError(
             f"The screen capture returned a {image.width}x{image.height} "
             f"picture, which does not cover the area being captured — "
-            f"({left}, {top}) to ({right}, {bottom}). This usually means the "
-            f"window is on a monitor the tool did not photograph; moving it to "
-            f"the main display is the reliable workaround."
+            f"({left}, {top}) to ({right}, {bottom}). Either the window is "
+            f"hanging off the edge of the screen, or it is on a display the "
+            f"capture did not reach. Moving it fully onto the main display "
+            f"resolves both."
         )
     return image.crop(bbox)

--- a/src/bootstack/_core/capture.py
+++ b/src/bootstack/_core/capture.py
@@ -25,9 +25,13 @@ from PIL import Image, ImageGrab
 
 from bootstack.errors import BootstackError
 
-# Formats with no alpha channel. A capture bound for one of these is
-# flattened first, because saving RGBA as JPEG fails outright.
+# Formats that store plain color and nothing else. A capture bound for one of
+# these is converted first, because saving an image that carries transparency
+# — or a color palette — as JPEG fails outright.
 _NO_ALPHA_FORMATS = {".jpg", ".jpeg", ".pdf", ".bmp"}
+
+# Image modes those formats accept as they are.
+_PLAIN_COLOR_MODES = ("RGB", "L")
 
 # Tried in order, first one installed wins.
 _SUBPROCESS_BACKENDS = (
@@ -46,8 +50,13 @@ def widget_region(tk_widget, inset: int = 0) -> tuple[int, int, int, int]:
 
     Args:
         tk_widget: The toolkit widget to measure.
-        inset: Pixels to trim from every edge.
+        inset: Pixels to trim from every edge. Zero or more.
     """
+    if inset < 0:
+        raise BootstackError(
+            f"inset={inset} is negative. An inset trims pixels from every "
+            f"edge, so it cannot reach past the widget onto its neighbors."
+        )
     x, y = tk_widget.winfo_rootx(), tk_widget.winfo_rooty()
     width, height = tk_widget.winfo_width(), tk_widget.winfo_height()
     left, top = x + inset, y + inset
@@ -144,7 +153,13 @@ def grab(bbox: tuple[int, int, int, int] | None = None) -> Image.Image:
 def save(image: Image.Image, path) -> Path:
     """Write an image to `path`, taking the format from its extension."""
     path = Path(path)
-    if image.mode == "RGBA" and path.suffix.lower() in _NO_ALPHA_FORMATS:
+    # Decided by the target format rather than one source mode: a desktop
+    # screenshot tool can hand back a palette or grayscale-with-alpha image,
+    # and those fail on the same formats RGBA does.
+    if (
+        path.suffix.lower() in _NO_ALPHA_FORMATS
+        and image.mode not in _PLAIN_COLOR_MODES
+    ):
         image = image.convert("RGB")
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -186,9 +201,34 @@ def _grab_via_subprocess(
             continue
         finally:
             tmp.unlink(missing_ok=True)
-        return image.crop(bbox) if bbox else image
+        return _crop_desktop(image, bbox) if bbox else image
 
     raise BootstackError(
         "No screen capture backend is available. Install a Pillow build with "
         "XCB support, or one of: grim, gnome-screenshot, spectacle, import."
     )
+
+
+def _crop_desktop(
+    image: Image.Image, bbox: tuple[int, int, int, int]
+) -> Image.Image:
+    """Cut a region out of a whole-desktop grab, refusing a region it misses.
+
+    The screenshot tools photograph the desktop and return an image measured
+    from their own origin, while the region is measured across the whole
+    virtual desktop. Those agree on an ordinary single-monitor session and can
+    disagree otherwise — most often when the window sits on a monitor the tool
+    did not photograph. Cropping past the edge of an image pads the result with
+    black rather than failing, so the caller would get a plausible-looking
+    all-black picture and no way to tell why. Raising is the better answer.
+    """
+    left, top, right, bottom = bbox
+    if left < 0 or top < 0 or right > image.width or bottom > image.height:
+        raise BootstackError(
+            f"The screen capture tool returned a {image.width}x{image.height} "
+            f"picture, which does not cover the area being captured — "
+            f"({left}, {top}) to ({right}, {bottom}). This usually means the "
+            f"window is on a monitor the tool did not photograph; moving it to "
+            f"the main display is the reliable workaround."
+        )
+    return image.crop(bbox)

--- a/src/bootstack/widgets/_core/base.py
+++ b/src/bootstack/widgets/_core/base.py
@@ -223,8 +223,9 @@ class PublicWidgetBase:
                 whole window to drop the native border artifact.
             settle: Seconds to let the desktop finish repainting before the
                 pixels are read. The default covers the common case of a dialog
-                closing just beforehand. The interface stays responsive while
-                this waits.
+                closing just beforehand. The interface pauses for this long,
+                so a second click on the control that started the capture waits
+                its turn rather than starting an overlapping one.
 
         Returns:
             The path that was written.
@@ -243,8 +244,10 @@ class PublicWidgetBase:
             # newly exposed area, and a widget created moments ago is not
             # mapped until the toolkit has processed its pending geometry.
             _capture.settle(target, settle)
-            # Settling turns the event loop, so anything queued runs here —
-            # including a handler that closes the window being photographed.
+            # Settling no longer dispatches events, but it still yields the
+            # interpreter, and the checks below cost nothing next to reading
+            # the screen. A target closed on another thread, or by a timer
+            # that ran before the capture started, still has to be caught.
             if not _capture.still_exists(target):
                 raise BootstackError(
                     f"{type(self).__name__} was closed while the capture was "

--- a/src/bootstack/widgets/_core/base.py
+++ b/src/bootstack/widgets/_core/base.py
@@ -9,6 +9,8 @@ from bootstack.events import Event, Subscription
 from bootstack.errors import ParentResolutionError
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from bootstack.scheduling import Schedule
     from bootstack.streams import Stream
 
@@ -185,6 +187,70 @@ class PublicWidgetBase:
             from bootstack.scheduling import Schedule
             self._schedule = Schedule(self._internal)
         return self._schedule
+
+    def capture(
+        self,
+        path: str | Path,
+        *,
+        inset: int = 0,
+        settle: float = 0.1,
+    ) -> Path:
+        """Save a picture of this widget to an image file.
+
+        Captures the area this widget occupies on screen — one widget, a whole
+        window, or the entire application, depending on what you call it on.
+        The file extension selects the format, so `.png`, `.jpg`, and `.pdf`
+        all work.
+
+        The widget has to be visible. A capture reads pixels from the display,
+        so the window is brought to the front first and a hidden or detached
+        widget cannot be captured at all. Any always-on-top setting the window
+        already had is left as it was found.
+
+        Pair it with a save dialog to let the user choose where it goes::
+
+            from bootstack.dialogs import ask_save_file
+
+            def on_export():
+                chosen = ask_save_file(initial_file="dashboard.png")
+                if chosen:
+                    app.capture(chosen)
+
+        Args:
+            path: Where to write the image. Missing parent folders are created,
+                and the extension chooses the format.
+            inset: Pixels to trim from every edge. Use `2` on a whole window to
+                drop the native border artifact.
+            settle: Seconds to let the desktop finish repainting before the
+                pixels are read. The default covers the common case of a dialog
+                closing just beforehand. The interface stays responsive while
+                this waits.
+
+        Returns:
+            The path that was written.
+
+        Raises:
+            BootstackError: If the widget is not visible on screen, if no
+                capture backend is available, or if the file cannot be written.
+        """
+        from bootstack._core import capture as _capture
+        from bootstack.errors import BootstackError
+
+        target = self._internal
+        with _capture.raised(target):
+            # Settle after raising: the desktop needs a moment to repaint the
+            # newly exposed area, and a widget created moments ago is not
+            # mapped until the toolkit has processed its pending geometry.
+            _capture.settle(target, settle)
+            if not target.winfo_ismapped():
+                raise BootstackError(
+                    f"{type(self).__name__} is not visible on screen, so there "
+                    f"is nothing to capture. Show the window and make sure the "
+                    f"widget is neither hidden nor detached before capturing it."
+                )
+            return _capture.capture_region(
+                _capture.widget_region(target, inset), path
+            )
 
     # ----- on() — overloaded -------------------------------------------------
 

--- a/src/bootstack/widgets/_core/base.py
+++ b/src/bootstack/widgets/_core/base.py
@@ -246,10 +246,10 @@ class PublicWidgetBase:
             # newly exposed area, and a widget created moments ago is not
             # mapped until the toolkit has processed its pending geometry.
             _capture.settle(target, settle)
-            # Settling no longer dispatches events, but it still yields the
-            # interpreter, and the checks below cost nothing next to reading
-            # the screen. A target closed on another thread, or by a timer
-            # that ran before the capture started, still has to be caught.
+            # Settling dispatches, so a timer that ran during it can have
+            # closed the target — and these checks cost nothing next to
+            # reading the screen. A target closed on another thread, or by a
+            # timer that ran before the capture started, has to be caught too.
             if not _capture.still_exists(target):
                 raise BootstackError(
                     f"{type(self).__name__} was closed while the capture was "

--- a/src/bootstack/widgets/_core/base.py
+++ b/src/bootstack/widgets/_core/base.py
@@ -230,9 +230,9 @@ class PublicWidgetBase:
             The path that was written.
 
         Raises:
-            BootstackError: If the widget is not visible on screen, if `inset`
-                is negative, if no capture backend is available, or if the file
-                cannot be written.
+            BootstackError: If the widget is not visible on screen or has been
+                scrolled out of view, if `inset` is negative, if no capture
+                backend is available, or if the file cannot be written.
         """
         from bootstack._core import capture as _capture
         from bootstack.errors import BootstackError
@@ -245,7 +245,7 @@ class PublicWidgetBase:
             _capture.settle(target, settle)
             # Settling turns the event loop, so anything queued runs here —
             # including a handler that closes the window being photographed.
-            if not target.winfo_exists():
+            if not _capture.still_exists(target):
                 raise BootstackError(
                     f"{type(self).__name__} was closed while the capture was "
                     f"waiting for the screen to settle, so there is nothing "
@@ -256,6 +256,16 @@ class PublicWidgetBase:
                     f"{type(self).__name__} is not visible on screen, so there "
                     f"is nothing to capture. Show the window and make sure the "
                     f"widget is neither hidden nor detached before capturing it."
+                )
+            # Being mapped is not the same as being in view: a widget scrolled
+            # out of a viewport stays mapped, and its rectangle then points at
+            # whatever else happens to be on screen there.
+            if _capture.clipped_out_of_view(target):
+                raise BootstackError(
+                    f"{type(self).__name__} has been scrolled out of view, so "
+                    f"the area it reports is no longer inside its window and "
+                    f"would photograph whatever is behind. Scroll it back into "
+                    f"view before capturing it."
                 )
             return _capture.capture_region(
                 _capture.widget_region(target, inset), path

--- a/src/bootstack/widgets/_core/base.py
+++ b/src/bootstack/widgets/_core/base.py
@@ -234,6 +234,8 @@ class PublicWidgetBase:
             BootstackError: If the widget is not visible on screen or has been
                 scrolled out of view, if `inset` is negative, if no capture
                 backend is available, or if the file cannot be written.
+
+        .. versionadded:: 0.3.0
         """
         from bootstack._core import capture as _capture
         from bootstack.errors import BootstackError

--- a/src/bootstack/widgets/_core/base.py
+++ b/src/bootstack/widgets/_core/base.py
@@ -209,18 +209,18 @@ class PublicWidgetBase:
 
         Pair it with a save dialog to let the user choose where it goes::
 
-            from bootstack.dialogs import ask_save_file
+            import bootstack as bs
 
             def on_export():
-                chosen = ask_save_file(initial_file="dashboard.png")
+                chosen = bs.ask_save_file(initial_file="dashboard.png")
                 if chosen:
                     app.capture(chosen)
 
         Args:
             path: Where to write the image. Missing parent folders are created,
                 and the extension chooses the format.
-            inset: Pixels to trim from every edge. Use `2` on a whole window to
-                drop the native border artifact.
+            inset: Pixels to trim from every edge, zero or more. Use `2` on a
+                whole window to drop the native border artifact.
             settle: Seconds to let the desktop finish repainting before the
                 pixels are read. The default covers the common case of a dialog
                 closing just beforehand. The interface stays responsive while
@@ -230,8 +230,9 @@ class PublicWidgetBase:
             The path that was written.
 
         Raises:
-            BootstackError: If the widget is not visible on screen, if no
-                capture backend is available, or if the file cannot be written.
+            BootstackError: If the widget is not visible on screen, if `inset`
+                is negative, if no capture backend is available, or if the file
+                cannot be written.
         """
         from bootstack._core import capture as _capture
         from bootstack.errors import BootstackError
@@ -242,6 +243,14 @@ class PublicWidgetBase:
             # newly exposed area, and a widget created moments ago is not
             # mapped until the toolkit has processed its pending geometry.
             _capture.settle(target, settle)
+            # Settling turns the event loop, so anything queued runs here —
+            # including a handler that closes the window being photographed.
+            if not target.winfo_exists():
+                raise BootstackError(
+                    f"{type(self).__name__} was closed while the capture was "
+                    f"waiting for the screen to settle, so there is nothing "
+                    f"left to photograph."
+                )
             if not target.winfo_ismapped():
                 raise BootstackError(
                     f"{type(self).__name__} is not visible on screen, so there "

--- a/tests/run_gui.py
+++ b/tests/run_gui.py
@@ -36,6 +36,11 @@ ISOLATED = [
     "tests/widgets/public/test_pagestack.py",
     "tests/widgets/public/test_hot_reload_app.py",
     "tests/widgets/public/test_hot_reload_shell.py",
+    # A capture reads pixels from the display, so its widgets have to be ON the
+    # display. In the shared root they land wherever the accumulated tests have
+    # pushed them — measured at y~2810 on a 956px-tall screen — and every grab
+    # asks for a region no monitor covers. A fresh root keeps them on screen.
+    "tests/widgets/public/test_capture.py",
 ]
 
 # Modules that construct a fresh root PER TEST (e.g. an App-config factory

--- a/tests/widgets/public/test_capture.py
+++ b/tests/widgets/public/test_capture.py
@@ -18,6 +18,7 @@ import pytest
 from PIL import Image
 
 import bootstack as bs
+from bootstack._core import capture as _capture
 from bootstack.errors import BootstackError
 
 pytestmark = pytest.mark.gui
@@ -128,3 +129,65 @@ def test_capture_leaves_a_deliberately_topmost_window_pinned(shown_app, tmp_path
         assert root.attributes("-topmost")
     finally:
         root.attributes("-topmost", False)
+
+
+def test_negative_inset_raises(shown_app, tmp_path):
+    """An inset trims. It must not be usable to photograph the neighbors."""
+    label = bs.Label("no growing")
+    shown_app.tk.update_idletasks()
+
+    with pytest.raises(BootstackError, match="is negative"):
+        label.capture(tmp_path / "grown.png", inset=-8, settle=0)
+
+
+def test_widget_closed_while_settling_raises_a_bootstack_error(
+    shown_app, tmp_path
+):
+    """Settling turns the event loop, so a queued handler can close the target.
+
+    Without the guard the next line reads geometry from a dead widget and a raw
+    toolkit error escapes a method documented to raise `BootstackError`. The
+    control is every other test in this file: the same call without a pending
+    destroy captures normally.
+    """
+    label = bs.Label("closing")
+    shown_app.tk.update_idletasks()
+    shown_app.tk.after(1, label.tk.destroy)
+
+    with pytest.raises(BootstackError, match="closed while the capture"):
+        label.capture(tmp_path / "gone.png", settle=0.1)
+
+
+def test_a_no_alpha_format_converts_a_mode_the_grabbers_never_produce(tmp_path):
+    """`save()` gates on the target format, not on one source mode.
+
+    Reached through the internal function on purpose. The Windows and macOS
+    grabbers only ever return RGB or RGBA, so this is unreachable from the
+    public method on either box — it is the Linux fallback, which opens
+    whatever the desktop screenshot tool wrote, that can produce a palette
+    image.
+    """
+    palette = Image.new("P", (4, 4))
+
+    with Image.open(_capture.save(palette, tmp_path / "flat.jpg")) as img:
+        assert img.mode == "RGB"
+
+    # Control: PNG stores a palette perfectly well, so nothing is converted.
+    with Image.open(_capture.save(palette, tmp_path / "kept.png")) as img:
+        assert img.mode == "P"
+
+
+def test_a_region_outside_the_grab_raises_instead_of_padding_black():
+    """A screenshot tool that missed the monitor must not yield a black picture.
+
+    Cropping past the edge of an image pads the result with black and raises
+    nothing, so the failure would reach the user as a plausible-looking
+    all-black file with nothing to debug.
+    """
+    desktop = Image.new("RGB", (1920, 1080), "white")
+
+    with pytest.raises(BootstackError, match="does not cover the area"):
+        _capture._crop_desktop(desktop, (1930, 10, 2200, 300))
+
+    # Control: a region the grab does cover crops normally.
+    assert _capture._crop_desktop(desktop, (10, 10, 110, 60)).size == (100, 50)

--- a/tests/widgets/public/test_capture.py
+++ b/tests/widgets/public/test_capture.py
@@ -21,7 +21,10 @@ import bootstack as bs
 from bootstack._core import capture as _capture
 from bootstack.errors import BootstackError
 
-pytestmark = pytest.mark.gui
+# `isolated` keeps these out of the shared-root leg, where accumulated tests
+# push the widgets clean off the display and every grab asks for a region no
+# monitor covers. See the note beside this module in `tests/run_gui.py`.
+pytestmark = [pytest.mark.gui, pytest.mark.isolated]
 
 
 def test_capture_writes_the_file_and_returns_its_path(shown_app, tmp_path):

--- a/tests/widgets/public/test_capture.py
+++ b/tests/widgets/public/test_capture.py
@@ -15,6 +15,7 @@ always-on-top setting left as it was found.
 from __future__ import annotations
 
 import sys
+import time
 import tkinter
 import types
 
@@ -129,7 +130,7 @@ def test_inset_larger_than_the_widget_raises(shown_app, tmp_path):
         label.capture(tmp_path / "over.png", inset=9999, settle=0)
 
 
-def _pin(root) -> bool:
+def _pin(root, timeout: float = 0.5) -> bool:
     """Pin a window on top, reporting whether the setting actually took.
 
     Always-on-top is a request to the window manager, not something the
@@ -138,11 +139,22 @@ def _pin(root) -> bool:
     tests below would otherwise be measuring the window manager rather than the
     capture. Measured on a bare X server: setting it reads back 0, with no
     capture involved anywhere.
+
+    A window manager that does honor the request answers asynchronously, and
+    that answer arrives as a window event rather than an idle callback — so the
+    read is polled rather than taken once. Reading too early reports "not
+    supported" on the machines that support it perfectly well, which would skip
+    both tests on exactly the boxes able to run them.
     """
     root.attributes("-topmost", True)
-    root.update_idletasks()
-    if root.attributes("-topmost"):
-        return True
+    deadline = time.monotonic() + timeout
+    while True:
+        root.update()
+        if root.attributes("-topmost"):
+            return True
+        if time.monotonic() >= deadline:
+            break
+        time.sleep(0.01)
     # Put the request back where it was found. A refused request still leaves
     # one recorded, and the next caller reads that record rather than the
     # window manager — which made this very check report differently depending
@@ -161,8 +173,10 @@ def test_capture_restores_a_window_that_was_not_topmost(shown_app, tmp_path):
     # "left off" cannot be told from "never went on".
     if not _pin(root):
         pytest.skip("this window manager does not honor always-on-top")
+    # `update()`, not `update_idletasks()`: clearing the setting is answered by
+    # the window manager the same way setting it is.
     root.attributes("-topmost", False)
-    root.update_idletasks()
+    root.update()
 
     bs.Label("restore me").capture(tmp_path / "restore.png", settle=0)
 

--- a/tests/widgets/public/test_capture.py
+++ b/tests/widgets/public/test_capture.py
@@ -26,6 +26,10 @@ import bootstack as bs
 from bootstack._core import capture as _capture
 from bootstack.errors import BootstackError
 
+# A color nothing in the theme uses, so any of it in a capture came from the
+# test's own cover window rather than from the application.
+_COVER_COLOR = "#ff00ff"
+
 # `isolated` keeps these out of the shared-root leg, where accumulated tests
 # push the widgets clean off the display and every grab asks for a region no
 # monitor covers. See the note beside this module in `tests/run_gui.py`.
@@ -232,30 +236,127 @@ def test_widget_closed_while_settling_raises_a_bootstack_error(
         label.capture(tmp_path / "gone.png", settle=0.1)
 
 
-def test_settling_does_not_run_queued_handlers(shown_app, tmp_path):
-    """Settling must not dispatch queued work — #429.
+def test_settling_repaints_the_area_a_closed_window_uncovered(
+    shown_app, tmp_path
+):
+    """The capture must show the widget, not the dialog that just closed — #429.
 
-    `settle()` used to turn the event loop so the desktop could repaint, which
-    ran everything queued along with it. For the person using the application
-    that meant a second click on an export button re-entered the handler
-    mid-capture, stacking a second save dialog they never asked for.
+    This is the whole point of settling. A save dialog sits over the target and
+    the capture happens the moment it closes, so the desktop has to repaint the
+    uncovered area before the pixels are read. On macOS that repaint does not
+    happen at all unless the event loop is turning, and the resulting file is a
+    photograph of the dismissed dialog — through the public method, following
+    the pattern the docstring teaches.
 
-    The second half of this test is its control: the timer is real and does
-    fire the moment the loop turns, so the first assertion is about WHEN it
-    runs, not about a timer that was never going to run at all.
+    The cover is a distinctive color so the assertion is about CONTENT rather
+    than geometry: any of it left in the frame means the stale pixels were
+    captured. Measured before the fix, this arm caught 51400 of 60800 pixels.
+
+    ⚠ Settling stopped dispatching for a first pass at #429 and this exact
+    scenario is what that broke, so the assertion is deliberately not on the
+    settle mechanism but on the picture it produces.
+
+    ⚠ The window is SIZED, and both the window and the saved image are checked
+    before the content assertion. The shared root collapses to 1x1 with no
+    content of its own, and a one-pixel capture sampling one point away from
+    the cover would report a clean picture no matter how broken settling was.
+    """
+    top = shown_app.tk.winfo_toplevel()
+    # ⚠ Released in the finally below, and released rather than restored. The
+    # root is SHARED, and any explicit geometry left on it — including the one
+    # it had before — pins the window at that size, so later tests' widgets
+    # land outside it and the scrolled-out-of-view guard refuses to capture
+    # them. That surfaced as two failures in tests this one never touched.
+    # An empty geometry hands sizing back to the content.
+    try:
+        top.geometry("320x200")
+        shown_app.tk.update()
+
+        # Precondition: the size request was actually serviced. Without this
+        # the content assertion below can pass on a degenerate rectangle.
+        assert top.winfo_width() >= 200 and top.winfo_height() >= 120, (
+            f"the window is {top.winfo_width()}x{top.winfo_height()}, too "
+            f"small for a capture that could show anything"
+        )
+
+        cover = tkinter.Toplevel(shown_app.tk)
+        cover.overrideredirect(True)
+        cover.configure(background=_COVER_COLOR)
+        cover.geometry(
+            f"{top.winfo_width()}x{top.winfo_height()}"
+            f"+{top.winfo_rootx()}+{top.winfo_rooty()}"
+        )
+        cover.lift()
+        cover.attributes("-topmost", True)
+        shown_app.tk.update()
+        # Closed the way a dialog closes: torn down, with no pumping after.
+        cover.destroy()
+
+        saved = shown_app.capture(tmp_path / "uncovered.png", settle=0.3)
+    finally:
+        top.wm_geometry("")
+        shown_app.tk.update()
+
+    with Image.open(saved) as img:
+        width, height = img.size
+        pixels = list(img.convert("RGB").getdata())
+
+    # Second precondition, on the image rather than the window: a grab that
+    # came back tiny cannot say anything about what is in the frame.
+    assert width >= 200 and height >= 120, (
+        f"the capture is {width}x{height}, too small to judge its content"
+    )
+
+    stale = sum(1 for r, g, b in pixels if r > 200 and g < 80 and b > 200)
+    assert stale == 0, (
+        f"{stale} of {len(pixels)} pixels still show the closed window, so the "
+        f"capture photographed it instead of the application"
+    )
+
+
+def test_settling_holds_the_window_busy_while_it_dispatches(
+    shown_app, tmp_path
+):
+    """Dispatching is what repaints, so input is blocked for the duration — #429.
+
+    Turning the event loop runs everything queued, including a second click on
+    the button that started the capture: that click would re-enter the caller's
+    handler and stack a second save dialog. `tk busy` routes it to a blocking
+    window instead.
+
+    Observed from inside the settle window, using the very dispatching this
+    guards: a timer scheduled to land mid-settle reads the busy state. The
+    assertions after the call are its controls — the timer really did fire (so
+    the reading is not of an empty list), and the hold is released on the way
+    out (so it does not leak onto the application).
+
+    ⚠ This asserts the GUARD IS IN PLACE, not that it swallows a click. A
+    synthesized click cannot test that: `event_generate` aimed at a widget
+    delivers straight to its bindings and never consults the busy window, so
+    it re-enters whether busy is held or not. Measured, with `tk busy status`
+    reading 1 at the time. The swallowing half is a manual check —
+    `development/demo_429_busy_during_settle.py`.
     """
     label = bs.Label("settling")
-    shown_app.tk.update_idletasks()
-
-    ran: list[str] = []
-    shown_app.tk.after(10, lambda: ran.append("queued"))
-
-    label.capture(tmp_path / "shot.png", settle=0.2)
-
-    assert ran == [], "settling dispatched queued work and re-entered the app"
-
     shown_app.tk.update()
-    assert ran == ["queued"], "the timer never fired, so the check above was vacuous"
+    top = label.tk.winfo_toplevel()
+
+    def busy_status() -> str:
+        return str(top.tk.call("tk", "busy", "status", top._w))
+
+    assert busy_status() == "0", "the window was already busy before settling"
+
+    seen: list[str] = []
+    shown_app.tk.after(60, lambda: seen.append(busy_status()))
+
+    label.capture(tmp_path / "shot.png", settle=0.3)
+
+    assert seen == ["1"], (
+        "the window was not held busy while settling dispatched events"
+        if seen
+        else "the timer never fired, so settling did not dispatch at all"
+    )
+    assert busy_status() == "0", "settling left the window busy"
 
 
 def test_a_no_alpha_format_converts_a_mode_the_grabbers_never_produce(tmp_path):

--- a/tests/widgets/public/test_capture.py
+++ b/tests/widgets/public/test_capture.py
@@ -129,9 +129,38 @@ def test_inset_larger_than_the_widget_raises(shown_app, tmp_path):
         label.capture(tmp_path / "over.png", inset=9999, settle=0)
 
 
+def _pin(root) -> bool:
+    """Pin a window on top, reporting whether the setting actually took.
+
+    Always-on-top is a request to the window manager, not something the
+    application decides. A session without a window manager — a headless test
+    display, most often — leaves the setting unset and raises nothing, so both
+    tests below would otherwise be measuring the window manager rather than the
+    capture. Measured on a bare X server: setting it reads back 0, with no
+    capture involved anywhere.
+    """
+    root.attributes("-topmost", True)
+    root.update_idletasks()
+    if root.attributes("-topmost"):
+        return True
+    # Put the request back where it was found. A refused request still leaves
+    # one recorded, and the next caller reads that record rather than the
+    # window manager — which made this very check report differently depending
+    # on whether a previous test had already tried. Measured: the two tests
+    # below both skipped when run alone, and the second one passed when run
+    # after the first.
+    root.attributes("-topmost", False)
+    root.update_idletasks()
+    return False
+
+
 def test_capture_restores_a_window_that_was_not_topmost(shown_app, tmp_path):
     """Capturing raises the window; it must put the setting back afterward."""
     root = shown_app.tk
+    # Without this the assertion below is free: where the setting never takes,
+    # "left off" cannot be told from "never went on".
+    if not _pin(root):
+        pytest.skip("this window manager does not honor always-on-top")
     root.attributes("-topmost", False)
     root.update_idletasks()
 
@@ -147,8 +176,8 @@ def test_capture_leaves_a_deliberately_topmost_window_pinned(shown_app, tmp_path
     starting state, so a fix that simply forced the flag off would fail here.
     """
     root = shown_app.tk
-    root.attributes("-topmost", True)
-    root.update_idletasks()
+    if not _pin(root):
+        pytest.skip("this window manager does not honor always-on-top")
     try:
         bs.Label("still pinned").capture(tmp_path / "pinned.png", settle=0)
         assert root.attributes("-topmost")

--- a/tests/widgets/public/test_capture.py
+++ b/tests/widgets/public/test_capture.py
@@ -1,0 +1,130 @@
+"""Tests for `widget.capture()` (#427).
+
+A capture reads pixels from the display, so what these can assert is limited on
+purpose. Whether the saved image shows *this* application depends on what else
+the machine has on screen, which no assertion can control — that question is
+settled by `development/verify_427_capture.py`, which toggles the theme between
+two captures and proves the pixels track this window. An earlier version of that
+probe passed every geometry check while capturing a browser, which is exactly
+why nothing here pretends to verify content.
+
+What is asserted instead are the invariants that hold regardless of what is on
+screen: the rectangle captured, the format chosen, the errors raised, and the
+always-on-top setting left as it was found.
+"""
+from __future__ import annotations
+
+import pytest
+from PIL import Image
+
+import bootstack as bs
+from bootstack.errors import BootstackError
+
+pytestmark = pytest.mark.gui
+
+
+def test_capture_writes_the_file_and_returns_its_path(shown_app, tmp_path):
+    label = bs.Label("capture me")
+    shown_app.tk.update_idletasks()
+
+    target = tmp_path / "shot.png"
+    written = label.capture(target, settle=0)
+
+    assert written == target
+    assert written.is_file() and written.stat().st_size > 0
+
+
+def test_capture_matches_the_widget_rectangle(shown_app, tmp_path):
+    """The grab is the widget's own rect, not the window's."""
+    label = bs.Label("measure me")
+    shown_app.tk.update_idletasks()
+    expected = (label.tk.winfo_width(), label.tk.winfo_height())
+
+    with Image.open(label.capture(tmp_path / "rect.png", settle=0)) as img:
+        assert img.size == expected
+
+
+def test_inset_trims_every_edge(shown_app, tmp_path):
+    label = bs.Label("trim me")
+    shown_app.tk.update_idletasks()
+    full = (label.tk.winfo_width(), label.tk.winfo_height())
+
+    with Image.open(label.capture(tmp_path / "inset.png", inset=2, settle=0)) as img:
+        assert img.size == (full[0] - 4, full[1] - 4)
+
+
+def test_extension_selects_the_format(shown_app, tmp_path):
+    """`.png`, `.jpg` and `.pdf` are the formats #425 asked for."""
+    label = bs.Label("format me")
+    shown_app.tk.update_idletasks()
+
+    for suffix, expected in ((".png", "PNG"), (".jpg", "JPEG")):
+        written = label.capture(tmp_path / f"shot{suffix}", settle=0)
+        with Image.open(written) as img:
+            assert img.format == expected
+
+    # Pillow writes PDF but cannot read it back, so check the magic bytes.
+    pdf = label.capture(tmp_path / "shot.pdf", settle=0)
+    assert pdf.read_bytes()[:4] == b"%PDF"
+
+
+def test_missing_parent_folders_are_created(shown_app, tmp_path):
+    label = bs.Label("nested")
+    shown_app.tk.update_idletasks()
+
+    written = label.capture(tmp_path / "a" / "b" / "shot.png", settle=0)
+    assert written.is_file()
+
+
+def test_unknown_extension_raises_a_bootstack_error(shown_app, tmp_path):
+    label = bs.Label("bad format")
+    shown_app.tk.update_idletasks()
+
+    with pytest.raises(BootstackError, match="extension selects the format"):
+        label.capture(tmp_path / "shot.wat", settle=0)
+
+
+def test_detached_widget_cannot_be_captured(shown_app, tmp_path):
+    """The guard that stops a capture from silently grabbing whatever is behind."""
+    label = bs.Label("gone")
+    shown_app.tk.update_idletasks()
+    label.detach()
+    shown_app.tk.update_idletasks()
+
+    with pytest.raises(BootstackError, match="not visible on screen"):
+        label.capture(tmp_path / "detached.png", settle=0)
+
+
+def test_inset_larger_than_the_widget_raises(shown_app, tmp_path):
+    label = bs.Label("tiny")
+    shown_app.tk.update_idletasks()
+
+    with pytest.raises(BootstackError, match="trims away the whole capture"):
+        label.capture(tmp_path / "over.png", inset=9999, settle=0)
+
+
+def test_capture_restores_a_window_that_was_not_topmost(shown_app, tmp_path):
+    """Capturing raises the window; it must put the setting back afterward."""
+    root = shown_app.tk
+    root.attributes("-topmost", False)
+    root.update_idletasks()
+
+    bs.Label("restore me").capture(tmp_path / "restore.png", settle=0)
+
+    assert not root.attributes("-topmost")
+
+
+def test_capture_leaves_a_deliberately_topmost_window_pinned(shown_app, tmp_path):
+    """An application that pinned its window must not be un-pinned by a capture.
+
+    This is the control for the test above: the same code path, opposite
+    starting state, so a fix that simply forced the flag off would fail here.
+    """
+    root = shown_app.tk
+    root.attributes("-topmost", True)
+    root.update_idletasks()
+    try:
+        bs.Label("still pinned").capture(tmp_path / "pinned.png", settle=0)
+        assert root.attributes("-topmost")
+    finally:
+        root.attributes("-topmost", False)

--- a/tests/widgets/public/test_capture.py
+++ b/tests/widgets/public/test_capture.py
@@ -330,12 +330,24 @@ def test_settling_holds_the_window_busy_while_it_dispatches(
     the reading is not of an empty list), and the hold is released on the way
     out (so it does not leak onto the application).
 
-    ⚠ This asserts the GUARD IS IN PLACE, not that it swallows a click. A
-    synthesized click cannot test that: `event_generate` aimed at a widget
-    delivers straight to its bindings and never consults the busy window, so
-    it re-enters whether busy is held or not. Measured, with `tk busy status`
-    reading 1 at the time. The swallowing half is a manual check —
-    `development/demo_429_busy_during_settle.py`.
+    ⚠ This asserts the hold is REQUESTED AND RELEASED, which is all that is
+    portable. It does NOT assert that input is blocked, and `tk busy status`
+    is not evidence that it is: macOS returns 1 for a busy window it never
+    maps, so the hold is accepted and does nothing and a real click re-enters
+    the handler. Confirmed by hand on Tk 8.6.17/aqua, and reproduced in plain
+    tkinter, so it is the toolkit rather than anything above it.
+
+    Whether a given platform honors the hold is arm 0 of
+    `development/probe_429_busy_during_settle.py` — it checks the busy window
+    is mapped and that Tk's hit test at a button resolves to it. That is
+    deliberately not asserted here, because it is platform-dependent and would
+    make this test fail on macOS for something it is not testing.
+
+    ⚠ A synthesized click cannot stand in for the manual check either:
+    `event_generate` aimed at a widget delivers straight to its bindings and
+    never consults the busy window, so it re-enters whether the hold is real
+    or not. The swallowing half is
+    `development/demo_429_busy_during_settle.py`, by hand.
     """
     label = bs.Label("settling")
     shown_app.tk.update()

--- a/tests/widgets/public/test_capture.py
+++ b/tests/widgets/public/test_capture.py
@@ -15,6 +15,7 @@ always-on-top setting left as it was found.
 from __future__ import annotations
 
 import sys
+import tkinter
 
 import pytest
 from PIL import Image, UnidentifiedImageError
@@ -214,6 +215,76 @@ def test_a_region_outside_the_grab_raises_instead_of_padding_black():
 
     # Control: a region the grab does cover crops normally.
     assert _capture._crop_desktop(desktop, (10, 10, 110, 60)).size == (100, 50)
+
+
+def test_a_widget_scrolled_out_of_view_cannot_be_captured(shown_app, tmp_path):
+    """Mapped is not the same as in view.
+
+    A widget scrolled out of a viewport stays mapped and keeps reporting the
+    position it would occupy if the window were tall enough to show it, so the
+    grab reads whatever else is on screen there and saves it without
+    complaining. Measured before the guard: a row reporting y=273 for a window
+    spanning 390 to 630 captured successfully and produced a 1-color image,
+    against 217 colors for the same row in view.
+    """
+    rows = []
+    with bs.ScrollView(scroll_direction="vertical", height=120) as view:
+        for i in range(30):
+            with bs.Card(padding=6) as row:
+                bs.Label(f"row {i}")
+            rows.append(row)
+    shown_app.tk.update_idletasks()
+    shown_app.tk.update()
+
+    first = rows[0]
+    # Control: in view, the very same widget captures normally. Without this a
+    # broken ScrollView would make the assertion below pass for free.
+    assert first.capture(tmp_path / "in-view.png", settle=0).is_file()
+
+    view.yview_moveto(0.5)
+    shown_app.tk.update_idletasks()
+    shown_app.tk.update()
+
+    window_top = shown_app.tk.winfo_rooty()
+    row_bottom = first.tk.winfo_rooty() + first.tk.winfo_height()
+    # Preconditions, so this cannot pass for the wrong reason: the row really
+    # did leave the window, and the toolkit really does still call it mapped —
+    # if it did not, the older visibility guard would be the one raising.
+    if row_bottom > window_top:
+        pytest.skip("the viewport did not scroll the row out of the window")
+    assert first.tk.winfo_ismapped()
+
+    with pytest.raises(BootstackError, match="scrolled out of view"):
+        first.capture(tmp_path / "scrolled-away.png", settle=0)
+
+
+def test_a_destroyed_root_is_reported_gone_rather_than_raising(shown_app):
+    """`winfo_exists()` answers for a dead child but RAISES for a dead root.
+
+    Measured: a destroyed child returns 0, while a destroyed root raises
+    `TclError: application has been destroyed` — there is no interpreter left
+    to ask. Both mean "nothing to photograph", so both must answer False, or a
+    raw toolkit error escapes a method documented to raise `BootstackError`.
+    This is the App-level arm of the guard already fixed for child widgets.
+
+    Asserted through the helper rather than through `capture()`: reaching it
+    for real means destroying the root mid-settle, which would take the rest of
+    this module's tests with it. So this guards against regression rather than
+    reproducing the defect — unfixed source can only fail it for the
+    uninteresting reason that the helper does not exist yet.
+    """
+    class DeadRoot:
+        def winfo_exists(self):
+            raise tkinter.TclError("application has been destroyed")
+
+    assert _capture.still_exists(DeadRoot()) is False
+
+    # Controls, through the real toolkit: alive, then destroyed.
+    live = bs.Label("alive")
+    shown_app.tk.update_idletasks()
+    assert _capture.still_exists(live.tk) is True
+    live.tk.destroy()
+    assert _capture.still_exists(live.tk) is False
 
 
 def test_a_region_on_no_display_names_the_real_cause(monkeypatch):

--- a/tests/widgets/public/test_capture.py
+++ b/tests/widgets/public/test_capture.py
@@ -211,19 +211,51 @@ def test_negative_inset_raises(shown_app, tmp_path):
 def test_widget_closed_while_settling_raises_a_bootstack_error(
     shown_app, tmp_path
 ):
-    """Settling turns the event loop, so a queued handler can close the target.
+    """Settling flushes pending drawing, so idle work can close the target.
 
     Without the guard the next line reads geometry from a dead widget and a raw
     toolkit error escapes a method documented to raise `BootstackError`. The
     control is every other test in this file: the same call without a pending
     destroy captures normally.
+
+    ⚠ The destroy is queued as IDLE work, not on a timer. Settling stopped
+    dispatching events for #429, so an `after(1, ...)` no longer runs during it
+    and this test would pass without ever destroying anything — vacuous, and
+    green either way. Idle callbacks are what `update_idletasks()` still runs,
+    which is the path that remains open.
     """
     label = bs.Label("closing")
     shown_app.tk.update_idletasks()
-    shown_app.tk.after(1, label.tk.destroy)
+    shown_app.tk.after_idle(label.tk.destroy)
 
     with pytest.raises(BootstackError, match="closed while the capture"):
         label.capture(tmp_path / "gone.png", settle=0.1)
+
+
+def test_settling_does_not_run_queued_handlers(shown_app, tmp_path):
+    """Settling must not dispatch queued work — #429.
+
+    `settle()` used to turn the event loop so the desktop could repaint, which
+    ran everything queued along with it. For the person using the application
+    that meant a second click on an export button re-entered the handler
+    mid-capture, stacking a second save dialog they never asked for.
+
+    The second half of this test is its control: the timer is real and does
+    fire the moment the loop turns, so the first assertion is about WHEN it
+    runs, not about a timer that was never going to run at all.
+    """
+    label = bs.Label("settling")
+    shown_app.tk.update_idletasks()
+
+    ran: list[str] = []
+    shown_app.tk.after(10, lambda: ran.append("queued"))
+
+    label.capture(tmp_path / "shot.png", settle=0.2)
+
+    assert ran == [], "settling dispatched queued work and re-entered the app"
+
+    shown_app.tk.update()
+    assert ran == ["queued"], "the timer never fired, so the check above was vacuous"
 
 
 def test_a_no_alpha_format_converts_a_mode_the_grabbers_never_produce(tmp_path):

--- a/tests/widgets/public/test_capture.py
+++ b/tests/widgets/public/test_capture.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import sys
 import tkinter
+import types
 
 import pytest
 from PIL import Image, UnidentifiedImageError
@@ -351,3 +352,30 @@ def test_a_window_hanging_off_the_edge_still_counts_as_on_screen():
     below_everything = max(m.y + m.height for m in monitors) + 5_000
     nowhere = (first.x + 10, below_everything, first.x + 60, below_everything + 100)
     assert _capture._covered_by_a_display(nowhere) is False
+
+
+def test_the_bounds_check_covers_the_library_path_not_only_the_fallback(
+    monkeypatch,
+):
+    """`grab()` must not hand the region to a cropper that does not check it.
+
+    Where the imaging library serves a region by grabbing the whole desktop
+    first, it crops without checking that what it grabbed covers the region —
+    it pads the difference with black and raises nothing. So the guard has to
+    sit on that path too, not only on the subprocess fallback.
+
+    Measured against the unfixed code with an undersized grab and a window
+    outside it: a capture saved a 400x300 file of one color, all black, and
+    raised nothing at all.
+    """
+    grabbed = Image.new("RGB", (800, 600), "white")
+    monkeypatch.setattr(_capture, "_LIBRARY_HANDLES_REGION", False)
+    monkeypatch.setattr(
+        _capture, "ImageGrab", types.SimpleNamespace(grab=lambda *a, **k: grabbed)
+    )
+
+    with pytest.raises(BootstackError, match="does not cover the area"):
+        _capture.grab((10, 10, 2000, 100))
+
+    # Control: a region that grab does cover still comes back cropped.
+    assert _capture.grab((10, 10, 110, 60)).size == (100, 50)

--- a/tests/widgets/public/test_capture.py
+++ b/tests/widgets/public/test_capture.py
@@ -422,3 +422,51 @@ def test_the_bounds_check_covers_the_library_path_not_only_the_fallback(
 
     # Control: a region that grab does cover still comes back cropped.
     assert _capture.grab((10, 10, 110, 60)).size == (100, 50)
+
+
+def test_the_region_stays_the_libraries_job_where_the_platform_needs_it(
+    monkeypatch,
+):
+    """The opposite direction of the test above, which only forces it off.
+
+    Windows crops against the origin its own grab reports, and macOS asks
+    `screencapture` for the region and rescales the answer — the rescale being
+    what keeps a Retina capture aligned. Cutting the region here instead would
+    silently break both, on boxes this suite is usually not running on. So the
+    hand-off is asserted rather than left implied: the library receives the
+    rectangle, and nothing here crops or bounds-checks it.
+    """
+    grabbed = Image.new("RGB", (800, 600), "white")
+    calls = []
+
+    def record(*args, **kwargs):
+        calls.append(kwargs)
+        return grabbed
+
+    monkeypatch.setattr(_capture, "_LIBRARY_HANDLES_REGION", True)
+    monkeypatch.setattr(
+        _capture, "ImageGrab", types.SimpleNamespace(grab=record)
+    )
+
+    # A region the grab does not cover: proof the crop was not taken over here,
+    # since doing so would raise exactly as the test above requires.
+    assert _capture.grab((10, 10, 2000, 100)) is grabbed
+    assert calls == [{"bbox": (10, 10, 2000, 100), "all_screens": True}]
+
+
+def test_only_windows_and_macos_leave_the_region_to_the_library():
+    """Guard the platform list itself, which both tests above have to force.
+
+    Each of them monkeypatches the flag, so dropping a platform from the list
+    would leave the pair green while changing what every capture on that
+    platform does. Restating the mapping is the cost of catching that.
+
+    The list is asserted rather than the flag derived from it. Comparing the
+    flag against `sys.platform` looks equivalent and is vacuous everywhere it
+    is False: on Linux, deleting the exemption entirely left both sides False
+    and the assertion green. Measured — that was this test's first version.
+    """
+    assert _capture._LIBRARY_REGION_PLATFORMS == ("win32", "darwin")
+    assert _capture._LIBRARY_HANDLES_REGION == (
+        sys.platform in _capture._LIBRARY_REGION_PLATFORMS
+    )

--- a/tests/widgets/public/test_capture.py
+++ b/tests/widgets/public/test_capture.py
@@ -14,8 +14,10 @@ always-on-top setting left as it was found.
 """
 from __future__ import annotations
 
+import sys
+
 import pytest
-from PIL import Image
+from PIL import Image, UnidentifiedImageError
 
 import bootstack as bs
 from bootstack._core import capture as _capture
@@ -25,6 +27,24 @@ from bootstack.errors import BootstackError
 # push the widgets clean off the display and every grab asks for a region no
 # monitor covers. See the note beside this module in `tests/run_gui.py`.
 pytestmark = [pytest.mark.gui, pytest.mark.isolated]
+
+
+def _monitors():
+    """The display layout, or a skip when this machine cannot report one.
+
+    Deliberately imported here rather than read off the capture module, so that
+    running these against unfixed source fails on the BEHAVIOR under test and
+    not on a missing attribute.
+    """
+    try:
+        from screeninfo import get_monitors
+
+        found = get_monitors()
+    except Exception as exc:  # noqa: BLE001 - headless boxes raise several types
+        pytest.skip(f"no display layout available: {exc}")
+    if not found:
+        pytest.skip("no monitors reported")
+    return found
 
 
 def test_capture_writes_the_file_and_returns_its_path(shown_app, tmp_path):
@@ -194,3 +214,69 @@ def test_a_region_outside_the_grab_raises_instead_of_padding_black():
 
     # Control: a region the grab does cover crops normally.
     assert _capture._crop_desktop(desktop, (10, 10, 110, 60)).size == (100, 50)
+
+
+def test_a_region_on_no_display_names_the_real_cause(monkeypatch):
+    """An off-display region must not be reported as a missing backend.
+
+    Pillow reports a region no monitor covers as `UnidentifiedImageError`,
+    which IS an `OSError` — the same exception raised by a Pillow built without
+    XCB. Reading the first as the second sends a macOS user off to install
+    Linux screenshot tools on a machine whose own backend works perfectly.
+
+    The failure is forced rather than provoked with a real off-screen grab:
+    Windows crops a whole-desktop grab and returns black instead of raising, so
+    a test that leaned on the genuine failure would assert a macOS-only answer.
+    """
+    def refuse(*args, **kwargs):
+        raise UnidentifiedImageError("cannot identify image file")
+
+    monkeypatch.setattr(_capture.ImageGrab, "grab", refuse)
+    # The real `sys`, not the capture module's reference to it — unfixed source
+    # does not import `sys` at all, and patching through it would turn this
+    # into an attribute error instead of the behavioral failure it should be.
+    monkeypatch.setattr(sys, "platform", "darwin")
+
+    monitors = _monitors()
+    below_everything = max(m.y + m.height for m in monitors) + 5_000
+    off = (10, below_everything, 110, below_everything + 100)
+
+    with pytest.raises(BootstackError, match="not on any display") as nowhere:
+        _capture.grab(off)
+    assert "grim" not in str(nowhere.value)
+
+    # Control: the identical forced failure over a region that IS on a display.
+    # A different cause earns a different message — and neither one may send a
+    # Mac user to install Linux tooling.
+    first = monitors[0]
+    on = (first.x + 10, first.y + 10, first.x + 60, first.y + 40)
+
+    with pytest.raises(BootstackError, match="capture failed") as covered:
+        _capture.grab(on)
+    assert "grim" not in str(covered.value)
+
+
+def test_a_window_hanging_off_the_edge_still_counts_as_on_screen():
+    """The guard must refuse only what no monitor touches at all.
+
+    A window dragged half off the bottom of the screen captures perfectly well
+    — measured on macOS, which clamps such a window and grabs it in full — so
+    treating partial overlap as off-display would reject a working capture.
+
+    This one guards against a future over-rejection rather than reproducing the
+    original defect: it exercises a helper that did not exist before the fix, so
+    unfixed source can only fail it for the uninteresting reason.
+    """
+    monitors = _monitors()
+    first = monitors[0]
+
+    fully_on = (first.x + 10, first.y + 10, first.x + 60, first.y + 40)
+    assert _capture._covered_by_a_display(fully_on) is True
+
+    half_off = (first.x + 10, first.y + first.height - 20,
+                first.x + 60, first.y + first.height + 200)
+    assert _capture._covered_by_a_display(half_off) is True
+
+    below_everything = max(m.y + m.height for m in monitors) + 5_000
+    nowhere = (first.x + 10, below_everything, first.x + 60, below_everything + 100)
+    assert _capture._covered_by_a_display(nowhere) is False


### PR DESCRIPTION
Closes #427. Closes #429.

Adds `widget.capture(path)` — save a widget, a window, or the whole app as a `.png`, `.jpg` or `.pdf`. Asked for by an external user in discussion #425. Call it on the app for the whole window or on any single widget for just that part of it; the extension picks the format, missing folders are created, and it returns the path it wrote so it pairs directly with `ask_save_file()`.

The window is raised before the shot and an always-on-top setting it already had is left exactly as found. Capturing a hidden or detached widget raises rather than silently saving whatever was behind it.

## #429 — the settle guard

Filed against this branch's own code during review: a click during `settle()` re-entered the caller's handler and stacked a second save dialog on the end user.

The first fix stopped `settle()` dispatching at all. **That was reversed**, because it traded a UX annoyance for wrong output: on macOS the area a closing window uncovers is repainted only while the loop turns, so a non-dispatching settle photographs whatever was there before — measured at 51400 of 60800 pixels wrong, a saved file that is a picture of the dismissed dialog. It needs no dialog to reproduce, either: `capture()` raises the window as documented, so any window overlapping the app is uncovered by the capture itself.

What ships instead is a settle that still dispatches and holds `tk busy` over the target while it does. Regression coverage for the repaint half fails against unfixed source at 64000/64000 px.

## Platform legs

Run on all three. The Windows leg was the one the branch was waiting on, because it decided whether the `tk busy` hold was worth keeping at all.

| | macOS | Windows |
|---|---|---|
| busy window actually mapped | **no** — Tk reports success and never maps it | **yes**, and the hit test at a button resolves away from it |
| input blocked during settle | no (documented limitation) | **yes** — confirmed by hand with a real double-click |
| busy visible in the photograph | trivially invisible | **invisible, 0 px against a 0 px floor** |
| repaint defect reproduces | **yes** | no — the DWM backing store covers it |

So the hold does real work on the platforms that map it, the macOS gap is a toolkit limitation rather than a wrong invocation (reproduced in plain tkinter with no bootstack involved), and nothing in the docs claims it works everywhere: the `settle()` docstring records the measurement and the how-to carries the workaround.

⚠ **A synthesized click cannot test this, by construction** — `event_generate` delivers straight to the widget's bindings and never consults the busy window, so it re-enters with the hold up. `development/demo_429_busy_during_settle.py` needs a human, and that is what confirmed the Windows result.

## Verification

Windows, Python 3.12.10 / Tk 8.6 / Pillow 12.0.0, with a second display at negative origin so that arm is exercised rather than skipped:

- `py -3.12 tests/run_gui.py` — exit 0, all legs passed. 20 legs, **1159 passed / 21 skipped**; shared root 962 / 14, `test_capture.py` 23 passed.
- `development/verify_427_capture.py` — **14 passed, 0 failed, 0 skipped**.
- Clean `-W` docs build — exit 0.

Rebased onto `main` after #442 merged; the CHANGELOG conflict was resolved keeping both features in Keep-a-Changelog order.

Full branch record, including the measurements not worth re-deriving, is at `development/handoff-429-settle.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
