### PR TITLE
Let the shared-root scene reset see what a test actually builds (#407)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,112 @@
+# PLAN — #407, the harness scene reset
+
+Branch `fix/harness-scene-reset-407`, off `main` at `76ae7a26` (`0.3.1` shipped).
+
+## Round cap: 2
+
+`REVIEW-PROTOCOL.md` gate 3. This is a **patch-safe** change — it touches
+`tests/conftest.py` and nothing under `src/`, so it adds no public surface. Two
+rounds, and anything surviving them is filed as an issue rather than fixed here.
+
+⚠ Gate 1 applies with unusual force on this branch: **a diff that touches no
+`src/` earns no review round at all.** If the whole branch stays inside `tests/`,
+round 1 is a self-check by the implementing session and there is no round 2.
+That is not a loophole — it is the rule that exists because this project spent
+four rounds reviewing test scaffolding a week ago. Open a round only if
+production code changes.
+
+## What is wrong
+
+`tests/conftest._region()` returns `app._region_root`, and **on a decorated
+`App` that attribute IS the root**. `_snapshot`/`_reset_scene` therefore walk the
+root's children twice and never look inside `App._content_frame`, which is where
+every widget a test builds actually lives.
+
+**Measured on `main` at `76ae7a26`**, five labels built the way a test builds
+them:
+
+```
+root          = .
+_region_root  = .          region IS root? True
+_content_frame= .!flexframe
+widgets a test created, inside _content_frame: 5
+of those, VISIBLE to _reset_scene's walk: 0 of 5
+```
+
+The reset finds `.!flexframe` in `keep`, treats it as permanent scaffolding —
+which it is — and stops. **So the scene reset has never torn down a content
+widget in the entire life of the shared-root harness**, and every test's widgets
+accumulate for the whole session.
+
+## What it is expected to explain
+
+Recorded in `CLAUDE.md`, to be **re-measured here rather than assumed**:
+
+- The widget leg runs **144s**; with the reset working it was measured at **80s**.
+- `PageStack` needs an `isolated` marker it should not need.
+- A geometry probe once turned "state pollution" into "reqheight 1242 > window
+  828, so the geometry manager unmapped it" — the direct consequence of a root
+  that never empties.
+
+And, newly suspected on 2026-08-12 — **suspicion, not a claim**:
+
+- **#447**, the dialog Enter/focus flakes, measured at **~5–8% of five-file
+  runs** (4/50 and 2/40). One failure carried `focus_lastfor()` returning the
+  empty string, and `focus_set()` silently no-ops on a window Tk does not
+  consider viewable. A root crowded with a session's worth of widgets is a
+  plausible cause; whether it is *the* cause is unknown.
+- **#432**, the shared-root GUI leg exiting silently mid-run on Linux.
+
+**None of these is a success criterion.** The fix is justified by the reset not
+doing what it says it does. If the flake rate does not move, that is a result to
+record, not a reason to keep changing the harness.
+
+## The change
+
+`_region()` returns `app._content_frame` when it exists, falling back to
+`_region_root` and then the root. `_reset_scene` already walks the root's
+children separately for stray toplevels, dialogs and chrome, so that half stays
+as it is.
+
+## Prior art, deliberately consulted
+
+`D:\Development\ttkbootstrap` — same maintainer, same shared-root design, and
+its `tests/conftest.py` says it followed bootstack's approach. Its `root` fixture
+snapshots `app.winfo_children()` and destroys what is new, which **works there
+because `Window` IS the root and tests parent directly into it**. bootstack
+interposes a content frame, so the identical snapshot is one level too shallow.
+The divergence is the whole bug.
+
+Two things from that repo are worth taking but are **NOT in this branch's
+scope**, because bundling them would make a test-infrastructure fix
+unreviewable:
+
+- Pinning Tk scaling to baseline inside `conftest`, so pixel assertions do not
+  depend on the host display (a laptop at 125% breaks them).
+- Its CI matrix, which is #380's answer — including `fail-fast: false` with a
+  stated reason, `xvfb-run -a -s "-screen 0 1280x1024x24 -dpi 96"`, and a
+  per-job step reporting the Tk build rather than inferring it.
+
+## Verification
+
+Against `main` at `76ae7a26`, measured — not reasoned from numbers in
+`CLAUDE.md`, which have been wrong six times:
+
+1. **The reset actually reaches content widgets.** The probe above, re-run: it
+   must report all 5 visible. This is the control; without it nothing else means
+   anything.
+2. **Full `py -3.12 tests/run_gui.py` stays green**, with the summed counts
+   recorded beside the commit. Any test that starts failing is the interesting
+   result — it was passing on state a previous test left behind.
+3. **Widget-leg wall clock**, before and after, same box, same session.
+4. **`PageStack` without its `isolated` marker.**
+5. **The #447 flake rate**, same 50-run five-file loop as on `main`. Report
+   whatever it is, including "unchanged".
+
+## Explicitly out of scope
+
+#380 (CI), #432 (the Linux leg), #447 (the dialog flakes), the `tests/widgets/*.py`
+files that `testpaths` never collects, and the second latent bug recorded under
+#407 (`test_select_change_event_value_space` picking up 5 change events from
+earlier tests). **If the reset fix exposes that one, it gets its own issue, not a
+fix here.**

--- a/development/probe_407_scene_reset.py
+++ b/development/probe_407_scene_reset.py
@@ -1,0 +1,126 @@
+"""#407 — does the shared-root scene reset reach what a test actually builds?
+
+Two arms, and the second one RECORDS A REFUTED HYPOTHESIS rather than a fix.
+
+  arm 1  the defect and the fix, side by side in one process
+  arm 2  a hypothesis that was WRONG: that destroying a content widget leaks a
+         queued event into the next test
+
+Run:  py -3.12 development/probe_407_scene_reset.py
+
+Output is ASCII only (this box's console is cp1252).
+"""
+from __future__ import annotations
+
+import sys
+
+sys.path.insert(0, "tests")
+
+import bootstack as bs  # noqa: E402
+from conftest import _region, _snapshot, _reset_scene  # noqa: E402
+
+
+def _old_region(app):
+    """The expression that shipped before the fix, kept as the control arm."""
+    return getattr(app, "_region_root", app._tk_root)
+
+
+def arm1(app) -> None:
+    """The defect: the reset never looked inside `_content_frame`."""
+    root = app._tk_root
+    print("ARM 1  which container does the reset walk?")
+    print(f"  old expression -> {_old_region(app)}")
+    print(f"  new expression -> {_region(app)}")
+    print(f"  root           -> {root}")
+    print(f"  _content_frame -> {app._content_frame}")
+
+    keep = _snapshot(app)
+    with app:
+        for i in range(5):
+            bs.Label(f"leftover {i}")
+
+    content = app._content_frame
+    made = [str(w) for w in content.winfo_children()]
+
+    # What the OLD walk could see: root children plus old-region children --
+    # which are the same set, so `_content_frame` itself and nothing under it.
+    old_reachable = {str(w) for w in root.winfo_children()}
+    old_reachable |= {str(w) for w in _old_region(app).winfo_children()}
+    visible_old = len([p for p in made if p in old_reachable])
+
+    before = len(content.winfo_children())
+    _reset_scene(app, keep)
+    after = len(content.winfo_children())
+
+    print(f"\n  test-created widgets: {len(made)}")
+    print(f"  visible to the OLD walk: {visible_old} of {len(made)}")
+    print(f"  content children: {before} before reset, {after} after")
+    verdict = "reset REACHES them" if after == 0 else f"{after} SURVIVED"
+    print(f"  VERDICT: {verdict}")
+    print("  EXPECTED: 0 of 5 visible to the old walk, 5 -> 0 with the fix.")
+
+
+def arm2(app) -> None:
+    """REFUTED. Kept because a wrong hypothesis with a control is worth more
+    than a deleted one.
+
+    The `_region()` fix made the reset destroy content widgets for the first
+    time, and `test_select_change_event_value_space` then failed once in about
+    ten full runs with `[None, 's'] == ['s']` -- a phantom change event ahead
+    of the test's own. The hypothesis was that destroying a `Select` leaves its
+    `<<Change>>` QUEUED (`SelectBox` emits with `when="tail"`), to be delivered
+    inside the next test, and that the reset therefore needed a drain.
+
+    It does not. Neither arm below leaks anything, so the drain was removed
+    again. The failure is a pre-existing fragility in that test -- it asserts an
+    exact list against an event stream, which the sibling
+    `test_selectbutton_change_event_value_space` already documents as emitting
+    more than once per set, and handles by asserting set membership instead.
+    """
+    root = app._tk_root
+    print("\nARM 2  does a destroyed widget leak a queued event? (REFUTED)")
+
+    def run(drain: bool) -> int:
+        seen: list[int] = []
+        root.bind_all("<<Change>>", lambda e: seen.append(1), add="+")
+        keep = _snapshot(app)
+        with app:
+            sel = bs.Select(options=["a", "b"], value="a")
+        root.update()
+        seen.clear()
+
+        sel.value = "b"
+        _reset_scene(app, keep)
+        if drain:
+            root.update()
+
+        seen.clear()
+        root.update()  # stands in for the NEXT test running
+        leaked = len(seen)
+        root.unbind_all("<<Change>>")
+        return leaked
+
+    no_drain = run(drain=False)
+    with_drain = run(drain=True)
+    print(f"  no drain -> leaked into next test: {no_drain}")
+    print(f"  drain    -> leaked into next test: {with_drain}")
+    if no_drain == 0:
+        print("  VERDICT: NO leak. The drain is NOT justified -- and was removed.")
+    else:
+        print("  VERDICT: a leak reproduced; re-open the question.")
+    print("  EXPECTED: 0 and 0. A non-zero first column would reverse this.")
+
+
+def main() -> int:
+    app = bs.App(title="probe 407 scene reset")
+    app._tk_root.update()
+    try:
+        arm1(app)
+        arm2(app)
+    finally:
+        app._tk_root.destroy()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,7 +37,32 @@ def _session_app():
 
 
 def _region(app):
-    """The container widgets parent into (the app's content region)."""
+    """The container widgets parent into (the app's content region).
+
+    ⚠ `_content_frame` FIRST, and that ordering is the whole of #407.
+    `_region_root` on a decorated `App` **is the root**, so asking for it
+    returned a container whose only child is the content frame itself — which is
+    permanent scaffolding and therefore in `keep`. The reset walked the root's
+    children twice, found nothing new, and stopped, while every widget a test
+    built sat one level deeper inside `_content_frame`. Measured before the fix,
+    with five labels created the way a test creates them: **0 of 5 visible to
+    the walk**. So the scene reset never tore down a content widget for the
+    entire life of the shared-root harness, and every test's widgets survived
+    the whole session.
+
+    ⚠ Do NOT "simplify" this back to a single attribute. ttkbootstrap's
+    equivalent fixture snapshots `app.winfo_children()` and is correct there
+    precisely because its `Window` IS the root and tests parent straight into
+    it; bootstack interposes a frame, so the same expression is one level too
+    shallow. Same design, different tree.
+    """
+    content = getattr(app, "_content_frame", None)
+    if content is not None:
+        try:
+            if content.winfo_exists():
+                return content
+        except Exception:
+            pass
     return getattr(app, "_region_root", app._tk_root)
 
 


### PR DESCRIPTION
Closes #407.

The shared-root harness has a scene reset that has never reset the scene. `_region()` returned `app._region_root`, and on a decorated `App` that attribute **is the root** — so `_snapshot`/`_reset_scene` walked the root's children twice and never looked inside `App._content_frame`, which is where every widget a test builds actually lives. The walk found the content frame in `keep` (correctly — it is permanent scaffolding) and stopped there.

Measured before the fix, with five labels created the way a test creates them: **0 of 5 visible to the walk**. So no content widget has ever been torn down between tests, and every test's widgets accumulated for the whole session.

## The change

`_region()` prefers `_content_frame` where it exists. `_reset_scene` already walks the root's children separately for stray toplevels, dialogs and chrome, so that half is untouched. The diff is 26 lines and 25 of them are the comment.

**`src/` is untouched** — `git diff main...HEAD -- src/` is empty. This is test infrastructure only.

## Measured, same box, same command before and after

| | before | after |
|---|---|---|
| shared leg wall clock | **215s** | **56s** |
| shared leg result | 1055 passed / 13 skipped | 1055 passed / 13 skipped |
| full `run_gui.py` | — | **66s**, exit 0, **1250 passed / 22 skipped** |
| content widgets the reset can see | **0 of 5** | **5 of 5**, destroyed 5 → 0 |

A 3.8× speedup on the leg, and larger than the 144s → 80s recorded when this root cause was first diagnosed. Counts are unchanged, so nothing was skipped into passing.

## Why the diagnosis was exact this time

`D:\Development\ttkbootstrap` — same maintainer, same shared-root design, and its `tests/conftest.py` says it followed bootstack's approach. Its `root` fixture snapshots `app.winfo_children()` and destroys what is new, which is **correct there because `Window` IS the root and tests parent straight into it**. bootstack interposes a content frame, so the identical expression is one level too shallow. The divergence between the two repos is the whole bug.

## ⚠ A fix that was added and then removed

When this exposed a failure, the hypothesis was that destroying a `Select` leaves its `when="tail"` `<<Change>>` queued for the next test, and a `root.update()` drain was added to `_reset_scene`. **Three full runs with the drain were green — and so were three without**, which decides nothing at a 1-in-10 rate.

So the question was settled by a probe that creates the condition instead: arm 2 of `development/probe_407_scene_reset.py` leaks **0 events with the drain and 0 without**. The hypothesis is refuted and the drain is gone. The refuting arm is committed rather than deleted, so it is not re-proposed.

## What did NOT hold

Two expectations recorded against #407 are not met, and saying so is the honest state:

- **PageStack still needs its `isolated` marker.** Removing it does not break PageStack — it surfaces an unrelated test (below). That half of the prediction is unconfirmed.
- **#447's flake rate went 4/50 → 2/50, which settles nothing.** At those sample sizes 8% versus 4% is inside noise. Recorded as unchanged rather than claimed as a win.

## One failure exposed, filed not fixed

**#449** — `test_select_change_event_value_space` pins an exact event list against an asynchronous change and fails ~1 in 10 full runs (0 in 6 shared-leg runs, 0 in 10 solo runs). Its own sibling two functions below documents the same quirk and handles it by asserting set membership. `PLAN.md` scoped it out up front so this stays reviewable as a harness fix.

> **Correction.** An earlier version of this body, and of #449, asked whether a `Select` emitting a `None` change **at construction** was correct. **It does not emit one.** Measured with `bind_all("<<Change>>")` installed before the widget is built: 0 events from construction, with or without `value=`, and exactly one from an ordinary set. That speculation is withdrawn in both places. The origin of the phantom `None` is recorded as unexplained rather than guessed at a second time - it is also not a leak from the reset, which arm 2 of the probe measures at 0.

## Review

`PLAN.md` declares a **round cap of 2** per `REVIEW-PROTOCOL.md` gate 3 — and gate 1 most likely means **zero** rounds, since the branch changes no production code. That gate exists because this project spent four rounds reviewing test scaffolding a week ago.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

