### PR TITLE
fix(core): signal no longer guards None when applying text value to field

### DIFF
--- a/src/bootstack/widgets/_impl/composites/textarea/core.py
+++ b/src/bootstack/widgets/_impl/composites/textarea/core.py
@@ -352,10 +352,9 @@ class _MultilineCore(tk.Frame):
             self.value = text
 
     def _on_signal_change(self, new_value) -> None:
-        if new_value is not None:
-            text = str(new_value)
-            if self._signal_text() != text:
-                self._apply_signal_text(text)
+        text = str(new_value or "")
+        if self._signal_text() != text:
+            self._apply_signal_text(text)
 
     # ── dirty tracking ────────────────────────────────────────────────────
 


### PR DESCRIPTION
The signal change was guarding against None and so the `_apply_signal_text` method was never called. This fix removes that guard and sets the text area value to an empty string when the new value is None via a signal that allows empty values. Fixes #490 