### PR TITLE
fix(select): read_only closes the option list (#453)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and from 0.1.0 onward the project adheres to
 
 ### Fixed
 
-- A read-only `Select` can no longer be changed. `read_only=True` was accepted and then ignored: clicking the field's text area still opened the option list and picked a new value, while the dropdown arrow greyed out — which made the field look read-only without being it. The list now stays shut from both the arrow and the text area, and `read_only` keeps working when combined with `searchable` or `allow_custom_values`, which previously discarded it outright. Reading `select.read_only` also reports the setting now rather than an internal state, so an ordinary `Select` no longer claims to be read-only when nobody asked for it. ([#453](https://github.com/israel-dryer/bootstack/issues/453))
+- A read-only `Select` can no longer be changed. `read_only=True` was accepted and then ignored: clicking the field's text area still opened the option list and picked a new value, while the dropdown arrow greyed out — which made the field look read-only without being it. The list now stays shut from both the arrow and the text area, and `read_only` keeps working when combined with `searchable` or `allow_custom_values`, which previously discarded it outright. Reading `select.read_only` also reports the setting now rather than an internal state, so an ordinary `Select` no longer claims to be read-only when nobody asked for it. `TimeField` is built on the same internals and carried the same defect on its own `read_only`, both when passed to the constructor and when set afterwards; a locked time field now really is locked, and its time list stays shut. ([#453](https://github.com/israel-dryer/bootstack/issues/453))
 
 ## [0.3.1] — Dialog keyboard and modality
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and from 0.1.0 onward the project adheres to
 
 <!-- release-notes-start -->
 
+## [Unreleased]
+
+### Fixed
+
+- A read-only `Select` can no longer be changed. `read_only=True` was accepted and then ignored: clicking the field's text area still opened the option list and picked a new value, while the dropdown arrow greyed out — which made the field look read-only without being it. The list now stays shut from both the arrow and the text area, and `read_only` keeps working when combined with `searchable` or `allow_custom_values`, which previously discarded it outright. Reading `select.read_only` also reports the setting now rather than an internal state, so an ordinary `Select` no longer claims to be read-only when nobody asked for it. ([#453](https://github.com/israel-dryer/bootstack/issues/453))
+
 ## [0.3.1] — Dialog keyboard and modality
 
 ### Fixed

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,226 @@
+# PLAN — #453: `Select.read_only` is declared but never implemented
+
+**Issue:** [#453](https://github.com/israel-dryer/bootstack/issues/453) — *Read-only `Select` not read-only*, reported by `@bLynnb2762` against `0.3.1` on Windows
+**Branch:** `fix/select-read-only-453` (off `main`)
+**Milestone:** `0.3.x — Patch line` *(maintainer, 2026-08-13 — no public surface added; the change makes documented behavior true)*
+**Round cap:** **2** (patch line, per `REVIEW-PROTOCOL.md` gate 3)
+
+---
+
+## The report
+
+> You are able to change a read-only `Select` widget by clicking in the text area vs. the drop-down arrow. […] The drop-down arrow seems to be inactive.
+
+```python
+import bootstack as bs
+
+with bs.App() as app:
+    sel = bs.Select(["A", "B", "C"], value="A", label="Read only", read_only=True)
+    sel.on_change(lambda e: bs.toast(e))
+app.run()
+```
+
+**Reproduced, both symptoms, one cause:**
+
+```
+read_only=True   arrow_dimmed=True   popup_opens=True
+plain            arrow_dimmed=False  popup_opens=True
+```
+
+`read_only=True` sends `state="readonly"` into `Field._delegate_state`, whose only effect here is calling `_sync_addon_state()` (field.py:532) — which dims the arrow. Nothing guards the popup, and the entry-click binding installed at selectbox.py:161 stays live. **The greyed-out arrow the reporter noticed is the entire observable effect of the option**, and it is an accident rather than an implementation.
+
+That is the visible tip of a larger conflation.
+
+## Root cause
+
+`read_only` exists **only on the public wrapper**. It appears nowhere in `selectbox.py` or `field.py` — verified with `grep -rn "read_only" src/bootstack/widgets/_impl/composites/selectbox.py src/bootstack/widgets/_impl/composites/field.py`, which returns nothing.
+
+| | |
+|---|---|
+| `select.py:102` | `read_only: bool = False` — constructor kwarg |
+| `select.py:62-63` | docstring: *"value is visible but the popup cannot be opened"* |
+| `select.py:134-135` | `elif read_only: internal_kwargs["state"] = "readonly"` — the entire implementation |
+| `select.py:283-290` | live property; getter and setter both read/write the ttk entry state |
+
+So the public layer invents a feature, translates it into a toolkit state string, and hands it to a layer that has never heard of it. `SelectBox` already owns that same ttk state as the implementation of "no free typing" (the inverse of `allow_custom_values`/`enable_search`) and recomputes it unconditionally at line 156, discarding whatever the public layer asked for.
+
+`_show_selection_options` (selectbox.py:352) guards only on `disabled`. Nothing anywhere guards the popup on read-only, because nothing downstream knows the concept exists.
+
+## Pre-fix control table — MEASURED, keep for the reviewer
+
+Measured on this branch at the plumbing commit (`_read_only` stored, nothing consuming it yet), `py -3.13`, probe `development/probe_select_read_only.py`:
+
+| construction | `_readonly` | typeable | popup opens | `.read_only` |
+|---|---|---|---|---|
+| `Select()` | False | False | True | **True** ← false positive |
+| `Select(read_only=True)` | True | False | **True** ← the report | True |
+| `Select(read_only=True, allow_custom_values=True)` | True | **True** | True | **False** |
+| `Select(read_only=True, searchable=True)` | True | **True** | True | **False** |
+| `Select(disabled=True)` — CONTROL | — | False | **False** | — |
+
+The `disabled` row is the control: it proves the probe can detect a blocked popup, so the `True`s above are real rather than a broken harness.
+
+Runtime, on a `Select(allow_custom_values=True)`:
+
+| step | typeable | popup | `.read_only` |
+|---|---|---|---|
+| initial | True | True | False |
+| `.read_only = True` | False | **True** | True |
+| `.read_only = False` | True | True | False |
+
+So construction lets `allow_custom_values` win outright, while runtime lets `read_only` win over typing but not over the popup. Neither is a decision anyone made — both fall out of the ttk state being the only storage, written last by whoever ran last.
+
+## Addon dimming — a second, latent defect found while scoping
+
+`Field._sync_addon_state` (field.py:663-681) dims every addon when the entry is `readonly`, on the reasonable assumption that addons mutate the value. `SelectBox` uses `readonly` to mean "not typeable", where the dropdown is the *primary* interaction. Measured:
+
+```
+default Select         : entry_readonly=True   dropdown_addon=enabled
+_readonly_active       : set()                 <- dropdown not registered read-only-safe
+after <<StateChanged>> : dropdown_addon=disabled
+after configure(state=): dropdown_addon=disabled
+button click opens popup = True                <- still works while disabled
+```
+
+1. The dropdown survives on a default `Select` only **by accident** — line 161's direct `entry.state(['readonly'])` does not fire `<<StateChanged>>`, so the sync never runs at construction.
+2. The first thing that does fire it dims the dropdown **permanently** on an ordinary `Select`.
+3. Even dimmed, the button still opens the popup — `_show_selection_options` checks the entry's disabled state, not the button's.
+
+## The contract
+
+**Inputs** (stored): `_read_only`, `_allow_custom_values`, `_search_enabled`, disabled (ttk), `show_dropdown_button` (construction-only).
+
+**Derived outputs** — nothing else may write these:
+
+```
+typeable      = not disabled and not read_only and (allow_custom_values or enable_search)
+popup_opens   = not disabled and not read_only
+dropdown_lit  = not disabled and not read_only
+click_to_open = not typeable        # a typeable entry must place a cursor instead
+```
+
+**Precedence ladder**, extending the one already implicit at select.py:132-135:
+
+```
+disabled  >  read_only  >  allow_custom_values | enable_search
+```
+
+`read_only` **suppresses** `allow_custom_values`; it does not overwrite it. Clearing `read_only` must restore the field to *typeable*, not to plain. Today the runtime path only restores correctly by luck, because `allow_custom_values=True` happens to make `state="normal"` the right answer; the same code on a plain `Select` gets it wrong.
+
+## Runtime writers — every one must route through the applier
+
+| writer | where |
+|---|---|
+| `configure(allow_custom_values=)` | selectbox.py:955 |
+| `configure(enable_search=)` | selectbox.py:968 |
+| `configure(state=)` | field.py:514 — writes disabled/readonly/normal directly |
+| `Field.enable()` / `.disable()` / `.readonly()` | field.py:489/495/501 — bypass the delegate entirely |
+| `Select.disabled` setter | select.py:299 → `configure(state=...)` |
+| `Select.read_only` setter | select.py:290 → to become `configure(read_only=)` |
+
+**Covering them all at once:** override `_sync_addon_state()` in `SelectBox` to call `super()` and then apply the read-only rule. It is already bound to `<<StateChanged>>` (field.py:235) and called from all five internal sites, so every existing path picks up the new behavior with no new writers to track.
+
+## Three things are construction-only and must not stay that way
+
+- **Click-to-open** is bound once, in the `else` branch, via `after_idle` (selectbox.py:161). Flip `allow_custom_values` True→False at runtime and the entry becomes non-typeable with no binding — no entrance at all. **Bind unconditionally at construction and gate inside the handler.** Do *not* bind/unbind on transitions: that is the tkinter funcid-recycling trap that cost a critical defect in #392.
+- **Button existence** is decided at selectbox.py:145 and never revisited, while both of its inputs are runtime-mutable. The delegates must insert the addon if it is missing and now needed (`insert_addon` works after construction).
+- **`state`** — `Select.disabled = False` writes `state="normal"`, clearing `readonly` wholesale. It must re-derive instead of writing raw.
+
+## Incomplete reachability guard — folded in deliberately
+
+selectbox.py:145 reads `allow_custom_values or show_dropdown_button`; line 156 reads `allow_custom_values or enable_search`. The two conditions have drifted, and `enable_search` makes the entry typeable exactly as `allow_custom_values` does. Measured:
+
+```
+custom=F search=F btn=T   button=True   typeable=False  click_opens=True
+custom=F search=F btn=F   button=False  typeable=False  click_opens=True
+custom=T          btn=F   button=True   typeable=True   click_opens=False   <- 145 forces it
+custom=F search=T btn=F   button=False  typeable=True   click_opens=False   <- no entrance
+```
+
+Latent only: public `Select` never passes `show_dropdown_button`, and neither internal caller does. **Folded into this branch rather than filed** because Step 1 rewrites those exact lines and the fix is hoisting the shared predicate — the same duplication that caused the primary bug. Called out here so the reviewer reads it as deliberate.
+
+## Post-fix result — MEASURED, same probe as the control table above
+
+| construction | typeable | popup opens | arrow dimmed | `.read_only` |
+|---|---|---|---|---|
+| `Select()` | False | True | False | **False** |
+| `Select(read_only=True)` | False | **False** | **True** | True |
+| `Select(read_only=True, allow_custom_values=True)` | **False** | **False** | **True** | **True** |
+| `Select(read_only=True, searchable=True)` | **False** | **False** | **True** | **True** |
+| `Select(disabled=True)` — CONTROL | False | False | True | False |
+
+Runtime transitions, all four correct:
+
+| scenario | result |
+|---|---|
+| custom-values select, `read_only` on then off | restores **typing**, not plain |
+| plain select, `read_only` on then off | stays plain — does **not** grant typing |
+| read-only select, `disabled` on then off | `read_only` survives |
+| plain select, `allow_custom_values` on then off | click entrance returns |
+
+Reachability, with `show_dropdown_button=False`: the `enable_search` row now gets a button like the `allow_custom_values` row already did.
+
+## Verification result
+
+- **Full suite: `py -3.12 tests/run_gui.py` → exit 0, all 20 legs.** Summed **1220 passed / 21 skipped**. Shared leg **1023 / 14**, up exactly **+12** from **1011 / 14** before this branch's tests — the 12 tests added here and nothing else.
+- **Clean docs build `-W --keep-going` → exit 0.**
+- ⚠ **The 1220/21 does NOT match this file's recorded baseline of 1250 / 22 at `288d2596`**, and neither does the shared leg (measured ceiling here is **1024** selected / 1099 collected / 75 deselected, and `1011 + 13 runtime skips = 1024` reconciles exactly; the table claims 1055 / 13 against a 1068 ceiling). This branch adds tests and touches none, so it cannot have shrunk collection. **Prefer the measured figure and reconcile the table separately — this would be the seventh wrong count.** The data leg reading **125 / 4** rather than **123 / 6** also indicates `pandas` is absent from 3.12 on this box today, which `CLAUDE.md` records as the environmental tell.
+
+## Steps
+
+0. ~~Branch, back up the working tree, write this plan.~~ **Done.**
+1. ~~**Plumbing.** `readonly` param on `SelectBox`, default `False`, stored as `_readonly`, documented in the main `Args:` block. Public `Select` forwards `read_only` into it.~~ **Done.**
+2. ~~**Derive the entry state.** Single `_apply_interaction_state()`; hoist the shared `typeable` predicate; fold in the reachability guard.~~ **Done.**
+3. ~~**Route every writer** through it — both typing-mode delegates, an overridden `state` delegate, and a new `@configure_delegate('readonly')`.~~ **Done.**
+4. ~~**Guard the popup** in `_show_selection_options`, and at both entrances.~~ **Done.**
+5. ~~**Dropdown button.** Addon registered `active_when_readonly=True` so the ttk state stops dimming it; dimmed from an overridden `_sync_addon_state` on the real flag instead.~~ **Done** — fixes the two latent defects above as a side effect.
+6. ~~**Click-to-open** bound unconditionally, gated in the handler.~~ **Done.**
+7. ~~**Public wrapper.** Getter reads the setting via `configure("readonly")`. Setter → `configure(readonly=)`. The dead `elif read_only: state="readonly"` at construction is removed.~~ **Done** — the `disabled` setter needed no change once the `state` delegate re-derives.
+8. ~~**Tests** — `tests/widgets/public/test_select_read_only.py`, 12 tests.~~ **Done.**
+9. ~~**CHANGELOG** under `## [Unreleased]`.~~ **Done** — re-created, one `### Fixed` bullet, unwrapped.
+
+## Control result — 12 tests, run against the unfixed source
+
+**9 fail pre-fix, 3 pass, and each of the 3 is explained in the test itself.** Run by swapping the source files rather than `git stash` (this repo carries old stashes).
+
+| passes pre-fix | why it is kept |
+|---|---|
+| `test_a_plain_select_still_opens_from_both_entrances` | the control — must pass on both sides, or the failures above it are harness noise |
+| `test_the_arrow_is_dimmed_when_read_only` | dimming was the ONE thing `read_only` already did, as an accident; now pinned as intended |
+| `test_clearing_read_only_restores_typing_when_custom_values_were_asked_for` | worked by luck pre-fix (`state="normal"` happened to be right); the mirror test is what caught it being wrong |
+
+⚠ **The first control run was WRONG and looked right.** Three tests failed pre-fix with `AttributeError` because the helper called `_on_entry_click` by name — a method that only exists post-fix — which proves nothing. Rewritten to generate a real `<Button-1>`, so it drives whichever binding the widget installed.
+
+⚠ **And that exposed a vacuity defect in the test for the reported bug itself.** `test_read_only_blocks_the_popup_from_an_entry_click` **passed** against the unfixed source: pre-fix the click binding is installed from `after_idle`, so a click generated before idle ran hit no binding, the popup stayed shut, and the test went green while the defect was fully present. It would never have caught #453. Fixed by settling idle work before the click. **A control that does not reach the path under test is indistinguishable from a fix that works.**
+
+## Tests — each needs a pre-fix control
+
+Run against unfixed source, each must fail for the **behavioral** reason, not an `AttributeError`:
+
+- `read_only=True` blocks the popup from the button **and** from an entry click.
+- `read_only=True, allow_custom_values=True` blocks both change paths.
+- Clearing `read_only` on a custom-values `Select` restores **typeability**, not plain.
+- A plain `Select` reports `.read_only is False`. *(Would pass vacuously today — needs the flag-backed getter to mean anything.)*
+- The dropdown addon is **lit** on a plain `Select` after `<<StateChanged>>`, and **dim** under `read_only`.
+- `sel.disabled = True` then `False` leaves `read_only` intact.
+- Runtime `configure(allow_custom_values=)` in both directions keeps exactly one entrance to the popup.
+
+## Verification
+
+`py -3.12 tests/run_gui.py`, full suite, sum the legs by hand (no aggregate is printed). Redirect to a file and read `$LASTEXITCODE` on the next statement — never pipe to `tail`/`Select-String`. Baseline on `main` at `d6c90534`: **exit 0, 20 legs, 1250 passed / 22 skipped**.
+
+Clean docs build: `rm -rf docs/_build && sphinx-build -b html docs docs/_build/html -W --keep-going`.
+
+⚠ A green run is not evidence here — the behavior under test is currently *unguarded*, so several of these pass vacuously without the flag-backed getter. The pre-fix control is what carries the proof.
+
+## Decisions taken (maintainer, 2026-08-13)
+
+1. **Dim the dropdown arrow under `read_only`.** #453 argues for it on its own: the reporter read the dimmed arrow as *meaning* read-only, so dimming is the signal users already expect. It also preserves the invariant line 145 exists to maintain — a lit, inert entrance would be the only place in `SelectBox` that breaks it.
+2. **Naming — `read_only` is the public spelling, `readonly` the internal one.** The impl layer already speaks ttk's spelling (`Field.readonly()`, the `'readonly'` state string) and `select.py` translates, as it already does for every other option. Verified there is no collision between the `configure` key `'readonly'` and `Field.readonly()`: `configure_delegate` stores keys on the function and builds a separate key→handler map (`configure_mixin.py:21-27`). The mixin also reads getters from `self._<key>`, so key `readonly` → `self._readonly`, which is what is already written. **No rename needed.**
+3. **Patch line.** No public surface is added — `read_only` already exists on `Select`. Both observable changes correct behavior *toward* what is documented: `read_only=True` starts doing what select.py:62-63 always promised, and the getter starts returning a true answer instead of a false positive. Neither breaks expected behavior; each removes a defect. Same reasoning that put #430 on `0.2.x` and the four dialog fixes on `0.3.1`.
+
+## Out of scope — file, do not fix here
+
+- **`Field.readonly()` (field.py:501) never clears the readonly state.** All three branches set `['readonly']`; the `False` branch also disables the field. Pre-existing, reachable from internal callers only.
+- **Public field widgets silently swallow unknown kwargs.** `bs.TextField(exportselection=False)` is indistinguishable from `bs.TextField(bogus_xyz=1)` — both construct, both do nothing — while the internal `Field` raises `TclError`. The public layer is the less strict of the two. Same class as `show_grid=True` on `Row`; belongs with **#383**.
+- **`FieldOptions` (field.py:41-91) carries raw Tk vocabulary** — `exportselection`, `textvariable: Variable` with a link to the tkinter docs, `xscrollcommand`, `takefocus`, `show`, `cursor`, `foreground`. Internal only and never reaches the docs site (`grep -rn "FieldOptions\|composites.field\|SelectBox" docs/ --include=*.rst` → zero), but it is the declared kwarg contract of seven composites and it violates the standing no-tkinter-in-docstrings rule.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,138 @@
+# REVIEW — `fix/select-read-only-453`
+
+**Round cap:** 2 (patch line, declared in `PLAN.md`).
+
+---
+
+## Round 1 — 2026-08-13
+
+Reviewed `git diff main...HEAD` at `545e98f4`. Three findings: one blocking,
+two nits. The fix step follows each finding under **Resolution**.
+
+Suite at review time: `py -3.12 tests/run_gui.py` exit 0, 33 legs, shared leg
+1023 passed / 14 skipped. Branch collection is main + 12 exactly, so no tests
+were silently dropped.
+
+---
+
+### F1 — `_impl/composites/selectbox.py:1087` — **blocking**
+
+`TimeField.read_only` is permanently dead on this branch.
+
+**Root cause.** `TimeField.read_only`'s setter wrote
+`configure(state="readonly")` onto its internal, which is a `TimeEntry` —
+a `SelectBox` always constructed `allow_custom_values=True, enable_search=True`.
+The branch makes the entry's ttk `readonly` state an OUTPUT of
+`_apply_interaction_state()` rather than storage, and the new `_delegate_state`
+override re-derives it after every state write. Nothing maps an incoming ttk
+`readonly` onto `self._readonly`, so `_entry_is_typeable()` was still `True` and
+the applier wrote `['!readonly']` straight back over the request, inside the
+same call.
+
+Measured on `main` and on the branch:
+
+```
+main    : t.read_only = True -> True   entry state ('readonly',)
+branch  : t.read_only = True -> False  entry state ()
+```
+
+So a `TimeField` an app locks stayed freely typeable. Not covered by any test —
+the suite was green on both refs.
+
+**Resolution — fixed in `timefield.py`, not in `selectbox.py`.** The setter
+routes through the `readonly` option instead:
+
+```python
+self._internal.configure(readonly=bool(v))
+```
+
+Mapping an incoming `state="readonly"` onto `self._readonly` was considered and
+rejected: `_delegate_readonly`'s own docstring draws the distinction that a
+plain select is already untypeable while its list still opens, so that mapping
+would suppress the popup for every select that asked only for "no typing".
+
+`TimeField` is the only member of the field family whose internal is a
+`SelectBox` (`datefield`, `pathfield`, `spinnerfield`, `passwordfield`,
+`numberfield` and `textfield` all wrap plain entries), so nothing else moved.
+Side benefit, now pinned by a test: `read_only = False` no longer clears
+`disabled` as a side effect of sending `state="normal"`.
+
+Regression tests: `test_timefield_read_only_is_not_discarded`,
+`test_timefield_read_only_closes_the_list`,
+`test_timefield_read_only_survives_a_disabled_round_trip` — all three fail
+behaviorally against the unfixed source (`assert False is True`,
+`assert True is False`). `test_timefield_clearing_read_only_restores_typing`
+passes pre-fix as well, because both writes were no-ops there; it pins the end
+state, not the transition, and says so in the test.
+
+---
+
+### F2 — `_impl/composites/selectbox.py:113` — **nit**
+
+`self._show_dropdown_button` was stored and never read, and the invariant the
+comment states was not the one the code enforced.
+
+**Root cause.** The only consumer of the setting is the construction-time check,
+which reads the local parameter, not the attribute. Meanwhile
+`_apply_interaction_state()` had an arm that *added* the dropdown addon whenever
+a runtime change made the entry typeable, and no arm that ever removed one. So
+`show_dropdown_button=False` followed by `configure(allow_custom_values=True)`
+inserted a button the caller had explicitly refused, permanently.
+
+**Resolution — maintainer's call (2026-08-13): the option is build-time, and the
+button must not be added back when it was not requested.** Un-building a button
+makes no sense, so the removal arm was not written either. Dropped the runtime
+insert arm from `_apply_interaction_state()`, deleted the dead attribute, and
+deleted `_has_dropdown_button()`, which had no other caller. Membership is now
+decided exactly once, in `__init__`, which is also what `main` does.
+
+The construction-time exception stays: a typeable entry gets a button even when
+`show_dropdown_button=False`, because a click there has to place a text cursor
+rather than open the list, so the button is the only entrance left. That
+exception is bought where the caller can still see the trade.
+
+**Known consequence, accepted.** A box built `readonly=True,
+allow_custom_values=True, show_dropdown_button=False` has no button (correct —
+it is not typeable at build), and clearing `readonly` later leaves it typeable
+with no entrance to the list. There is no keyboard entrance either: the
+`<Down>`/`<Up>`/`<Return>` bindings are created inside the popup-open routine
+and torn down on close. This is `main`'s behavior today, so removing the arm
+restores it rather than regressing it.
+
+Regression test: `test_a_runtime_flip_does_not_build_a_button_that_was_refused`,
+which fails against the unfixed source with the button present. It is the
+deliberate mirror of the existing
+`test_search_forces_the_dropdown_button_like_custom_values_does`, and together
+they pin the build-time / runtime boundary from both sides.
+
+---
+
+### F3 — `select.py:295` — **nit**
+
+`read_only`'s getter used `configure("readonly")` where every sibling property on
+the class uses `cget`.
+
+**Root cause.** `ConfigureDelegationMixin.configure` answers a query with the
+Tkinter 5-tuple `(name, dbName, dbClass, None, value)`, and `bool(<5-tuple>)` is
+unconditionally `True`. The property worked only because `SelectBox` resolves
+`TTKWrapperBase.configure`, which returns the bare delegate value.
+
+**Verified latent, not live** — measured `configure("readonly")` returning
+`True`, a bare bool, on the built widget. So this was a fragility, not an active
+bug: an MRO change that put the delegating mixin in front would have restored
+exactly the always-`True` behavior #453 was filed to remove, undetectably at
+write time.
+
+**Resolution.** Switched to `bool(self._internal.cget("readonly"))` — the
+spelling `options`, `group_by` and `max_visible_items` already use, and one with
+no such failure mode. Added the reason to the property docstring so it is not
+"simplified" back later.
+
+---
+
+### Verification
+
+`development/` probe not added — the fix is pinned by the four tests above plus
+the existing 13 in `tests/widgets/public/test_select_read_only.py`. The control
+was run the required way: `src/` reverted, the new tests run against the
+unfixed source, 4 of 5 failing behaviorally with the symptoms quoted above.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -136,3 +136,175 @@ no such failure mode. Added the reason to the property docstring so it is not
 the existing 13 in `tests/widgets/public/test_select_read_only.py`. The control
 was run the required way: `src/` reverted, the new tests run against the
 unfixed source, 4 of 5 failing behaviorally with the symptoms quoted above.
+
+---
+
+## Round 2 — 2026-08-13 — **the cap; the branch closes here**
+
+Reviewed `git diff main...HEAD` at `6d3c7f56`, the reviewer handed round 1's
+record per the standing rule. Four findings: one medium, three low. Three fixed,
+one filed. A fifth defect was found during the fix step and is recorded below
+with the rest.
+
+`PLAN.md` declares a cap of **2**, so this is the last round. The fixes below
+touch `src/`, which gate 1 would otherwise read as a trigger — the cap is what
+stops it, and the survivor is filed rather than reviewed.
+
+---
+
+### F1 — `timefield.py:117` — **medium**
+
+`TimeField(read_only=True)` was discarded at construction.
+
+**Root cause.** Round 1's F1 fixed the `read_only` **setter** and left the
+constructor sending `internal_kwargs["state"] = "readonly"` — the same write,
+through the same doomed path, one scope up. A `TimeEntry` is always built
+`allow_custom_values=True, enable_search=True`, so `_apply_interaction_state()`
+at the end of `SelectBox.__init__` recomputes `typeable=True` and writes
+`['!readonly']` over it before `__init__` returns. No test constructed a
+read-only `TimeField`; all four of round 1's use the setter, which is exactly
+why round 1's own fix looked complete.
+
+**Resolution.** `internal_kwargs["readonly"] = read_only`, mirroring
+`select.py:125`. The `elif` went with it: `disabled` no longer shadows
+`read_only`, so both are set and clearing `disabled` cannot hand back an
+unlocked field.
+
+Control, five arms in one process, committed at
+`development/probe_453_timefield_read_only_ctor.py`:
+
+```
+pre-fix   arm 1  read_only=False  typeable=True   popup=True   states=()
+post-fix  arm 1  read_only=True   typeable=False  popup=False  states=('readonly',)
+```
+
+Arms 2–4 (the setter, a plain field, `disabled` alone) read identically either
+way, so arm 1's difference is behavioral rather than a broken harness.
+
+Regression tests: `test_timefield_read_only_at_construction_is_not_discarded`,
+`test_timefield_disabled_and_read_only_together_at_construction`, plus
+`test_timefield_construction_defaults_to_typeable` as the control that lets the
+first one's assertions come out the other way. Pre-fix: 2 failed, 18 passed.
+
+---
+
+### F2 — `timefield.py:166` — **low**
+
+The `read_only` getter read the derived ttk state while its setter wrote the
+flag — the getter shape #453 was filed for, on the property the same diff had
+just fixed at the other end.
+
+**Verified reachable, but only through the escape hatch.** The value setter
+clears and restores the ttk `readonly` state around a write, and anything
+observing inside that window sees the wrong answer:
+
+```
+during timefield var trace   read_only=False    <- derived read
+during select var trace      read_only=True     <- reads the flag
+```
+
+Through documented public surface — a time-typed `Signal` subscriber,
+`on_change` — it never diverges: 5 of 5 observations `True`. So this was a
+latent wrong answer, not a live user bug. Recorded that way rather than as the
+stronger claim.
+
+**Resolution.** `bool(self._internal.cget("readonly"))`, matching `Select`. The
+correctness argument for a one-line change: today the derived read agrees only
+because a `TimeEntry` is `allow_custom_values=True` forever, so
+`typeable == not _readonly` by coincidence of two constants.
+
+Regression test:
+`test_timefield_read_only_reports_the_setting_not_the_derived_state`. It drives
+a textvariable trace, which fires synchronously inside the write, so the test
+reproduces the mechanism deterministically rather than racing a symptom.
+Pre-fix: `AssertionError: read_only answered [False] during a value write`.
+
+---
+
+### F3 — `_impl/composites/selectbox.py:210` — **low** — FILED, NOT FIXED
+
+`Field.enable()`, `disable()` and `readonly()` write the ttk `readonly` state
+directly and none re-derives, against `_apply_interaction_state`'s own
+docstring: *"the ttk `readonly` state is an OUTPUT of this method, never
+storage."*
+
+Measured on `bs.Select(["A","B"], read_only=True)` followed by
+`_internal.enable()`: entry states `('readonly',)` → `()`, so the entry becomes
+freely typeable while `read_only` still reports `True` and the re-lit arrow is
+inert (`_popup_allowed()` is `False`).
+
+**Not fixed, deliberately.** Widened the reviewer's grep from `src/` to `src`,
+`tests` and `development`: **zero callers anywhere in the repo**. The public
+`disabled` setter routes through `configure(state=)` → `_delegate_state`, which
+already re-derives. So closing it means writing three overrides against a hole
+nothing reaches, on the branch whose point is that the invariant now lives in
+one place.
+
+Filed together with `PLAN.md`'s out-of-scope item *"`Field.readonly()` never
+clears the readonly state"* — same three methods, same file, one issue.
+
+---
+
+### F4 — `select.py:287` — **low**
+
+The public `read_only` docstring carried `#453`, `cget` vs `configure`, and
+"the delegating form of `configure` answers a query with a 5-tuple" into the
+rendered API Reference.
+
+**This reverses a round 1 decision, on the maintainer's instruction
+(2026-08-13).** F3 of round 1 resolved with *"added the reason to the property
+docstring so it is not 'simplified' back later"* — correct instinct, wrong
+surface. `Select` is autodoc'd `:members:`, so it shipped Tkinter vocabulary to
+users on a page describing a framework that exists to hide it.
+
+**Resolution.** Docstring reduced to what the property means; the maintenance
+warning moved verbatim into a `#` comment above the `return`, where it still
+guards against the "simplification" round 1 was protecting. Verified in the
+rebuilt site rather than assumed: `grep -rlE "cget|instate|5-tuple|textvariable"
+docs/_build/html --include=*.html` returns nothing.
+
+---
+
+### F5 — `timefield.py:55` — **found during the fix step, not by the reviewer**
+
+`TimeField`'s constructor doc for `read_only` read *"free-text entry is blocked;
+user must pick from the dropdown."* That is the pre-#453 misunderstanding
+written down as documentation, and F1 made it actively false — the dropdown is
+precisely what read-only now closes. It renders on the public page, so a user
+would have been told the opposite of what the widget does.
+
+Rewritten to match `select.py:62`'s, in `TimeField`'s vocabulary (clock button,
+time list), and checked in the rebuilt HTML.
+
+Worth carrying: F4 and F5 are the same defect class — a docstring that outlived
+its code — but F4 leaked *toolkit detail* while F5 leaked *stale behavior*. The
+second is the more expensive kind, because nothing about it looks wrong to a
+reader.
+
+---
+
+### Verification
+
+Full `py -3.12 tests/run_gui.py` at the fixed head: **exit 0, all 20 legs**,
+summed **1229 passed / 21 skipped**. Shared leg **1032 passed / 14 skipped
+against 1045 selected**, which reconciles the documented way — `1032 + 13`
+runtime skips = 1045, the 14th being the collection-time skip that is summarized
+but never selected.
+
+Count reconciliation against `main`, run because this file has been wrong about
+counts seven times: `main` selects **1024**, the branch selected **1041** before
+this round (main + 17), and **1045** after — exactly the four tests added here.
+Nothing was silently dropped.
+
+⚠ Round 1's verification block records **33 legs**; this branch has **20**.
+33 is `ci/test-workflow-380`'s leg count. The passed figure it quotes (1023) is
+consistent with this branch at that commit, so the leg count looks like a
+transcription error rather than a different checkout — but prefer a measured
+number over either.
+
+Clean docs build: `rm -rf docs/_build && sphinx-build -W --keep-going` exit 0,
+warning-free.
+
+Control run the required way for every behavioral fix: `src/` reverted, the new
+tests run against the unfixed source, each failing with the symptom quoted under
+its finding.

--- a/development/demo_453_select_read_only.py
+++ b/development/demo_453_select_read_only.py
@@ -1,0 +1,132 @@
+"""Manual visual check for #453 — a read-only Select must actually be read-only.
+
+Run it:  py -3.13 development/demo_453_select_read_only.py
+
+WHAT TO DO — work down the numbered checklist in the window. The pass/fail for
+each row is written beside it, so nothing has to be remembered. The CHANGED
+banner at the bottom turns red the moment ANY select reports a new value; on
+the unfixed build, step 2 alone is enough to light it up.
+
+Pre-fix behavior, for comparison while testing:
+  step 2  clicking the text area opens the list and changes the value
+  step 2  the arrow looks dim, which is the only thing read_only ever did
+  step 3  read_only is discarded entirely; you can type freely
+  step 6  a plain select claims read_only == True
+"""
+import bootstack as bs
+
+OPTIONS = ["Alpha", "Bravo", "Charlie", "Delta"]
+
+changed = bs.Signal("no change yet")
+status = bs.Signal("")
+
+
+def note_change(event):
+    """Any value change at all is a failure for the read-only rows."""
+    changed.set(f"CHANGED -> {event.value!r}   (fine for row 1, a FAILURE for rows 2-5)")
+
+
+with bs.App(title="#453 — read-only Select", minsize=(780, 1), padding=16, gap=12) as app:
+
+    bs.Label("Read-only Select — manual check", font="heading-md")
+    bs.Label(
+        "Click the ARROW and then the TEXT AREA of each field. Both are separate "
+        "ways into the list, and #453 was the text area staying live.",
+        font="caption",
+    )
+    bs.Divider()
+
+    # ---------------------------------------------------------------- static
+    with bs.Card(padding=12, gap=10):
+        bs.Label("Static states", font="heading-md")
+
+        with bs.Row(gap=16, vertical_items="top"):
+            with bs.Column(gap=2):
+                s1 = bs.Select(OPTIONS, value="Alpha", label="1. plain", width=16)
+                bs.Label("arrow opens - text area opens - cannot type", font="caption")
+
+            with bs.Column(gap=2):
+                s2 = bs.Select(OPTIONS, value="Alpha", label="2. read_only", width=16,
+                               read_only=True)
+                bs.Label("NEITHER opens - arrow dimmed  <-- the report", font="caption")
+
+        with bs.Row(gap=16, vertical_items="top"):
+            with bs.Column(gap=2):
+                s3 = bs.Select(OPTIONS, value="Alpha", label="3. read_only + custom values",
+                               width=16, read_only=True, allow_custom_values=True)
+                bs.Label("NEITHER opens - and typing does nothing", font="caption")
+
+            with bs.Column(gap=2):
+                s4 = bs.Select(OPTIONS, value="Alpha", label="4. read_only + searchable",
+                               width=16, read_only=True, searchable=True)
+                bs.Label("NEITHER opens - and typing does nothing", font="caption")
+
+        with bs.Row(gap=16, vertical_items="top"):
+            with bs.Column(gap=2):
+                s5 = bs.Select(OPTIONS, value="Alpha", label="5. disabled (control)",
+                               width=16, disabled=True)
+                bs.Label("greyed out entirely - the control", font="caption")
+
+            with bs.Column(gap=2):
+                s6 = bs.Select(OPTIONS, value="Alpha", label="6. plain, for the readout",
+                               width=16)
+                bs.Label("its read_only must report False", font="caption")
+
+    # --------------------------------------------------------------- runtime
+    with bs.Card(padding=12, gap=10):
+        bs.Label("7. Runtime toggles — the half that construction cannot show", font="heading-md")
+        bs.Label(
+            "Flip these while watching the field. Turning read_only OFF must give back "
+            "whatever the field was built with, not turn every field into a text box.",
+            font="caption",
+        )
+
+        live = bs.Select(OPTIONS, value="Alpha", label="live field",
+                         allow_custom_values=True, width=20)
+
+        def refresh():
+            entry = live._entry_widget()
+            typeable = not entry.instate(["readonly"]) and not entry.instate(["disabled"])
+            arrow = live._internal._addons.get("dropdown")
+            status.set(
+                f"read_only={live.read_only}   disabled={live.disabled}   "
+                f"can type={typeable}   arrow dimmed="
+                f"{arrow.instate(['disabled']) if arrow else 'n/a'}"
+            )
+
+        def toggle_read_only():
+            live.read_only = not live.read_only
+            refresh()
+
+        def toggle_disabled():
+            live.disabled = not live.disabled
+            refresh()
+
+        def toggle_custom():
+            now = live._internal.configure("allow_custom_values")
+            live._internal.configure(allow_custom_values=not now)
+            refresh()
+
+        with bs.Row(gap=8):
+            bs.Button("toggle read_only", accent="primary", on_click=toggle_read_only)
+            bs.Button("toggle disabled", on_click=toggle_disabled)
+            bs.Button("toggle allow_custom_values", on_click=toggle_custom)
+
+        bs.Label(textsignal=status, font="code")
+        bs.Label(
+            "This field is built with allow_custom_values=True. read_only ON then OFF "
+            "must leave you able to TYPE again. On a plain field the same round trip "
+            "must leave you UNABLE to type.",
+            font="caption",
+        )
+
+    # --------------------------------------------------------------- banner
+    bs.Divider()
+    bs.Label(textsignal=changed, font="code", accent="danger")
+
+    for sel in (s1, s2, s3, s4, s5, s6, live):
+        sel.on_change(note_change)
+
+    refresh()
+
+app.run()

--- a/development/probe_453_precedence.py
+++ b/development/probe_453_precedence.py
@@ -1,0 +1,76 @@
+"""Probe: what wins when read_only is paired with each other flag?  (#453)
+
+Prints state, asserts nothing. The point is the PRECEDENCE, which pre-fix
+disagreed between construction and runtime because the ttk `readonly` entry
+state was the only storage and whichever writer ran last won.
+
+MEASURED PRE-FIX:
+
+    read_only=True, allow_custom=True   typeable=True  popup=True  .read_only=False
+    read_only=True, searchable=True     typeable=True  popup=True  .read_only=False
+    read_only=True, disabled=True       typeable=False popup=False .read_only=False
+    allow_custom=True .read_only=True   typeable=False popup=True  .read_only=True
+                      .read_only=False  typeable=True  popup=True  .read_only=False
+
+So construction let allow_custom_values discard read_only outright, while at
+runtime read_only won over typing but never over the popup. The last row only
+restored correctly BY LUCK -- state="normal" happened to be right because
+custom values were on; the same code on a plain Select granted typing instead.
+
+POST-FIX the ladder is `disabled > read_only > allow_custom_values|searchable`,
+and read_only SUPPRESSES the typing modes rather than overwriting them, so
+clearing it restores whichever was asked for.
+
+ASCII output only.
+"""
+import bootstack as bs
+
+OPTS = ["Alpha", "Beta", "Gamma"]
+
+
+def report(name, sel):
+    e = sel._entry_widget()
+    inner = sel._internal
+    inner._popup_open = False
+    try:
+        inner._show_selection_options()
+        opened = bool(inner._popup_open)
+        if opened:
+            try:
+                inner._close_popup(inner._popup_frame.winfo_toplevel(), inner._popup_state)
+            except Exception:
+                inner._popup_open = False
+    except Exception as exc:
+        opened = "RAISED %s" % type(exc).__name__
+    print("%-38s typeable=%-5s popup=%-5s .read_only=%-5s _allow_custom=%s" % (
+        name,
+        not e.instate(["readonly"]) and not e.instate(["disabled"]),
+        opened,
+        sel.read_only,
+        inner._allow_custom_values,
+    ))
+
+
+with bs.App(title="probe") as app:
+    a = bs.Select(OPTS, read_only=True, allow_custom_values=True)
+    b = bs.Select(OPTS, read_only=True, searchable=True)
+    c = bs.Select(OPTS, read_only=True, disabled=True)
+    d = bs.Select(OPTS, allow_custom_values=True)
+
+app.tk.update_idletasks()
+app.tk.update()
+
+print("-- construction-time pairings --")
+report("read_only=True, allow_custom=True", a)
+report("read_only=True, searchable=True", b)
+report("read_only=True, disabled=True", c)
+
+print()
+print("-- runtime: set read_only on a custom-values Select --")
+report("allow_custom=True (before)", d)
+d.read_only = True
+report("  .read_only = True (after)", d)
+d.read_only = False
+report("  .read_only = False (back)", d)
+
+app.tk.destroy()

--- a/development/probe_453_read_only.py
+++ b/development/probe_453_read_only.py
@@ -1,0 +1,124 @@
+"""Probe: is Select.read_only distinct from allow_custom_values=False?  (#453)
+
+This prints state; it asserts nothing, so it cannot report a stale failure.
+Arm 7 (`disabled`) is the CONTROL: it proves the probe can detect a blocked
+popup, without which every `popup opens = True` above it would be unreadable.
+
+MEASURED PRE-FIX, so the post-fix run means something:
+
+    ARM 1  plain Select()                  .read_only=True   popup opens=True
+    ARM 2  Select(read_only=True)          .read_only=True   popup opens=True
+    ARM 3  Select(searchable=True)         .read_only=False
+    ARM 4  Select(allow_custom_values=True) .read_only=False
+    ARM 5  plain, then .read_only=False    -> becomes keyboard-editable
+    ARM 6  Select(searchable, read_only)   .read_only=False  popup opens=True
+    ARM 7  Select(disabled=True)  CONTROL  popup opens=False
+
+i.e. read_only never blocked the popup, a plain Select claimed to BE read-only,
+and asking for read_only alongside a typing mode discarded it outright.
+
+POST-FIX every arm inverts except 1, 3, 4 and the control: read_only blocks the
+popup, survives the typing modes, and a plain Select reports False.
+
+ASCII output only (cp1252 console).
+
+Arms:
+  1. plain Select                      -> what does .read_only report?
+  2. Select(read_only=True)            -> does the popup still open?
+  3. Select(searchable=True)           -> .read_only?
+  4. Select(allow_custom_values=True)  -> .read_only?
+  5. plain Select, .read_only = False  -> does the entry become typeable?
+  6. searchable Select, .read_only=True-> does the popup open? is it typeable?
+  7. control: disabled=True            -> does the popup open? (must be NO)
+"""
+import bootstack as bs
+
+OPTS = ["Alpha", "Beta", "Gamma"]
+
+
+def entry_state(sel):
+    e = sel._entry_widget()
+    return "readonly=%s disabled=%s cget=%s" % (
+        e.instate(["readonly"]), e.instate(["disabled"]), e.cget("state"))
+
+
+def popup_opens(sel):
+    """Return True if a popup toplevel actually came up."""
+    inner = sel._internal
+    inner._popup_open = False
+    try:
+        inner._show_selection_options()
+    except Exception as exc:  # pragma: no cover - diagnostic
+        return "RAISED %s" % type(exc).__name__
+    opened = bool(inner._popup_open)
+    if opened:
+        try:
+            inner._close_popup(inner._popup_frame.winfo_toplevel(), inner._popup_state)
+        except Exception:
+            inner._popup_open = False
+    return opened
+
+
+def typeable(sel):
+    """Can a keystroke reach the entry? readonly ttk entries refuse insert."""
+    e = sel._entry_widget()
+    before = e.get()
+    try:
+        e.insert(0, "X")
+    except Exception as exc:
+        return "RAISED %s" % type(exc).__name__
+    after = e.get()
+    if after != before:
+        e.delete(0, len(after) - len(before))
+    # A ttk entry in the 'readonly' STATE still accepts programmatic insert;
+    # what it refuses is keyboard input. Report the state instead.
+    return not e.instate(["readonly"])
+
+
+with bs.App(title="probe") as app:
+    plain = bs.Select(OPTS)
+    ro = bs.Select(OPTS, read_only=True)
+    search = bs.Select(OPTS, searchable=True)
+    custom = bs.Select(OPTS, allow_custom_values=True)
+    flipped = bs.Select(OPTS)
+    search_ro = bs.Select(OPTS, searchable=True, read_only=True)
+    dis = bs.Select(OPTS, disabled=True)
+
+app.tk.update_idletasks()
+app.tk.update()  # let after_idle click-binding install
+
+print("ARM 1  plain Select()")
+print("       .read_only      = %s   <- user never asked for read_only" % plain.read_only)
+print("       entry           : %s" % entry_state(plain))
+print("       popup opens     = %s" % popup_opens(plain))
+
+print("ARM 2  Select(read_only=True)")
+print("       .read_only      = %s" % ro.read_only)
+print("       entry           : %s" % entry_state(ro))
+print("       popup opens     = %s   <- read_only is documented to BLOCK this" % popup_opens(ro))
+
+print("ARM 3  Select(searchable=True)")
+print("       .read_only      = %s" % search.read_only)
+print("       entry           : %s" % entry_state(search))
+
+print("ARM 4  Select(allow_custom_values=True)")
+print("       .read_only      = %s" % custom.read_only)
+print("       entry           : %s" % entry_state(custom))
+
+print("ARM 5  plain Select then .read_only = False")
+print("       before          : %s keyboard-editable=%s" % (entry_state(flipped), typeable(flipped)))
+flipped.read_only = False
+print("       after           : %s keyboard-editable=%s" % (entry_state(flipped), typeable(flipped)))
+print("       .read_only      = %s   <- did it become a free-text field?" % flipped.read_only)
+
+print("ARM 6  Select(searchable=True, read_only=True)")
+print("       .read_only      = %s" % search_ro.read_only)
+print("       entry           : %s" % entry_state(search_ro))
+print("       popup opens     = %s" % popup_opens(search_ro))
+
+print("ARM 7  CONTROL Select(disabled=True)")
+print("       .disabled       = %s" % dis.disabled)
+print("       entry           : %s" % entry_state(dis))
+print("       popup opens     = %s   <- control: must be False" % popup_opens(dis))
+
+app.tk.destroy()

--- a/development/probe_453_timefield_read_only_ctor.py
+++ b/development/probe_453_timefield_read_only_ctor.py
@@ -1,0 +1,59 @@
+"""Does `TimeField(read_only=True)` survive construction? (#453, round-2 F1)
+
+Round 1 fixed the `read_only` SETTER on `TimeField` and left the constructor
+sending `state="readonly"`. A `TimeEntry` is always built with
+`allow_custom_values=True, enable_search=True`, so `_apply_interaction_state()`
+at the end of `SelectBox.__init__` recomputes `typeable=True` and writes
+`['!readonly']` straight over it -- the field a caller asked to lock came back
+freely typeable, with its time list still opening.
+
+Run it on both sides of the fix. Arms 2-4 are the controls: they must read the
+same either way, so an arm-1 difference is behavioral rather than a broken
+harness. Output is ASCII (this box's console is cp1252).
+
+    py -3.12 development/probe_453_timefield_read_only_ctor.py
+
+Pre-fix  arm 1: read_only=False typeable=True  popup=True   states=()
+Post-fix arm 1: read_only=True  typeable=False popup=False  states=('readonly',)
+"""
+import bootstack as bs
+
+app = bs.App(title="probe 453")
+
+
+def report(name, f):
+    entry = f._internal._entry
+    print(
+        "%-28s read_only=%-5s _readonly=%-5s typeable=%-5s popup=%-5s states=%s"
+        % (
+            name,
+            f.read_only,
+            f._internal._readonly,
+            not entry.instate(["readonly"]),
+            f._internal._popup_allowed(),
+            tuple(str(s) for s in entry.state()),
+        )
+    )
+
+
+# The defect under test.
+report("1 ctor read_only=True", bs.TimeField(read_only=True, parent=app))
+
+# Control: the setter path, fixed in round 1. Must stay fixed.
+f2 = bs.TimeField(parent=app)
+f2.read_only = True
+report("2 setter read_only=True", f2)
+
+# Control: a plain field must stay typeable, or arm 1 could not come out the
+# other way and would be pinning nothing.
+report("3 plain", bs.TimeField(parent=app))
+
+# Control: `disabled` used to shadow `read_only` in an elif. Both are set now.
+report("4 disabled", bs.TimeField(disabled=True, parent=app))
+report("5 disabled+read_only", bs.TimeField(disabled=True, read_only=True, parent=app))
+
+app.tk.update_idletasks()
+print()
+print("EXPECT post-fix: arms 1, 2, 5 read_only=True typeable=False popup=False")
+print("EXPECT both ways: arm 3 read_only=False typeable=True popup=True")
+print("EXPECT both ways: arms 4, 5 carry 'disabled'")

--- a/development/review-brief-453-round2.md
+++ b/development/review-brief-453-round2.md
@@ -1,0 +1,131 @@
+# Review brief — #453, round 2
+
+**For a FRESH session.** A session that has written code never reviews code, so
+whoever wrote `937b0aa2` must not be the one to read it.
+
+---
+
+## Scope — the FIX diff only
+
+```
+git diff 545e98f4..872aa862
+```
+
+Two commits:
+
+| SHA | Kind | In scope? |
+|---|---|---|
+| `937b0aa2` | `src/` + tests — the round-1 fixes | **YES, this is the round** |
+| `872aa862` | `REVIEW.md` only | record, not reviewed code |
+
+**Round 1 already reviewed the whole branch.** Do not re-review `b65ca66d`
+(the original #453 fix), the probes, the demo, or `PLAN.md`. Re-reviewing
+settled code is what produced `0.3.1`'s round 3, where three of four findings
+were items already triaged.
+
+The round opens legitimately under `REVIEW-PROTOCOL.md` gate 1: `937b0aa2` has
+a non-empty `git diff -- src/`.
+
+---
+
+## This is the LAST round
+
+`PLAN.md` declares a **round cap of 2** (patch line, gate 3). Anything that
+survives this round is **filed as an issue, not fixed here**.
+
+---
+
+## Read first, so nothing is re-filed
+
+- **`REVIEW.md` at the repo root** — round 1's three findings, their root
+  causes, and what the fix step actually changed. This is the triage state.
+  Round 2 of `0.3.1` was handed its predecessor's record and re-filed nothing;
+  round 3 was not, and re-filed three settled items. That is a harness failure,
+  not a reviewer failure.
+- **`PLAN.md`** for the contract and the precedence rule. Read it for
+  requirements, not for the implementer's argument that the approach was sound
+  — rationale is what produces "yes, that seems right" instead of scrutiny.
+
+---
+
+## Settled — do not re-litigate
+
+1. **Dropdown-button membership is decided ONCE, at construction.** This is a
+   **maintainer decision** (2026-08-13), not an implementation convenience:
+   building a button and later un-building it makes no sense, and a runtime
+   insert adds a button the caller explicitly refused. Do not propose a removal
+   arm, and do not propose restoring the insert arm.
+   - **The consequence is KNOWN AND ACCEPTED**, and is in `REVIEW.md`: a box
+     built `readonly=True, allow_custom_values=True, show_dropdown_button=False`
+     has no button, and clearing `readonly` later leaves it typeable with no
+     entrance to the list. There is no keyboard entrance either — the
+     `<Down>`/`<Up>`/`<Return>` bindings are created inside the popup-open
+     routine and torn down on close. **This is `main`'s behavior today**, so the
+     change restores it rather than regressing it. Re-raising it is only useful
+     if the *evidence* changed, not the *judgment*.
+2. **F1 was fixed in `timefield.py`, not `selectbox.py`, deliberately.** Mapping
+   an incoming ttk `state="readonly"` onto `self._readonly` was considered and
+   rejected: a plain select is already untypeable while its list still opens, so
+   that mapping would suppress the popup for every select that asked only for
+   "no typing". `_delegate_readonly`'s docstring draws that distinction.
+3. **F3 is LATENT, not live.** `SelectBox` resolves `TTKWrapperBase.configure`,
+   which returns the bare value — measured, `configure("readonly")` → `True`.
+   The `cget` change is hardening against an MRO shift. Do not report it as a
+   bug that was shipping.
+
+---
+
+## Measured — do not re-derive
+
+- **Full suite at `872aa862`:** `py -3.12 tests/run_gui.py`, **exit 0, 20 legs,
+  1225 passed / 21 skipped**. Shared leg **1028 / 14**, collection line
+  `collected 1116 / 75 deselected / 1 skipped / 1041 selected`, and
+  `1028 + 13 = 1041`.
+- **`main` is 1208 / 21**, shared leg **1011 / 14** against **1024**. ⚠ The
+  `1250 / 22` and `1055 / 13 / 1068` that `CLAUDE.md` carried were **wrong** and
+  were corrected on `main` at `7ff25930`. If a stale copy is in context, prefer
+  the corrected table.
+- **Control, run the required way:** `src/` reverted, the 5 new tests run against
+  the unfixed source. **4 of 5 fail behaviorally** — `assert False is True` on
+  the TimeField getter, `assert True is False` on the popup gate, and
+  `assert 'dropdown' not in {'dropdown': <Button ...>}` on the runtime flip. The
+  fifth pins an end state rather than a transition, passes pre-fix, and says so
+  in place.
+- **`pandas` is ABSENT on this box**, so the data leg reads `125 / 4`. That is
+  the documented environmental pair, not a discrepancy.
+
+---
+
+## Gate 2 — how to review the test half
+
+`937b0aa2` is roughly a third production, two thirds tests. Test code is
+reviewed on **ONE axis: what defect can it let through.** Only two things are
+actionable:
+
+- **vacuity** — it passes while the behavior is broken;
+- **false alarm** — it fails while the behavior is fine.
+
+Diagnostics, wording, symmetry and ergonomics are **notes in the record, never
+fixes**. Under this gate `0.3.1`'s round 4 yields 2 findings instead of 5.
+
+The specific vacuity question worth asking here: `test_select_read_only.py` now
+has 17 tests across two concerns (`Select` and `TimeField`) sharing helpers
+written for the first. Does any `TimeField` assertion read a path the helpers
+were not built for?
+
+---
+
+## Environment
+
+- **`py -3.12` for tests and docs.** pytest is installed ONLY on 3.12. `py -3.13`
+  fails every leg with *"No module named pytest"* while still printing a
+  plausible harness summary.
+- **Never pipe a build or test command to `tail`** — you capture `tail`'s exit 0.
+  In PowerShell, `| Select-String` leaves `$LASTEXITCODE` from the pipeline.
+  Redirect to a file, capture the code on the next statement, then grep it.
+- **A worktree runs against `main`'s source unless `PYTHONPATH` is set** — and
+  setting `PYTHONPATH` while passing the PRIMARY checkout's test paths runs the
+  new tests against the old source, which reads as a real result. Pass the
+  worktree's absolute test paths too, and print
+  `os.path.dirname(bootstack.__file__)` before trusting a number.
+- Probe output must be **ASCII** — this box's console is cp1252.

--- a/src/bootstack/widgets/_impl/composites/selectbox.py
+++ b/src/bootstack/widgets/_impl/composites/selectbox.py
@@ -110,7 +110,6 @@ class SelectBox(Field):
         # `_sync_addon_state()`, which this class overrides to read them.
         self._readonly = readonly
         self._search_enabled = enable_search
-        self._show_dropdown_button = show_dropdown_button
         # Localization mode for option display (entry face + popup rows). None
         # defers to the app's localize_mode; False keeps the raw labels.
         self._localize = kwargs.pop('localize', None)
@@ -156,6 +155,9 @@ class SelectBox(Field):
         # click there has to place a text cursor rather than open the list, so
         # the button becomes the sole way in. `show_dropdown_button=False` is
         # honored only while the entry is NOT typeable.
+        #
+        # This decision is made ONCE, here. A later `configure()` that turns
+        # typing on does NOT insert a button the caller asked not to build.
         if self._entry_is_typeable() or show_dropdown_button:
             self._insert_dropdown_button()
 
@@ -187,9 +189,6 @@ class SelectBox(Field):
             return False
         return not self.entry_widget.instate(['disabled'])
 
-    def _has_dropdown_button(self) -> bool:
-        return 'dropdown' in self._addons
-
     def _insert_dropdown_button(self) -> None:
         """Add the dropdown addon, marked read-only safe.
 
@@ -218,10 +217,6 @@ class SelectBox(Field):
         """
         typeable = self._entry_is_typeable()
         self.entry_widget.state(['!readonly'] if typeable else ['readonly'])
-
-        # A runtime switch into typing must not leave the list unreachable.
-        if typeable and not self._has_dropdown_button():
-            self._insert_dropdown_button()
 
         # Only a click that actually opens the list should advertise itself.
         if typeable or not self._popup_allowed():

--- a/src/bootstack/widgets/_impl/composites/selectbox.py
+++ b/src/bootstack/widgets/_impl/composites/selectbox.py
@@ -1,4 +1,4 @@
-from tkinter import Toplevel
+from tkinter import TclError, Toplevel
 
 from typing_extensions import Unpack
 
@@ -44,6 +44,7 @@ class SelectBox(Field):
             enable_search: bool = False,
             group_by: str = None,
             max_visible_items: int = None,
+            readonly: bool = False,
             **kwargs: Unpack[FieldOptions]
     ):
         """Args:
@@ -60,6 +61,12 @@ class SelectBox(Field):
             message: Optional helper/error message shown below the field.
             allow_custom_values: If True, the entry is editable so users can type
                 arbitrary values in addition to choosing from the list.
+            readonly: If True, the value is visible but cannot be changed — no
+                typing and no popup, from the dropdown button or the entry. It
+                suppresses `allow_custom_values`/`enable_search` rather than
+                discarding them, so clearing it restores whichever was asked
+                for. Distinct from `state='disabled'`, which also dims the
+                whole field and drops it out of the tab order.
             show_dropdown_button: If True (default), the dropdown button is shown. This option is
                 ignored if custom values are allowed.
             dropdown_button_icon: The icon to display on the dropdown button.
@@ -95,6 +102,15 @@ class SelectBox(Field):
             width: Width of the entry in characters.
             required: If True, field cannot be empty.
         """
+        # On select, readonly means the popup does not open and no typing, but allow_custom_values by itself
+        # without readonly just means standard combobox behavior.
+        #
+        # Every input the interaction state is derived from is set BEFORE
+        # `super().__init__()`, because Field's constructor calls
+        # `_sync_addon_state()`, which this class overrides to read them.
+        self._readonly = readonly
+        self._search_enabled = enable_search
+        self._show_dropdown_button = show_dropdown_button
         # Localization mode for option display (entry face + popup rows). None
         # defers to the app's localize_mode; False keeps the raw labels.
         self._localize = kwargs.pop('localize', None)
@@ -126,7 +142,6 @@ class SelectBox(Field):
         # Re-translate the displayed text + option maps on a live locale switch.
         self.winfo_toplevel().bind('<<LocaleChanged>>', self._on_locale_changed_refresh, add='+')
 
-        self._search_enabled = enable_search
         self._group_by = group_by
         self._max_visible_items = max_visible_items
         self._popup_open = False
@@ -137,24 +152,102 @@ class SelectBox(Field):
         self._item_labels = []
         self._group_headers = []
 
-        # Add dropdown button if needed
-        if allow_custom_values or show_dropdown_button:
-            self.insert_addon(
-                Button,
-                position="after",
-                name="dropdown",
-                icon=self._dropdown_button_icon,
-                icon_only=True,
-                command=self._on_dropdown_click
-            )
+        # A typeable entry is the only way the popup can lose an entrance: a
+        # click there has to place a text cursor rather than open the list, so
+        # the button becomes the sole way in. `show_dropdown_button=False` is
+        # honored only while the entry is NOT typeable.
+        if self._entry_is_typeable() or show_dropdown_button:
+            self._insert_dropdown_button()
 
-        # Configure entry state based on search and custom value settings
-        if allow_custom_values or enable_search:
-            self.entry_widget.state(['!readonly'])
+        # Bind click-to-open unconditionally and gate it inside the handler.
+        # Binding on the transition instead would mean unbinding on the way
+        # back, and a released tkinter binding name is reused immediately, so a
+        # deferred unbind can delete a different, live binding (cost a critical
+        # defect in #392).
+        self.entry_widget.bind('<Button-1>', self._on_entry_click, add='+')
+
+        self._apply_interaction_state()
+
+    # ----- Interaction state: typing, popup, dropdown button -----
+
+    def _entry_is_typeable(self) -> bool:
+        """Whether the user may type into the entry.
+
+        Read-only SUPPRESSES free typing rather than discarding it, so clearing
+        it restores whatever `allow_custom_values`/`enable_search` asked for
+        instead of falling back to a plain select.
+        """
+        if self._readonly:
+            return False
+        return bool(self._allow_custom_values or self._search_enabled)
+
+    def _popup_allowed(self) -> bool:
+        """Whether the option list may open, from either entrance."""
+        if self._readonly:
+            return False
+        return not self.entry_widget.instate(['disabled'])
+
+    def _has_dropdown_button(self) -> bool:
+        return 'dropdown' in self._addons
+
+    def _insert_dropdown_button(self) -> None:
+        """Add the dropdown addon, marked read-only safe.
+
+        `active_when_readonly=True` stops `Field` dimming it for the ttk
+        `readonly` state, which on a select only means "no free typing" and is
+        the default. Dimming for a genuine read-only select is applied in
+        `_sync_addon_state` instead, off `_readonly`.
+        """
+        self.insert_addon(
+            Button,
+            position="after",
+            name="dropdown",
+            icon=self._dropdown_button_icon,
+            icon_only=True,
+            command=self._on_dropdown_click,
+            active_when_readonly=True,
+        )
+
+    def _apply_interaction_state(self) -> None:
+        """Recompute everything derived from readonly / custom values / search.
+
+        The ttk `readonly` state is an OUTPUT of this method, never storage.
+        It doubles as the widget's own "no free typing" flag, and writing it
+        from more than one place is exactly what let a caller's `read_only`
+        be silently overwritten (#453).
+        """
+        typeable = self._entry_is_typeable()
+        self.entry_widget.state(['!readonly'] if typeable else ['readonly'])
+
+        # A runtime switch into typing must not leave the list unreachable.
+        if typeable and not self._has_dropdown_button():
+            self._insert_dropdown_button()
+
+        # Only a click that actually opens the list should advertise itself.
+        if typeable or not self._popup_allowed():
+            self.entry_widget.configure(cursor='')
         else:
-            # Set entry to readonly but keep dropdown button enabled
-            self.entry_widget.state(['readonly'])
-            self.after_idle(self._bind_readonly_selection_on_click)
+            self.entry_widget.configure(cursor='hand2')
+
+        self._sync_addon_state()
+
+    def _sync_addon_state(self, event: Any = None) -> None:
+        """Match the addons to the field state, then apply the read-only rule.
+
+        `Field` dims every addon while the entry is `readonly`, assuming an
+        addon mutates the value. Here `readonly` is also how "no free typing"
+        is expressed and the dropdown is the primary interaction, so it opts
+        out via `active_when_readonly` and is dimmed from here on the real
+        read-only flag instead.
+        """
+        super()._sync_addon_state(event)
+        button = self._addons.get('dropdown')
+        if button is None:
+            return
+        try:
+            button.configure(state='!disabled' if self._popup_allowed() else 'disabled')
+        except TclError:
+            pass
 
     # ----- Option normalization + value<->text mapping -----
 
@@ -332,19 +425,29 @@ class SelectBox(Field):
 
     def _on_dropdown_click(self):
         """Handle dropdown button click by focusing entry then showing popup."""
+        if not self._popup_allowed():
+            return
         self.entry_widget.focus_set()
         self._show_selection_options()
 
-    def _bind_readonly_selection_on_click(self):
-        """Bind entry click to show popup when in readonly mode."""
-        self.entry_widget.configure(cursor="hand2")
-        self.entry_widget.bind('<Button-1>', lambda _: self.after_idle(self._show_selection_options), add='+')
+    def _on_entry_click(self, _event: Any = None) -> None:
+        """Open the list when a click on the entry cannot mean anything else.
+
+        Bound for the widget's whole life and gated here, because a typeable
+        entry has to place a text cursor instead — and rebinding on every
+        transition risks deleting a recycled binding name (#392).
+        """
+        if self._entry_is_typeable() or not self._popup_allowed():
+            return
+        self.after_idle(self._show_selection_options)
 
     def _show_selection_options(self):
         """Create and display the popup list of selectable items."""
         if not self._records or self._popup_open:
             return
-        if self.entry_widget.instate(['disabled']):
+        # Both entrances gate on this too; it is repeated here so no future
+        # caller can reach the popup around them.
+        if not self._popup_allowed():
             return
 
         self._popup_open = True
@@ -954,10 +1057,7 @@ class SelectBox(Field):
             return self._allow_custom_values
         else:
             self._allow_custom_values = value
-            if value or self._search_enabled:
-                self.entry_widget.state(['!readonly'])
-            else:
-                self.readonly(True)
+            self._apply_interaction_state()
         return None
 
     @configure_delegate('enable_search')
@@ -967,11 +1067,35 @@ class SelectBox(Field):
             return self._search_enabled
         else:
             self._search_enabled = value
-            if value or self._allow_custom_values:
-                self.entry_widget.state(['!readonly'])
-            else:
-                self.readonly(True)
+            self._apply_interaction_state()
         return None
+
+    @configure_delegate('readonly')
+    def _delegate_readonly(self, value: bool = None):
+        """Get or set read-only: the value is visible but cannot be changed.
+
+        Distinct from a plain select, which is already untypeable but whose
+        list still opens, and from `disabled`, which additionally dims the
+        field and drops it out of the tab order.
+        """
+        if value is None:
+            return self._readonly
+        self._readonly = bool(value)
+        self._apply_interaction_state()
+        return None
+
+    @configure_delegate('state')
+    def _delegate_state(self, value=None):
+        """Apply the field state, then re-derive what read-only owns.
+
+        `Field` writes `readonly`/`normal` straight onto the entry, so
+        `state='normal'` — which is what clearing `disabled` sends — would
+        otherwise silently clear a read-only select as well.
+        """
+        result = super()._delegate_state(value)
+        if value is not None:
+            self._apply_interaction_state()
+        return result
 
     @configure_delegate('group_by')
     def _delegate_group_by(self, value=None):

--- a/src/bootstack/widgets/select.py
+++ b/src/bootstack/widgets/select.py
@@ -59,8 +59,12 @@ class Select(PublicWidgetBase):
             before it scrolls (height is `max_visible_items * row_height`).
             Group headers and separators consume some of that budget, so the
             count is approximate. `None` (default) uses the built-in cap.
-        read_only: If `True`, value is visible but the popup cannot be
-            opened.
+        read_only: If `True`, the value is visible but cannot be changed —
+            neither the dropdown arrow nor a click in the field opens the
+            option list, and the arrow is dimmed to show it. Takes precedence
+            over `searchable` and `allow_custom_values` while set, and restores
+            them when cleared. Unlike `disabled`, the field keeps its normal
+            appearance and stays in the tab order. Defaults to `False`.
         disabled: If `True`, field is fully non-interactive and dimmed.
         width: Width in character units.
         accent: Accent token applied to the focus ring.
@@ -118,6 +122,7 @@ class Select(PublicWidgetBase):
             "allow_custom_values": allow_custom_values,
             "group_by":            group_by,
             "max_visible_items":   max_visible_items,
+            "readonly": read_only
         }
         if value is not None:
             internal_kwargs["value"] = value
@@ -131,8 +136,6 @@ class Select(PublicWidgetBase):
             internal_kwargs["required"] = True
         if disabled:
             internal_kwargs["state"] = "disabled"
-        elif read_only:
-            internal_kwargs["state"] = "readonly"
         if width is not None:
             internal_kwargs["width"] = width
         if accent is not None:
@@ -282,12 +285,18 @@ class Select(PublicWidgetBase):
 
     @property
     def read_only(self) -> bool:
-        """Whether the field is visible but the popup cannot be opened."""
-        return str(self._entry_widget().cget("state")) == "readonly"
+        """Whether the field is visible but the popup cannot be opened.
+
+        Reads the setting, not the widget's internal state. A `Select` is
+        already untypeable by default — that is not the same as read-only, and
+        reading it as though it were is what made this report `True` for every
+        select (#453).
+        """
+        return bool(self._internal.configure("readonly"))
 
     @read_only.setter
     def read_only(self, v: bool) -> None:
-        self._internal.configure(state="readonly" if v else "normal")
+        self._internal.configure(readonly=bool(v))
 
     @property
     def disabled(self) -> bool:

--- a/src/bootstack/widgets/select.py
+++ b/src/bootstack/widgets/select.py
@@ -285,17 +285,17 @@ class Select(PublicWidgetBase):
 
     @property
     def read_only(self) -> bool:
-        """Whether the field is visible but the popup cannot be opened.
+        """Whether the field is read-only — the value shows but cannot be changed.
 
-        Reads the setting, not the widget's internal state. A `Select` is
-        already untypeable by default — that is not the same as read-only, and
-        reading it as though it were is what made this report `True` for every
-        select (#453).
-
-        Read it with `cget`, never `configure(name)`: the delegating form of
-        `configure` answers a query with a 5-tuple, which is unconditionally
-        truthy and would silently restore the #453 behavior.
+        An ordinary `Select` already refuses free typing, which is not the same
+        thing. A read-only one also keeps the option list shut, from both the
+        dropdown button and the field itself.
         """
+        # Report the setting, never the state derived from it — reporting the
+        # derivation is what made every select claim to be read-only (#453).
+        # Read it with `cget`, never `configure(name)`: the delegating form of
+        # `configure` answers a query with a 5-tuple, which is unconditionally
+        # truthy and would silently restore that behavior.
         return bool(self._internal.cget("readonly"))
 
     @read_only.setter

--- a/src/bootstack/widgets/select.py
+++ b/src/bootstack/widgets/select.py
@@ -291,8 +291,12 @@ class Select(PublicWidgetBase):
         already untypeable by default — that is not the same as read-only, and
         reading it as though it were is what made this report `True` for every
         select (#453).
+
+        Read it with `cget`, never `configure(name)`: the delegating form of
+        `configure` answers a query with a 5-tuple, which is unconditionally
+        truthy and would silently restore the #453 behavior.
         """
-        return bool(self._internal.configure("readonly"))
+        return bool(self._internal.cget("readonly"))
 
     @read_only.setter
     def read_only(self, v: bool) -> None:

--- a/src/bootstack/widgets/timefield.py
+++ b/src/bootstack/widgets/timefield.py
@@ -52,8 +52,10 @@ class TimeField(ValueSignalMixin, FieldAddonMixin, PublicWidgetBase):
             way to bind a time field.
         required: If `True`, field cannot be left empty.
         disabled: If `True`, field is non-interactive.
-        read_only: If `True`, free-text entry is blocked; user must pick
-            from the dropdown.
+        read_only: If `True`, the time is visible but cannot be changed —
+            typing is blocked, and neither the clock button nor a click in the
+            field opens the time list. Unlike `disabled`, the field keeps its
+            normal appearance and stays in the tab order. Defaults to `False`.
         width: Width in character cells.
         accent: Accent color applied to the focus ring. Default `'primary'`.
         density: Widget density.
@@ -111,10 +113,14 @@ class TimeField(ValueSignalMixin, FieldAddonMixin, PublicWidgetBase):
             internal_kwargs["message"] = message
         if required:
             internal_kwargs["required"] = True
+        # Read-only rides its own option, not `state="readonly"` — the internal
+        # here is a select, where the ttk `readonly` state is an OUTPUT of the
+        # interaction state ("no free typing") and is re-derived at the end of
+        # construction, so a state write is overwritten before anyone sees it
+        # (#453). Same shape as the setter below and as `Select`.
+        internal_kwargs["readonly"] = read_only
         if disabled:
             internal_kwargs["state"] = "disabled"
-        elif read_only:
-            internal_kwargs["state"] = "readonly"
         if width is not None:
             internal_kwargs["width"] = width
         if accent is not None:
@@ -162,8 +168,14 @@ class TimeField(ValueSignalMixin, FieldAddonMixin, PublicWidgetBase):
 
     @property
     def read_only(self) -> bool:
-        """Whether the field is read-only (selectable but not editable)."""
-        return self._internal._entry.instate(("readonly",))
+        """Whether the field is read-only — the time shows but cannot be changed."""
+        # Report the setting, not the state derived from it. The two agree at
+        # rest, but the derivation is cleared and restored around a programmatic
+        # value write, so reading it answers `False` for a locked field from
+        # inside that window (#453). Same reason `Select.read_only` reads the
+        # setting; `cget`, never `configure(name)`, which answers a query with a
+        # truthy 5-tuple.
+        return bool(self._internal.cget("readonly"))
 
     @read_only.setter
     def read_only(self, v: bool) -> None:

--- a/src/bootstack/widgets/timefield.py
+++ b/src/bootstack/widgets/timefield.py
@@ -167,7 +167,11 @@ class TimeField(ValueSignalMixin, FieldAddonMixin, PublicWidgetBase):
 
     @read_only.setter
     def read_only(self, v: bool) -> None:
-        self._internal.configure(state="readonly" if v else "normal")
+        # Route through the `readonly` option, not `state="readonly"`. The
+        # internal here is a select, where the ttk `readonly` state is an
+        # OUTPUT of the interaction state ("no free typing") and is re-derived
+        # on every change — so a state write is overwritten immediately (#453).
+        self._internal.configure(readonly=bool(v))
 
     # ----- Methods -----
 

--- a/tests/widgets/public/test_select_read_only.py
+++ b/tests/widgets/public/test_select_read_only.py
@@ -1,0 +1,207 @@
+"""#453 — `read_only` on `Select` is a real setting, not the entry's ttk state.
+
+A `Select` is already untypeable by default; that is NOT read-only. Read-only
+additionally closes the option list, from both entrances, and dims the dropdown
+arrow to say so. It suppresses `allow_custom_values`/`searchable` rather than
+discarding them, so clearing it restores whichever was asked for.
+
+Every test here fails against the pre-fix source for a BEHAVIORAL reason, not
+an `AttributeError` — `read_only` was accepted and ignored before, so nothing
+raises either way.
+"""
+import bootstack as bs
+
+
+def _popup_opens(sel) -> bool:
+    """Drive the real popup entry point and report whether the list came up."""
+    inner = sel._internal
+    inner._popup_open = False
+    inner._show_selection_options()
+    opened = bool(inner._popup_open)
+    if opened:
+        try:
+            inner._close_popup(inner._popup_frame.winfo_toplevel(), inner._popup_state)
+        except Exception:
+            inner._popup_open = False
+    return opened
+
+
+def _click_opens(sel) -> bool:
+    """Drive the entry-click entrance by generating the real `<Button-1>`.
+
+    This is the path #453 reported: clicking the text area rather than the
+    arrow. It is a separate entrance from `_popup_opens` and was the one that
+    stayed live under `read_only=True`.
+
+    It generates the event rather than calling the handler by name, so the test
+    exercises whatever binding the widget actually installed — otherwise this
+    would raise `AttributeError` against the unfixed source and prove nothing.
+    Both the old and new bindings defer through `after_idle`, hence the update.
+    """
+    inner = sel._internal
+    entry = sel._entry_widget()
+    # Settle pending idle work FIRST. The unfixed source installed the click
+    # binding from `after_idle`, so clicking before idle ran hit no binding at
+    # all and this helper reported False — passing the read-only test for the
+    # wrong reason and missing the very defect #453 reported.
+    entry.update()
+    inner._popup_open = False
+    entry.event_generate("<Button-1>", x=5, y=5)
+    entry.update()
+    opened = bool(inner._popup_open)
+    if opened:
+        try:
+            inner._close_popup(inner._popup_frame.winfo_toplevel(), inner._popup_state)
+        except Exception:
+            inner._popup_open = False
+    return opened
+
+
+def _typeable(sel) -> bool:
+    entry = sel._entry_widget()
+    return not entry.instate(["readonly"]) and not entry.instate(["disabled"])
+
+
+def _arrow_dimmed(sel) -> bool:
+    return sel._internal._addons["dropdown"].instate(["disabled"])
+
+
+# --------------------------------------------------------------------------
+# The report: read_only must close both entrances
+# --------------------------------------------------------------------------
+
+def test_read_only_blocks_the_popup_from_the_arrow(app):
+    sel = bs.Select(["A", "B", "C"], value="A", read_only=True, parent=app)
+    assert _popup_opens(sel) is False
+
+
+def test_read_only_blocks_the_popup_from_an_entry_click(app):
+    # #453 as reported: the arrow looked inactive but clicking the text area
+    # still opened the list and changed the value.
+    sel = bs.Select(["A", "B", "C"], value="A", read_only=True, parent=app)
+    assert _click_opens(sel) is False
+
+
+def test_a_plain_select_still_opens_from_both_entrances(app):
+    # The control. Read-only must close the list; being merely untypeable —
+    # which every Select is by default — must not.
+    sel = bs.Select(["A", "B", "C"], value="A", parent=app)
+    assert _typeable(sel) is False
+    assert _popup_opens(sel) is True
+    assert _click_opens(sel) is True
+
+
+# --------------------------------------------------------------------------
+# The getter reports the setting, not the widget's internal state
+# --------------------------------------------------------------------------
+
+def test_a_plain_select_is_not_read_only(app):
+    # Pre-fix this read True for every Select ever built, because the property
+    # read the ttk state the widget sets for its own "no free typing" reason.
+    sel = bs.Select(["A", "B", "C"], parent=app)
+    assert sel.read_only is False
+
+
+def test_read_only_survives_being_combined_with_typing_modes(app):
+    # Pre-fix, construction applied `state="readonly"` and the entry state was
+    # then recomputed from the typing modes, discarding the request outright.
+    for kwargs in ({"allow_custom_values": True}, {"searchable": True}):
+        sel = bs.Select(["A", "B", "C"], read_only=True, parent=app, **kwargs)
+        assert sel.read_only is True, kwargs
+        assert _typeable(sel) is False, kwargs
+        assert _popup_opens(sel) is False, kwargs
+
+
+# --------------------------------------------------------------------------
+# The dropdown arrow tracks read-only, not the entry's ttk state
+# --------------------------------------------------------------------------
+
+def test_the_arrow_is_lit_on_a_plain_select_even_after_a_state_sync(app):
+    # `Field` dims every addon while the entry is `readonly`, and a Select is
+    # `readonly` by default. The arrow survived only because construction never
+    # fired <<StateChanged>>; the first sync dimmed it on an ordinary Select.
+    sel = bs.Select(["A", "B", "C"], parent=app)
+    sel._internal._entry.event_generate("<<StateChanged>>")
+    sel._internal.update_idletasks()
+    assert _arrow_dimmed(sel) is False
+
+
+def test_the_arrow_is_dimmed_when_read_only(app):
+    # Passes against the unfixed source too, and deliberately kept: dimming was
+    # the ONE thing `read_only=True` did before, as an accident of routing
+    # `state="readonly"` through Field's addon sync. It is the symptom the
+    # reporter read as meaning read-only, so it is now pinned as intended.
+    sel = bs.Select(["A", "B", "C"], read_only=True, parent=app)
+    assert _arrow_dimmed(sel) is True
+
+
+# --------------------------------------------------------------------------
+# Runtime: read_only suppresses the typing modes, it does not overwrite them
+# --------------------------------------------------------------------------
+
+def test_clearing_read_only_restores_typing_when_custom_values_were_asked_for(app):
+    # Passes against the unfixed source as well, but only by luck: writing
+    # state="normal" happened to be the right answer when custom values were
+    # on. The mirror test below is the one that caught it being wrong.
+    sel = bs.Select(["A", "B", "C"], allow_custom_values=True, parent=app)
+    sel.read_only = True
+    assert _typeable(sel) is False
+    sel.read_only = False
+    # Restores what was asked for, rather than falling back to a plain select.
+    assert _typeable(sel) is True
+    assert sel.read_only is False
+
+
+def test_clearing_read_only_does_not_grant_typing_to_a_plain_select(app):
+    # The mirror case. Pre-fix the setter wrote state="normal" unconditionally,
+    # silently turning a plain Select into a free-text field.
+    sel = bs.Select(["A", "B", "C"], parent=app)
+    sel.read_only = True
+    sel.read_only = False
+    assert _typeable(sel) is False
+    assert _popup_opens(sel) is True
+
+
+def test_read_only_survives_a_disabled_round_trip(app):
+    # Clearing `disabled` sends state="normal", which cleared read-only too.
+    sel = bs.Select(["A", "B", "C"], read_only=True, parent=app)
+    sel.disabled = True
+    sel.disabled = False
+    assert sel.read_only is True
+    assert _popup_opens(sel) is False
+
+
+def test_the_list_keeps_exactly_one_entrance_across_a_runtime_mode_flip(app):
+    # Click-to-open is bound for the widget's whole life and gated in the
+    # handler, so flipping back out of a typing mode restores the entrance.
+    sel = bs.Select(["A", "B", "C"], parent=app)
+    assert _click_opens(sel) is True
+
+    sel._internal.configure(allow_custom_values=True)
+    assert _typeable(sel) is True
+    assert _click_opens(sel) is False   # a click must place a text cursor now
+    assert _popup_opens(sel) is True    # ...so the arrow is the only way in
+
+    sel._internal.configure(allow_custom_values=False)
+    assert _typeable(sel) is False
+    assert _click_opens(sel) is True
+
+
+# --------------------------------------------------------------------------
+# Reachability: a typeable entry must never be left with no way to the list
+# --------------------------------------------------------------------------
+
+def test_search_forces_the_dropdown_button_like_custom_values_does(app):
+    # `show_dropdown_button=False` is honored only while the entry is not
+    # typeable. It covered allow_custom_values but not enable_search, leaving
+    # that combination with no entrance at all.
+    from bootstack.widgets._impl.composites.selectbox import SelectBox
+
+    box = SelectBox(
+        app._child_master(),
+        items=["A", "B"],
+        enable_search=True,
+        show_dropdown_button=False,
+    )
+    box.pack()
+    assert "dropdown" in box._addons

--- a/tests/widgets/public/test_select_read_only.py
+++ b/tests/widgets/public/test_select_read_only.py
@@ -9,6 +9,8 @@ Every test here fails against the pre-fix source for a BEHAVIORAL reason, not
 an `AttributeError` — `read_only` was accepted and ignored before, so nothing
 raises either way.
 """
+import datetime
+
 import bootstack as bs
 
 
@@ -274,3 +276,54 @@ def test_timefield_read_only_survives_a_disabled_round_trip(app):
     tf.disabled = False
     assert tf.disabled is False
     assert tf.read_only is True
+
+
+def test_timefield_read_only_at_construction_is_not_discarded(app):
+    # The setter was the only path covered above, and it was the only one
+    # fixed. The constructor sent state="readonly", which the interaction
+    # state re-derives away before `__init__` returns — so a field asked to
+    # be locked came back freely typeable, with its time list still opening.
+    tf = bs.TimeField(read_only=True, parent=app)
+    assert tf.read_only is True
+    assert tf._internal._entry.instate(["readonly"]) is True
+    assert tf._internal._popup_allowed() is False
+
+
+def test_timefield_construction_defaults_to_typeable(app):
+    # Control for the test above: a plain TimeField allows custom values, so
+    # the assertions there have to be able to come out the other way.
+    tf = bs.TimeField(parent=app)
+    assert tf.read_only is False
+    assert tf._internal._entry.instate(["readonly"]) is False
+    assert tf._internal._popup_allowed() is True
+
+
+def test_timefield_read_only_reports_the_setting_not_the_derived_state(app):
+    # The ttk `readonly` state is cleared and restored around a programmatic
+    # value write, so a getter reading that state answers `False` for a locked
+    # field from inside the window. A textvariable trace lands squarely in it,
+    # and fires synchronously, so this is deterministic rather than a race.
+    tf = bs.TimeField(read_only=True, parent=app)
+    seen = []
+    tf._internal._entry.textvariable.trace_add(
+        "write", lambda *a: seen.append(tf.read_only)
+    )
+
+    tf.value = datetime.time(9, 30)
+
+    assert seen, "the trace never fired — the window was never entered"
+    assert all(seen), f"read_only answered {seen} during a value write"
+    assert tf.read_only is True
+
+
+def test_timefield_disabled_and_read_only_together_at_construction(app):
+    # `disabled` used to shadow `read_only` in an elif. Both are set now, so
+    # clearing the disabled state must not hand back an unlocked field.
+    tf = bs.TimeField(disabled=True, read_only=True, parent=app)
+    assert tf.disabled is True
+    assert tf.read_only is True
+
+    tf.disabled = False
+    assert tf.disabled is False
+    assert tf.read_only is True
+    assert tf._internal._popup_allowed() is False

--- a/tests/widgets/public/test_select_read_only.py
+++ b/tests/widgets/public/test_select_read_only.py
@@ -205,3 +205,72 @@ def test_search_forces_the_dropdown_button_like_custom_values_does(app):
     )
     box.pack()
     assert "dropdown" in box._addons
+
+
+def test_a_runtime_flip_does_not_build_a_button_that_was_refused(app):
+    # The mirror of the test above, and the boundary between them: membership
+    # is decided ONCE, at construction. Turning typing on later must not insert
+    # a button the caller explicitly refused — the reachability rule buys its
+    # exception at build time, where the caller can still see the trade.
+    from bootstack.widgets._impl.composites.selectbox import SelectBox
+
+    box = SelectBox(
+        app._child_master(),
+        items=["A", "B"],
+        show_dropdown_button=False,
+    )
+    box.pack()
+    assert "dropdown" not in box._addons
+
+    box.configure(allow_custom_values=True)
+    assert "dropdown" not in box._addons
+
+    box.configure(enable_search=True)
+    assert "dropdown" not in box._addons
+
+
+# --------------------------------------------------------------------------
+# TimeField: the same setting reached through a different public property
+# --------------------------------------------------------------------------
+# `TimeField` is the only field family member whose internal is a SelectBox,
+# so it is the only one whose `read_only` had to stop writing the ttk state.
+# The state is an OUTPUT of the interaction rules now and is re-derived on
+# every change, so writing it was overwritten within the same call.
+
+def test_timefield_read_only_is_not_discarded(app):
+    tf = bs.TimeField(parent=app)
+    tf.read_only = True
+    assert tf.read_only is True
+    assert tf._internal._entry.instate(["readonly"]) is True
+
+
+def test_timefield_read_only_closes_the_list(app):
+    # The point of the property: a locked field must not offer the time list.
+    tf = bs.TimeField(parent=app)
+    tf.read_only = True
+    assert tf._internal._popup_allowed() is False
+
+
+def test_timefield_clearing_read_only_restores_typing(app):
+    # A TimeEntry is built with allow_custom_values=True, so clearing read-only
+    # must give typing back rather than leaving a permanently locked field.
+    #
+    # Passes against the unfixed source too, and only because BOTH writes were
+    # no-ops there — it pins the end state, not the transition. The three tests
+    # around it are the ones that fail behaviorally pre-fix.
+    tf = bs.TimeField(parent=app)
+    tf.read_only = True
+    tf.read_only = False
+    assert tf.read_only is False
+    assert tf._internal._entry.instate(["readonly"]) is False
+
+
+def test_timefield_read_only_survives_a_disabled_round_trip(app):
+    # Clearing `disabled` sends state="normal". Read-only is held as its own
+    # flag now, so it is re-derived rather than cleared as a side effect.
+    tf = bs.TimeField(parent=app)
+    tf.read_only = True
+    tf.disabled = True
+    tf.disabled = False
+    assert tf.disabled is False
+    assert tf.read_only is True


### PR DESCRIPTION
Closes #453.

## The report

`read_only=True` on a `Select` was accepted and then ignored. The dropdown arrow greyed out, so the field *looked* read-only, while clicking the field's text area still opened the option list and picked a new value. Reading `select.read_only` back reported `True` for every `Select` ever built, read-only or not.

## Root cause

`read_only` existed only on the public wrapper, where it was translated into `state="readonly"` and handed to `SelectBox` — which already owned that ttk state as its own "no free typing" flag and recomputed it unconditionally at construction, discarding the request. Nothing downstream guarded the popup, because nothing downstream knew the concept existed. The dimmed arrow was the entire observable effect of the option, and it was an accident rather than a partial implementation.

## The fix

The entry's ttk `readonly` state is now **derived, never storage**. `_apply_interaction_state()` computes it from `_readonly`, `_allow_custom_values` and `_search_enabled`, and every writer routes through it. Both entrances to the list — the arrow and a click in the text area — gate on `_popup_allowed()`.

`read_only` **suppresses** the typing modes rather than overwriting them, so clearing it restores whichever was asked for instead of falling back to a plain select. Precedence is `disabled` > `read_only` > `allow_custom_values`|`enable_search`.

Two latent defects fell out of the same rework: an ordinary `Select` dimmed its arrow the first time anything fired `<<StateChanged>>`, and a dimmed arrow opened the list anyway.

## Review round 1 — three findings, all fixed here

One blocking, two nits. Full record in `REVIEW.md`; the round-2 brief is `development/review-brief-453-round2.md`.

- **Blocking — `TimeField.read_only` was permanently dead.** Its setter wrote `configure(state="readonly")` onto its internal, which is a `TimeEntry`, a `SelectBox` always built typeable. With the ttk state now an *output* re-derived after every write, and nothing mapping an incoming ttk `readonly` onto `_readonly`, the applier wrote `['!readonly']` back over the request inside the same call. Measured: `main` reports `True` with the entry `('readonly',)`; this branch reported `False` with the entry `()`. Fixed in `timefield.py` by routing through the `readonly` option — mapping `state="readonly"` onto `_readonly` was rejected, because a plain select is already untypeable while its list still opens, so that mapping would suppress the popup for every select that asked only for "no typing".
- **Dropdown button membership is decided once, at construction.** `_apply_interaction_state()` had been inserting the button whenever a runtime change made the entry typeable, so `show_dropdown_button=False` followed by `configure(allow_custom_values=True)` built a button the caller had explicitly refused, permanently. Maintainer's call: build-time only, and no removal arm either, since un-building a button makes no sense. This is what `main` already does.
- **`Select.read_only` read `configure("readonly")` where its siblings use `cget`.** The delegating mixin answers a query with a 5-tuple, which is unconditionally truthy — exactly the always-`True` behavior this issue exists to remove. Verified **latent, not live**: `SelectBox` resolves `TTKWrapperBase.configure`, which returns the bare value. Switched to `cget` so an MRO change cannot restore the bug silently.

## Verification

17 tests in `tests/widgets/public/test_select_read_only.py`. Each was run against the unfixed source: 9 of the original 12 fail there, and 4 of the 5 added in the review fix fail behaviorally — `assert False is True` on the TimeField getter, `assert True is False` on the popup gate, `assert 'dropdown' not in {'dropdown': <Button ...>}` on the runtime flip. The tests that pass on both sides are each explained in place, including the control that must.

Full suite at `872aa862`: `py -3.12 tests/run_gui.py`, **exit 0, 20 legs, 1225 passed / 21 skipped**. The shared leg reconciles against its own collection line — `collected 1116 / 75 deselected / 1 skipped / 1041 selected`, and `1028 passed + 13 runtime skips = 1041`.

## Not ready to merge yet

Review round 2 has not run. `PLAN.md` declares a cap of 2 rounds, and round 1's fixes carry a non-empty `src/` diff, which is what opens the next round under `REVIEW-PROTOCOL.md` gate 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
