### PR TITLE
docs(audit): measure the wrapper/internal parameter delta (#463)

### DIFF
--- a/development/probe_wrapper_parameter_delta.py
+++ b/development/probe_wrapper_parameter_delta.py
@@ -1,0 +1,1462 @@
+"""Probe: wrapper vs internal parameter delta (#463).
+
+WHAT THIS IS
+------------
+A mechanical scan of the public wrapper layer against the internal widgets it
+composes. The internal widget is the specification; this probe diffs the two
+signatures and classifies the delta.
+
+It exists because the check this project has been using --
+`git show main:<wrapper> | grep <kwarg>` -- catches exactly ONE of the five
+ways a wrapper goes wrong (the mode table below), and the one that keeps
+landing (mode 2, forwarded to the WRONG destination: #458, #461) is not it.
+
+THE FIVE FAILURE MODES
+----------------------
+  1 never forwarded      the kwarg exists on the wrapper, never reaches the
+                         internal                                 (#383 gap 3)
+  2 wrong destination    forwarded, to the wrong internal parameter (#458, #461)
+  3 swallowed as layout  falls into **kwargs, _split_layout_kwargs eats it,
+                         nothing raises                                 (#456)
+  4 accepted then        reaches the internal and is overwritten by something
+    ignored              recomputed                                     (#453)
+  5 the type lies        the annotation describes a value the code cannot
+                         produce                                        (#460)
+
+Modes 1, 2, 3 and 5 are static and are what this probe measures. Mode 4 is NOT
+statically decidable and this probe DOES NOT claim to find it -- see
+`--arm roundtrip` and the honesty note it prints.
+
+ARMS
+----
+  --arm scan       the static pass (default)
+  --arm control    the non-vacuity controls; run this before believing any
+                   "no findings" result
+  --arm roundtrip  the runtime construct-and-read-back heuristic (needs a
+                   display; a PARTIAL view of mode 4, limits printed inline)
+
+SCOPE -- stated mechanically, because a completeness claim whose scope was
+never written down reads as global and is checked as local:
+
+  scanned:  src/bootstack/widgets/*.py           (override with --src)
+  NOT scanned unless asked: src/bootstack/dialogs/  (--src accepts it)
+  skipped classes and the reason are printed in the SKIPPED section
+  forwarding idioms understood are printed in the IDIOMS section; a wrapper
+  whose idiom is not understood is reported as UNANALYZED, never as clean
+
+Output is ASCII only (the Windows box console is cp1252).
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import importlib
+import inspect
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+# --------------------------------------------------------------------------
+# source loading -- utf-8-sig, and NO bare except swallowing a parse failure
+# --------------------------------------------------------------------------
+
+def load_module_asts(src: Path) -> tuple[dict[str, ast.Module], list[str]]:
+    """Parse every .py under `src`. Returns (asts_by_stem, failures).
+
+    A completeness scan in this project once reported zero hits because
+    `ast.parse` choked on a UTF-8 BOM and a bare `except Exception: continue`
+    swallowed it. Files are read as utf-8-sig and every failure is COUNTED and
+    RETURNED, so `files_parsed + failures == files_found` can be asserted.
+    """
+    trees: dict[str, ast.Module] = {}
+    failures: list[str] = []
+    for path in sorted(src.glob("*.py")):
+        text = path.read_bytes().decode("utf-8-sig")
+        try:
+            trees[path.stem] = ast.parse(text, filename=str(path))
+        except SyntaxError as exc:
+            failures.append("%s: %s" % (path.name, exc))
+    return trees, failures
+
+
+# --------------------------------------------------------------------------
+# static model of one module
+# --------------------------------------------------------------------------
+
+def import_alias_map(tree: ast.Module) -> dict[str, str]:
+    """Map a bound name to the dotted path it was imported from.
+
+    Walks the whole tree, not just the module body: several wrappers import the
+    internal inside `__init__` or under `if TYPE_CHECKING`.
+    """
+    aliases: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
+            for a in node.names:
+                aliases.setdefault(a.asname or a.name, "%s.%s" % (node.module, a.name))
+        elif isinstance(node, ast.Import):
+            for a in node.names:
+                aliases.setdefault(a.asname or a.name, a.name)
+    return aliases
+
+
+def classes_of(tree: ast.Module) -> dict[str, ast.ClassDef]:
+    return {n.name: n for n in tree.body if isinstance(n, ast.ClassDef)}
+
+
+def base_names(cls: ast.ClassDef) -> list[str]:
+    out = []
+    for b in cls.bases:
+        if isinstance(b, ast.Name):
+            out.append(b.id)
+        elif isinstance(b, ast.Attribute):
+            out.append(b.attr)
+    return out
+
+
+def find_in_mro(name: str, classes: dict[str, ast.ClassDef], want):
+    """Walk `name` and its bases within this module for what `want` returns."""
+    seen: set[str] = set()
+    stack = [name]
+    while stack:
+        cur = stack.pop(0)
+        if cur in seen or cur not in classes:
+            continue
+        seen.add(cur)
+        found = want(classes[cur])
+        if found is not None:
+            return found, cur
+        stack.extend(base_names(classes[cur]))
+    return None, None
+
+
+def _own_init(cls: ast.ClassDef):
+    for n in cls.body:
+        if isinstance(n, ast.FunctionDef) and n.name == "__init__":
+            return n
+    return None
+
+
+def _own_internal_class(cls: ast.ClassDef):
+    for n in cls.body:
+        if isinstance(n, ast.Assign):
+            for t in n.targets:
+                if isinstance(t, ast.Name) and t.id == "_internal_class" \
+                        and isinstance(n.value, ast.Name):
+                    return n.value.id
+    return None
+
+
+def init_params(fn: ast.FunctionDef) -> tuple[list[str], str | None]:
+    """Return ([param names in declaration order], kwargs catch-all name)."""
+    a = fn.args
+    names = [arg.arg for arg in list(a.posonlyargs) + list(a.args) + list(a.kwonlyargs)
+             if arg.arg != "self"]
+    return names, (a.kwarg.arg if a.kwarg else None)
+
+
+def names_in(node: ast.AST) -> set[str]:
+    return {n.id for n in ast.walk(node) if isinstance(n, ast.Name)}
+
+
+# --------------------------------------------------------------------------
+# the forwarding analysis
+# --------------------------------------------------------------------------
+
+class Dest:
+    """One key the wrapper writes into the internal's kwargs."""
+
+    def __init__(self, key: str, names: set[str], guards: set[str],
+                 direct: str | None, text: str, line: int) -> None:
+        self.key = key
+        self.names = names          # params flowing into the VALUE
+        self.guards = guards        # params only guarding whether it is written
+        self.direct = direct        # param name if the value is exactly that name
+        self.text = text
+        self.line = line
+
+
+class Forwarding:
+    def __init__(self) -> None:
+        self.internal_expr: str | None = None
+        self.dest: list[Dest] = []
+        self.splat_vars: list[str] = []
+        self.opaque: list[str] = []
+        self.forwards_catchall = False
+        self.passthrough: set[str] = set()   # params merged in wholesale
+        self.understood = False
+        self.why_not = ""
+        self.via = ""               # non-empty when not the plain idiom
+        self.terminal: Any = None   # the __init__ that builds the internal
+
+
+def _assignments(fn: ast.FunctionDef):
+    """Every simple assignment in `fn`, as (target_node, value_node)."""
+    for node in ast.walk(fn):
+        if isinstance(node, ast.Assign) and len(node.targets) == 1:
+            yield node.targets[0], node.value
+        elif isinstance(node, ast.AnnAssign) and node.value is not None:
+            yield node.target, node.value
+
+
+def _is_self_attr(node: ast.AST, attr: str | None = None) -> bool:
+    return (isinstance(node, ast.Attribute)
+            and isinstance(node.value, ast.Name) and node.value.id == "self"
+            and (attr is None or node.attr == attr))
+
+
+def _find_internal_call(fn: ast.FunctionDef,
+                        aliases: dict[str, str] | None = None):
+    """The call that builds the internal widget, and how it was reached.
+
+    Three idioms, in order:
+      1. `self._internal = Internal(...)`                       -- the common one
+      2. `self._tk_root = Internal(...)` ... `self._internal = self._tk_root`
+         -- the window family (App, Window, Splash) builds the root first and
+         aliases it afterwards, so a tool that only matches idiom 1 reports
+         those wrappers (80+ parameters) as unanalysable
+      3. no `self._internal` at all -- a page/handle class that builds a layout
+         frame directly. Analysed against that frame, and LABELLED, because it
+         is not the wrapper-over-internal shape this audit is about.
+    """
+    # idiom 1
+    for target, value in _assignments(fn):
+        if _is_self_attr(target, "_internal") and isinstance(value, ast.Call):
+            return value, ""
+    # idiom 2 -- one alias hop
+    alias_of = None
+    for target, value in _assignments(fn):
+        if _is_self_attr(target, "_internal"):
+            if _is_self_attr(value):
+                alias_of = value.attr
+            elif isinstance(value, ast.Name):
+                alias_of = value.id
+    if alias_of is not None:
+        for target, value in _assignments(fn):
+            hit = (_is_self_attr(target) and target.attr == alias_of) or (
+                isinstance(target, ast.Name) and target.id == alias_of)
+            if hit and isinstance(value, ast.Call):
+                return value, "self._internal = self.%s, built earlier" % alias_of
+    # idiom 3 -- a handle class; use the first _impl widget it builds
+    if aliases:
+        for target, value in _assignments(fn):
+            if not (isinstance(value, ast.Call) and _is_self_attr(target)):
+                continue
+            func = value.func
+            name = func.id if isinstance(func, ast.Name) else None
+            if name and "_impl" in aliases.get(name, ""):
+                return value, ("no self._internal; analysed against self.%s = %s()"
+                               % (target.attr, name))
+    return None, ""
+
+
+def _dict_writes(fn: ast.FunctionDef, var: str, catchall: str | None,
+                 fwd: Forwarding) -> None:
+    """Collect every write into `var`, remembering the `if` tests that guard it.
+
+    The guard matters: `if disabled: kw['state'] = 'disabled'` forwards the
+    parameter even though its name never appears in the value.
+    """
+
+    def visit(stmts, guards: set[str]) -> None:
+        for st in stmts:
+            if isinstance(st, ast.If):
+                g = guards | names_in(st.test)
+                visit(st.body, g)
+                visit(st.orelse, g)
+                continue
+            if isinstance(st, (ast.For, ast.AsyncFor)):
+                # `for k, v in {"padding": padding, ...}.items(): var[k] = v`
+                # -- Grid's idiom for "only forward the ones that are set". The
+                # key is a loop variable, so the plain subscript rule sees a
+                # computed key and gives up; the dict literal right there names
+                # every key and value. Without this, `Grid(padding=)` reads as
+                # never forwarded, which it plainly is.
+                literal = None
+                if (isinstance(st.iter, ast.Call)
+                        and isinstance(st.iter.func, ast.Attribute)
+                        and st.iter.func.attr == "items"
+                        and isinstance(st.iter.func.value, ast.Dict)):
+                    literal = st.iter.func.value
+                if literal is not None and isinstance(st.target, ast.Tuple) \
+                        and len(st.target.elts) == 2:
+                    kvar = st.target.elts[0]
+                    vvar = st.target.elts[1]
+                    writes_through = any(
+                        isinstance(t, ast.Subscript) and isinstance(t.value, ast.Name)
+                        and t.value.id == var
+                        and isinstance(t.slice, ast.Name)
+                        and isinstance(kvar, ast.Name) and t.slice.id == kvar.id
+                        and isinstance(val, ast.Name) and isinstance(vvar, ast.Name)
+                        and val.id == vvar.id
+                        for t, val in _assignments(st))
+                    if writes_through:
+                        for k, v in zip(literal.keys, literal.values):
+                            if isinstance(k, ast.Constant) and isinstance(k.value, str):
+                                _add(fwd, k.value, v, guards)
+                        continue
+                visit(st.body, guards | names_in(st.iter))
+                visit(st.orelse, guards)
+                continue
+            if isinstance(st, (ast.While, ast.With, ast.AsyncWith)):
+                visit(st.body, guards)
+                visit(getattr(st, "orelse", []), guards)
+                continue
+            if isinstance(st, ast.Try):
+                visit(st.body, guards)
+                for h in st.handlers:
+                    visit(h.body, guards)
+                visit(st.orelse, guards)
+                visit(st.finalbody, guards)
+                continue
+
+            tgt = None
+            if isinstance(st, ast.Assign) and len(st.targets) == 1:
+                tgt = st.targets[0]
+            elif isinstance(st, ast.AnnAssign):
+                tgt = st.target
+
+            # var = {...}
+            if isinstance(tgt, ast.Name) and tgt.id == var and st.value is not None \
+                    and isinstance(st.value, ast.Dict):
+                for k, v in zip(st.value.keys, st.value.values):
+                    if isinstance(k, ast.Constant) and isinstance(k.value, str):
+                        _add(fwd, k.value, v, guards)
+                    else:
+                        fwd.opaque.append("non-literal key in %s" % var)
+            # var["k"] = expr
+            if isinstance(tgt, ast.Subscript) and isinstance(tgt.value, ast.Name) \
+                    and tgt.value.id == var and st.value is not None:
+                if isinstance(tgt.slice, ast.Constant) and isinstance(tgt.slice.value, str):
+                    _add(fwd, tgt.slice.value, st.value, guards)
+                else:
+                    fwd.opaque.append("computed key into %s" % var)
+            # var.update(...) / var.setdefault("k", expr)
+            for node in ast.walk(st):
+                if not (isinstance(node, ast.Call)
+                        and isinstance(node.func, ast.Attribute)
+                        and isinstance(node.func.value, ast.Name)
+                        and node.func.value.id == var):
+                    continue
+                if node.func.attr == "update" and node.args:
+                    arg0 = node.args[0]
+                    if isinstance(arg0, ast.Dict):
+                        for k, v in zip(arg0.keys, arg0.values):
+                            if isinstance(k, ast.Constant) and isinstance(k.value, str):
+                                _add(fwd, k.value, v, guards)
+                    elif isinstance(arg0, ast.Name) and catchall and arg0.id == catchall:
+                        fwd.forwards_catchall = True
+                    elif isinstance(arg0, ast.Name):
+                        # `internal_kwargs.update(_internal_options)` -- a
+                        # pass-through slot. The keys are not visible here; a
+                        # subclass fills the dict and hands it down, so the
+                        # composition step resolves them.
+                        fwd.passthrough.add(arg0.id)
+                    else:
+                        fwd.opaque.append("%s.update(%s)" % (var, ast.unparse(arg0)))
+                elif node.func.attr == "setdefault" and len(node.args) == 2:
+                    k = node.args[0]
+                    if isinstance(k, ast.Constant) and isinstance(k.value, str):
+                        _add(fwd, k.value, node.args[1], guards)
+
+    visit(fn.body, set())
+
+
+def _add(fwd: Forwarding, key: str, value: ast.AST, guards: set[str]) -> None:
+    direct = value.id if isinstance(value, ast.Name) else None
+    fwd.dest.append(Dest(key, names_in(value), set(guards), direct,
+                         ast.unparse(value), getattr(value, "lineno", 0)))
+
+
+def analyse_construction(fn: ast.FunctionDef, catchall: str | None,
+                         aliases: dict[str, str] | None = None) -> Forwarding:
+    fwd = Forwarding()
+    call, via = _find_internal_call(fn, aliases)
+    if call is None:
+        fwd.why_not = "this __init__ builds no internal widget"
+        return fwd
+
+    fwd.via = via
+    fwd.terminal = fn
+    fwd.internal_expr = ast.unparse(call.func)
+    for kw in call.keywords:
+        if kw.arg is None:
+            if isinstance(kw.value, ast.Name):
+                if catchall and kw.value.id == catchall:
+                    fwd.forwards_catchall = True
+                else:
+                    fwd.splat_vars.append(kw.value.id)
+            else:
+                fwd.opaque.append(ast.unparse(kw.value))
+        else:
+            _add(fwd, kw.arg, kw.value, set())
+    for var in fwd.splat_vars:
+        _dict_writes(fn, var, catchall, fwd)
+
+    # `for k, v in kwargs.items(): internal_kwargs[k] = v` -- MenuButton merges
+    # leftovers with a loop rather than `.update()`. The cross-check arm caught
+    # this: static said the leftovers were dropped, and MenuButton actually
+    # raises because they reach the internal.
+    if catchall:
+        for node in ast.walk(fn):
+            if not (isinstance(node, ast.For) and isinstance(node.iter, ast.Call)
+                    and isinstance(node.iter.func, ast.Attribute)
+                    and node.iter.func.attr == "items"
+                    and isinstance(node.iter.func.value, ast.Name)
+                    and node.iter.func.value.id == catchall):
+                continue
+            for target, _value in _assignments(node):
+                if isinstance(target, ast.Subscript) and isinstance(target.value, ast.Name) \
+                        and target.value.id in fwd.splat_vars:
+                    fwd.forwards_catchall = True
+
+    fwd.understood = True
+    return fwd
+
+
+def _find_super_init(fn: ast.FunctionDef) -> ast.Call | None:
+    for node in ast.walk(fn):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "__init__"
+            and isinstance(node.func.value, ast.Call)
+            and isinstance(node.func.value.func, ast.Name)
+            and node.func.value.func.id == "super"
+        ):
+            return node
+    return None
+
+
+def analyse_chain(cls_name: str, classes: dict[str, ast.ClassDef],
+                  aliases: dict[str, str], depth: int = 0):
+    """Forwarding for `cls_name`, following `super().__init__` when the class
+    does not build the internal itself.
+
+    Several families (`Checkbox`/`Switch`/`ToggleButton`, `Radio`, `Row`/`Column`)
+    give each subclass its own `__init__` for the Sphinx signature and construct
+    the internal in a shared private base. A tool that stops at the subclass
+    reports 40-odd parameters as unanalysable.
+
+    Returns (fwd, init_fn, defining_class) with `fwd.dest` expressed in terms of
+    `init_fn`'s OWN parameter names.
+    """
+    init, init_from = find_in_mro(cls_name, classes, _own_init)
+    if init is None:
+        return None, None, None
+    _params, catchall = init_params(init)
+    fwd = analyse_construction(init, catchall, aliases)
+    if fwd.understood or depth >= 4:
+        return fwd, init, init_from
+
+    supercall = _find_super_init(init)
+    if supercall is None:
+        return fwd, init, init_from
+
+    base = None
+    for b in base_names(classes[init_from]):
+        cand, _ = find_in_mro(b, classes, _own_init)
+        if cand is not None:
+            base = b
+            break
+    if base is None:
+        return fwd, init, init_from
+
+    base_fwd, base_init, base_from = analyse_chain(base, classes, aliases, depth + 1)
+    if base_fwd is None or not base_fwd.understood:
+        return fwd, init, init_from
+
+    base_params, _ = init_params(base_init)
+    argmap: dict[str, ast.AST] = {}
+    for i, a in enumerate(supercall.args):
+        if i < len(base_params):
+            argmap[base_params[i]] = a
+    for kw in supercall.keywords:
+        if kw.arg is not None:
+            argmap[kw.arg] = kw.value
+        elif isinstance(kw.value, ast.Name) and kw.value.id == catchall:
+            fwd.forwards_catchall = fwd.forwards_catchall or base_fwd.forwards_catchall
+
+    composed = Forwarding()
+    composed.understood = True
+    composed.internal_expr = base_fwd.internal_expr
+    composed.splat_vars = list(base_fwd.splat_vars)
+    composed.opaque = list(base_fwd.opaque)
+    composed.forwards_catchall = base_fwd.forwards_catchall or fwd.forwards_catchall
+    composed.terminal = base_fwd.terminal
+    composed.via = "super().__init__ -> %s" % base_from
+
+    def translate(base_name_set: set[str]) -> tuple[set[str], str | None]:
+        own: set[str] = set()
+        only = None
+        for bn in base_name_set:
+            if bn in argmap:
+                sub = names_in(argmap[bn])
+                own |= sub
+                if isinstance(argmap[bn], ast.Name):
+                    only = argmap[bn].id
+        return own, only
+
+    for d in base_fwd.dest:
+        own_names, direct_own = translate(d.names)
+        own_guards, _ = translate(d.guards)
+        direct = None
+        if d.direct is not None and d.direct in argmap \
+                and isinstance(argmap[d.direct], ast.Name):
+            direct = argmap[d.direct].id
+        elif direct_own is not None and len(d.names) == 1 and d.direct is not None:
+            direct = direct_own
+        if not own_names and not own_guards:
+            continue
+        composed.dest.append(Dest(d.key, own_names, own_guards, direct,
+                                  "%s  [via %s]" % (d.text, base_from), d.line))
+
+    # Resolve the base's pass-through slots against the dict the subclass fills.
+    # `Checkbox` builds a local `options` dict of icon/indicator keys and hands
+    # it down as `_internal_options=`, which the base merges wholesale. Without
+    # this step those parameters read as "referenced but never forwarded".
+    for slot in base_fwd.passthrough:
+        arg = argmap.get(slot)
+        if not isinstance(arg, ast.Name):
+            composed.opaque.append("pass-through slot %r unresolved" % slot)
+            continue
+        local = Forwarding()
+        _dict_writes(init, arg.id, catchall, local)
+        for d in local.dest:
+            composed.dest.append(Dest(d.key, d.names, d.guards, d.direct,
+                                      "%s  [via %s=%s]" % (d.text, slot, arg.id),
+                                      d.line))
+    return composed, init, init_from
+
+
+def leftover_policy(fn: ast.FunctionDef, forwards_catchall: bool) -> str:
+    """What happens to a name the wrapper does not recognise.
+
+    `_split_layout_kwargs` strips the layout keys in place; whatever is left is
+    either forwarded to the internal (where it raises), rejected explicitly, or
+    silently discarded. Only the third is mode 3.
+    """
+    _params, catchall = init_params(fn)
+    if not catchall:
+        return "no catch-all"
+    splits = any(isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
+                 and n.func.attr == "_split_layout_kwargs" for n in ast.walk(fn))
+    if not splits:
+        return "no split"
+    if forwards_catchall:
+        return "forwarded"
+    for node in ast.walk(fn):
+        # `if kwargs: raise` -- a LEFTOVER guard. NOT `if "textsignal" in kwargs:
+        # raise`, which rejects one known name and says nothing about the rest.
+        # Accepting the looser test credited Select, DateField, NumberField and
+        # TimeField with rejecting unknown names; all four construct silently.
+        # Measured, not reasoned: see `--arm leftovers`.
+        if isinstance(node, ast.If) and isinstance(node.test, ast.Name) \
+                and node.test.id == catchall:
+            if any(isinstance(n, ast.Raise) for n in ast.walk(node)):
+                return "rejected"
+    return "dropped"
+
+
+def local_origins(fn: ast.FunctionDef, params: list[str]) -> dict[str, set[str]]:
+    """Map each local name to the parameters its value derives from.
+
+    `ToggleButton` computes `resolved_on = on_icon if on_icon is not None else
+    icon` and files THAT into the options dict. Matching on the parameter name
+    alone would report `on_icon` and `icon` as never forwarded, which is the
+    same false-clean the existing grep produces.
+    """
+    origins: dict[str, set[str]] = {}
+    pset = set(params)
+    for _ in range(3):                     # fixpoint; three passes is plenty
+        changed = False
+        for target, value in _assignments(fn):
+            if not isinstance(target, ast.Name):
+                continue
+            derived: set[str] = set()
+            for n in names_in(value):
+                if n in pset:
+                    derived.add(n)
+                elif n in origins:
+                    derived |= origins[n]
+            if derived and origins.get(target.id) != origins.get(target.id, set()) | derived:
+                origins[target.id] = origins.get(target.id, set()) | derived
+                changed = True
+        if not changed:
+            break
+    return origins
+
+
+def expand(names: set[str], origins: dict[str, set[str]], params: set[str]) -> set[str]:
+    """Resolve a Dest's name set back to the parameters that fed it."""
+    out = {n for n in names if n in params}
+    for n in names:
+        if n not in params and n in origins:
+            out |= origins[n]
+    return out
+
+
+def param_uses(fn: ast.FunctionDef, param: str) -> list[int]:
+    """Lines in the body (not the signature) that mention `param`."""
+    return sorted({n.lineno for n in ast.walk(fn)
+                   if isinstance(n, ast.Name) and n.id == param})
+
+
+def classify_other_use(fn: ast.FunctionDef, param: str) -> str:
+    """Why a parameter that reaches no internal kwarg is still referenced."""
+    via_calls: list[str] = []
+    stored = False
+
+    # A second widget: several wrappers build a content FRAME beside the widget
+    # this audit calls "the internal" (App and Window build the root, then a
+    # FlexFrame for content). Those parameters ARE forwarded -- just not to the
+    # object the tool measured -- and saying so is the difference between a
+    # finding and a false alarm.
+    dict_vars: set[str] = set()
+    for target, value in _assignments(fn):
+        if param not in names_in(value):
+            continue
+        if isinstance(target, ast.Subscript) and isinstance(target.value, ast.Name):
+            dict_vars.add(target.value.id)
+        elif isinstance(target, ast.Name) and isinstance(value, ast.Dict):
+            dict_vars.add(target.id)
+    for target, value in _assignments(fn):
+        if isinstance(target, ast.Name) and isinstance(value, ast.Dict):
+            for k, v in zip(value.keys, value.values):
+                if k is not None and param in names_in(v):
+                    dict_vars.add(target.id)
+    if dict_vars:
+        for node in ast.walk(fn):
+            if not isinstance(node, ast.Call):
+                continue
+            for kw in node.keywords:
+                if kw.arg is None and isinstance(kw.value, ast.Name) \
+                        and kw.value.id in dict_vars:
+                    callee = (node.func.id if isinstance(node.func, ast.Name)
+                              else ast.unparse(node.func))
+                    return "into %s, splatted into %s() -- a SECOND widget, not " \
+                           "the internal measured here" % (kw.value.id, callee)
+
+    for node in ast.walk(fn):
+        if isinstance(node, ast.Call):
+            args = list(node.args) + [k.value for k in node.keywords]
+            if any(param in names_in(a) for a in args):
+                func = node.func
+                if isinstance(func, ast.Attribute):
+                    owner = ast.unparse(func.value)
+                    via_calls.append("%s.%s()" % (owner, func.attr)
+                                     if owner in ("self", "self._internal")
+                                     else "%s()" % func.attr)
+                elif isinstance(func, ast.Name):
+                    via_calls.append("%s()" % func.id)
+        if isinstance(node, ast.Assign):
+            for t in node.targets:
+                if isinstance(t, ast.Attribute) and isinstance(t.value, ast.Name) \
+                        and t.value.id == "self" and param in names_in(node.value):
+                    stored = True
+    if via_calls:
+        uniq = sorted(set(via_calls))
+        return "passed to %s" % ", ".join(uniq[:3])
+    if stored:
+        return "stored on self, never forwarded"
+    return "referenced but neither forwarded nor stored"
+
+
+# --------------------------------------------------------------------------
+# the internal side -- resolved at runtime, so the oracle is the real signature
+# --------------------------------------------------------------------------
+
+def resolve_internal(expr: str, aliases: dict[str, str], internal_cls_name: str | None):
+    """Import the internal class the wrapper builds. Returns (cls, note)."""
+    name = expr
+    if name.startswith("self."):
+        if internal_cls_name is None:
+            return None, "self._internal_class is not bound in this module"
+        name = internal_cls_name
+    dotted = aliases.get(name)
+    if dotted is None:
+        return None, "no import binds %r in this module" % name
+    mod_path, _, attr = dotted.rpartition(".")
+    try:
+        mod = importlib.import_module(mod_path)
+    except ImportError as exc:
+        return None, "import %s failed: %s" % (mod_path, exc)
+    cls = getattr(mod, attr, None)
+    if cls is None:
+        return None, "%s has no attribute %r" % (mod_path, attr)
+    return cls, ""
+
+
+_UNPACK = __import__("re").compile(r"Unpack\[\s*([A-Za-z_][A-Za-z0-9_]*)\s*\]")
+
+
+def internal_signature(cls) -> tuple[set[str], bool, str]:
+    """What the internal accepts: (names, still open-ended, note).
+
+    Naming the parameters is not enough. The internals take
+    `**kwargs: Unpack[SomeKwargs]` and declare their real vocabulary in that
+    TypedDict -- `OptionMenu` names four parameters and accepts twenty-four.
+    A tool reading only the signature concludes every destination key is
+    unrecognised, and then has to disable the check entirely to avoid drowning
+    in false alarms. Resolving the TypedDict (which merges its bases' keys at
+    class creation) turns the destination check back on.
+    """
+    names: set[str] = set()
+    var_kw = False
+    open_ended = False
+    # Union the WHOLE mro, not just this class. `TimeEntry` names eight
+    # parameters and hands the rest to `Field`, which is where `readonly` is
+    # accepted -- a first pass read only the leaf class and reported
+    # `TimeField(read_only=True)` as writing a key nothing accepts. It works;
+    # the tool was wrong. A vocabulary that stops at the leaf manufactures
+    # false alarms in exactly the wrappers that delegate most.
+    for klass in getattr(cls, "__mro__", [cls]):
+        init = klass.__dict__.get("__init__")
+        if init is None:
+            continue
+        try:
+            sig = inspect.signature(init)
+        except (ValueError, TypeError) as exc:
+            return set(), True, "signature unavailable: %s" % exc
+        for p in sig.parameters.values():
+            if p.name == "self":
+                continue
+            if p.kind is inspect.Parameter.VAR_KEYWORD:
+                var_kw = True
+                ann = p.annotation
+                match = _UNPACK.search(ann if isinstance(ann, str) else "")
+                resolved = False
+                if match:
+                    mod = sys.modules.get(klass.__module__)
+                    td = getattr(mod, match.group(1), None) if mod else None
+                    keys = getattr(td, "__annotations__", None)
+                    if keys:
+                        names |= set(keys)
+                        resolved = True
+                if not resolved:
+                    open_ended = True
+            elif p.kind is not inspect.Parameter.VAR_POSITIONAL:
+                names.add(p.name)
+    note = "" if not var_kw else (
+        "vocabulary is the union over the internal's mro"
+        if not open_ended
+        else "some class in the mro takes an unannotated **kwargs -- the "
+             "vocabulary is open-ended and destinations are NOT checked")
+    return names, open_ended, note
+
+
+# --------------------------------------------------------------------------
+# mode 5 -- an annotation that cannot be produced
+# --------------------------------------------------------------------------
+
+def _getattr_none_property(fn: ast.FunctionDef):
+    """`@property def x(self) -> T | None: return getattr(self._internal, 'a', None)`"""
+    if not any(isinstance(d, ast.Name) and d.id == "property" for d in fn.decorator_list):
+        return None
+    ann = ast.unparse(fn.returns) if fn.returns is not None else ""
+    if "None" not in ann:
+        return None
+    body = [n for n in fn.body
+            if not (isinstance(n, ast.Expr) and isinstance(n.value, ast.Constant))]
+    if len(body) != 1 or not isinstance(body[0], ast.Return):
+        return None
+    call = body[0].value
+    if not (isinstance(call, ast.Call) and isinstance(call.func, ast.Name)
+            and call.func.id == "getattr" and len(call.args) == 3):
+        return None
+    obj, attr, default = call.args
+    if not (isinstance(obj, ast.Attribute) and obj.attr == "_internal"):
+        return None
+    if not (isinstance(attr, ast.Constant) and isinstance(attr.value, str)):
+        return None
+    if not (isinstance(default, ast.Constant) and default.value is None):
+        return None
+    return ann.strip('"\''), attr.value, fn.lineno
+
+
+def internal_can_be_absent(internal, attr: str) -> tuple[str, str]:
+    """Can `getattr(internal, attr, None)` ever fall through to the default?"""
+    if internal is None:
+        return "UNKNOWN", "internal class unresolved"
+    member = inspect.getattr_static(internal, attr, None)
+    if member is None:
+        return "OK", ("the internal has no class-level %r, so the instance "
+                      "attribute may legitimately be absent" % attr)
+    if isinstance(member, property):
+        try:
+            src = inspect.getsource(member.fget)
+        except (OSError, TypeError) as exc:
+            return "UNKNOWN", "property source unavailable: %s" % exc
+        # A property ALWAYS resolves, so the getattr default is dead. The only
+        # way the wrapper can still answer None is the property itself doing so.
+        if "return None" in src or "or None" in src:
+            return "OK", "the internal property has a `return None` path"
+        return "DEAD-DEFAULT", (
+            "the internal defines %r as a property with no None path, so the "
+            "getattr default is unreachable and `| None` cannot occur" % attr)
+    return "OK", "the internal binds %r as %s" % (attr, type(member).__name__)
+
+
+# --------------------------------------------------------------------------
+# the scan
+# --------------------------------------------------------------------------
+
+MODE_NAMES = {
+    1: "never forwarded",
+    2: "wrong destination",
+    3: "swallowed as a layout key",
+    5: "the type lies",
+}
+
+
+def public_names() -> set[str]:
+    """Names the framework actually exports, resolved at runtime."""
+    names: set[str] = set()
+    try:
+        import bootstack
+        names |= set(getattr(bootstack, "__all__", []))
+        import bootstack.widgets as _w
+        names |= set(getattr(_w, "__all__", []))
+        import bootstack.dialogs as _d
+        names |= set(getattr(_d, "__all__", []))
+    except ImportError as exc:
+        print("WARNING: could not import bootstack to resolve the export list "
+              "(%s); falling back to name-based publicity" % exc)
+    return names
+
+
+def scan(src: Path) -> dict:
+    trees, failures = load_module_asts(src)
+    found = len(list(src.glob("*.py")))
+    exported = public_names()
+
+    rows: list[dict] = []
+    skipped: list[tuple[str, str]] = []
+    mode5: list[dict] = []
+    idioms: dict[str, int] = {}
+
+    def bump(key: str) -> None:
+        idioms[key] = idioms.get(key, 0) + 1
+
+    for module, tree in sorted(trees.items()):
+        aliases = import_alias_map(tree)
+        classes = classes_of(tree)
+
+        for cname in sorted(classes):
+            if cname.startswith("_"):
+                continue
+            if exported and cname not in exported:
+                skipped.append(("%s.%s" % (module, cname), "not in a public __all__"))
+                continue
+
+            fwd, init, init_from = analyse_chain(cname, classes, aliases)
+            if init is None:
+                skipped.append(("%s.%s" % (module, cname),
+                                "no __init__ in this module's class graph"))
+                continue
+            params, catchall = init_params(init)
+            icname, _ = find_in_mro(cname, classes, _own_internal_class)
+            inherited = None if init_from == cname else init_from
+
+            internal, note = (None, "")
+            if fwd.understood and fwd.internal_expr:
+                internal, note = resolve_internal(fwd.internal_expr, aliases, icname)
+
+            base = {"module": module, "class": cname, "inherited_init": inherited,
+                    "via": fwd.via}
+
+            if not fwd.understood:
+                bump("UNANALYZED: %s" % fwd.why_not)
+                for pname in params:
+                    if pname in ("parent", "master"):
+                        continue
+                    uses = param_uses(init, pname)
+                    rows.append(dict(base, param=pname, dest="-",
+                                     verdict="UNANALYZED" if uses else "UNUSED",
+                                     mode=None if uses else 1, note=fwd.why_not))
+                continue
+
+            bump("understood: %s%s" % (
+                "direct keywords" if not fwd.splat_vars
+                else "dict splat (%s)" % ",".join(fwd.splat_vars),
+                " via super()" if fwd.via else ""))
+            isig, ivar_kw, isig_note = (internal_signature(internal) if internal
+                                        else (set(), True, note))
+
+            pset = set(params)
+            origins = local_origins(init, params)
+            if fwd.terminal is not None and fwd.terminal is not init:
+                for k, v in local_origins(fwd.terminal, params).items():
+                    origins[k] = origins.get(k, set()) | v
+            for d in fwd.dest:
+                d.names = expand(d.names, origins, pset) | (d.names & pset)
+                d.guards = expand(d.guards, origins, pset) | (d.guards & pset)
+
+            for pname in params:
+                if pname in ("parent", "master"):
+                    continue
+                by_value = [d for d in fwd.dest if pname in d.names]
+                by_guard = [d for d in fwd.dest if pname in d.guards and pname not in d.names]
+                uses = param_uses(init, pname)
+
+                if not by_value and not by_guard:
+                    if not uses:
+                        rows.append(dict(base, param=pname, dest="-", verdict="UNUSED",
+                                         mode=1,
+                                         note="the name appears nowhere in the "
+                                              "__init__ body"))
+                    else:
+                        rows.append(dict(base, param=pname, dest="-",
+                                         verdict="USED-ELSEWHERE", mode=None,
+                                         note=classify_other_use(init, pname)))
+                    continue
+
+                for d in by_value:
+                    direct = d.direct == pname
+                    if d.key == pname:
+                        verdict, mode = ("FORWARDED" if direct
+                                         else "FORWARDED-TRANSFORMED"), None
+                    else:
+                        verdict, mode = ("RENAMED" if direct
+                                         else "RENAMED-TRANSFORMED"), 2
+                    why = isig_note
+                    if internal is not None and not ivar_kw and d.key not in isig:
+                        verdict, mode = "DEST-NOT-A-PARAM", 2
+                        why = "the internal %s does not accept %r" % (
+                            internal.__name__, d.key)
+                    # THE RANKING SIGNAL. A rename is ordinary (`max_value` ->
+                    # `maxvalue`). A rename is SUSPECT when the internal also
+                    # has a parameter of the wrapper's own name -- the wrapper
+                    # had that slot available and passed it over. That is
+                    # exactly the shape of #458 and #461: `signal` existed on
+                    # the internal and the wrapper wrote `textsignal`.
+                    collision = (internal is not None and mode == 2
+                                 and pname in isig and d.key != pname)
+                    if collision:
+                        why = ("the internal %s ALSO has a %r parameter and the "
+                               "wrapper writes %r instead" % (
+                                   internal.__name__, pname, d.key))
+                    rows.append(dict(base, param=pname, dest=d.key, verdict=verdict,
+                                     mode=mode, expr=d.text, line=d.line, note=why,
+                                     collision=collision))
+
+                for d in by_guard:
+                    why = isig_note
+                    verdict, mode = "CONDITIONAL", None
+                    if internal is not None and not ivar_kw and d.key not in isig:
+                        verdict, mode = "DEST-NOT-A-PARAM", 2
+                        why = "the internal %s does not accept %r" % (
+                            internal.__name__, d.key)
+                    rows.append(dict(base, param=pname, dest=d.key, verdict=verdict,
+                                     mode=mode, expr="if %s: -> %s=%s" % (
+                                         pname, d.key, d.text),
+                                     line=d.line, note=why))
+
+            # mode 3 -- unknown names silently dropped
+            if catchall:
+                policy = leftover_policy(fwd.terminal or init, fwd.forwards_catchall)
+                if policy == "dropped":
+                    rows.append(dict(base, param="**%s" % catchall, dest="-",
+                                     verdict="LEFTOVERS-DROPPED", mode=3,
+                                     note="_split_layout_kwargs() strips the layout "
+                                          "keys and nothing reads what is left, so "
+                                          "an unknown name is accepted silently"))
+                else:
+                    rows.append(dict(base, param="**%s" % catchall, dest="-",
+                                     verdict="LEFTOVERS-" + policy.upper(),
+                                     mode=None, note="unknown-name policy: %s" % policy))
+
+            # mode 5 -- resolved against the internal this class actually builds
+            prop, prop_from = find_in_mro(
+                cname, classes,
+                lambda c: next((_getattr_none_property(f) for f in c.body
+                                if isinstance(f, ast.FunctionDef)
+                                and _getattr_none_property(f) is not None), None))
+            if prop is not None:
+                ann, attr, line = prop
+                verdict, why = internal_can_be_absent(internal, attr)
+                mode5.append({"module": module, "class": cname, "property": "signal",
+                              "annotation": ann, "internal_attr": attr, "line": line,
+                              "verdict": verdict, "why": why,
+                              "defined_on": None if prop_from == cname else prop_from})
+
+    # DIVERGENCE -- the ranking signal that actually separates #458/#461 from a
+    # cosmetic rename. `max_value -> maxvalue` is one public name landing on one
+    # internal key everywhere it appears; nobody has to look at it. A public
+    # name that lands on DIFFERENT internal keys in different wrappers means the
+    # family disagrees with itself, and that is where both #458 and #461 lived
+    # (`signal` -> `signal` on the boolean controls, `signal` -> `textsignal` on
+    # SelectButton). It is also the mechanical form of what #460 and #369
+    # describe: a family decision nobody made.
+    # Value flows only. A guard-driven write (`if icon_only: kw['compound']=...`)
+    # says nothing about where `icon_only` is stored, and counting it made
+    # `text`, `image` and `icon` all look divergent because Label guards one
+    # `compound` write with several of them.
+    VALUE_FLOW = {"FORWARDED", "FORWARDED-TRANSFORMED", "RENAMED",
+                  "RENAMED-TRANSFORMED", "DEST-NOT-A-PARAM"}
+    div: dict[str, dict[str, list[str]]] = {}
+    for r in rows:
+        dest = r.get("dest")
+        if r["verdict"] not in VALUE_FLOW:
+            continue
+        if dest and dest != "-" and not r["param"].startswith("**"):
+            div.setdefault(r["param"], {}).setdefault(dest, []).append(
+                "%s.%s" % (r["module"], r["class"]))
+    divergent = {p: m for p, m in div.items() if len(m) > 1}
+    for r in rows:
+        r["divergent"] = r["param"] in divergent
+
+    return {"rows": rows, "skipped": skipped, "mode5": mode5, "idioms": idioms,
+            "divergent": divergent,
+            "files_found": found, "files_parsed": len(trees), "failures": failures,
+            "src": str(src)}
+
+
+# --------------------------------------------------------------------------
+# reporting
+# --------------------------------------------------------------------------
+
+def report(res: dict, verbose: bool = False) -> None:
+    rows = res["rows"]
+    print("=" * 78)
+    print("WRAPPER / INTERNAL PARAMETER DELTA -- #463")
+    print("=" * 78)
+    print("src             : %s" % res["src"])
+    print("files found     : %d" % res["files_found"])
+    print("files parsed    : %d" % res["files_parsed"])
+    if res["failures"]:
+        print("PARSE FAILURES  : %d  <-- the scan is INCOMPLETE" % len(res["failures"]))
+        for f in res["failures"]:
+            print("   %s" % f)
+    else:
+        print("parse failures  : 0")
+    assert res["files_parsed"] + len(res["failures"]) == res["files_found"], (
+        "files_parsed + failures != files_found -- files vanished silently")
+
+    classes = sorted({(r["module"], r["class"]) for r in rows})
+    params = sorted({(r["module"], r["class"], r["param"]) for r in rows
+                     if not r["param"].startswith("**")})
+    print("classes analysed: %d" % len(classes))
+    print("distinct params : %d" % len(params))
+    print()
+
+    print("IDIOMS -- what the tool understands, and therefore what it can speak about")
+    print("-" * 78)
+    for k, v in sorted(res["idioms"].items(), key=lambda kv: (-kv[1], kv[0])):
+        print("  %4d  %s" % (v, k))
+    print()
+
+    def line_for(r: dict) -> str:
+        inh = ""
+        if r.get("via"):
+            inh = "  [%s]" % r["via"]
+        elif r.get("inherited_init"):
+            inh = "  (init from %s)" % r["inherited_init"]
+        return "  %-26s %-20s -> %-22s %s%s" % (
+            "%s.%s" % (r["module"], r["class"]), r["param"], r.get("dest", "-"),
+            r["verdict"], inh)
+
+    for mode in (2, 1, 3):
+        hits = [r for r in rows if r.get("mode") == mode]
+        print("MODE %d -- %s : %d" % (mode, MODE_NAMES[mode], len(hits)))
+        print("-" * 78)
+        if mode == 2:
+            top = [r for r in hits if r.get("divergent") or r.get("collision")]
+            rest = [r for r in hits if not (r.get("divergent") or r.get("collision"))]
+            print("  RANK A -- the public name lands on a DIFFERENT internal key in")
+            print("            some other wrapper: the family disagrees : %d" % len(top))
+            print("            (this is the shape of #458 and #461)")
+            for r in sorted(top, key=lambda r: (r["param"], r["module"], r["class"])):
+                print(line_for(r))
+            print()
+            print("  RANK B -- one public name, one internal key everywhere it")
+            print("            appears: a consistent rename : %d" % len(rest))
+            hits = rest
+        for r in sorted(hits, key=lambda r: (r["module"], r["class"], r["param"])):
+            print(line_for(r))
+            if verbose and r.get("expr"):
+                print("        expr: %s   (line %s)" % (r["expr"], r.get("line")))
+            if verbose and r.get("note"):
+                print("        %s" % r["note"])
+        print()
+
+    print("UNKNOWN-NAME POLICY -- what each wrapper does with a keyword it does")
+    print("not recognise (cross-checked against real construction by --arm leftovers)")
+    print("-" * 78)
+    pol: dict[str, list[str]] = {}
+    for r in rows:
+        if r["param"].startswith("**"):
+            pol.setdefault(r["verdict"].replace("LEFTOVERS-", ""), []).append(r["class"])
+    for k in sorted(pol, key=lambda k: -len(pol[k])):
+        print("  %-10s %3d  %s" % (k, len(pol[k]), ", ".join(sorted(pol[k])[:8])
+                                   + ("" if len(pol[k]) <= 8 else " ...")))
+    if "REJECTED" in pol:
+        print()
+        print("  The %d REJECTED wrappers are the precedent #383 gap 3 needs: the"
+              % len(pol["REJECTED"]))
+        print("  guard already exists in this codebase and is six lines long.")
+    print()
+
+    m5 = [f for f in res["mode5"] if f["verdict"] == "DEAD-DEFAULT"]
+    other = [f for f in res["mode5"] if f["verdict"] != "DEAD-DEFAULT"]
+    print("MODE 5 -- %s : %d" % (MODE_NAMES[5], len(m5)))
+    print("-" * 78)
+    for f in sorted(m5, key=lambda f: (f["module"], f["class"])):
+        where = "" if not f["defined_on"] else "  (property on %s)" % f["defined_on"]
+        print("  %-26s .%-8s %-22s line %d%s" % (
+            "%s.%s" % (f["module"], f["class"]), f["property"], f["annotation"],
+            f["line"], where))
+        if verbose:
+            print("        %s" % f["why"])
+    if other:
+        print("  -- checked and CLEARED (the None is reachable):")
+        for f in sorted(other, key=lambda f: (f["module"], f["class"])):
+            print("     %-26s %-14s %s" % (
+                "%s.%s" % (f["module"], f["class"]), f["verdict"], f["why"]))
+    print()
+
+    print("DIVERGENCE -- one public name, more than one internal destination : %d"
+          % len(res["divergent"]))
+    print("-" * 78)
+    print("  Read this list first. A name here means the wrapper family does not")
+    print("  agree on where the parameter goes; #458 and #461 are both instances.")
+    for pname in sorted(res["divergent"]):
+        dests = res["divergent"][pname]
+        print("  %-20s %d destinations" % (pname, len(dests)))
+        for key in sorted(dests):
+            who = sorted(set(dests[key]))
+            print("      -> %-22s %s%s" % (
+                key, ", ".join(w.split(".")[-1] for w in who[:5]),
+                "" if len(who) <= 5 else " (+%d more)" % (len(who) - 5)))
+    print()
+
+    cond = [r for r in rows if r["verdict"] == "CONDITIONAL"]
+    print("CONDITIONAL -- forwarded by a guard, not by value : %d" % len(cond))
+    print("-" * 78)
+    if verbose:
+        for r in sorted(cond, key=lambda r: (r["module"], r["class"], r["param"])):
+            print("  %-26s %s" % ("%s.%s" % (r["module"], r["class"]), r["expr"]))
+    else:
+        seen: dict[str, list[str]] = {}
+        for r in cond:
+            seen.setdefault("%s -> %s" % (r["param"], r["dest"]), []).append(r["class"])
+        for k in sorted(seen):
+            print("  %-34s %d class(es): %s" % (
+                k, len(seen[k]), ", ".join(sorted(set(seen[k]))[:6])))
+    print()
+
+    unan = [r for r in rows if r["verdict"] == "UNANALYZED"]
+    if unan:
+        byclass: dict[str, int] = {}
+        for r in unan:
+            key = "%s.%s" % (r["module"], r["class"])
+            byclass[key] = byclass.get(key, 0) + 1
+        print("UNANALYZED -- the tool CANNOT speak about these; do NOT read as clean")
+        print("-" * 78)
+        for k, v in sorted(byclass.items()):
+            note = next(r["note"] for r in unan
+                        if "%s.%s" % (r["module"], r["class"]) == k)
+            print("  %-28s %3d params   (%s)" % (k, v, note))
+        print()
+
+    triage = [r for r in rows if r["verdict"] == "USED-ELSEWHERE"]
+    print("USED-ELSEWHERE -- reaches no internal kwarg; needs a human : %d" % len(triage))
+    print("-" * 78)
+    for r in sorted(triage, key=lambda r: (r["module"], r["class"], r["param"])):
+        print("  %-26s %-20s %s" % (
+            "%s.%s" % (r["module"], r["class"]), r["param"], r["note"]))
+    print()
+
+    print("MODE 4 -- accepted then ignored : NOT MEASURED BY THIS ARM")
+    print("-" * 78)
+    print("  Mode 4 is not statically decidable and this probe does not claim to")
+    print("  find it. `--arm roundtrip` is a PARTIAL heuristic; read its own")
+    print("  honesty note before quoting it.")
+    print()
+
+    print("SKIPPED CLASSES : %d" % len(res["skipped"]))
+    print("-" * 78)
+    if verbose:
+        for name, why in res["skipped"]:
+            print("  %-38s %s" % (name, why))
+    else:
+        reasons: dict[str, int] = {}
+        for _, why in res["skipped"]:
+            reasons[why] = reasons.get(why, 0) + 1
+        for k, v in sorted(reasons.items(), key=lambda kv: -kv[1]):
+            print("  %4d  %s" % (v, k))
+
+
+# --------------------------------------------------------------------------
+# controls -- a probe that finds nothing must be proven able to find something
+# --------------------------------------------------------------------------
+
+def materialize(commit: str, src_rel: str) -> Path:
+    """Write `src_rel` at `commit` into a temp dir. Portable: git show only."""
+    out = Path(tempfile.mkdtemp(prefix="wrapdelta_"))
+    listing = subprocess.check_output(
+        ["git", "ls-tree", "--name-only", commit, src_rel.replace("\\", "/") + "/"]
+    ).decode("utf-8").split()
+    for rel in listing:
+        if not rel.endswith(".py"):
+            continue
+        blob = subprocess.check_output(["git", "show", "%s:%s" % (commit, rel)])
+        (out / Path(rel).name).write_bytes(blob)
+    return out
+
+
+PRE_458 = "1f9a62d1^"    # parent of the #458 fix -- the last commit with the defect
+
+
+def control(src: Path) -> int:
+    """The four known positives. Three are OPEN on main and must be FOUND;
+    #458 is FIXED and must appear at the pre-fix commit and NOT on main."""
+    print("=" * 78)
+    print("NON-VACUITY CONTROLS")
+    print("=" * 78)
+    failures = 0
+    res = scan(src)
+    rows = res["rows"]
+
+    def has(cls: str, param: str, mode: int, dest: str | None = None) -> bool:
+        return any(
+            r["class"] == cls and r["param"] == param and r.get("mode") == mode
+            and (dest is None or r.get("dest") == dest)
+            for r in rows
+        )
+
+    dead = [f["class"] for f in res["mode5"] if f["verdict"] == "DEAD-DEFAULT"]
+    checks = [
+        ("#461   SelectButton signal= -> textsignal= (mode 2, OPEN)",
+         has("SelectButton", "signal", 2, "textsignal"), True),
+        ("#460   .signal annotated `| None` it cannot return (mode 5, OPEN)",
+         len(dead) >= 8, True),
+        ("#383g3 TextField accepts an unknown name silently (mode 3, OPEN)",
+         has("TextField", "**kwargs", 3), True),
+        ("#458   Select signal= -> textsignal= (mode 2, FIXED on main)",
+         has("Select", "signal", 2, "textsignal"), False),
+    ]
+    for label, got, want in checks:
+        ok = got == want
+        failures += 0 if ok else 1
+        print("  [%s] %-58s found=%-5s want=%s" % (
+            "PASS" if ok else "FAIL", label, got, want))
+    print("         (#460 names EIGHT widgets; this scan finds %d: %s)" % (
+        len(dead), ", ".join(sorted(dead))))
+
+    print()
+    print("  #458 is the strongest control available -- a real instance of the")
+    print("  exact mode the tool exists to catch, with a known before and after.")
+    print("  The same scan run against the pre-fix commit MUST find it:")
+    print()
+    # `1f9a62d1` is the fix ("fix(select): bind signal= to the option's value,
+    # not the entry text (#458)"); its parent is the last commit carrying the
+    # defect. NOT `main~` -- main~ is two docs commits after the merge, and a
+    # first pass used it and got a false PASS-shaped FAIL. The commit that
+    # bounds a control has to be the one the defect actually lived in.
+    try:
+        old = materialize(PRE_458, "src/bootstack/widgets")
+        old_res = scan(old)
+        found_old = any(
+            r["class"] == "Select" and r["param"] == "signal"
+            and r.get("mode") == 2 and r.get("dest") == "textsignal"
+            for r in old_res["rows"]
+        )
+        failures += 0 if found_old else 1
+        print("  [%s] %-58s found=%-5s want=True" % (
+            "PASS" if found_old else "FAIL",
+            "#458 at %s (the pre-fix commit)" % PRE_458,
+            found_old))
+        print("        (%d files parsed there, parse failures: %d)" % (
+            old_res["files_parsed"], len(old_res["failures"])))
+    except (subprocess.CalledProcessError, OSError) as exc:
+        failures += 1
+        print("  [FAIL] could not materialize %s: %s" % (PRE_458, exc))
+
+    print()
+    print("CONTROLS: %s" % (
+        "ALL PASS -- a null result from this tool is meaningful" if failures == 0
+        else "%d FAILED -- do NOT trust a null result" % failures))
+    return failures
+
+
+# --------------------------------------------------------------------------
+# mode 4 heuristic -- runtime, and honest about what it cannot see
+# --------------------------------------------------------------------------
+
+ROUNDTRIP_LIMITS = """
+  WHAT THIS ARM DOES: constructs each wrapper with one non-default value for a
+  parameter that has a same-named public property, then reads the property back.
+  A disagreement is a mode-4 CANDIDATE.
+
+  WHAT IT CANNOT SEE, stated up front so a null result is not over-read:
+    * #453 -- the defect this mode is named for -- WOULD NOT BE CAUGHT. The
+      wrapper's own `read_only` property answered True for every Select; the
+      only honest observable was the inner entry's ttk state. A property that
+      echoes the stored setting cannot witness the setting being ignored.
+    * A parameter with no same-named property is not tested at all.
+    * A widget that will not construct headless is SKIPPED, not cleared.
+"""
+
+
+def roundtrip(src: Path) -> int:
+    print("=" * 78)
+    print("MODE 4 ROUNDTRIP HEURISTIC")
+    print("=" * 78)
+    print(ROUNDTRIP_LIMITS)
+    try:
+        import bootstack as bs
+    except ImportError as exc:
+        print("  SKIP: bootstack did not import (%s)" % exc)
+        return 0
+
+    res = scan(src)
+    classes = sorted({r["class"] for r in res["rows"]})
+    try:
+        app = bs.App(title="probe")
+    except Exception as exc:                    # noqa: BLE001 -- reported, not hidden
+        print("  SKIP: no display / App would not build (%s: %s)"
+              % (type(exc).__name__, exc))
+        return 0
+
+    checked = mismatched = skipped = 0
+    findings = []
+    with app:
+        for cname in classes:
+            cls = getattr(bs, cname, None)
+            if cls is None:
+                continue
+            try:
+                sig = inspect.signature(cls.__init__)
+            except (ValueError, TypeError):
+                continue
+            for pname, p in sig.parameters.items():
+                if pname in ("self", "parent") or p.kind in (
+                        inspect.Parameter.VAR_KEYWORD,
+                        inspect.Parameter.VAR_POSITIONAL):
+                    continue
+                if not isinstance(inspect.getattr_static(cls, pname, None), property):
+                    continue
+                default = p.default
+                if isinstance(default, bool):
+                    probe_val = not default
+                elif isinstance(default, str):
+                    probe_val = "probe" if default != "probe" else "other"
+                elif isinstance(default, int):
+                    probe_val = 7 if default != 7 else 9
+                else:
+                    skipped += 1
+                    continue
+                try:
+                    widget = cls(**{pname: probe_val})
+                    got = getattr(widget, pname)
+                except Exception:               # noqa: BLE001 -- construction refused
+                    skipped += 1
+                    continue
+                checked += 1
+                if got != probe_val:
+                    mismatched += 1
+                    findings.append((cname, pname, probe_val, got))
+    print("  checked=%d  mismatched=%d  skipped=%d" % (checked, mismatched, skipped))
+    for cname, pname, sent, got in findings:
+        print("    %-20s %-20s sent=%r read back=%r" % (cname, pname, sent, got))
+    return 0
+
+
+BOGUS = "bogus_zzz_probe"
+
+
+def leftovers(src: Path) -> int:
+    """Cross-check the static mode-3 verdict against what actually happens.
+
+    Constructs every wrapper with an unknown keyword and records whether it
+    raises. The static pass reads the source; this reads the behaviour. A
+    disagreement is a TOOL defect, and the first run of this arm found two --
+    `Select` and `DateField` were credited with rejecting unknown names because
+    they carry an `if "textsignal" in kwargs: raise` guard, which rejects one
+    known name and says nothing about the rest.
+    """
+    print("=" * 78)
+    print("MODE 3 CROSS-CHECK -- static verdict vs actual construction")
+    print("=" * 78)
+    try:
+        import bootstack as bs
+    except ImportError as exc:
+        print("  SKIP: bootstack did not import (%s)" % exc)
+        return 0
+
+    res = scan(src)
+    static = {r["class"]: r["verdict"] for r in res["rows"]
+              if r["param"].startswith("**")}
+    try:
+        app = bs.App(title="probe")
+    except Exception as exc:                    # noqa: BLE001 -- reported, not hidden
+        print("  SKIP: no display / App would not build (%s: %s)"
+              % (type(exc).__name__, exc))
+        return 0
+
+    agree = disagree = inconclusive = 0
+    problems = []
+    with app:
+        for cname, verdict in sorted(static.items()):
+            cls = getattr(bs, cname, None)
+            if cls is None:
+                continue
+            try:
+                cls(**{BOGUS: 1})
+                actual = "dropped"
+            except TypeError as exc:
+                actual = "rejected" if BOGUS in str(exc) else "inconclusive"
+            except Exception as exc:            # noqa: BLE001 -- classified below
+                actual = ("rejected" if BOGUS in str(exc) else "inconclusive")
+            expected = verdict.replace("LEFTOVERS-", "").lower()
+            if actual == "inconclusive":
+                inconclusive += 1
+                continue
+            if (actual == "dropped") == (expected == "dropped"):
+                agree += 1
+            else:
+                disagree += 1
+                problems.append((cname, expected, actual))
+    print("  agree=%d  DISAGREE=%d  inconclusive=%d" % (agree, disagree, inconclusive))
+    for cname, expected, actual in problems:
+        print("    %-22s static says %-10s actually %s" % (cname, expected, actual))
+    print()
+    print("  A disagreement here is a defect in THIS PROBE, not in the wrapper.")
+    return 1 if disagree else 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="wrapper/internal parameter delta (#463)")
+    ap.add_argument("--arm", choices=("scan", "control", "roundtrip", "leftovers"), default="scan")
+    ap.add_argument("--src", default="src/bootstack/widgets")
+    ap.add_argument("--from-commit", default=None,
+                    help="scan the sources as of this commit instead of the worktree")
+    ap.add_argument("-v", "--verbose", action="store_true")
+    args = ap.parse_args()
+
+    if args.from_commit:
+        src = materialize(args.from_commit, args.src)
+        print("(scanning %s as of %s -> %s)" % (args.src, args.from_commit, src))
+    else:
+        src = Path(args.src)
+    if not src.is_dir():
+        print("no such directory: %s" % src)
+        return 2
+
+    if args.arm == "control":
+        return 1 if control(src) else 0
+    if args.arm == "roundtrip":
+        return roundtrip(src)
+    if args.arm == "leftovers":
+        return leftovers(src)
+    report(scan(src), verbose=args.verbose)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/development/wrapper-parameter-audit-463.md
+++ b/development/wrapper-parameter-audit-463.md
@@ -1,0 +1,181 @@
+# Wrapper / internal parameter audit — the measurement pass (#463)
+
+**Issue:** [#463](https://github.com/israel-dryer/bootstack/issues/463) · **Milestone:** `Wrapper and internal parity` (unnumbered)
+**Branch:** `audit/wrapper-parameter-delta`, cut from `main` @ `22f045db`
+**Run:** 2026-08-20, Windows box, `py -3.12`
+**Ships no production code.** `git diff main...HEAD -- src/` is empty and stays empty.
+
+**The instrument:** `development/probe_wrapper_parameter_delta.py`, four arms. Raw output is committed beside it as `wrapper-parameter-delta-{scan,control,leftovers,roundtrip}.txt`.
+
+```
+py -3.12 development/probe_wrapper_parameter_delta.py --arm scan -v
+py -3.12 development/probe_wrapper_parameter_delta.py --arm control
+py -3.12 development/probe_wrapper_parameter_delta.py --arm leftovers     # needs a display
+py -3.12 development/probe_wrapper_parameter_delta.py --arm roundtrip     # needs a display
+```
+
+---
+
+## Read this first: the result in three lines
+
+1. **Modes 1 and 2 are essentially clean.** Zero never-forwarded parameters, and of 100 renamed destinations exactly **one** is a defect — **#461, already filed**. The wrapper layer's forwarding is in better shape than the recent defect run suggested.
+2. **Mode 3 is the real exposure and it is broad: 40 of 52 wrappers silently accept a keyword they do not recognise.** Five wrappers already reject it, with a six-line guard that is in the codebase today. That is #383 gap 3, now measured and with its own precedent.
+3. **Mode 5 is exactly #460 — eight widgets, no more and no fewer.** The scan reproduces that issue's population precisely, which is also the strongest evidence the tool is calibrated.
+
+---
+
+## Non-vacuity — run before believing any of the above
+
+`--arm control`, all five checks **PASS**:
+
+| control | mode | expected | found |
+|---|---|---|---|
+| #461 `SelectButton` `signal=` → `textsignal=` | 2 | present on `main` | ✅ found |
+| #460 `.signal` annotated `\| None` it cannot return | 5 | present on `main` | ✅ found, and **exactly 8 widgets** |
+| #383 gap 3 `TextField` accepts an unknown name silently | 3 | present on `main` | ✅ found |
+| #458 `Select` `signal=` → `textsignal=` | 2 | **absent** on `main` | ✅ absent |
+| #458 at `1f9a62d1^`, the pre-fix commit | 2 | **present** | ✅ found |
+
+⚠ **The `main~` trap, worth keeping.** The first run of the #458 before/after arm used `main~` and failed. `main~` is two `docs(claude):` commits *after* the merge, so the defect was long gone. **The commit that bounds a control has to be the one the defect actually lived in** — here `1f9a62d1^`, the parent of the fix. The control is hardcoded to that SHA with a comment saying why.
+
+**Parse integrity:** 58 files found, 58 parsed, 0 failures, and the report asserts `files_parsed + failures == files_found` rather than trusting it. Sources are read `utf-8-sig`; no bare `except` can swallow a parse failure. (This is the documented BOM trap that once made a completeness scan report zero hits.)
+
+**Mode 3 is cross-checked against reality, not just read.** `--arm leftovers` constructs all 52 wrappers with an unknown keyword and compares the outcome to the static verdict: **51 agree, 0 disagree, 1 inconclusive.**
+
+---
+
+## Scope — the command, not the conclusion
+
+```
+scanned      src/bootstack/widgets/*.py        58 files, 65 public classes, 810 distinct params
+NOT scanned  src/bootstack/dialogs/            (the probe accepts --src; this pass did not run it)
+```
+
+**Five classes the tool cannot speak about — do NOT read them as clean:**
+
+| class | params | why |
+|---|---|---|
+| `AppShell` | 31 | builds no internal in its own `__init__` (`_init_shell` on `_ShellBase`) |
+| `Workbench` | 34 | same |
+| `ThemeToggle` | 5 | composes a `Button`, no internal of its own |
+| `Notification` | 7 | toast host, no internal widget |
+| `Snackbar` | 7 | same |
+
+⚠ **`App`, `Window` and `Splash` were in this list and are now analysed** — they build the root first and alias it (`self._internal = self._tk_root`), which the first version of the tool could not follow. **The PLAN's warning was right and it was worth 84 parameters.**
+
+**Forwarding idioms understood** (a wrapper using one not on this list is reported UNANALYZED, never clean):
+
+- `internal_kwargs` / `kw` / `frame_kwargs` / `lf_kwargs` / `ps_kwargs` / `pw_kwargs` / `init_kwargs` dict splat
+- direct keyword arguments on the construction call
+- one alias hop (`self._tk_root = Internal(...)` … `self._internal = self._tk_root`)
+- `super().__init__()` composition, including positional-to-name mapping
+- pass-through slots (`_internal_options=options` merged wholesale by the base)
+- `internal_kwargs.update(kwargs)`, `for k, v in kwargs.items(): internal_kwargs[k] = v`
+- `for k, v in {"padding": padding, ...}.items(): frame_kwargs[k] = v`
+
+---
+
+## Results by mode
+
+| mode | what | count | verdict |
+|---|---|---|---|
+| 1 | never forwarded | **0** | clean |
+| 2 | wrong destination | 100 rows → **35 rank A / 65 rank B** | **1 defect (#461)**; the rest are internal naming |
+| 3 | swallowed as a layout key | **40 of 52** wrappers | **the finding** |
+| 4 | accepted then ignored | not statically decidable | 1 weak candidate, see below |
+| 5 | the type lies | **8** | **= #460 exactly** |
+
+### Mode 2 — how 100 rows became 1
+
+A rename on its own says nothing (`max_value` → `maxvalue` is ordinary). The ranking signal is **divergence**: a public parameter name that lands on a **different** internal key in some other wrapper means the family disagrees with itself, and that is where both #458 and #461 lived. Sixteen names diverge; all sixteen were read.
+
+| public name | destinations | verdict |
+|---|---|---|
+| **`signal`** | `signal` (9) · `signals` (Chart) · **`textsignal` (SelectButton)** | ⚠ **#461.** Chart normalizes one-or-many into a list — deliberate |
+| `accent` | `accent` (39) · `surface` (Card) | ✅ deliberate — an accented Card is `accent[subtle]` surface *and* accent |
+| `undecorated` | `override_redirect` (App) · `overrideredirect` (Window) | ✅ both correct — the two internals spell it differently |
+| `read_only` | `read_only` · `readonly` · (`state` by guard) | ✅ three internals, three spellings; all work |
+| `options` | `items` · `options` · `values` | ✅ internal naming only |
+| `label` / `title` / `theme` / `variant` / `step` / `max_value` / `show_separators` / `data_source` / `icon` / `width` / `height` | see scan output | ✅ internal naming only |
+
+**So: mode 2 produces no new defect.** ⚠ **That is a negative result and it is only worth something because the controls pass** — the same scan finds #461 on `main` and finds #458 at the pre-fix commit.
+
+⚠ **A note that is real but OUT OF SCOPE by the PLAN's own boundary:** the *internal* layer spells the same concept a dozen ways (`readonly`/`read_only`, `maxvalue`/`maximum`, `items`/`options`/`values`, `override_redirect`/`overrideredirect`). No user can see it. It is an `_impl` defect and the PLAN says those get filed, not chased.
+
+### Mode 3 — 40 wrappers accept anything
+
+`_split_layout_kwargs()` strips the layout keys in place and **nothing reads what is left**, so `bs.TextField(bogus_xyz=1)` constructs silently while the internal `Field(master, bogus_xyz=1)` raises. **The public layer is the less strict of the two.**
+
+| policy | count | wrappers |
+|---|---|---|
+| **DROPPED — silently accepted** | **40** | Accordion, Avatar, Badge, Button, ButtonGroup, Calendar, Card, Carousel, CodeEditor, Column, DataTable, DateField, Divider, Form, Gallery, Gauge, Grid, GroupBox, Label, ListView, NumberField, PageStack, PasswordField, PathField, ProgressBar, RadioGroup, RangeSlider, Row, ScrollView, Select, SelectButton, Slider, SpinnerField, SplitView, Tabs, TextArea, TextField, TimeField, ToggleGroup, Tree |
+| REJECTED — raises `TypeError` naming the key | 5 | Checkbox, Radio, RadioToggleButton, Switch, ToggleButton |
+| FORWARDED — reaches the internal, which raises | 5 | Chart, MenuButton, Picture, StatusBar, Toolbar |
+| no split | 2 | App, Window |
+
+⚠ **`Select`, `DateField`, `NumberField` and `TimeField` look like they reject and do not.** They carry an `if "textsignal" in kwargs: raise` guard, which rejects **one known name** and says nothing about the rest. A first version of the tool credited all four with rejecting; `--arm leftovers` caught it by construction. **A specific-key guard is not a leftover guard**, and the four are the wrappers most likely to be mistaken for strict.
+
+✅ **The fix already exists in this codebase.** `_BooleanControlBase.__init__`:
+
+```python
+layout_kw = self._split_layout_kwargs(kwargs)
+if kwargs:
+    raise TypeError(
+        f"{type(self).__name__}() got unexpected keyword argument(s): "
+        f"{', '.join(sorted(kwargs))}"
+    )
+```
+
+Six lines, already shipped, already covering five public widgets. **#383 gap 3 does not need a design — it needs this pasted at the shared split seam**, which is what that issue's open question ("the obvious home … needs the wrappers that legitimately forward `**kwargs` counted first") was waiting on. **They are now counted: five forward legitimately, two do not split.**
+
+### Mode 5 — exactly #460
+
+Eight widgets annotate `.signal` as `Signal | None` and return `getattr(self._internal, 'signal', None)` where the internal defines `signal` as a lazily-creating property with **no `None` path** — the default is unreachable:
+
+`Checkbox`, `Switch`, `ToggleButton` (via `_BooleanControlBase`), `PasswordField`, `PathField`, `SelectButton`, `SpinnerField`, `TextField`
+
+**`TextArea` was checked and CLEARED** — its internal has no class-level `signal`, so the attribute genuinely can be absent. That matches CLAUDE.md's standing warning not to "fix" TextArea, CodeEditor or the `ValueSignalMixin` trio, and the tool arrives at it independently.
+
+### Mode 4 — one weak candidate, and an honest limit
+
+`--arm roundtrip` constructs each wrapper with a non-default value for a parameter that has a same-named property and reads it back: **80 checked, 1 mismatch, 72 skipped.**
+
+- `Carousel(index=7).index` reads back `0`. **Probably benign** — with no slides loaded there is nothing at index 7 to clamp to. Worth one look, not an issue on its own.
+
+⚠ **This arm would NOT have caught #453**, the defect mode 4 is named for. `Select.read_only` answered `True` for every Select; the only honest observable was the inner entry's ttk state. **A property that echoes the stored setting cannot witness the setting being ignored.** The arm prints this limit before its results so a null is not over-read.
+
+---
+
+## Findings, ranked
+
+| # | finding | mode | evidence | proposed |
+|---|---|---|---|---|
+| **1** | **40 of 52 wrappers silently accept an unrecognised keyword**, while 5 reject it with a guard that already exists | 3 | measured statically, cross-checked by construction (51/51 agree) | **fold the measurement into #383** — it is that issue's gap 3 with the counts it was blocked on |
+| **2** | Eight widgets annotate `.signal` as `\| None` and cannot return it | 5 | scan reproduces #460's population exactly | **already #460**; this pass confirms the list is complete and that `TextArea` is correctly excluded |
+| **3** | `SelectButton` `signal=` → `textsignal=` | 2 | scan rank A | **already #461** |
+| 4 | The `_impl` layer spells one concept several ways | — | divergence table | **note only** — no user impact, out of the PLAN's scope |
+| 5 | `Carousel(index=7).index == 0` | 4? | roundtrip arm | **note only** until someone reproduces it with slides loaded |
+
+**No new issue needs filing.** Every real finding lands on an issue that already exists. The audit's product is the *measurement* those issues were missing — particularly #383 gap 3, which now has its population (40), its precedent (5), and its exclusions (5 forward, 2 no-split).
+
+---
+
+## Tool defects found and fixed during the run
+
+Recorded because a probe whose conclusion will be cited has to show its own error history.
+
+1. **Stopped at the subclass.** 19 classes read as unanalysable because the internal is built in a shared private base (`Checkbox`, `Row`, `Radio`, …). Fixed by composing through `super().__init__()`; ⚠ **without it the tool reported 40-odd parameters as unspeakable and would have looked thorough doing it.**
+2. **Read only the leaf's vocabulary.** Reported `TimeField(read_only=True)` as writing a key nothing accepts. **It works** — `TimeEntry` delegates to `Field`. Fixed by unioning `Unpack[TypedDict]` over the internal's whole MRO. Caught by construction, not by reading.
+3. **Counted a specific-key guard as a leftover guard.** Credited `Select`, `DateField`, `NumberField`, `TimeField` with strictness they do not have. Caught by `--arm leftovers`.
+4. **Missed two merge idioms** — `for k, v in kwargs.items()` (MenuButton) and `for k, v in {...}.items()` (Grid) — producing one false "dropped" and two false "never forwarded".
+5. **Pointed the before/after control at `main~`**, which is after the fix.
+
+⚠ **Four of these five were caught by running something, not by reading something**, and three of them were false alarms pointing at working code. **A static wrapper audit that is not cross-checked against construction will ship false findings** — that is the transferable lesson, and it is why `--arm leftovers` exists.
+
+---
+
+## The durable guard — deliberately not built here
+
+A one-time audit decays. The valuable half is a `test_public_surface.py`-style test at the **parameter** level, designed to these five modes. It is a separate branch and needs this taxonomy to exist first, which it now does.
+
+⚠ The existing `tests/test_public_surface.py` has a blind spot of exactly this kind — it gates the top-level *name set* but never asserts a submodule is unreachable as `bs.*`, which is why the `bs.events.X` drift went uncaught for two months. **Design the new guard to the modes, or it inherits the same shape.**

--- a/development/wrapper-parameter-delta-control.txt
+++ b/development/wrapper-parameter-delta-control.txt
@@ -1,0 +1,17 @@
+﻿==============================================================================
+NON-VACUITY CONTROLS
+==============================================================================
+  [PASS] #461   SelectButton signal= -> textsignal= (mode 2, OPEN)  found=True  want=True
+  [PASS] #460   .signal annotated `| None` it cannot return (mode 5, OPEN) found=True  want=True
+  [PASS] #383g3 TextField accepts an unknown name silently (mode 3, OPEN) found=True  want=True
+  [PASS] #458   Select signal= -> textsignal= (mode 2, FIXED on main) found=False want=False
+         (#460 names EIGHT widgets; this scan finds 8: Checkbox, PasswordField, PathField, SelectButton, SpinnerField, Switch, TextField, ToggleButton)
+
+  #458 is the strongest control available -- a real instance of the
+  exact mode the tool exists to catch, with a known before and after.
+  The same scan run against the pre-fix commit MUST find it:
+
+  [PASS] #458 at 1f9a62d1^ (the pre-fix commit)                     found=True  want=True
+        (58 files parsed there, parse failures: 0)
+
+CONTROLS: ALL PASS -- a null result from this tool is meaningful

--- a/development/wrapper-parameter-delta-leftovers.txt
+++ b/development/wrapper-parameter-delta-leftovers.txt
@@ -1,0 +1,6 @@
+﻿==============================================================================
+MODE 3 CROSS-CHECK -- static verdict vs actual construction
+==============================================================================
+  agree=51  DISAGREE=0  inconclusive=1
+
+  A disagreement here is a defect in THIS PROBE, not in the wrapper.

--- a/development/wrapper-parameter-delta-roundtrip.txt
+++ b/development/wrapper-parameter-delta-roundtrip.txt
@@ -1,0 +1,18 @@
+﻿==============================================================================
+MODE 4 ROUNDTRIP HEURISTIC
+==============================================================================
+
+  WHAT THIS ARM DOES: constructs each wrapper with one non-default value for a
+  parameter that has a same-named public property, then reads the property back.
+  A disagreement is a mode-4 CANDIDATE.
+
+  WHAT IT CANNOT SEE, stated up front so a null result is not over-read:
+    * #453 -- the defect this mode is named for -- WOULD NOT BE CAUGHT. The
+      wrapper's own `read_only` property answered True for every Select; the
+      only honest observable was the inner entry's ttk state. A property that
+      echoes the stored setting cannot witness the setting being ignored.
+    * A parameter with no same-named property is not tested at all.
+    * A widget that will not construct headless is SKIPPED, not cleared.
+
+  checked=80  mismatched=1  skipped=72
+    Carousel             index                sent=7 read back=0

--- a/development/wrapper-parameter-delta-scan.txt
+++ b/development/wrapper-parameter-delta-scan.txt
@@ -1,0 +1,667 @@
+﻿==============================================================================
+WRAPPER / INTERNAL PARAMETER DELTA -- #463
+==============================================================================
+src             : src\bootstack\widgets
+files found     : 58
+files parsed    : 58
+parse failures  : 0
+classes analysed: 65
+distinct params : 810
+
+IDIOMS -- what the tool understands, and therefore what it can speak about
+------------------------------------------------------------------------------
+    37  understood: dict splat (internal_kwargs)
+     5  UNANALYZED: this __init__ builds no internal widget
+     5  understood: dict splat (internal_kwargs) via super()
+     5  understood: direct keywords via super()
+     3  understood: direct keywords
+     2  understood: dict splat (frame_kwargs) via super()
+     2  understood: dict splat (init_kwargs) via super()
+     2  understood: dict splat (kw)
+     1  understood: dict splat (frame_kwargs)
+     1  understood: dict splat (lf_kwargs)
+     1  understood: dict splat (ps_kwargs)
+     1  understood: dict splat (pw_kwargs)
+
+MODE 2 -- wrong destination : 100
+------------------------------------------------------------------------------
+  RANK A -- the public name lands on a DIFFERENT internal key in
+            some other wrapper: the family disagrees : 35
+            (this is the shape of #458 and #461)
+  card.Card                  accent               -> surface                RENAMED-TRANSFORMED
+  carousel.Carousel          data_source          -> datasource             RENAMED
+  datatable.DataTable        data_source          -> datasource             RENAMED
+  gallery.Gallery            data_source          -> datasource             RENAMED
+  listview.ListView          data_source          -> datasource             RENAMED
+  picture.Picture            height               -> img_height             RENAMED
+  boolean_controls.ToggleButton icon                 -> on_icon                RENAMED-TRANSFORMED  [super().__init__ -> _BooleanControlBase]
+  boolean_controls.ToggleButton icon                 -> off_icon               RENAMED-TRANSFORMED  [super().__init__ -> _BooleanControlBase]
+  boolean_controls.Checkbox  label                -> text                   RENAMED  [super().__init__ -> _BooleanControlBase]
+  boolean_controls.Switch    label                -> text                   RENAMED  [super().__init__ -> _BooleanControlBase]
+  radio_variants.Radio       label                -> text                   RENAMED  (init from _RadioBase)
+  radio_variants.RadioToggleButton label                -> text                   RENAMED  [super().__init__ -> _RadioBase]
+  gauge.Gauge                max_value            -> maxvalue               RENAMED
+  numberfield.NumberField    max_value            -> maxvalue               RENAMED
+  progressbar.ProgressBar    max_value            -> maximum                RENAMED
+  slider.RangeSlider         max_value            -> maxvalue               RENAMED
+  slider.Slider              max_value            -> maxvalue               RENAMED
+  spinnerfield.SpinnerField  max_value            -> maxvalue               RENAMED
+  select.Select              options              -> items                  RENAMED-TRANSFORMED
+  spinnerfield.SpinnerField  options              -> values                 RENAMED
+  select.Select              read_only            -> readonly               RENAMED
+  timefield.TimeField        read_only            -> readonly               RENAMED
+  listview.ListView          show_separators      -> show_separator         RENAMED
+  chart.Chart                signal               -> signals                RENAMED-TRANSFORMED
+  selectbutton.SelectButton  signal               -> textsignal             RENAMED
+  gauge.Gauge                step                 -> step_size              RENAMED
+  numberfield.NumberField    step                 -> increment              RENAMED
+  spinnerfield.SpinnerField  step                 -> increment              RENAMED
+  codeeditor.CodeEditor      theme                -> pygments_style         RENAMED
+  groupbox.GroupBox          title                -> text                   RENAMED
+  radiogroup.RadioGroup      title                -> text                   RENAMED
+  app.App                    undecorated          -> override_redirect      RENAMED  [self._internal = self._tk_root, built earlier]
+  window.Window              undecorated          -> overrideredirect       RENAMED  [self._internal = self._tk_toplevel, built earlier]
+  gauge.Gauge                variant              -> meter_type             RENAMED
+  picture.Picture            width                -> img_width              RENAMED
+
+  RANK B -- one public name, one internal key everywhere it
+            appears: a consistent rename : 65
+  app.App                    max_size             -> maxsize                RENAMED  [self._internal = self._tk_root, built earlier]
+        expr: max_size   (line 166)
+        some class in the mro takes an unannotated **kwargs -- the vocabulary is open-ended and destinations are NOT checked
+  app.App                    min_size             -> minsize                RENAMED  [self._internal = self._tk_root, built earlier]
+        expr: min_size   (line 164)
+        some class in the mro takes an unannotated **kwargs -- the vocabulary is open-ended and destinations are NOT checked
+  boolean_controls.Checkbox  checked_value        -> onvalue                RENAMED  [super().__init__ -> _BooleanControlBase]
+        expr: checked_value  [via _BooleanControlBase]   (line 68)
+        some class in the mro takes an unannotated **kwargs -- the vocabulary is open-ended and destinations are NOT checked
+  boolean_controls.Checkbox  unchecked_value      -> offvalue               RENAMED  [super().__init__ -> _BooleanControlBase]
+        expr: unchecked_value  [via _BooleanControlBase]   (line 70)
+        some class in the mro takes an unannotated **kwargs -- the vocabulary is open-ended and destinations are NOT checked
+  boolean_controls.Switch    checked_value        -> onvalue                RENAMED  [super().__init__ -> _BooleanControlBase]
+        expr: checked_value  [via _BooleanControlBase]   (line 68)
+        some class in the mro takes an unannotated **kwargs -- the vocabulary is open-ended and destinations are NOT checked
+  boolean_controls.Switch    unchecked_value      -> offvalue               RENAMED  [super().__init__ -> _BooleanControlBase]
+        expr: unchecked_value  [via _BooleanControlBase]   (line 70)
+        some class in the mro takes an unannotated **kwargs -- the vocabulary is open-ended and destinations are NOT checked
+  boolean_controls.ToggleButton checked_value        -> onvalue                RENAMED  [super().__init__ -> _BooleanControlBase]
+        expr: checked_value  [via _BooleanControlBase]   (line 68)
+        some class in the mro takes an unannotated **kwargs -- the vocabulary is open-ended and destinations are NOT checked
+  boolean_controls.ToggleButton unchecked_value      -> offvalue               RENAMED  [super().__init__ -> _BooleanControlBase]
+        expr: unchecked_value  [via _BooleanControlBase]   (line 70)
+        some class in the mro takes an unannotated **kwargs -- the vocabulary is open-ended and destinations are NOT checked
+  button.Button              icon_position        -> compound               RENAMED
+        expr: icon_position   (line 99)
+        some class in the mro takes an unannotated **kwargs -- the vocabulary is open-ended and destinations are NOT checked
+  card.Card                  layout               -> direction              RENAMED-TRANSFORMED
+        expr: 'vertical' if layout == 'column' else 'horizontal'   (line 101)
+        some class in the mro takes an unannotated **kwargs -- the vocabulary is open-ended and destinations are NOT checked
+  contextmenu.ContextMenu    min_height           -> minheight              RENAMED
+        expr: min_height   (line 133)
+        some class in the mro takes an unannotated **kwargs -- the vocabulary is open-ended and destinations are NOT checked
+  contextmenu.ContextMenu    min_width            -> minwidth               RENAMED
+        expr: min_width   (line 123)
+        some class in the mro takes an unannotated **kwargs -- the vocabulary is open-ended and destinations are NOT checked
+  datatable.DataTable        allow_add            -> enable_adding          RENAMED
+        expr: allow_add   (line 167)
+        some class in the mro takes an unannotated **kwargs -- the vocabulary is open-ended and destinations are NOT checked
+  datatable.DataTable        allow_delete         -> enable_deleting        RENAMED
+        expr: allow_delete   (line 169)
+        some class in the mro takes an unannotated **kwargs -- the vocabulary is open-ended and destinations are NOT checked
+  datatable.DataTable        allow_edit           -> enable_editing         RENAMED
+        expr: allow_edit   (line 168)
+        some class in the mro takes an unannotated **kwargs -- the vocabulary is open-ended and destinations are NOT checked
+  datatable.DataTable        allow_export         -> enable_exporting       RENAMED
+        expr: allow_export   (line 170)
+        some class in the mro takes an unannotated **kwargs -- the vocabulary is open-ended and destinations are NOT checked
+  datatable.DataTable        allow_filter         -> enable_filtering       RENAMED
+        expr: allow_filter   (line 164)
+        some class in the mro takes an unannotated **kwargs -- the vocabulary is open-ended and destinations are NOT checked
+  datatable.DataTable        allow_group          -> allow_grouping         RENAMED
+        expr: allow_group   (line 173)
+        some class in the mro takes an unannotated **kwargs -- the vocabulary is open-ended and destinations are NOT checked
+  datatable.DataTable        form                 -> form_options           RENAMED
+        expr: form   (line 187)
+        some class in the mro takes an unannotated **kwargs -- the vocabulary is open-ended and destinations are NOT checked
+  datatable.DataTable        searchable           -> enable_search          RENAMED
+        expr: searchable   (line 162)
+        some class in the mro takes an unannotated **kwargs -- the vocabulary is open-ended and destinations are NOT checked
+  datatable.DataTable        show_status_bar      -> show_table_status      RENAMED
+        expr: show_status_bar   (line 174)
+        some class in the mro takes an unannotated **kwargs -- the vocabulary is open-ended and destinations are NOT checked
+  datefield.DateField        range_end            -> end_date               RENAMED
+        expr: range_end   (line 128)
+        some class in the mro takes an unannotated **kwargs -- the vocabulary is open-ended and destinations are NOT checked
+  datefield.DateField        range_start          -> start_date             RENAMED
+        expr: range_start   (line 126)
+        some class in the mro takes an unannotated **kwargs -- the vocabulary is open-ended and destinations are NOT checked
+  expander.AccordionSection  layout               -> direction              RENAMED-TRANSFORMED  [no self._internal; analysed against self._layout_frame = FlexFrame()]
+        expr: 'vertical' if layout == 'column' else 'horizontal'   (line 257)
+        some class in the mro takes an unannotated **kwargs -- the vocabulary is open-ended and destinations are NOT checked
+  gauge.Gauge                min_value            -> minvalue               RENAMED
+        expr: min_value   (line 81)
+        some class in the mro takes an unannotated **kwargs -- the vocabulary is open-ended and destinations are NOT checked
+  gauge.Gauge                value_template       -> value_format           RENAMED
+        expr: value_template   (line 83)
+        some class in the mro takes an unannotated **kwargs -- the vocabulary is open-ended and destinations are NOT checked
+  label.Label                icon_position        -> compound               RENAMED
+        expr: icon_position   (line 116)
+        some class in the mro takes an unannotated **kwargs -- the vocabulary is open-ended and destinations are NOT checked
+  label.Label                icon_position        -> compound               RENAMED
+        expr: icon_position   (line 126)
+        some class in the mro takes an unannotated **kwargs -- the vocabulary is open-ended and destinations are NOT checked
+  label.Label                wrap_width           -> wraplength             RENAMED
+        expr: wrap_width   (line 138)
+        some class in the mro takes an unannotated **kwargs -- the vocabulary is open-ended and destinations are NOT checked
+  listview.ListView          allow_remove         -> enable_removing        RENAMED
+        expr: allow_remove   (line 97)
+        some class in the mro takes an unannotated **kwargs -- the vocabulary is open-ended and destinations are NOT checked
+  listview.ListView          allow_reorder        -> enable_dragging        RENAMED
+        expr: allow_reorder   (line 98)
+        some class in the mro takes an unannotated **kwargs -- the vocabulary is open-ended and destinations are NOT checked
+  listview.ListView          show_scrollbar       -> scrollbar_visibility   RENAMED-TRANSFORMED
+        expr: 'always' if show_scrollbar else 'never'   (line 101)
+        some class in the mro takes an unannotated **kwargs -- the vocabulary is open-ended and destinations are NOT checked
+  menubutton.MenuButton      menu_options         -> popdown_options        RENAMED
+        expr: menu_options   (line 131)
+        some class in the mro takes an unannotated **kwargs -- the vocabulary is open-ended and destinations are NOT checked
+  menubutton.MenuButton      show_arrow           -> show_dropdown_button   RENAMED
+        expr: show_arrow   (line 128)
+        some class in the mro takes an unannotated **kwargs -- the vocabulary is open-ended and destinations are NOT checked
+  numberfield.NumberField    min_value            -> minvalue               RENAMED
+        expr: min_value   (line 147)
+        some class in the mro takes an unannotated **kwargs -- the vocabulary is open-ended and destinations are NOT checked
+  numberfield.NumberField    show_steppers        -> show_spin_buttons      RENAMED
+        expr: show_steppers   (line 136)
+        some class in the mro takes an unannotated **kwargs -- the vocabulary is open-ended and destinations are NOT checked
+  pagestack.StackPage        layout               -> direction              RENAMED-TRANSFORMED  [no self._internal; analysed against self._layout_frame = FlexFrame()]
+        expr: 'vertical' if layout == 'column' else 'horizontal'   (line 69)
+        some class in the mro takes an unannotated **kwargs -- the vocabulary is open-ended and destinations are NOT checked
+  passwordfield.PasswordField mask                 -> show                   RENAMED
+        expr: mask   (line 86)
+        some class in the mro takes an unannotated **kwargs -- the vocabulary is open-ended and destinations are NOT checked
+  radio_variants.Radio       icon_position        -> compound               RENAMED  (init from _RadioBase)
+        expr: icon_position   (line 83)
+        some class in the mro takes an unannotated **kwargs -- the vocabulary is open-ended and destinations are NOT checked
+  radio_variants.Radio       selected_icon        -> on_icon                RENAMED  (init from _RadioBase)
+        expr: selected_icon   (line 75)
+        some class in the mro takes an unannotated **kwargs -- the vocabulary is open-ended and destinations are NOT checked
+  radio_variants.Radio       text_signal          -> textsignal             RENAMED  (init from _RadioBase)
+        expr: text_signal   (line 71)
+        some class in the mro takes an unannotated **kwargs -- the vocabulary is open-ended and destinations are NOT checked
+  radio_variants.Radio       unselected_icon      -> off_icon               RENAMED  (init from _RadioBase)
+        expr: unselected_icon   (line 77)
+        some class in the mro takes an unannotated **kwargs -- the vocabulary is open-ended and destinations are NOT checked
+  radio_variants.RadioToggleButton selected_icon        -> on_icon                RENAMED  [super().__init__ -> _RadioBase]
+        expr: selected_icon  [via _RadioBase]   (line 75)
+        some class in the mro takes an unannotated **kwargs -- the vocabulary is open-ended and destinations are NOT checked
+  radio_variants.RadioToggleButton text_signal          -> textsignal             RENAMED  [super().__init__ -> _RadioBase]
+        expr: text_signal  [via _RadioBase]   (line 71)
+        some class in the mro takes an unannotated **kwargs -- the vocabulary is open-ended and destinations are NOT checked
+  radio_variants.RadioToggleButton unselected_icon      -> off_icon               RENAMED  [super().__init__ -> _RadioBase]
+        expr: unselected_icon  [via _RadioBase]   (line 77)
+        some class in the mro takes an unannotated **kwargs -- the vocabulary is open-ended and destinations are NOT checked
+  select.Select              searchable           -> enable_search          RENAMED
+        expr: searchable   (line 128)
+        some class in the mro takes an unannotated **kwargs -- the vocabulary is open-ended and destinations are NOT checked
+  slider.RangeSlider         high_signal          -> hi_signal              RENAMED
+        expr: high_signal   (line 285)
+        some class in the mro takes an unannotated **kwargs -- the vocabulary is open-ended and destinations are NOT checked
+  slider.RangeSlider         high_value           -> hivalue                RENAMED
+        expr: high_value   (line 271)
+        some class in the mro takes an unannotated **kwargs -- the vocabulary is open-ended and destinations are NOT checked
+  slider.RangeSlider         low_signal           -> lo_signal              RENAMED
+        expr: low_signal   (line 283)
+        some class in the mro takes an unannotated **kwargs -- the vocabulary is open-ended and destinations are NOT checked
+  slider.RangeSlider         low_value            -> lovalue                RENAMED
+        expr: low_value   (line 270)
+        some class in the mro takes an unannotated **kwargs -- the vocabulary is open-ended and destinations are NOT checked
+  slider.RangeSlider         min_value            -> minvalue               RENAMED
+        expr: min_value   (line 272)
+        some class in the mro takes an unannotated **kwargs -- the vocabulary is open-ended and destinations are NOT checked
+  slider.RangeSlider         tick_step            -> tick_interval          RENAMED
+        expr: tick_step   (line 276)
+        some class in the mro takes an unannotated **kwargs -- the vocabulary is open-ended and destinations are NOT checked
+  slider.Slider              min_value            -> minvalue               RENAMED
+        expr: min_value   (line 88)
+        some class in the mro takes an unannotated **kwargs -- the vocabulary is open-ended and destinations are NOT checked
+  slider.Slider              tick_step            -> tick_interval          RENAMED
+        expr: tick_step   (line 93)
+        some class in the mro takes an unannotated **kwargs -- the vocabulary is open-ended and destinations are NOT checked
+  spinnerfield.SpinnerField  min_value            -> minvalue               RENAMED
+        expr: min_value   (line 105)
+        some class in the mro takes an unannotated **kwargs -- the vocabulary is open-ended and destinations are NOT checked
+  splitview.SplitPane        layout               -> direction              RENAMED-TRANSFORMED  [no self._internal; analysed against self._layout_frame = FlexFrame()]
+        expr: 'vertical' if layout == 'column' else 'horizontal'   (line 65)
+        some class in the mro takes an unannotated **kwargs -- the vocabulary is open-ended and destinations are NOT checked
+  splitview.SplitView        sash_thickness       -> style_options          RENAMED-TRANSFORMED
+        expr: {'sash_thickness': sash_thickness}   (line 194)
+        some class in the mro takes an unannotated **kwargs -- the vocabulary is open-ended and destinations are NOT checked
+  tabs.TabPage               layout               -> direction              RENAMED-TRANSFORMED  [no self._internal; analysed against self._layout_frame = FlexFrame()]
+        expr: 'vertical' if layout == 'column' else 'horizontal'   (line 71)
+        some class in the mro takes an unannotated **kwargs -- the vocabulary is open-ended and destinations are NOT checked
+  tabs.Tabs                  allow_add            -> enable_adding          RENAMED
+        expr: allow_add   (line 204)
+        some class in the mro takes an unannotated **kwargs -- the vocabulary is open-ended and destinations are NOT checked
+  tabs.Tabs                  allow_close          -> enable_closing         RENAMED
+        expr: allow_close   (line 203)
+        some class in the mro takes an unannotated **kwargs -- the vocabulary is open-ended and destinations are NOT checked
+  textfield.TextField        mask                 -> show                   RENAMED
+        expr: mask   (line 123)
+        some class in the mro takes an unannotated **kwargs -- the vocabulary is open-ended and destinations are NOT checked
+  tooltip.Tooltip            wrap_width           -> wraplength             RENAMED
+        expr: wrap_width   (line 64)
+        some class in the mro takes an unannotated **kwargs -- the vocabulary is open-ended and destinations are NOT checked
+  tree.Tree                  show_scrollbar       -> scrollbar_visibility   RENAMED-TRANSFORMED
+        expr: 'always' if show_scrollbar else 'never'   (line 134)
+        some class in the mro takes an unannotated **kwargs -- the vocabulary is open-ended and destinations are NOT checked
+  window.Window              max_size             -> maxsize                RENAMED  [self._internal = self._tk_toplevel, built earlier]
+        expr: max_size   (line 161)
+        some class in the mro takes an unannotated **kwargs -- the vocabulary is open-ended and destinations are NOT checked
+  window.Window              min_size             -> minsize                RENAMED  [self._internal = self._tk_toplevel, built earlier]
+        expr: min_size   (line 159)
+        some class in the mro takes an unannotated **kwargs -- the vocabulary is open-ended and destinations are NOT checked
+
+MODE 1 -- never forwarded : 0
+------------------------------------------------------------------------------
+
+MODE 3 -- swallowed as a layout key : 40
+------------------------------------------------------------------------------
+  avatar.Avatar              **kwargs             -> -                      LEFTOVERS-DROPPED
+        _split_layout_kwargs() strips the layout keys and nothing reads what is left, so an unknown name is accepted silently
+  button.Button              **kwargs             -> -                      LEFTOVERS-DROPPED
+        _split_layout_kwargs() strips the layout keys and nothing reads what is left, so an unknown name is accepted silently
+  buttongroup.ButtonGroup    **kwargs             -> -                      LEFTOVERS-DROPPED
+        _split_layout_kwargs() strips the layout keys and nothing reads what is left, so an unknown name is accepted silently
+  calendar.Calendar          **kwargs             -> -                      LEFTOVERS-DROPPED
+        _split_layout_kwargs() strips the layout keys and nothing reads what is left, so an unknown name is accepted silently
+  card.Card                  **kwargs             -> -                      LEFTOVERS-DROPPED
+        _split_layout_kwargs() strips the layout keys and nothing reads what is left, so an unknown name is accepted silently
+  carousel.Carousel          **kwargs             -> -                      LEFTOVERS-DROPPED
+        _split_layout_kwargs() strips the layout keys and nothing reads what is left, so an unknown name is accepted silently
+  codeeditor.CodeEditor      **kwargs             -> -                      LEFTOVERS-DROPPED
+        _split_layout_kwargs() strips the layout keys and nothing reads what is left, so an unknown name is accepted silently
+  datatable.DataTable        **kwargs             -> -                      LEFTOVERS-DROPPED
+        _split_layout_kwargs() strips the layout keys and nothing reads what is left, so an unknown name is accepted silently
+  datefield.DateField        **kwargs             -> -                      LEFTOVERS-DROPPED
+        _split_layout_kwargs() strips the layout keys and nothing reads what is left, so an unknown name is accepted silently
+  divider.Divider            **kwargs             -> -                      LEFTOVERS-DROPPED
+        _split_layout_kwargs() strips the layout keys and nothing reads what is left, so an unknown name is accepted silently
+  expander.Accordion         **kwargs             -> -                      LEFTOVERS-DROPPED
+        _split_layout_kwargs() strips the layout keys and nothing reads what is left, so an unknown name is accepted silently
+  form.Form                  **kwargs             -> -                      LEFTOVERS-DROPPED
+        _split_layout_kwargs() strips the layout keys and nothing reads what is left, so an unknown name is accepted silently
+  gallery.Gallery            **kwargs             -> -                      LEFTOVERS-DROPPED
+        _split_layout_kwargs() strips the layout keys and nothing reads what is left, so an unknown name is accepted silently
+  gauge.Gauge                **kwargs             -> -                      LEFTOVERS-DROPPED
+        _split_layout_kwargs() strips the layout keys and nothing reads what is left, so an unknown name is accepted silently
+  grid.Grid                  **kwargs             -> -                      LEFTOVERS-DROPPED
+        _split_layout_kwargs() strips the layout keys and nothing reads what is left, so an unknown name is accepted silently
+  groupbox.GroupBox          **kwargs             -> -                      LEFTOVERS-DROPPED
+        _split_layout_kwargs() strips the layout keys and nothing reads what is left, so an unknown name is accepted silently
+  label.Badge                **kwargs             -> -                      LEFTOVERS-DROPPED  [super().__init__ -> Label]
+        _split_layout_kwargs() strips the layout keys and nothing reads what is left, so an unknown name is accepted silently
+  label.Label                **kwargs             -> -                      LEFTOVERS-DROPPED
+        _split_layout_kwargs() strips the layout keys and nothing reads what is left, so an unknown name is accepted silently
+  listview.ListView          **kwargs             -> -                      LEFTOVERS-DROPPED
+        _split_layout_kwargs() strips the layout keys and nothing reads what is left, so an unknown name is accepted silently
+  numberfield.NumberField    **kwargs             -> -                      LEFTOVERS-DROPPED
+        _split_layout_kwargs() strips the layout keys and nothing reads what is left, so an unknown name is accepted silently
+  pagestack.PageStack        **kwargs             -> -                      LEFTOVERS-DROPPED
+        _split_layout_kwargs() strips the layout keys and nothing reads what is left, so an unknown name is accepted silently
+  passwordfield.PasswordField **kwargs             -> -                      LEFTOVERS-DROPPED
+        _split_layout_kwargs() strips the layout keys and nothing reads what is left, so an unknown name is accepted silently
+  pathfield.PathField        **kwargs             -> -                      LEFTOVERS-DROPPED
+        _split_layout_kwargs() strips the layout keys and nothing reads what is left, so an unknown name is accepted silently
+  progressbar.ProgressBar    **kwargs             -> -                      LEFTOVERS-DROPPED
+        _split_layout_kwargs() strips the layout keys and nothing reads what is left, so an unknown name is accepted silently
+  radiogroup.RadioGroup      **kwargs             -> -                      LEFTOVERS-DROPPED
+        _split_layout_kwargs() strips the layout keys and nothing reads what is left, so an unknown name is accepted silently
+  scrollview.ScrollView      **kwargs             -> -                      LEFTOVERS-DROPPED
+        _split_layout_kwargs() strips the layout keys and nothing reads what is left, so an unknown name is accepted silently
+  select.Select              **kwargs             -> -                      LEFTOVERS-DROPPED
+        _split_layout_kwargs() strips the layout keys and nothing reads what is left, so an unknown name is accepted silently
+  selectbutton.SelectButton  **kwargs             -> -                      LEFTOVERS-DROPPED
+        _split_layout_kwargs() strips the layout keys and nothing reads what is left, so an unknown name is accepted silently
+  slider.RangeSlider         **kwargs             -> -                      LEFTOVERS-DROPPED
+        _split_layout_kwargs() strips the layout keys and nothing reads what is left, so an unknown name is accepted silently
+  slider.Slider              **kwargs             -> -                      LEFTOVERS-DROPPED
+        _split_layout_kwargs() strips the layout keys and nothing reads what is left, so an unknown name is accepted silently
+  spinnerfield.SpinnerField  **kwargs             -> -                      LEFTOVERS-DROPPED
+        _split_layout_kwargs() strips the layout keys and nothing reads what is left, so an unknown name is accepted silently
+  splitview.SplitView        **kwargs             -> -                      LEFTOVERS-DROPPED
+        _split_layout_kwargs() strips the layout keys and nothing reads what is left, so an unknown name is accepted silently
+  stacks.Column              **kwargs             -> -                      LEFTOVERS-DROPPED  [super().__init__ -> _FlexBase]
+        _split_layout_kwargs() strips the layout keys and nothing reads what is left, so an unknown name is accepted silently
+  stacks.Row                 **kwargs             -> -                      LEFTOVERS-DROPPED  [super().__init__ -> _FlexBase]
+        _split_layout_kwargs() strips the layout keys and nothing reads what is left, so an unknown name is accepted silently
+  tabs.Tabs                  **kwargs             -> -                      LEFTOVERS-DROPPED
+        _split_layout_kwargs() strips the layout keys and nothing reads what is left, so an unknown name is accepted silently
+  textarea.TextArea          **kwargs             -> -                      LEFTOVERS-DROPPED
+        _split_layout_kwargs() strips the layout keys and nothing reads what is left, so an unknown name is accepted silently
+  textfield.TextField        **kwargs             -> -                      LEFTOVERS-DROPPED
+        _split_layout_kwargs() strips the layout keys and nothing reads what is left, so an unknown name is accepted silently
+  timefield.TimeField        **kwargs             -> -                      LEFTOVERS-DROPPED
+        _split_layout_kwargs() strips the layout keys and nothing reads what is left, so an unknown name is accepted silently
+  togglegroup.ToggleGroup    **kwargs             -> -                      LEFTOVERS-DROPPED
+        _split_layout_kwargs() strips the layout keys and nothing reads what is left, so an unknown name is accepted silently
+  tree.Tree                  **kwargs             -> -                      LEFTOVERS-DROPPED
+        _split_layout_kwargs() strips the layout keys and nothing reads what is left, so an unknown name is accepted silently
+
+UNKNOWN-NAME POLICY -- what each wrapper does with a keyword it does
+not recognise (cross-checked against real construction by --arm leftovers)
+------------------------------------------------------------------------------
+  DROPPED     40  Accordion, Avatar, Badge, Button, ButtonGroup, Calendar, Card, Carousel ...
+  REJECTED     5  Checkbox, Radio, RadioToggleButton, Switch, ToggleButton
+  FORWARDED    5  Chart, MenuButton, Picture, StatusBar, Toolbar
+  NO SPLIT     2  App, Window
+
+  The 5 REJECTED wrappers are the precedent #383 gap 3 needs: the
+  guard already exists in this codebase and is six lines long.
+
+MODE 5 -- the type lies : 8
+------------------------------------------------------------------------------
+  boolean_controls.Checkbox  .signal   Signal | None          line 174  (property on _BooleanControlBase)
+        the internal defines 'signal' as a property with no None path, so the getattr default is unreachable and `| None` cannot occur
+  boolean_controls.Switch    .signal   Signal | None          line 174  (property on _BooleanControlBase)
+        the internal defines 'signal' as a property with no None path, so the getattr default is unreachable and `| None` cannot occur
+  boolean_controls.ToggleButton .signal   Signal | None          line 174  (property on _BooleanControlBase)
+        the internal defines 'signal' as a property with no None path, so the getattr default is unreachable and `| None` cannot occur
+  passwordfield.PasswordField .signal   Signal[str] | None     line 140
+        the internal defines 'signal' as a property with no None path, so the getattr default is unreachable and `| None` cannot occur
+  pathfield.PathField        .signal   Signal[str] | None     line 218
+        the internal defines 'signal' as a property with no None path, so the getattr default is unreachable and `| None` cannot occur
+  selectbutton.SelectButton  .signal   Signal[str] | None     line 149
+        the internal defines 'textsignal' as a property with no None path, so the getattr default is unreachable and `| None` cannot occur
+  spinnerfield.SpinnerField  .signal   Signal[str] | None     line 170
+        the internal defines 'signal' as a property with no None path, so the getattr default is unreachable and `| None` cannot occur
+  textfield.TextField        .signal   Signal[str] | None     line 165
+        the internal defines 'signal' as a property with no None path, so the getattr default is unreachable and `| None` cannot occur
+  -- checked and CLEARED (the None is reachable):
+     textarea.TextArea          OK             the internal has no class-level 'signal', so the instance attribute may legitimately be absent
+
+DIVERGENCE -- one public name, more than one internal destination : 16
+------------------------------------------------------------------------------
+  Read this list first. A name here means the wrapper family does not
+  agree on where the parameter goes; #458 and #461 are both instances.
+  accent               2 destinations
+      -> accent                 Checkbox, Switch, ToggleButton, Button, ButtonGroup (+34 more)
+      -> surface                Card
+  data_source          2 destinations
+      -> data_source            Chart
+      -> datasource             Carousel, DataTable, Gallery, ListView
+  height               2 destinations
+      -> height                 Carousel, CodeEditor, ContextMenu, Form, Grid (+6 more)
+      -> img_height             Picture
+  icon                 3 destinations
+      -> icon                   Button, Label, MenuButton, Radio, RadioToggleButton (+1 more)
+      -> off_icon               ToggleButton
+      -> on_icon                ToggleButton
+  label                2 destinations
+      -> label                  DateField, NumberField, PasswordField, PathField, Select (+4 more)
+      -> text                   Checkbox, Switch, Radio, RadioToggleButton
+  max_value            2 destinations
+      -> maximum                ProgressBar
+      -> maxvalue               Gauge, NumberField, RangeSlider, Slider, SpinnerField
+  options              3 destinations
+      -> items                  Select
+      -> options                SelectButton
+      -> values                 SpinnerField
+  read_only            2 destinations
+      -> read_only              CodeEditor, TextArea
+      -> readonly               Select, TimeField
+  show_separators      2 destinations
+      -> show_separator         ListView
+      -> show_separators        Accordion
+  signal               3 destinations
+      -> signal                 Checkbox, Switch, ToggleButton, ProgressBar, Radio (+4 more)
+      -> signals                Chart
+      -> textsignal             SelectButton
+  step                 3 destinations
+      -> increment              NumberField, SpinnerField
+      -> step                   RangeSlider, Slider
+      -> step_size              Gauge
+  theme                2 destinations
+      -> pygments_style         CodeEditor
+      -> theme                  App
+  title                2 destinations
+      -> text                   GroupBox, RadioGroup
+      -> title                  App, Window
+  undecorated          2 destinations
+      -> override_redirect      App
+      -> overrideredirect       Window
+  variant              2 destinations
+      -> meter_type             Gauge
+      -> variant                ToggleButton, Button, ButtonGroup, Accordion, Badge (+4 more)
+  width                2 destinations
+      -> img_width              Picture
+      -> width                  Button, ContextMenu, Form, Grid, Label (+12 more)
+
+CONDITIONAL -- forwarded by a guard, not by value : 89
+------------------------------------------------------------------------------
+  boolean_controls.Checkbox  if disabled: -> state='disabled'  [via _BooleanControlBase]
+  boolean_controls.Checkbox  if icon_only: -> icon_only=True  [via _internal_options=options]
+  boolean_controls.Checkbox  if show_indicator: -> show_indicator=False  [via _internal_options=options]
+  boolean_controls.Switch    if disabled: -> state='disabled'  [via _BooleanControlBase]
+  boolean_controls.ToggleButton if disabled: -> state='disabled'  [via _BooleanControlBase]
+  boolean_controls.ToggleButton if icon_only: -> icon_only=True  [via _internal_options=options]
+  button.Button              if disabled: -> state='disabled'
+  button.Button              if icon_only: -> compound=icon_position
+  button.Button              if icon_only: -> icon_only=True
+  buttongroup.ButtonGroup    if disabled: -> state='disabled'
+  contextmenu.ContextMenu    if on_select: -> command=_on_select
+  datefield.DateField        if disabled: -> state='disabled'
+  datefield.DateField        if disabled: -> state='readonly'
+  datefield.DateField        if read_only: -> state='readonly'
+  datefield.DateField        if required: -> required=True
+  expander.Accordion         if show_border: -> show_border=True
+  grid.Grid                  if height: -> propagate=False
+  grid.Grid                  if show_border: -> show_border=True
+  grid.Grid                  if width: -> propagate=False
+  label.Label                if icon: -> icon_only=True
+  label.Label                if icon: -> compound='image'
+  label.Label                if icon: -> compound=icon_position
+  label.Label                if icon: -> icon_only=True
+  label.Label                if icon_only: -> icon_only=True
+  label.Label                if icon_only: -> compound='image'
+  label.Label                if icon_only: -> compound=icon_position
+  label.Label                if icon_only: -> icon_only=True
+  label.Label                if icon_only: -> compound='image'
+  label.Label                if icon_only: -> compound=icon_position
+  label.Label                if icon_only: -> icon_only=True
+  label.Label                if image: -> icon_only=True
+  label.Label                if image: -> compound='image'
+  label.Label                if image: -> compound=icon_position
+  label.Label                if text: -> icon_only=True
+  label.Label                if text: -> compound='image'
+  label.Label                if text: -> compound=icon_position
+  label.Label                if text: -> icon_only=True
+  label.Label                if text: -> compound='image'
+  label.Label                if text: -> compound=icon_position
+  label.Label                if textsignal: -> icon_only=True
+  label.Label                if textsignal: -> compound='image'
+  label.Label                if textsignal: -> compound=icon_position
+  label.Label                if textsignal: -> icon_only=True
+  label.Label                if textsignal: -> compound='image'
+  label.Label                if textsignal: -> compound=icon_position
+  menubutton.MenuButton      if disabled: -> state='disabled'
+  menubutton.MenuButton      if icon_only: -> icon_only=True
+  menubutton.MenuButton      if on_select: -> command=_on_select
+  numberfield.NumberField    if disabled: -> state='disabled'
+  numberfield.NumberField    if disabled: -> state='readonly'
+  numberfield.NumberField    if read_only: -> state='readonly'
+  numberfield.NumberField    if required: -> required=True
+  numberfield.NumberField    if wrap: -> wrap=True
+  passwordfield.PasswordField if disabled: -> state='disabled'
+  passwordfield.PasswordField if disabled: -> state='readonly'
+  passwordfield.PasswordField if read_only: -> state='readonly'
+  passwordfield.PasswordField if required: -> required=True
+  pathfield.PathField        if disabled: -> state='disabled'
+  pathfield.PathField        if disabled: -> state='readonly'
+  pathfield.PathField        if read_only: -> state='readonly'
+  pathfield.PathField        if required: -> required=True
+  radio_variants.Radio       if disabled: -> state='disabled'
+  radio_variants.Radio       if icon_only: -> icon_only=True
+  radio_variants.Radio       if show_indicator: -> show_indicator=False
+  radio_variants.RadioToggleButton if disabled: -> state='disabled'  [via _RadioBase]
+  radio_variants.RadioToggleButton if icon_only: -> icon_only=True  [via _RadioBase]
+  radiogroup.RadioGroup      if disabled: -> state='disabled'
+  scrollview.ScrollView      if show_border: -> show_border=True
+  select.Select              if disabled: -> state='disabled'
+  select.Select              if required: -> required=True
+  selectbutton.SelectButton  if disabled: -> state='disabled'
+  slider.RangeSlider         if disabled: -> state='disabled'
+  slider.Slider              if disabled: -> state='disabled'
+  spinnerfield.SpinnerField  if disabled: -> state='disabled'
+  spinnerfield.SpinnerField  if disabled: -> state='readonly'
+  spinnerfield.SpinnerField  if read_only: -> state='readonly'
+  spinnerfield.SpinnerField  if required: -> required=True
+  stacks.Column              if height: -> propagate=False  [via _FlexBase]
+  stacks.Column              if width: -> propagate=False  [via _FlexBase]
+  stacks.Row                 if height: -> propagate=False  [via _FlexBase]
+  stacks.Row                 if width: -> propagate=False  [via _FlexBase]
+  textarea.TextArea          if required: -> required=True
+  textfield.TextField        if disabled: -> state='disabled'
+  textfield.TextField        if disabled: -> state='readonly'
+  textfield.TextField        if read_only: -> state='readonly'
+  textfield.TextField        if required: -> required=True
+  timefield.TimeField        if disabled: -> state='disabled'
+  timefield.TimeField        if required: -> required=True
+  togglegroup.ToggleGroup    if disabled: -> state='disabled'
+
+UNANALYZED -- the tool CANNOT speak about these; do NOT read as clean
+------------------------------------------------------------------------------
+  appshell.AppShell             31 params   (this __init__ builds no internal widget)
+  appshell.Workbench            34 params   (this __init__ builds no internal widget)
+  theme_toggle.ThemeToggle       5 params   (this __init__ builds no internal widget)
+  toast.Notification             7 params   (this __init__ builds no internal widget)
+  toast.Snackbar                 7 params   (this __init__ builds no internal widget)
+
+USED-ELSEWHERE -- reaches no internal kwarg; needs a human : 100
+------------------------------------------------------------------------------
+  app.App                    gap                  into frame_kwargs, splatted into FlexFrame() -- a SECOND widget, not the internal measured here
+  app.App                    grow_items           into frame_kwargs, splatted into FlexFrame() -- a SECOND widget, not the internal measured here
+  app.App                    horizontal_items     into frame_kwargs, splatted into FlexFrame() -- a SECOND widget, not the internal measured here
+  app.App                    icon                 passed to resolve_window_icon()
+  app.App                    padding              into frame_kwargs, splatted into FlexFrame() -- a SECOND widget, not the internal measured here
+  app.App                    surface              into frame_kwargs, splatted into FlexFrame() -- a SECOND widget, not the internal measured here
+  app.App                    vertical_items       into frame_kwargs, splatted into FlexFrame() -- a SECOND widget, not the internal measured here
+  avatar.Avatar              image                passed to self._coerce_image()
+  boolean_controls.Checkbox  on_change            passed to __init__()
+  boolean_controls.Checkbox  tristate             passed to __init__()
+  boolean_controls.Checkbox  value                passed to __init__()
+  boolean_controls.Switch    on_change            passed to __init__()
+  boolean_controls.Switch    value                passed to __init__()
+  boolean_controls.ToggleButton on_change            passed to __init__()
+  boolean_controls.ToggleButton value                passed to __init__()
+  button.Button              on_click             stored on self, never forwarded
+  buttongroup.ButtonGroup    localize             stored on self, never forwarded
+  card.Card                  auto_flow            passed to GridFrame()
+  card.Card                  columns              passed to GridFrame()
+  card.Card                  rows                 passed to GridFrame()
+  datefield.DateField        signal               passed to self._bind_value_signal()
+  expander.AccordionSection  auto_flow            passed to GridFrame()
+  expander.AccordionSection  columns              passed to GridFrame()
+  expander.AccordionSection  internal_expander    stored on self, never forwarded
+  expander.AccordionSection  key                  stored on self, never forwarded
+  expander.AccordionSection  rows                 passed to GridFrame()
+  grid.Grid                  horizontal_items     stored on self, never forwarded
+  grid.Grid                  vertical_items       stored on self, never forwarded
+  groupbox.GroupBox          auto_flow            passed to GridFrame()
+  groupbox.GroupBox          columns              passed to GridFrame()
+  groupbox.GroupBox          gap                  passed to FlexFrame(), GridFrame()
+  groupbox.GroupBox          grow_items           passed to FlexFrame()
+  groupbox.GroupBox          horizontal_items     passed to FlexFrame(), resolve_layout_items()
+  groupbox.GroupBox          layout               passed to FlexFrame(), ValueError(), resolve_layout_items()
+  groupbox.GroupBox          rows                 passed to GridFrame()
+  groupbox.GroupBox          vertical_items       passed to FlexFrame(), resolve_layout_items()
+  listview.ListView          height               passed to self._internal.configure()
+  numberfield.NumberField    signal               passed to self._bind_value_signal()
+  pagestack.StackPage        auto_flow            passed to GridFrame()
+  pagestack.StackPage        columns              passed to GridFrame()
+  pagestack.StackPage        key                  stored on self, never forwarded
+  pagestack.StackPage        owner                stored on self, never forwarded
+  pagestack.StackPage        page_widget          passed to FlexFrame(), GridFrame()
+  pagestack.StackPage        rows                 passed to GridFrame()
+  picture.Picture            image                passed to self._coerce_image()
+  radio_variants.Radio       _internal_options    passed to update()
+  radio_variants.Radio       on_change            referenced but neither forwarded nor stored
+  radio_variants.RadioToggleButton density              passed to __init__()
+  radio_variants.RadioToggleButton on_change            passed to __init__()
+  radiogroup.RadioGroup      options              passed to normalize_options()
+  select.Select              signal               passed to self._bind_value_signal()
+  splash.Splash              fade                 stored on self, never forwarded
+  splash.Splash              gap                  passed to FlexFrame()
+  splash.Splash              min_duration         passed to float(), max()
+  splash.Splash              padding              passed to FlexFrame()
+  splash.Splash              size                 stored on self, never forwarded
+  splash.Splash              skippable            stored on self, never forwarded
+  splash.Splash              surface              passed to FlexFrame()
+  splash.Splash              until                passed to BootstackError(), float(), isinstance()
+  splitview.SplitPane        auto_flow            passed to GridFrame()
+  splitview.SplitPane        columns              passed to GridFrame()
+  splitview.SplitPane        frame                passed to FlexFrame(), GridFrame()
+  splitview.SplitPane        key                  stored on self, never forwarded
+  splitview.SplitPane        owner                stored on self, never forwarded
+  splitview.SplitPane        paned                stored on self, never forwarded
+  splitview.SplitPane        rows                 passed to GridFrame()
+  stacks.Spacer              size                 stored on self, never forwarded
+  stacks.Spacer              weight               stored on self, never forwarded
+  statusbar.StatusBar        _show                stored on self, never forwarded
+  statusbar.StatusBar        _toolbar             stored on self, never forwarded
+  tabs.TabPage               auto_flow            passed to GridFrame()
+  tabs.TabPage               columns              passed to GridFrame()
+  tabs.TabPage               key                  stored on self, never forwarded
+  tabs.TabPage               owner                stored on self, never forwarded
+  tabs.TabPage               page_widget          passed to FlexFrame(), GridFrame()
+  tabs.TabPage               rows                 passed to GridFrame()
+  textarea.TextArea          width                into internal_kwargs, splatted into _InternalTextArea() -- a SECOND widget, not the internal measured here
+  timefield.TimeField        signal               passed to self._bind_value_signal()
+  togglegroup.ToggleGroup    localize             stored on self, never forwarded
+  togglegroup.ToggleGroup    options              passed to normalize_options()
+  toolbar.Toolbar            _host                stored on self, never forwarded
+  toolbar.Toolbar            _toolbar             stored on self, never forwarded
+  tooltip.Tooltip            target               passed to isinstance()
+  tree.Tree                  data_source          passed to SourceBinding()
+  tree.Tree                  height               passed to self._internal.configure()
+  tree.Tree                  icon_field           passed to SourceBinding()
+  tree.Tree                  label_field          passed to SourceBinding()
+  tree.Tree                  node_builder         passed to SourceBinding()
+  tree.Tree                  nodes                passed to self._internal.load()
+  tree.Tree                  order                passed to SourceBinding()
+  tree.Tree                  parent_field         passed to SourceBinding()
+  tree.Tree                  root_value           passed to SourceBinding()
+  window.Window              gap                  into frame_kwargs, splatted into FlexFrame() -- a SECOND widget, not the internal measured here
+  window.Window              grow_items           into frame_kwargs, splatted into FlexFrame() -- a SECOND widget, not the internal measured here
+  window.Window              horizontal_items     into frame_kwargs, splatted into FlexFrame() -- a SECOND widget, not the internal measured here
+  window.Window              icon                 passed to resolve_window_icon()
+  window.Window              padding              into frame_kwargs, splatted into FlexFrame() -- a SECOND widget, not the internal measured here
+  window.Window              surface              into frame_kwargs, splatted into FlexFrame() -- a SECOND widget, not the internal measured here
+  window.Window              vertical_items       into frame_kwargs, splatted into FlexFrame() -- a SECOND widget, not the internal measured here
+  window.Window              window_controls      stored on self, never forwarded
+
+MODE 4 -- accepted then ignored : NOT MEASURED BY THIS ARM
+------------------------------------------------------------------------------
+  Mode 4 is not statically decidable and this probe does not claim to
+  find it. `--arm roundtrip` is a PARTIAL heuristic; read its own
+  honesty note before quoting it.
+
+SKIPPED CLASSES : 17
+------------------------------------------------------------------------------
+  appshell.Page                          not in a public __all__
+  appshell.PageNav                       not in a public __all__
+  appshell.Rail                          not in a public __all__
+  appshell.Workspace                     not in a public __all__
+  chart.ChartAnimation                   not in a public __all__
+  datatable.ExportJob                    not in a public __all__
+  expander.Expander                      not in a public __all__
+  scrollbar.Scrollbar                    not in a public __all__
+  sidebar_toggle.SidebarToggle           not in a public __all__
+  sizegrip.SizeGrip                      not in a public __all__
+  spinbox.Spinbox                        not in a public __all__
+  types.BaseWidgetKwargs                 not in a public __all__
+  types.ColumnSpec                       not in a public __all__
+  types.FormOptions                      not in a public __all__
+  types.IconSpec                         not in a public __all__
+  types.OptionDict                       not in a public __all__
+  types.StyledKwargs                     not in a public __all__


### PR DESCRIPTION
The measurement pass planned in `PLAN.md` for #463.

**Ships no production code.** `git diff main...HEAD -- src/` is empty and stayed empty for the whole pass, which is the constraint the plan set. Gate 1 therefore triggers no review round: this is a probe, a table and raw output.

## What landed

`development/probe_wrapper_parameter_delta.py` — four arms (`scan`, `control`, `leftovers`, `roundtrip`), the ranked table in `development/wrapper-parameter-audit-463.md`, and each arm's raw output committed beside it.

## The result

Measured on 58 files / 65 public classes / 810 parameters:

| mode | what | count | verdict |
|---|---|---|---|
| 1 | never forwarded | 0 | clean |
| 2 | wrong destination | 100 rows → 35 rank A / 65 rank B | **1 defect (#461)**; the rest are internal spelling |
| 3 | swallowed as a layout key | **40 of 52** wrappers | **the finding** |
| 4 | accepted then ignored | not statically decidable | 1 weak candidate |
| 5 | the type lies | **8** | **= #460 exactly** |

**No new issue needs filing.** Every real finding lands on #383, #460 or #461. The product is the *measurement* those issues were missing — particularly #383 gap 3, which now has its population (40 wrappers drop unknown names), its precedent (5 already reject, with a six-line guard shipped in `_BooleanControlBase`), and its exclusions (5 forward leftovers deliberately, 2 do not split).

Mode 2 producing only one defect is a negative result, and it is only worth something because the controls pass.

## Non-vacuity

All five controls pass, including the #458 before/after pair — found at the pre-fix commit `1f9a62d1^`, absent on `main`.

⚠ The first run of that arm used `main~` and failed: `main~` is two `docs(claude):` commits *after* the merge, so the defect was long gone. The commit that bounds a control has to be the one the defect actually lived in. It is now pinned to the fix's parent with a comment saying why.

Mode 3 is cross-checked against reality rather than only read: `--arm leftovers` constructs all 52 wrappers with an unknown keyword and compares the outcome to the static verdict — **51 agree, 0 disagree, 1 inconclusive.**

Parse integrity: 58 found, 58 parsed, 0 failures, asserted rather than assumed; sources read `utf-8-sig` with no bare `except` able to swallow a failure.

## Scope, stated as a command

```
scanned      src/bootstack/widgets/*.py
NOT scanned  src/bootstack/dialogs/            (the probe accepts --src; this pass did not run it)
```

⚠ Five classes are reported **UNANALYZED and must not be read as clean** — `AppShell` (31), `Workbench` (34), `ThemeToggle` (5), `Notification` (7), `Snackbar` (7), 84 parameters in total. `App`, `Window` and `Splash` were in that list until the tool learned to follow the alias hop, which the plan predicted and which was worth 84 more parameters.

## Tool defects found during the run

Recorded in the table because a probe whose conclusion gets cited has to show its own error history. Four of the five were caught by *running* something rather than reading it, and three were false alarms pointing at working code — `TimeField(read_only=True)` was reported as writing a key nothing accepts, and it works.

**A static wrapper audit that is not cross-checked against construction will ship false findings.** That is the transferable lesson, and it is why `--arm leftovers` exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
