### PR TITLE
Run the test suite on every push and pull request (#380)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,11 +117,15 @@ jobs:
 
       # The suite never blocks on input, but nearly every test builds a real Tk
       # root, so x11 needs a display and Tk's own shared libraries.
+      #
+      # `openbox` is not decoration — see the "Run the suite (Linux)" step below.
+      # `x11-utils` supplies `xprop`, which is how that step proves the window
+      # manager actually came up instead of assuming it did.
       - name: Install Tk and a virtual display
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends xvfb tk
+          sudo apt-get install -y --no-install-recommends xvfb tk openbox x11-utils
 
       - name: Install
         run: |
@@ -140,6 +144,22 @@ jobs:
       # get their own process; bare pytest gives them one shared one. The runner
       # also reaches the legs `testpaths` does not list.
       #
+      # A WINDOW MANAGER IS REQUIRED, and bare `xvfb-run` does not start one.
+      # Under X11 it is the window manager, not the server, that assigns input
+      # focus to a newly mapped top-level window. With none running, a dialog is
+      # mapped but never focused, `focus_set()` inside it silently no-ops, and
+      # the toplevel's <Return> binding has nothing to fire against — which is
+      # the whole of #447. Measured on WSL: same kernel, distro, Tk, Python and
+      # commit, seven dialog failures with no window manager and zero with one,
+      # deterministic in both directions.
+      #
+      # ⚠ Do NOT replace the poll with `sleep`. A window manager that fails to
+      # start leaves the suite running on an unmanaged display and reproduces
+      # #447 exactly, which reads as a product bug rather than a broken step —
+      # that false result was measured once already. `_NET_SUPPORTING_WM_CHECK`
+      # is the difference between "we started a window manager" and "a window
+      # manager is running", so a missing one fails the job loudly and early.
+      #
       # -dpi 96 is load-bearing, not decoration. `detect_scale_factor()` is
       # `winfo_fpixels('1i')/72`, so under Xvfb it returns whatever DPI the
       # virtual screen was given. Xvfb's default is around 75, which puts
@@ -147,7 +167,19 @@ jobs:
       # padding-scaling bug structurally invisible.
       - name: Run the suite (Linux)
         if: runner.os == 'Linux'
-        run: xvfb-run -a -s "-screen 0 1280x1024x24 -dpi 96" python tests/run_gui.py -q
+        run: |
+          xvfb-run -a -s "-screen 0 1280x1024x24 -dpi 96" sh -c '
+            openbox &
+            for i in $(seq 1 50); do
+              xprop -root _NET_SUPPORTING_WM_CHECK 2>/dev/null | grep -q "window id" && break
+              sleep 0.2
+            done
+            xprop -root _NET_SUPPORTING_WM_CHECK 2>/dev/null | grep -q "window id" || {
+              echo "::error::No window manager on the virtual display. The dialog"
+              echo "::error::focus suite cannot pass without one - see #447."
+              exit 1
+            }
+            exec python tests/run_gui.py -q'
 
       # Windows and macOS talk to win32 and to aqua directly, so there is no
       # display to set up.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,175 @@
+name: CI
+
+# Nothing ran this suite anywhere but two developer machines. Every Tk 9 bug so
+# far (#372, #375, #376) was found by a user or by hand, and `release.yml` will
+# happily publish a red tree. This is #380.
+#
+# It became affordable rather than merely desirable when #407 landed: the full
+# suite went from roughly five minutes to about a minute, because the shared-root
+# scene reset started actually resetting the scene.
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# A newer push supersedes an in-flight run on the same ref.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # The cheapest useful signal, and the only job that needs no display at all.
+  #
+  # ⚠ An explicit ALLOWLIST (`HEADLESS` in tests/run_gui.py), never `-m "not
+  # gui"`. That marker selects 741 tests and produces 494 errors with root
+  # creation blocked, because most of them still pull the session `app` fixture.
+  # Worse, some tests run headless and report GARBAGE rather than failing:
+  # `Treeview.bbox()` returns `''` instead of raising until the window is
+  # mapped, so a geometry assertion with no display compares nothing to nothing
+  # and passes. Growing this job means fixing markers first (#380), not
+  # loosening the filter.
+  headless:
+    name: headless (no display)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      # tkinter must be importable even though no root is ever created here.
+      - name: Install Tk
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends tk
+
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .
+          python -m pip install pytest
+
+      # Root creation is BLOCKED, so a test that quietly grew a display
+      # dependency fails here instead of silently becoming a GUI test.
+      - name: Run the display-free legs
+        run: |
+          python - <<'PY'
+          import sys, tkinter, pytest
+          sys.path.insert(0, "tests")
+          from run_gui import HEADLESS
+
+          def blocked(self, *a, **k):
+              raise RuntimeError(
+                  "this leg runs with no display: a test here must never build a Tk root"
+              )
+
+          tkinter.Tk.__init__ = blocked
+          raise SystemExit(pytest.main([*HEADLESS, "-q", "-p", "no:cacheprovider"]))
+          PY
+
+  tests:
+    name: tests (${{ matrix.os }}, py${{ matrix.python }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      # Never let one platform's failure hide another's. This project has twice
+      # read a green run on one box as a green suite -- and the whole reason
+      # this workflow exists is that two developer machines were the only thing
+      # ever running it.
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            python: "3.13"
+          - os: windows-latest
+            python: "3.13"
+          # aqua is the third windowing system and behaves differently enough to
+          # have had its own fixes (the Tk 9 dpi baseline, native popup chrome).
+          - os: macos-latest
+            python: "3.13"
+          # The floor declared in pyproject.toml, so a 3.13+ construct cannot
+          # slip in unnoticed.
+          - os: ubuntu-latest
+            python: "3.12"
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python }}
+
+      # The suite never blocks on input, but nearly every test builds a real Tk
+      # root, so x11 needs a display and Tk's own shared libraries.
+      - name: Install Tk and a virtual display
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends xvfb tk
+
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .
+          python -m pip install pytest
+
+      # Which Tk line a runner carries is not something to infer from the Python
+      # version: the aqua dpi baseline and the scroll-event contract both differ
+      # between 8.6 and 9, and this project has no Tk 9 box at all. Record it.
+      - name: Report the Tk build
+        run: python -c "import sys, tkinter; print(f'{sys.platform} python={sys.version.split()[0]} tcl={tkinter.TclVersion} tk={tkinter.TkVersion}')"
+
+      # ⚠ `run_gui.py`, NOT bare pytest. Destroying a Tk root and creating
+      # another in-process crashes natively, so a handful of modules must each
+      # get their own process; bare pytest gives them one shared one. The runner
+      # also reaches the legs `testpaths` does not list.
+      #
+      # -dpi 96 is load-bearing, not decoration. `detect_scale_factor()` is
+      # `winfo_fpixels('1i')/72`, so under Xvfb it returns whatever DPI the
+      # virtual screen was given. Xvfb's default is around 75, which puts
+      # ui_scale below 1.0, floors every padding at base, and makes a
+      # padding-scaling bug structurally invisible.
+      - name: Run the suite (Linux)
+        if: runner.os == 'Linux'
+        run: xvfb-run -a -s "-screen 0 1280x1024x24 -dpi 96" python tests/run_gui.py -q
+
+      # Windows and macOS talk to win32 and to aqua directly, so there is no
+      # display to set up.
+      - name: Run the suite
+        if: runner.os != 'Linux'
+        run: python tests/run_gui.py -q
+
+  # `docs.yml` only deploys AFTER a successful release, so a broken
+  # cross-reference currently sits on `main` unnoticed until release day.
+  #
+  # ⚠ Clean build every time. An incremental Sphinx build MASKS warnings, which
+  # is why this checks out fresh and never caches `docs/_build`.
+  docs:
+    name: docs (-W)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      # autodoc imports the package, which imports tkinter.
+      - name: Install Tk
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends tk
+
+      # The same install `docs.yml` uses, so the check and the deploy cannot
+      # drift into testing different dependency sets.
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[docs]"
+
+      - name: Build
+        run: python -m sphinx -b html -W --keep-going -q docs _ci_docs_build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,8 @@ jobs:
   headless:
     name: headless (no display)
     runs-on: ubuntu-latest
+    # Runs in seconds. A minute is generous and caps a hang.
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v5
 
@@ -75,6 +77,11 @@ jobs:
   tests:
     name: tests (${{ matrix.os }}, py${{ matrix.python }})
     runs-on: ${{ matrix.os }}
+    # ⚠ The suite takes ~90s locally and ~75s on a Linux runner. This cap
+    # exists because the FIRST run of this workflow had a macOS job still
+    # going at 90 MINUTES, hung inside the suite. Without it a hang burns to
+    # GitHub's 6-hour default.
+    timeout-minutes: 15
     strategy:
       # Never let one platform's failure hide another's. This project has twice
       # read a green run on one box as a green suite -- and the whole reason
@@ -87,10 +94,15 @@ jobs:
             python: "3.13"
           - os: windows-latest
             python: "3.13"
-          # aqua is the third windowing system and behaves differently enough to
-          # have had its own fixes (the Tk 9 dpi baseline, native popup chrome).
-          - os: macos-latest
-            python: "3.13"
+          # ⚠ NO macOS LEG, and this was MEASURED rather than assumed. #380
+          # flagged that Tk-on-Aqua was unverified on GitHub's runners; the
+          # first run of this workflow answered it. Install and the Tk report
+          # both succeeded, then "Run the suite" HUNG - still going at 90
+          # minutes for a suite that takes 90 SECONDS locally. aqua is a
+          # platform we support and this leg is wanted, but a hanging job is
+          # worse than no job: it teaches people to ignore the workflow and it
+          # burns a runner for hours. Tracked separately; re-add it with a
+          # timeout once the hang is understood.
           # The floor declared in pyproject.toml, so a 3.13+ construct cannot
           # slip in unnoticed.
           - os: ubuntu-latest
@@ -151,6 +163,7 @@ jobs:
   docs:
     name: docs (-W)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v5
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,102 @@
+# PLAN — #380, a CI workflow that runs the suite
+
+Branch `ci/test-workflow-380`, off `main` at `ece32a38`.
+
+## Round cap: 2
+
+`REVIEW-PROTOCOL.md` gate 3. No public surface changes, so this is patch-safe.
+
+⚠ Gate 1: **a round is triggered by a non-empty `git diff <range> -- src/`.**
+This branch is expected to touch `.github/` and `tests/` only, so the likely
+number of review rounds is **zero**. If `src/` does change, that is a signal the
+branch has grown past its scope — stop and re-read this file before continuing.
+
+## Why now, and what changed
+
+`.github/workflows/` has only `docs.yml` and `release.yml`, so **nothing runs the
+suite**. Every Tk 9 bug so far (#372, #375, #376) was found by a user or by hand.
+
+The issue has been open a long time because it was expensive. Both objections
+have weakened:
+
+- **The suite was slow.** #407 landed on 2026-08-12: full `run_gui.py` went from
+  ~5 minutes to **66–88s**. Running it on every push is now cheap.
+- **The design was unknown.** It is not. **`D:\Development\ttkbootstrap` has a
+  working `ci.yml`** for the same toolkit and the same shared-root design, whose
+  `conftest.py` says it followed bootstack's approach. This is adaptation, not
+  design.
+
+## What #380's own measurements say — read before scoping
+
+Recorded on the issue and **not to be re-derived**:
+
+- **`-m "not gui"` is NOT a usable headless filter.** It selects 741 tests, and
+  running that selection with root creation blocked gives **11 failed, 222
+  passed, 14 skipped, 494 errors** — most nominally non-gui tests still pull the
+  session `app` fixture. Growing a headless job past ~222 tests needs marker
+  cleanup first, which is **out of scope here**.
+- **Some tests run headless and report garbage silently.** `Treeview.bbox()`
+  returns `''` — not an error — until the window is mapped, so a geometry
+  assertion without a display compares nothing to nothing and passes. This is the
+  vacuous-pass mode that let #358 ship twice. **A headless job must therefore be
+  an explicit allowlist, never a marker filter.**
+- **Scaling assertions cannot be faked.** `detect_scale_factor()` is
+  `winfo_fpixels('1i')/72`, so under Xvfb it returns the virtual screen's DPI. At
+  Xvfb's common 75 dpi default a padding-scaling bug becomes structurally
+  invisible. ttkbootstrap's answer is `-dpi 96`, with the reasoning written into
+  its workflow.
+
+## The jobs
+
+1. **`headless`** (ubuntu, no display, no xvfb) — an **explicit allowlist**, per
+   the trap above. Measured on this box with `tkinter.Tk.__init__` patched to
+   raise: **174 passed**, being `tests/test_public_surface.py` (166) and
+   `tests/widgets/public/test_tk9_scaling_baseline.py` (8). A `ubuntu-latest` job
+   with no display would have caught #375.
+2. **`tests`** — matrix over **ubuntu (xvfb) / windows / macos**, on the floor
+   Python (**3.12**, from `requires-python`) and 3.13. Runs
+   `python tests/run_gui.py`, NOT bare `pytest`: the isolated legs genuinely need
+   their own processes, and bare `pytest` would not give them one.
+3. **`docs`** — a clean `-W` Sphinx build. `docs.yml` only deploys after a
+   successful release, so a broken cross-reference currently reaches `main`
+   unnoticed until release time.
+
+⚠ **NO macOS + Tk 9 leg.** #380 itself says it would be **red from day one**
+until #378 is fixed (the suite cannot complete on Tk 9 at all), and it is
+unverified whether Tk-on-Aqua works on GitHub's runners. A permanently red leg
+teaches people to ignore the workflow.
+
+## The coverage gaps, folded in as #380 asks
+
+`testpaths` is `tests/cli`, `tests/widgets/public`, `tests/data`, so anything
+outside those **never runs**, in CI or locally:
+
+- **`tests/widgets/*.py` — 12 files, 25 tests.** Verified today: **all 12 pass
+  individually**, each in its own process, because each builds its own root. They
+  go into `run_gui.py`'s `ISOLATED` list, which is exactly what that list is for.
+- **`tests/test_public_surface.py` — 166 tests**, the guard for the curated
+  public namespace (PR #104), which the widget-review standard lists as a verify
+  step. It needs no display, so it rides the headless job — and gets a local leg
+  too, so `run_gui.py` and CI agree about what "the suite" means.
+
+## Verification
+
+1. `python tests/run_gui.py` green locally **with the new legs**, counts recorded
+   beside the commit. Expect **+25 and +166** over today's 1250 / 22.
+2. The headless allowlist re-measured with root creation blocked.
+3. **The workflow's own first run is the real test**, and it is the one thing
+   that cannot be checked from this box. Two questions it answers for free:
+   - **#432** — does the Linux shared-root leg still exit silently mid-run? It
+     may not, now that #407 removed the widget accumulation. **Do not scope #432
+     before reading that run.**
+   - Whether Windows and macOS runners agree with the two boxes here.
+
+⚠ **A first CI run that fails is a RESULT, not a setback.** The whole point is
+that nothing has ever run this suite anywhere but two developer machines.
+
+## Explicitly out of scope
+
+Marker cleanup to grow the headless job (#380 records the 494 errors), the macOS
+Tk 9 leg (#378), #432 itself beyond reading what CI reports, #447/#449, and
+pinning Tk scaling in `conftest` — that last one is worth doing and is its own
+change, because it alters what every pixel-exact test measures.

--- a/PLAN.md
+++ b/PLAN.md
@@ -94,9 +94,78 @@ outside those **never runs**, in CI or locally:
 ⚠ **A first CI run that fails is a RESULT, not a setback.** The whole point is
 that nothing has ever run this suite anywhere but two developer machines.
 
+## AMENDMENT (2026-08-14) — the Linux leg, after the WSL box reported
+
+The first CI run was the "result, not a setback" this plan anticipated. It came
+back red on both Linux legs, and answering *why* is what the WSL box was briefed
+to do. It has now reported, so the branch takes on exactly what is needed to make
+the Linux leg green — and nothing else.
+
+**#447 was out of scope above and now is not.** That is not scope creep: the
+answer turned out to be a property of the *workflow this branch authors*, not of
+the product. There is no way to land a Linux leg without deciding what display it
+runs on.
+
+### What changed, and why each is here
+
+1. **`ci.yml` starts a window manager.** Under X11 it is the window manager, not
+   the server, that assigns input focus to a newly mapped top-level window. Bare
+   `xvfb-run` starts none, so a dialog is mapped but never focused and the
+   toplevel's `<Return>` binding has nothing to fire against. Measured on WSL
+   across three arms with only the window manager varying: **7 dialog failures
+   without one, 0 with one**, deterministic in both directions.
+   ⚠ The poll on `_NET_SUPPORTING_WM_CHECK` is load-bearing. A window manager
+   that fails to start silently reproduces #447 exactly, which reads as a product
+   bug — that false result was measured once already on the WSL box.
+2. **#434 / #431 — the NumLock bit is resolved per platform.** Bit 8 is `Mod1`,
+   and what `Mod1` carries is the platform's business: NumLock on Windows, **Alt
+   on X11**, Command on Aqua. Hardcoding 8 asserted a different key on each
+   platform. Verified the replacement bit is genuinely delivered (`state seen =
+   16`) rather than dropped, so the test still carries a real modifier instead of
+   quietly becoming a copy of the no-modifier control beside it.
+3. **#433 — `cget("padding")[0]` read through `str()`.** Tk 8.6.12 on Ubuntu
+   hands back a `_tkinter.Tcl_Obj` where other builds return a string. The
+   padding is identical; only the binding's surfacing of it differs.
+4. **`test_capture_restores_a_window_that_was_not_topmost`.** Not previously
+   filed, and **only a window manager can expose it**: the test skips where
+   always-on-top is not honored, so bare Xvfb never ran it. Always-on-top is a
+   request answered asynchronously, which `_pin` already polls for on the way in
+   — the assertion did not on the way out. Measured: the restore lands in ~1 ms,
+   but the immediate read still returns the old value. **Product code is
+   correct**; `capture.py` restores only what it changed. Non-vacuity confirmed by
+   disabling that restore and watching the polled assertion still fail.
+
+### `src/` IS UNTOUCHED — gate 1 therefore opens no round
+
+`git diff main...HEAD -- src/` is empty, verified rather than assumed. Every
+change above is `.github/` or `tests/`. Under `REVIEW-PROTOCOL.md` gate 1 that is
+**zero review rounds**, against the cap of 2 declared at the top of this file.
+
+### Measured, on the WSL box, at `5921dc41`
+
+Ubuntu 22.04.5, Python 3.13.11, Tk 8.6.12, `pandas` absent (so the data leg reads
+125 / 4 — the documented environmental pair, not a discrepancy). 33 legs.
+
+| arm | exit | passed | failed | skipped |
+|---|---|---|---|---|
+| Xvfb **+ window manager** | 0 | **1427** | **0** | 22 |
+| Xvfb **bare** — what CI does today | 1 | 1418 | **7** | 24 |
+
+⚠ **It reconciles against itself**: `1418 + 7 failed + 2 extra skips = 1427`,
+the two extra skips being the capture topmost tests standing down where no window
+manager honors always-on-top. And the 7 are exactly the #447 cluster, so **the
+test fixes above did not mask it** — remove the window manager and it returns.
+
+⚠ **This does NOT reconcile with the `1449` recorded for this branch earlier**,
+which CLAUDE.md already flags as never having been reconciled. 1427 is a Linux
+figure and the 1449 was not; platform gating differs, so they are not the same
+quantity. **Do not repair the arithmetic by picking whichever number closes the
+gap** — re-measure per platform. CI's own matrix now reports all three.
+
 ## Explicitly out of scope
 
 Marker cleanup to grow the headless job (#380 records the 494 errors), the macOS
-Tk 9 leg (#378), #432 itself beyond reading what CI reports, #447/#449, and
-pinning Tk scaling in `conftest` — that last one is worth doing and is its own
-change, because it alters what every pixel-exact test measures.
+Tk 9 leg (#378), #452 (the macOS runner hang) beyond leaving that leg out, #432
+itself beyond reading what CI reports, #449, and pinning Tk scaling in `conftest`
+— that last one is worth doing and is its own change, because it alters what
+every pixel-exact test measures.

--- a/tests/run_gui.py
+++ b/tests/run_gui.py
@@ -41,6 +41,46 @@ ISOLATED = [
     # pushed them — measured at y~2810 on a 956px-tall screen — and every grab
     # asks for a region no monitor covers. A fresh root keeps them on screen.
     "tests/widgets/public/test_capture.py",
+    # ⚠ Everything below sits DIRECTLY under tests/widgets/, which `testpaths`
+    # does not list — so until #380 these 12 files (25 tests) were collected by
+    # NOTHING. Not by `pytest`, not by this runner, not by CI, which did not
+    # exist. They were dead coverage, not failing coverage: every one passes on
+    # its own, which is why nobody noticed.
+    #
+    # They belong here rather than in `testpaths` because each builds its own
+    # root, which is precisely what this list is for.
+    "tests/widgets/test_icon_image_props.py",
+    "tests/widgets/test_rebuild_regressions.py",
+    "tests/widgets/test_shell_collapse.py",
+    "tests/widgets/test_shell_custompanel.py",
+    "tests/widgets/test_shell_groups.py",
+    "tests/widgets/test_shell_layout.py",
+    "tests/widgets/test_shell_listnav.py",
+    "tests/widgets/test_shell_nav.py",
+    "tests/widgets/test_shell_toolbar.py",
+    "tests/widgets/test_shell_treenav.py",
+    "tests/widgets/test_shell_twotier.py",
+    "tests/widgets/test_toolbar_drag.py",
+]
+
+# Display-free legs. These never build a Tk root, so they run anywhere — CI runs
+# them as their own job with no display at all, which is what makes that job
+# meaningful rather than decorative.
+#
+# ⚠ An ALLOWLIST, deliberately, not `-m "not gui"`. That marker selects 741
+# tests and yields 494 errors with root creation blocked, because most of them
+# still pull the session `app` fixture (#380). Worse, some tests DO run headless
+# and report garbage: `Treeview.bbox()` returns `''` rather than raising until
+# the window is mapped, so a geometry assertion without a display compares
+# nothing to nothing and passes.
+HEADLESS = [
+    # The guard for the curated public namespace (PR #104), which the widget
+    # review standard lists as a verify step -- and which `testpaths` also never
+    # collected. 166 tests that had never run in any automated way.
+    "tests/test_public_surface.py",
+    # Monkeypatches platform.system() and tkinter.TkVersion, so it needs neither
+    # a display nor a Tk 9 build. This is the leg that would have caught #375.
+    "tests/widgets/public/test_tk9_scaling_baseline.py",
 ]
 
 # Modules that construct a fresh root PER TEST (e.g. an App-config factory
@@ -78,6 +118,11 @@ SHARED_GROUPS = [
 def main() -> int:
     extra = sys.argv[1:]
     failed = []
+
+    # 0) Display-free legs. Cheap, and first so a namespace break is reported
+    #    before three minutes of GUI work rather than after it.
+    if _run([*HEADLESS, *extra]) != 0:
+        failed.append("headless: " + " ".join(HEADLESS))
 
     # 1) Shared-root suite, each group in its own process (not isolated tests).
     for group in SHARED_GROUPS:

--- a/tests/widgets/public/test_appshell_shortcuts.py
+++ b/tests/widgets/public/test_appshell_shortcuts.py
@@ -5,8 +5,10 @@ into a field: Tk resolves the `Command` modifier word to `Mod1` on Windows and
 X11, and Windows reports `Mod1` for NumLock, so a `<Command-b>` binding left
 unguarded off macOS matched every unmodified `b` on a machine with NumLock on.
 
-The NumLock bit is supplied explicitly (`state=8`) rather than being taken from
-the host, so the test reproduces the reported failure on any machine.
+The NumLock bit is supplied explicitly rather than being taken from the host, so
+the test reproduces the reported failure on a machine whose NumLock is off — but
+*which* bit means NumLock is a property of the platform, so it is resolved per
+windowing system rather than hardcoded. See `_numlock_bit`.
 """
 
 from __future__ import annotations
@@ -17,8 +19,28 @@ import bootstack as bs
 
 pytestmark = pytest.mark.isolated
 
-# Tk's Mod1 bit — set by NumLock on Windows, by Alt on X11.
-_MOD1 = 8
+
+def _numlock_bit(widget) -> int | None:
+    """The modifier bit this platform reports for NumLock, or None if it has none.
+
+    Bit 8 is Tk's `Mod1`, but what `Mod1` carries is decided by the platform, not
+    by Tk. Windows reports NumLock there — which is the whole of #403, since an
+    unguarded `<Command-b>` binding normalizes to `<Mod1-b>` off macOS and so
+    matched every bare `b` on a machine with NumLock on. X11 binds `Mod1` to Alt
+    and puts NumLock on `Mod2`, bit 16 (`xmodmap -pm` names it outright). Aqua
+    reports Command on bit 8.
+
+    So hardcoding 8 asserts a different key on each platform: `Alt-b` on X11,
+    which correctly inserts nothing, and `Cmd-B` on Aqua, which is the real
+    shortcut. Both were filed — #434 and #431 — as the same wrong premise seen
+    from two platforms.
+    """
+    winsys = widget.tk.call("tk", "windowingsystem")
+    if winsys == "x11":
+        return 16
+    if winsys == "aqua":
+        return None
+    return 8
 
 
 @pytest.fixture(scope="module")
@@ -66,9 +88,12 @@ def test_modifier_shortcut_toggles_the_sidebar(expanded):
 
 
 def test_bare_b_does_not_toggle_the_sidebar(expanded):
-    # A plain "b" — no modifier, but carrying the NumLock bit that Windows
-    # reports as Mod1. Typing must reach the field and leave the sidebar alone.
-    expanded._entry_widget.event_generate("<KeyPress-b>", state=_MOD1)
+    # A plain "b" — no modifier, but carrying this platform's NumLock bit.
+    # Typing must reach the field and leave the sidebar alone.
+    numlock = _numlock_bit(expanded._entry_widget)
+    if numlock is None:
+        pytest.skip("Aqua has no NumLock modifier — bit 8 there is Command, the real shortcut")
+    expanded._entry_widget.event_generate("<KeyPress-b>", state=numlock)
     expanded._internal.update()
     assert expanded.sidebar_mode == "expanded"
     assert expanded._field.text == "b"

--- a/tests/widgets/public/test_capture.py
+++ b/tests/widgets/public/test_capture.py
@@ -170,6 +170,27 @@ def _pin(root, timeout: float = 0.5) -> bool:
     return False
 
 
+def _topmost_settles_to(root, expected: bool, timeout: float = 0.5) -> bool:
+    """Poll `-topmost` until it reaches `expected`, and report what it ended at.
+
+    The mirror of `_pin`'s poll, for the way back out. Always-on-top is a
+    request the window manager answers asynchronously, and that is as true of
+    clearing it as of setting it — so a single read taken right after a capture
+    can see the state the window manager has not caught up to yet. Measured on
+    X11: the restore lands in about a millisecond, but a read taken immediately
+    still returns the old value, which failed this test on every Linux run while
+    passing on Windows and macOS, where the attribute is answered synchronously.
+    """
+    deadline = time.monotonic() + timeout
+    while True:
+        root.update()
+        if bool(root.attributes("-topmost")) == expected:
+            return expected
+        if time.monotonic() >= deadline:
+            return bool(root.attributes("-topmost"))
+        time.sleep(0.01)
+
+
 def test_capture_restores_a_window_that_was_not_topmost(shown_app, tmp_path):
     """Capturing raises the window; it must put the setting back afterward."""
     root = shown_app.tk
@@ -184,7 +205,7 @@ def test_capture_restores_a_window_that_was_not_topmost(shown_app, tmp_path):
 
     bs.Label("restore me").capture(tmp_path / "restore.png", settle=0)
 
-    assert not root.attributes("-topmost")
+    assert not _topmost_settles_to(root, False)
 
 
 def test_capture_leaves_a_deliberately_topmost_window_pinned(shown_app, tmp_path):

--- a/tests/widgets/public/test_field_hidpi_padding.py
+++ b/tests/widgets/public/test_field_hidpi_padding.py
@@ -15,6 +15,18 @@ import bootstack as bs
 from bootstack._runtime.utility import _ScalingState, scale_padding_floor
 
 
+def _first_pad(widget) -> int:
+    """The first element of a widget's `padding`, as an int.
+
+    Tk hands the element back as a `_tkinter.Tcl_Obj` on some builds (8.6.12 on
+    Ubuntu 22.04) and as a string on others, so `int()` alone raises `TypeError`
+    on the former — #433. `str()` normalizes both, since `Tcl_Obj.__str__` yields
+    the same text the other platforms return directly. The padding itself is
+    identical either way; only the binding's surfacing of it differs.
+    """
+    return int(str(widget.cget("padding")[0]))
+
+
 def test_scale_padding_floor_never_below_base():
     # Below the baseline (low DPI) it must hold the tuned base, not shrink — a
     # smaller gap clips the rounded corners.
@@ -41,14 +53,14 @@ def test_field_padding_tracks_dpi(app):
     # The TextField's TField frame padding is built from scale_padding_floor.
     _ScalingState.set_scale_factor(1.0)
     low = bs.TextField(label="a")
-    low_pad = low._internal._field.cget("padding")[0]
+    low_pad = _first_pad(low._internal._field)
 
     _ScalingState.set_scale_factor(2.667)
     high = bs.TextField(label="b")
-    high_pad = high._internal._field.cget("padding")[0]
+    high_pad = _first_pad(high._internal._field)
 
-    assert int(high_pad) > int(low_pad)
-    assert int(low_pad) >= 5
+    assert high_pad > low_pad
+    assert low_pad >= 5
 
 
 @pytest.mark.gui
@@ -57,4 +69,4 @@ def test_textarea_padding_tracks_dpi(app):
     _ScalingState.set_scale_factor(2.667)
     ta = bs.TextArea(label="notes")
     assert ta._internal._field_frame is not None
-    assert int(ta._internal._field_frame.cget("padding")[0]) > 5
+    assert _first_pad(ta._internal._field_frame) > 5


### PR DESCRIPTION
Closes #380.

`.github/workflows/` had only `docs.yml` and `release.yml`, so **nothing ran the test suite**. Every Tk 9 bug so far (#372, #375, #376) was found by a user or by hand, and `release.yml` will publish a red tree without complaint.

This sat open because it was expensive. Two things changed:

- **#407 landed**, taking the full suite from ~5 minutes to ~1. Running it on every push is now cheap.
- **`ttkbootstrap` already solved this** — same toolkit, same shared-root design, and its `conftest.py` says outright that it followed bootstack's approach. This is adaptation, not design.

## Three jobs

| job | what |
|---|---|
| `headless` | an explicit allowlist run with **no display and Tk root creation blocked** |
| `tests` | ubuntu / windows / macos on 3.13, plus the **3.12 floor**, `fail-fast: false`, xvfb on Linux |
| `docs` | a clean `-W` build, which today only happens at release time |

**No macOS + Tk 9 leg.** #380 itself says it would be **red from day one** until #378 is fixed (the suite cannot complete on Tk 9), and it is unverified whether Tk-on-Aqua works on GitHub's runners at all. A permanently red leg teaches people to ignore the workflow.

## Three decisions that are load-bearing, not stylistic

**The headless job is an allowlist and must stay one.** `-m "not gui"` looks like the obvious filter and is not: it selects 741 tests and yields **494 errors** with root creation blocked, because most still pull the session `app` fixture. Worse, some tests *do* run headless and report **garbage rather than failing** — `Treeview.bbox()` returns `''` instead of raising until the window is mapped, so a geometry assertion with no display compares nothing to nothing and passes. That is the vacuous-pass mode that let #358 ship twice. Root creation is blocked in the job so a test that grows a display dependency fails loudly instead of quietly becoming a GUI test.

**`-dpi 96` is load-bearing.** `detect_scale_factor()` is `winfo_fpixels('1i')/72`, so under Xvfb it returns whatever DPI the virtual screen was given. At Xvfb's ~75 default, `ui_scale` lands below 1.0, `scale_padding_floor` floors everything at base, and a padding-scaling bug becomes structurally invisible.

**It runs `tests/run_gui.py`, not bare `pytest`.** Destroying a Tk root and creating another in-process crashes natively, so several modules need their own process; bare pytest gives them one shared one.

## Coverage gaps folded in, as #380 asked

Both had **never run anywhere** — not in CI, which did not exist, and not locally, because `testpaths` does not list them:

- **`tests/widgets/*.py` — 12 files, 25 tests.** Verified individually first: all 12 pass, each in its own process, because each builds its own root. Added to `run_gui.py`'s `ISOLATED` list, which is exactly what that list is for.
- **`tests/test_public_surface.py` — 166 tests**, the guard for the curated public namespace (PR #104), which the widget-review standard lists as a verify step. Display-free, so it rides the headless leg — and `run_gui.py` runs it too, so local and CI agree about what "the suite" means.

## Verified locally

`py -3.12 tests/run_gui.py`: **exit 0, 33 legs, 1449 passed / 22 skipped, 98s.**

The count reconciles exactly: **1250** (before) **+ 25** never-collected **+ 166** public-surface **+ 8** for `test_tk9_scaling_baseline.py`, which now runs twice — once headless, proving it needs no display, and once in the shared leg as before.

The headless step body was executed verbatim on this box with root creation blocked: **174 passed**.

## ⚠ What this PR cannot verify, and what its own first run answers

**The workflow's first run is the real test**, and it is the one thing no developer box here can check. Two questions it answers for free:

- **#432** — does the Linux shared-root leg still exit silently mid-run? It may not, now that #407 removed the widget accumulation. **Do not scope #432 before reading that run.**
- Whether the Windows and macOS runners agree with the two machines this project has ever been tested on.

**A first run that fails is a result, not a setback.** The entire point is that nothing has ever run this suite anywhere else.

## Review

`PLAN.md` declares a **round cap of 2** per `REVIEW-PROTOCOL.md` gate 3, and gate 1 most likely means **zero** — `git diff main...HEAD -- src/` is empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

# UPDATE (2026-08-14) — the Linux legs are GREEN, and #447 was the display

The first run did exactly what the section above hoped: it failed, and the failure was informative. Both Linux legs came back red with a seven-test dialog focus cluster, and the WSL box was briefed to answer one question — is that X11 generally, or `xvfb-run` specifically?

**It is `xvfb-run` specifically. Bare `xvfb-run` starts no window manager, and under X11 it is the window manager — not the server — that assigns input focus to a newly mapped top-level window.** With none running, a dialog is mapped but never focused, `focus_set()` inside it silently no-ops, and the toplevel's `<Return>` binding has nothing to fire against. `focus_lastfor()` returning the **empty string** was the tell all along: not "focus is on the wrong widget" but "nothing in this toplevel ever held focus".

Measured across three arms with only the window manager varying — same kernel, distro, Tk, Python and commit:

| arm | window manager | dialog failures |
|---|---|---|
| WSLg | Weston | **0** |
| Xvfb, bare — what this workflow did | none | **7** |
| Xvfb + a window manager | Xfwm4 | **0** |

Deterministic in both directions, seven for seven. **So the `0.3.1` dialog keyboard work is fine on X11**, and the fix belongs here rather than in the product.

## What changed

| # | change | issue |
|---|---|---|
| 1 | `ci.yml` installs `openbox` and starts it, polling `_NET_SUPPORTING_WM_CHECK` before running the suite | #447 |
| 2 | the NumLock modifier bit is resolved per platform instead of hardcoded to 8 | #434, #431 |
| 3 | `cget("padding")[0]` read through `str()`, for Tk's `Tcl_Obj` | #433 |
| 4 | the capture topmost-restore assertion waits for the window manager to answer | — |

**⚠ The poll is load-bearing, not defensive.** A window manager that fails to start leaves the suite on an unmanaged display and reproduces #447 exactly, which reads as a product bug rather than a broken step — and that false result was measured once already, when `xfwm4 --daemon` silently failed to start and the arm came back byte-identical to the no-WM arm. **Do not replace it with a `sleep`.** Both arms of the guard were exercised before committing: a window manager that never starts exits 1 with a `::error::`, a real one runs the payload.

**Change 4 was not previously filed and only a window manager can expose it.** That test *skips* where always-on-top is not honored, so bare Xvfb never ran it — it is newly reachable, not a regression. Always-on-top is a request the window manager answers asynchronously, which `_pin()` already polls for on the way in; the assertion did not on the way out. Measured: the restore lands in about **one millisecond**, but the immediate read still returns the old value. **Product code is correct and untouched** — `capture.py` restores only what it changed. Non-vacuity was confirmed by breaking that restore and watching the polled assertion still fail, rather than by re-running.

## Verified on the WSL box, then verified again by CI

Ubuntu 22.04.5, Python 3.13.11, Tk 8.6.12, 33 legs:

| arm | exit | passed | failed | skipped |
|---|---|---|---|---|
| Xvfb **+ window manager** | 0 | **1427** | **0** | 22 |
| Xvfb **bare** | 1 | 1418 | **7** | 24 |

**It reconciles against itself**: `1418 + 7 failed + 2 extra skips = 1427`, the two extra skips being the capture topmost tests standing down where no window manager honors always-on-top. And the 7 are exactly the #447 cluster — **the test fixes above did not mask it**; remove the window manager and it returns.

CI run [`31797591244`](https://github.com/israel-dryer/bootstack/actions/runs/31797591244) is **green on all five jobs**, and its Linux shared leg reads `1032 passed, 14 skipped, 75 deselected` — identical to the local figure.

**⚠ The `1449` quoted further up was never reconciled and should not be trusted.** 1427 is a Linux number and 1449 was not, so they are not the same quantity; platform gating differs. Re-measure per platform rather than repairing the arithmetic — the matrix now reports all three.

## What this does NOT settle

**#447 should not be closed by this PR.** It was originally reported as a Windows flake at ~4/50, on a machine that *has* a window manager, and nothing here explains that. The missing-WM mechanism is a plausible reason the same condition would need a race to appear where a window manager exists, but that is a **hypothesis, not a measurement**. This PR removes the CI reproduction; the Windows flake stays open.

**#432 did not reproduce.** Both Linux legs ran all 33 legs to completion and reported normally. That is evidence for closing or re-scoping it, but it is the maintainer's call.

## Review

`src/` is still untouched — `git diff main...HEAD -- src/` is empty, verified rather than assumed — so gate 1 opens **zero rounds** against the declared cap of 2.
